### PR TITLE
perf: bound file IO concurrency

### DIFF
--- a/src/services/teamMemorySync/index.test.ts
+++ b/src/services/teamMemorySync/index.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test'
+import type { Dirent } from 'fs'
+import { join, relative, sep } from 'path'
+import { PathTraversalError } from '../../memdir/teamMemPaths.js'
+import { __test } from './index.js'
+
+function deferred(): {
+  promise: Promise<void>
+  resolve: () => void
+} {
+  let resolve!: () => void
+  const promise = new Promise<void>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+async function waitFor(
+  condition: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (Date.now() < deadline) {
+    if (condition()) return
+    await new Promise(resolve => setTimeout(resolve, 1))
+  }
+  throw new Error(message)
+}
+
+type FakeDirent = Pick<Dirent, 'name' | 'isDirectory' | 'isFile'>
+
+function file(name: string): FakeDirent {
+  return {
+    name,
+    isDirectory: () => false,
+    isFile: () => true,
+  }
+}
+
+describe('team memory local read perf contracts', () => {
+  test('bounds concurrent file reads while preserving sorted output keys', async () => {
+    const root = `/tmp/team-memory-${Date.now()}`
+    const gate = deferred()
+    let activeReads = 0
+    let maxActiveReads = 0
+
+    const deps = {
+      getTeamMemPath: () => root + sep,
+      readdir: async (path: string) => {
+        if (path === root + sep) {
+          return Array.from(
+            { length: __test.TEAM_MEMORY_FILE_IO_CONCURRENCY * 3 },
+            (_, i) => file(`file-${String(i).padStart(2, '0')}.md`),
+          )
+        }
+        return []
+      },
+      stat: async () => ({ size: 10 }),
+      readFile: async (path: string) => {
+        activeReads++
+        maxActiveReads = Math.max(maxActiveReads, activeReads)
+        await gate.promise
+        activeReads--
+        return relative(root, path)
+      },
+      scanForSecrets: () => [],
+    }
+
+    const promise = __test.readLocalTeamMemoryWithDependencies(null, deps)
+    await waitFor(
+      () => activeReads === __test.TEAM_MEMORY_FILE_IO_CONCURRENCY,
+      'expected first bounded read batch to start',
+    )
+
+    expect(maxActiveReads).toBeLessThanOrEqual(
+      __test.TEAM_MEMORY_FILE_IO_CONCURRENCY,
+    )
+    gate.resolve()
+
+    const result = await promise
+    expect(Object.keys(result.entries)).toEqual(
+      Object.keys(result.entries).sort(),
+    )
+  })
+
+  test('keeps learned-cap truncation deterministic after secret filtering', async () => {
+    const root = `/tmp/team-memory-${Date.now()}`
+    const deps = {
+      getTeamMemPath: () => root + sep,
+      readdir: async () => [
+        file('a.md'),
+        file('b-secret.md'),
+        file('c.md'),
+        file('d.md'),
+      ],
+      stat: async () => ({ size: 10 }),
+      readFile: async (path: string) => path,
+      scanForSecrets: (content: string) =>
+        content.endsWith('b-secret.md')
+          ? [{ ruleId: 'github-pat', label: 'Github Pat' }]
+          : [],
+    }
+
+    const result = await __test.readLocalTeamMemoryWithDependencies(2, deps)
+
+    expect(Object.keys(result.entries)).toEqual(['a.md', 'c.md'])
+    expect(result.skippedSecrets).toEqual([
+      { path: 'b-secret.md', ruleId: 'github-pat', label: 'Github Pat' },
+    ])
+  })
+})
+
+describe('team memory remote write perf contracts', () => {
+  test('bounds concurrent remote writes', async () => {
+    const root = `/tmp/team-memory-${Date.now()}`
+    const gate = deferred()
+    let activeWrites = 0
+    let maxActiveWrites = 0
+
+    const deps = {
+      validateTeamMemKey: async (relPath: string) => join(root, relPath),
+      readFile: async () => {
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+      },
+      mkdir: async () => {},
+      writeFile: async () => {
+        activeWrites++
+        maxActiveWrites = Math.max(maxActiveWrites, activeWrites)
+        await gate.promise
+        activeWrites--
+      },
+    }
+
+    const entries = Object.fromEntries(
+      Array.from(
+        { length: __test.TEAM_MEMORY_FILE_IO_CONCURRENCY * 3 },
+        (_, i) => [`file-${i}.md`, `content-${i}`],
+      ),
+    )
+
+    const promise = __test.writeRemoteEntriesToLocalWithDependencies(
+      entries,
+      deps,
+    )
+    await waitFor(
+      () => activeWrites === __test.TEAM_MEMORY_FILE_IO_CONCURRENCY,
+      'expected first bounded write batch to start',
+    )
+
+    expect(maxActiveWrites).toBeLessThanOrEqual(
+      __test.TEAM_MEMORY_FILE_IO_CONCURRENCY,
+    )
+    gate.resolve()
+    await expect(promise).resolves.toBe(Object.keys(entries).length)
+  })
+
+  test('still skips path traversal entries', async () => {
+    const deps = {
+      validateTeamMemKey: async () => {
+        throw new PathTraversalError('bad path')
+      },
+      readFile: async () => '',
+      mkdir: async () => {},
+      writeFile: async () => {},
+    }
+
+    const written = await __test.writeRemoteEntriesToLocalWithDependencies(
+      { '../bad.md': 'bad' },
+      deps,
+    )
+
+    expect(written).toBe(0)
+  })
+})

--- a/src/services/teamMemorySync/index.test.ts
+++ b/src/services/teamMemorySync/index.test.ts
@@ -68,7 +68,7 @@ describe('team memory local read perf contracts', () => {
 
     const promise = __test.readLocalTeamMemoryWithDependencies(null, deps)
     await waitFor(
-      () => activeReads === __test.TEAM_MEMORY_FILE_IO_CONCURRENCY,
+      () => activeReads >= __test.TEAM_MEMORY_FILE_IO_CONCURRENCY,
       'expected first bounded read batch to start',
     )
 
@@ -143,7 +143,7 @@ describe('team memory remote write perf contracts', () => {
       deps,
     )
     await waitFor(
-      () => activeWrites === __test.TEAM_MEMORY_FILE_IO_CONCURRENCY,
+      () => activeWrites >= __test.TEAM_MEMORY_FILE_IO_CONCURRENCY,
       'expected first bounded write batch to start',
     )
 

--- a/src/services/teamMemorySync/index.ts
+++ b/src/services/teamMemorySync/index.ts
@@ -26,6 +26,7 @@
 
 import axios from 'axios'
 import { createHash } from 'crypto'
+import type { Dirent } from 'fs'
 import { mkdir, readdir, readFile, stat, writeFile } from 'fs/promises'
 import { join, relative, sep } from 'path'
 import {
@@ -40,6 +41,7 @@ import {
   validateTeamMemKey,
 } from '../../memdir/teamMemPaths.js'
 import { count } from '../../utils/array.js'
+import { mapWithConcurrency } from '../../utils/boundedAsync.js'
 import {
   checkAndRefreshOAuthTokenIfNeeded,
   getClaudeAIOAuthTokens,
@@ -89,6 +91,39 @@ const MAX_FILE_SIZE_BYTES = 250_000
 const MAX_PUT_BODY_BYTES = 200_000
 const MAX_RETRIES = 3
 const MAX_CONFLICT_RETRIES = 2
+const TEAM_MEMORY_FILE_IO_CONCURRENCY = 8
+
+type TeamMemoryDirent = Pick<Dirent, 'name' | 'isDirectory' | 'isFile'>
+
+type TeamMemoryReadDeps = {
+  getTeamMemPath: () => string
+  readdir: (dir: string) => Promise<TeamMemoryDirent[]>
+  stat: (path: string) => Promise<{ size: number }>
+  readFile: (path: string) => Promise<string>
+  scanForSecrets: typeof scanForSecrets
+}
+
+type TeamMemoryWriteDeps = {
+  validateTeamMemKey: typeof validateTeamMemKey
+  readFile: (path: string) => Promise<string>
+  mkdir: (path: string, options: { recursive: true }) => Promise<unknown>
+  writeFile: (path: string, content: string) => Promise<unknown>
+}
+
+const defaultReadDeps: TeamMemoryReadDeps = {
+  getTeamMemPath,
+  readdir: dir => readdir(dir, { withFileTypes: true }),
+  stat,
+  readFile: path => readFile(path, 'utf8'),
+  scanForSecrets,
+}
+
+const defaultWriteDeps: TeamMemoryWriteDeps = {
+  validateTeamMemKey,
+  readFile: path => readFile(path, 'utf8'),
+  mkdir: (path, options) => mkdir(path, options),
+  writeFile: (path, content) => writeFile(path, content, 'utf8'),
+}
 
 // ─── Sync state ─────────────────────────────────────────────
 
@@ -568,71 +603,120 @@ async function readLocalTeamMemory(maxEntries: number | null): Promise<{
   entries: Record<string, string>
   skippedSecrets: SkippedSecretFile[]
 }> {
-  const teamDir = getTeamMemPath()
-  const entries: Record<string, string> = {}
-  const skippedSecrets: SkippedSecretFile[] = []
+  return readLocalTeamMemoryWithDependencies(maxEntries, defaultReadDeps)
+}
+
+type LocalTeamMemoryFile = {
+  fullPath: string
+  relPath: string
+}
+
+async function collectLocalTeamMemoryFiles(
+  teamDir: string,
+  deps: TeamMemoryReadDeps,
+): Promise<LocalTeamMemoryFile[]> {
+  const files: LocalTeamMemoryFile[] = []
 
   async function walkDir(dir: string): Promise<void> {
+    let dirEntries: TeamMemoryDirent[]
     try {
-      const dirEntries = await readdir(dir, { withFileTypes: true })
-      await Promise.all(
-        dirEntries.map(async entry => {
-          const fullPath = join(dir, entry.name)
-          if (entry.isDirectory()) {
-            await walkDir(fullPath)
-          } else if (entry.isFile()) {
-            try {
-              const stats = await stat(fullPath)
-              if (stats.size > MAX_FILE_SIZE_BYTES) {
-                logForDebugging(
-                  `team-memory-sync: skipping oversized file ${entry.name} (${stats.size} > ${MAX_FILE_SIZE_BYTES} bytes)`,
-                  { level: 'info' },
-                )
-                return
-              }
-              const content = await readFile(fullPath, 'utf8')
-              const relPath = relative(teamDir, fullPath).replaceAll('\\', '/')
-
-              // PSR M22174: scan for secrets BEFORE adding to the upload
-              // payload. If a secret is detected, skip this file entirely
-              // so it never leaves the machine.
-              const secretMatches = scanForSecrets(content)
-              if (secretMatches.length > 0) {
-                // Report only the first match per file — one secret is
-                // enough to skip the file and we don't want to log more
-                // than necessary about credential locations.
-                const firstMatch = secretMatches[0]!
-                skippedSecrets.push({
-                  path: relPath,
-                  ruleId: firstMatch.ruleId,
-                  label: firstMatch.label,
-                })
-                logForDebugging(
-                  `team-memory-sync: skipping "${relPath}" — detected ${firstMatch.label}`,
-                  { level: 'warn' },
-                )
-                return
-              }
-
-              entries[relPath] = content
-            } catch {
-              // Skip unreadable files
-            }
-          }
-        }),
-      )
+      dirEntries = await deps.readdir(dir)
     } catch (e) {
       if (isErrnoException(e)) {
         if (e.code !== 'ENOENT' && e.code !== 'EACCES' && e.code !== 'EPERM') {
           throw e
         }
-      } else {
-        throw e
+        return
       }
+      throw e
+    }
+
+    for (const entry of dirEntries) {
+      const fullPath = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        await walkDir(fullPath)
+        continue
+      }
+      if (!entry.isFile()) {
+        continue
+      }
+
+      files.push({
+        fullPath,
+        relPath: relative(teamDir, fullPath).replaceAll('\\', '/'),
+      })
     }
   }
 
   await walkDir(teamDir)
+  return files.sort((a, b) => a.relPath.localeCompare(b.relPath))
+}
+
+async function readLocalTeamMemoryWithDependencies(
+  maxEntries: number | null,
+  deps: TeamMemoryReadDeps,
+): Promise<{
+  entries: Record<string, string>
+  skippedSecrets: SkippedSecretFile[]
+}> {
+  const teamDir = deps.getTeamMemPath()
+  const entries: Record<string, string> = {}
+  const skippedSecrets: SkippedSecretFile[] = []
+  const files = await collectLocalTeamMemoryFiles(teamDir, deps)
+
+  const results = await mapWithConcurrency(
+    files,
+    TEAM_MEMORY_FILE_IO_CONCURRENCY,
+    async file => {
+      try {
+        const stats = await deps.stat(file.fullPath)
+        if (stats.size > MAX_FILE_SIZE_BYTES) {
+          logForDebugging(
+            `team-memory-sync: skipping oversized file ${file.relPath} (${stats.size} > ${MAX_FILE_SIZE_BYTES} bytes)`,
+            { level: 'info' },
+          )
+          return null
+        }
+        const content = await deps.readFile(file.fullPath)
+        const secretMatches = deps.scanForSecrets(content)
+        if (secretMatches.length > 0) {
+          const firstMatch = secretMatches[0]!
+          logForDebugging(
+            `team-memory-sync: skipping "${file.relPath}" - detected ${firstMatch.label}`,
+            { level: 'warn' },
+          )
+          return {
+            type: 'secret' as const,
+            path: file.relPath,
+            ruleId: firstMatch.ruleId,
+            label: firstMatch.label,
+          }
+        }
+        return {
+          type: 'entry' as const,
+          path: file.relPath,
+          content,
+        }
+      } catch {
+        return null
+      }
+    },
+  )
+
+  for (const result of results) {
+    if (!result) {
+      continue
+    }
+    if (result.type === 'secret') {
+      skippedSecrets.push({
+        path: result.path,
+        ruleId: result.ruleId,
+        label: result.label,
+      })
+      continue
+    }
+    entries[result.path] = result.content
+  }
 
   // Truncate only if we've LEARNED a cap from the server (via a structured
   // 413's extra_details.max_entries — anthropic/anthropic#293258).  The
@@ -642,11 +726,10 @@ async function readLocalTeamMemory(maxEntries: number | null): Promise<{
   // authoritative.  The server validates total stored entries after merge
   // (not PUT body count) and rejects atomically — nothing is written on 413.
   //
-  // Sorting before truncation is what makes delta computation work: without
-  // it, the parallel walk above picks a different N-of-M subset each push
-  // (Promise.all resolves in completion order), serverChecksums misses keys,
-  // and the "delta" balloons to near-full snapshot.  With deterministic
-  // truncation, the same N keys are compared against the same server state.
+  // Sorting before truncation is what makes delta computation work. Without
+  // deterministic key order, serverChecksums can miss keys and the "delta"
+  // balloons to near-full snapshot.  With deterministic truncation, the same
+  // N keys are compared against the same server state.
   //
   // When disk has more files than the learned cap, alphabetically-last ones
   // consistently never sync.  When the merged (server + delta) count exceeds
@@ -689,11 +772,20 @@ async function readLocalTeamMemory(maxEntries: number | null): Promise<{
 async function writeRemoteEntriesToLocal(
   entries: Record<string, string>,
 ): Promise<number> {
-  const results = await Promise.all(
-    Object.entries(entries).map(async ([relPath, content]) => {
+  return writeRemoteEntriesToLocalWithDependencies(entries, defaultWriteDeps)
+}
+
+async function writeRemoteEntriesToLocalWithDependencies(
+  entries: Record<string, string>,
+  deps: TeamMemoryWriteDeps,
+): Promise<number> {
+  const results = await mapWithConcurrency(
+    Object.entries(entries),
+    TEAM_MEMORY_FILE_IO_CONCURRENCY,
+    async ([relPath, content]) => {
       let validatedPath: string
       try {
-        validatedPath = await validateTeamMemKey(relPath)
+        validatedPath = await deps.validateTeamMemKey(relPath)
       } catch (e) {
         if (e instanceof PathTraversalError) {
           logForDebugging(`team-memory-sync: ${e.message}`, { level: 'warn' })
@@ -715,7 +807,7 @@ async function writeRemoteEntriesToLocal(
       // where pull returns unchanged entries (skipEtagCache path, first
       // pull of a session with warm disk state from prior session).
       try {
-        const existing = await readFile(validatedPath, 'utf8')
+        const existing = await deps.readFile(validatedPath)
         if (existing === content) {
           return false
         }
@@ -738,8 +830,8 @@ async function writeRemoteEntriesToLocal(
           0,
           validatedPath.lastIndexOf(sep),
         )
-        await mkdir(parentDir, { recursive: true })
-        await writeFile(validatedPath, content, 'utf8')
+        await deps.mkdir(parentDir, { recursive: true })
+        await deps.writeFile(validatedPath, content)
         return true
       } catch (e) {
         logForDebugging(
@@ -748,7 +840,7 @@ async function writeRemoteEntriesToLocal(
         )
         return false
       }
-    }),
+    },
   )
 
   return count(results, Boolean)
@@ -1253,4 +1345,10 @@ function logPush(
       server_received_entries: outcome.serverReceivedEntries,
     }),
   })
+}
+
+export const __test = {
+  TEAM_MEMORY_FILE_IO_CONCURRENCY,
+  readLocalTeamMemoryWithDependencies,
+  writeRemoteEntriesToLocalWithDependencies,
 }

--- a/src/utils/attachments.performance.test.ts
+++ b/src/utils/attachments.performance.test.ts
@@ -39,6 +39,24 @@ describe('attachment perf contracts', () => {
     await expect(resultPromise).resolves.toEqual([])
   })
 
+  test('maybe does not invoke producer when signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    let started = false
+
+    await expect(
+      __test.maybe(
+        'pre_aborted_attachment',
+        async () => {
+          started = true
+          return []
+        },
+        controller.signal,
+      ),
+    ).resolves.toEqual([])
+    expect(started).toBe(false)
+  })
+
   test('processAtMentionedFiles bounds scheduled file work', async () => {
     const gate = deferred()
     let activeStats = 0

--- a/src/utils/attachments.performance.test.ts
+++ b/src/utils/attachments.performance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
-import { getEmptyToolPermissionContext } from '../Tool.js'
+import { getEmptyToolPermissionContext, type ToolUseContext } from '../Tool.js'
 import { __test } from './attachments.js'
+import { createFileStateCacheWithSizeLimit } from './fileStateCache.js'
 
 function deferred(): {
   promise: Promise<void>
@@ -95,10 +96,122 @@ describe('attachment perf contracts', () => {
     )
 
     await waitFor(
-      () => activeStats === __test.ATTACHMENT_FILE_IO_CONCURRENCY,
+      () => activeStats >= __test.ATTACHMENT_FILE_IO_CONCURRENCY,
       'expected first bounded stat batch to start',
     )
     expect(maxActiveStats).toBeLessThanOrEqual(
+      __test.ATTACHMENT_FILE_IO_CONCURRENCY,
+    )
+
+    gate.resolve()
+    await expect(resultPromise).resolves.toHaveLength(files.length)
+  })
+
+  test('processAtMentionedFiles keeps in-flight file work when attachment timeout aborts', async () => {
+    const gate = deferred()
+    const abortController = new AbortController()
+    let activeStats = 0
+
+    const cwd = process.cwd()
+    const files = Array.from(
+      { length: __test.ATTACHMENT_FILE_IO_CONCURRENCY * 2 },
+      (_, i) => `${cwd}/slow-mentioned-${i}.ts`,
+    )
+
+    const resultPromise = __test.processAtMentionedFilesWithDependencies(
+      files.map(file => `@${file}`).join(' '),
+      {
+        abortController,
+        getAppState: () => ({
+          toolPermissionContext: getEmptyToolPermissionContext(),
+        }),
+      },
+      {
+        stat: async () => {
+          activeStats++
+          await gate.promise
+          activeStats--
+          return { isDirectory: () => false }
+        },
+        readdir: async () => [],
+        generateFileAttachment: async filename => ({
+          type: 'file',
+          filename,
+          content: {} as never,
+          displayPath: filename,
+        }),
+      },
+    )
+
+    await waitFor(
+      () => activeStats >= __test.ATTACHMENT_FILE_IO_CONCURRENCY,
+      'expected first bounded stat batch to start',
+    )
+
+    abortController.abort()
+    gate.resolve()
+
+    await expect(resultPromise).resolves.toHaveLength(files.length)
+  })
+
+  test('getChangedFiles bounds scheduled file reads', async () => {
+    const gate = deferred()
+    let activeReads = 0
+    let maxActiveReads = 0
+
+    const readFileState = createFileStateCacheWithSizeLimit(100)
+    const cwd = process.cwd()
+    const files = Array.from(
+      { length: __test.ATTACHMENT_FILE_IO_CONCURRENCY * 3 },
+      (_, i) => `${cwd}/changed-${i}.ts`,
+    )
+    for (const file of files) {
+      readFileState.set(file, {
+        content: 'before\n',
+        timestamp: 0,
+        offset: undefined,
+        limit: undefined,
+      })
+    }
+
+    const resultPromise = __test.getChangedFilesWithDependencies(
+      {
+        abortController: new AbortController(),
+        readFileState,
+        getAppState: () => ({
+          toolPermissionContext: getEmptyToolPermissionContext(),
+        }),
+      } as ToolUseContext,
+      {
+        getFileModificationTime: async () => 1,
+        validateFileReadInput: async () => ({ result: true }),
+        readFile: async input => {
+          activeReads++
+          maxActiveReads = Math.max(maxActiveReads, activeReads)
+          await gate.promise
+          activeReads--
+          return {
+            data: {
+              type: 'text',
+              file: {
+                filePath: input.file_path,
+                content: 'before\nafter\n',
+                numLines: 2,
+                startLine: 1,
+                totalLines: 2,
+              },
+            },
+          }
+        },
+        readEditedImageAttachment: async () => null,
+      },
+    )
+
+    await waitFor(
+      () => activeReads >= __test.ATTACHMENT_FILE_IO_CONCURRENCY,
+      'expected first bounded read batch to start',
+    )
+    expect(maxActiveReads).toBeLessThanOrEqual(
       __test.ATTACHMENT_FILE_IO_CONCURRENCY,
     )
 

--- a/src/utils/attachments.performance.test.ts
+++ b/src/utils/attachments.performance.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test'
+import { getEmptyToolPermissionContext } from '../Tool.js'
+import { __test } from './attachments.js'
+
+function deferred(): {
+  promise: Promise<void>
+  resolve: () => void
+} {
+  let resolve!: () => void
+  const promise = new Promise<void>(res => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+async function waitFor(
+  condition: () => boolean,
+  message: string,
+): Promise<void> {
+  const deadline = Date.now() + 1000
+  while (Date.now() < deadline) {
+    if (condition()) return
+    await new Promise(resolve => setTimeout(resolve, 1))
+  }
+  throw new Error(message)
+}
+
+describe('attachment perf contracts', () => {
+  test('maybe returns [] when signal aborts even if producer hangs', async () => {
+    const controller = new AbortController()
+    const resultPromise = __test.maybe(
+      'hanging_attachment',
+      () => new Promise<unknown[]>(() => {}),
+      controller.signal,
+    )
+
+    controller.abort()
+
+    await expect(resultPromise).resolves.toEqual([])
+  })
+
+  test('processAtMentionedFiles bounds scheduled file work', async () => {
+    const gate = deferred()
+    let activeStats = 0
+    let maxActiveStats = 0
+
+    const cwd = process.cwd()
+    const files = Array.from(
+      { length: __test.ATTACHMENT_FILE_IO_CONCURRENCY * 3 },
+      (_, i) => `${cwd}/mentioned-${i}.ts`,
+    )
+
+    const resultPromise = __test.processAtMentionedFilesWithDependencies(
+      files.map(file => `@${file}`).join(' '),
+      {
+        abortController: new AbortController(),
+        getAppState: () => ({
+          toolPermissionContext: getEmptyToolPermissionContext(),
+        }),
+      },
+      {
+        stat: async () => {
+          activeStats++
+          maxActiveStats = Math.max(maxActiveStats, activeStats)
+          await gate.promise
+          activeStats--
+          return { isDirectory: () => false }
+        },
+        readdir: async () => [],
+        generateFileAttachment: async filename => ({
+          type: 'file',
+          filename,
+          content: {} as never,
+          displayPath: filename,
+        }),
+      },
+    )
+
+    await waitFor(
+      () => activeStats === __test.ATTACHMENT_FILE_IO_CONCURRENCY,
+      'expected first bounded stat batch to start',
+    )
+    expect(maxActiveStats).toBeLessThanOrEqual(
+      __test.ATTACHMENT_FILE_IO_CONCURRENCY,
+    )
+
+    gate.resolve()
+    await expect(resultPromise).resolves.toHaveLength(files.length)
+  })
+})

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -119,6 +119,7 @@ import {
   createAbortController,
   createChildAbortController,
 } from './abortController.js'
+import { mapWithConcurrency, raceAbort } from './boundedAsync.js'
 import { isAbortError } from './errors.js'
 import {
   getFileModificationTimeAsync,
@@ -764,6 +765,8 @@ export type TeamContextAttachment = {
   taskListPath: string
 }
 
+const ATTACHMENT_FILE_IO_CONCURRENCY = 8
+
 /**
  * This is janky
  * TODO: Generate attachments when we create messages
@@ -794,19 +797,27 @@ export async function getAttachments(
   const abortController = createAbortController()
   const timeoutId = setTimeout(ac => ac.abort(), 1000, abortController)
   const context = { ...toolUseContext, abortController }
+  const maybeAttachment = <A>(
+    label: string,
+    f: () => Promise<A[]>,
+  ): Promise<A[]> => maybe(label, f)
+  const maybeTimedAttachment = <A>(
+    label: string,
+    f: () => Promise<A[]>,
+  ): Promise<A[]> => maybe(label, f, context.abortController.signal)
 
   const isMainThread = !toolUseContext.agentId
 
   // Attachments which are added in response to on user input
   const userInputAttachments = input
     ? [
-        maybe('at_mentioned_files', () =>
+        maybeTimedAttachment('at_mentioned_files', () =>
           processAtMentionedFiles(input, context),
         ),
-        maybe('mcp_resources', () =>
+        maybeTimedAttachment('mcp_resources', () =>
           processMcpResourceAttachments(input, context),
         ),
-        maybe('agent_mentions', () =>
+        maybeAttachment('agent_mentions', () =>
           Promise.resolve(
             processAgentMentions(
               input,
@@ -830,7 +841,7 @@ export async function getAttachments(
         skillSearchModules &&
         !options?.skipSkillDiscovery
           ? [
-              maybe('skill_discovery', () =>
+              maybeTimedAttachment('skill_discovery', () =>
                 skillSearchModules.prefetch.getTurnZeroSkillDiscovery(
                   input,
                   messages ?? [],
@@ -854,17 +865,19 @@ export async function getAttachments(
     // main thread gets agentId===undefined, subagents get their own agentId.
     // Must run for all threads or subagent notifications drain into the void
     // (removed from queue by removeFromQueue but never attached).
-    maybe('queued_commands', () => getQueuedCommandAttachments(queuedCommands)),
-    maybe('date_change', () =>
+    maybeAttachment('queued_commands', () =>
+      getQueuedCommandAttachments(queuedCommands),
+    ),
+    maybeAttachment('date_change', () =>
       Promise.resolve(getDateChangeAttachments(messages)),
     ),
-    maybe('ultrathink_effort', () =>
+    maybeAttachment('ultrathink_effort', () =>
       Promise.resolve(getUltrathinkEffortAttachment(input)),
     ),
-    maybe('ultracode_mode', () =>
+    maybeAttachment('ultracode_mode', () =>
       Promise.resolve(getUltracodePermissionAttachment(toolUseContext)),
     ),
-    maybe('deferred_tools_delta', () =>
+    maybeAttachment('deferred_tools_delta', () =>
       Promise.resolve(
         getDeferredToolsDeltaAttachment(
           toolUseContext.options.tools,
@@ -879,10 +892,10 @@ export async function getAttachments(
         ),
       ),
     ),
-    maybe('agent_listing_delta', () =>
+    maybeAttachment('agent_listing_delta', () =>
       Promise.resolve(getAgentListingDeltaAttachment(toolUseContext, messages)),
     ),
-    maybe('mcp_instructions_delta', () =>
+    maybeAttachment('mcp_instructions_delta', () =>
       Promise.resolve(
         getMcpInstructionsDeltaAttachment(
           toolUseContext.options.mcpClients,
@@ -894,36 +907,48 @@ export async function getAttachments(
     ),
     ...(isBuddyEnabled()
         ? [
-            maybe('companion_intro', () =>
+            maybeAttachment('companion_intro', () =>
               Promise.resolve(getCompanionIntroAttachment(messages)),
           ),
         ]
       : []),
-    maybe('changed_files', () => getChangedFiles(context)),
-    maybe('nested_memory', () => getNestedMemoryAttachments(context)),
+    maybeTimedAttachment('changed_files', () => getChangedFiles(context)),
+    maybeTimedAttachment('nested_memory', () =>
+      getNestedMemoryAttachments(context),
+    ),
     // relevant_memories moved to async prefetch (startRelevantMemoryPrefetch)
-    maybe('dynamic_skill', () => getDynamicSkillAttachments(context)),
+    maybeTimedAttachment('dynamic_skill', () =>
+      getDynamicSkillAttachments(context),
+    ),
     ...(shouldIncludeSkillListingAttachment(querySource)
-      ? [maybe('skill_listing', () => getSkillListingAttachments(context))]
+      ? [
+          maybeTimedAttachment('skill_listing', () =>
+            getSkillListingAttachments(context),
+          ),
+        ]
       : []),
     // Inter-turn skill discovery now runs via startSkillDiscoveryPrefetch
     // (query.ts, concurrent with the main turn). The blocking call that
     // previously lived here was the assistant_turn signal — 97% of those
     // Haiku calls found nothing in prod. Prefetch + await-at-collection
     // replaces it; see src/services/skillSearch/prefetch.ts.
-    maybe('plan_mode', () => getPlanModeAttachments(messages, toolUseContext)),
-    maybe('plan_mode_exit', () => getPlanModeExitAttachment(toolUseContext)),
+    maybeAttachment('plan_mode', () =>
+      getPlanModeAttachments(messages, toolUseContext),
+    ),
+    maybeAttachment('plan_mode_exit', () =>
+      getPlanModeExitAttachment(toolUseContext),
+    ),
     ...(feature('TRANSCRIPT_CLASSIFIER')
       ? [
-          maybe('auto_mode', () =>
+          maybeAttachment('auto_mode', () =>
             getAutoModeAttachments(messages, toolUseContext),
           ),
-          maybe('auto_mode_exit', () =>
+          maybeAttachment('auto_mode_exit', () =>
             getAutoModeExitAttachment(toolUseContext),
           ),
         ]
       : []),
-    maybe('todo_reminders', () =>
+    maybeAttachment('todo_reminders', () =>
       isTodoV2Enabled()
         ? getTaskReminderAttachments(messages, toolUseContext)
         : getTodoReminderAttachments(messages, toolUseContext),
@@ -937,24 +962,24 @@ export async function getAttachments(
           ...(querySource === 'session_memory'
             ? []
             : [
-                maybe('teammate_mailbox', async () =>
+                maybeAttachment('teammate_mailbox', async () =>
                   getTeammateMailboxAttachments(toolUseContext),
                 ),
               ]),
-          maybe('team_context', async () =>
+          maybeAttachment('team_context', async () =>
             getTeamContextAttachment(messages ?? []),
           ),
         ]
       : []),
-    maybe('agent_pending_messages', async () =>
+    maybeAttachment('agent_pending_messages', async () =>
       getAgentPendingMessageAttachments(toolUseContext),
     ),
-    maybe('critical_system_reminder', () =>
+    maybeAttachment('critical_system_reminder', () =>
       Promise.resolve(getCriticalSystemReminderAttachment(toolUseContext)),
     ),
     ...(feature('COMPACTION_REMINDERS')
       ? [
-          maybe('compaction_reminder', () =>
+          maybeAttachment('compaction_reminder', () =>
             Promise.resolve(
               getCompactionReminderAttachment(
                 messages ?? [],
@@ -966,7 +991,7 @@ export async function getAttachments(
       : []),
     ...(feature('HISTORY_SNIP')
       ? [
-          maybe('context_efficiency', () =>
+          maybeAttachment('context_efficiency', () =>
             Promise.resolve(
               getContextEfficiencyAttachment(
                 messages ?? [],
@@ -981,28 +1006,28 @@ export async function getAttachments(
   // Attachments which are semantically only for the main conversation or don't have concurrency-safe implementations
   const mainThreadAttachments = isMainThread
     ? [
-        maybe('ide_selection', async () =>
+        maybeAttachment('ide_selection', async () =>
           getSelectedLinesFromIDE(ideSelection, toolUseContext),
         ),
-        maybe('ide_opened_file', async () =>
+        maybeAttachment('ide_opened_file', async () =>
           getOpenedFileFromIDE(ideSelection, toolUseContext),
         ),
-        maybe('output_style', async () =>
+        maybeAttachment('output_style', async () =>
           Promise.resolve(getOutputStyleAttachment()),
         ),
-        maybe('diagnostics', async () =>
+        maybeAttachment('diagnostics', async () =>
           getDiagnosticAttachments(toolUseContext),
         ),
-        maybe('lsp_diagnostics', async () =>
+        maybeAttachment('lsp_diagnostics', async () =>
           getLSPDiagnosticAttachments(toolUseContext),
         ),
-        maybe('unified_tasks', async () =>
+        maybeAttachment('unified_tasks', async () =>
           getUnifiedTaskAttachments(toolUseContext),
         ),
-        maybe('async_hook_responses', async () =>
+        maybeAttachment('async_hook_responses', async () =>
           getAsyncHookResponseAttachments(),
         ),
-        maybe('token_usage', async () =>
+        maybeAttachment('token_usage', async () =>
           Promise.resolve(
             getTokenUsageAttachment(
               messages ?? [],
@@ -1010,15 +1035,15 @@ export async function getAttachments(
             ),
           ),
         ),
-        maybe('budget_usd', async () =>
+        maybeAttachment('budget_usd', async () =>
           Promise.resolve(
             getMaxBudgetUsdAttachment(toolUseContext.options.maxBudgetUsd),
           ),
         ),
-        maybe('output_token_usage', async () =>
+        maybeAttachment('output_token_usage', async () =>
           Promise.resolve(getOutputTokenUsageAttachment()),
         ),
-        maybe('verify_plan_reminder', async () =>
+        maybeAttachment('verify_plan_reminder', async () =>
           getVerifyPlanReminderAttachment(messages, toolUseContext),
         ),
       ]
@@ -1040,10 +1065,14 @@ export async function getAttachments(
   ].filter(a => a !== undefined && a !== null)
 }
 
-async function maybe<A>(label: string, f: () => Promise<A[]>): Promise<A[]> {
+async function maybe<A>(
+  label: string,
+  f: () => Promise<A[]>,
+  signal?: AbortSignal,
+): Promise<A[]> {
   const startTime = Date.now()
   try {
-    const result = await f()
+    const result = await raceAbort(f(), signal, `Attachment ${label} timed out`)
     const duration = Date.now() - startTime
     // Log only 5% of events to reduce volume
     if (Math.random() < 0.05) {
@@ -1071,9 +1100,11 @@ async function maybe<A>(label: string, f: () => Promise<A[]>): Promise<A[]> {
         error: true,
       } as AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS)
     }
-    logError(e)
-    // For Ant users, log the full error to help with debugging
-    logAntError(`Attachment error in ${label}`, e)
+    if (!isAbortError(e)) {
+      logError(e)
+      // For Ant users, log the full error to help with debugging
+      logAntError(`Attachment error in ${label}`, e)
+    }
 
     return []
   }
@@ -1961,16 +1992,84 @@ async function getOpenedFileFromIDE(
   ]
 }
 
+type AttachmentFileContext = {
+  abortController: AbortController
+  getAppState: () => { toolPermissionContext: ToolPermissionContext }
+}
+
+type AtMentionedFileStat = {
+  isDirectory: () => boolean
+}
+
+type AtMentionedFileDirent = {
+  name: string
+}
+
+type AtMentionedFileDeps = {
+  stat: (path: string) => Promise<AtMentionedFileStat>
+  readdir: (
+    path: string,
+    options: { withFileTypes: true },
+  ) => Promise<AtMentionedFileDirent[]>
+  generateFileAttachment: (
+    filename: string,
+    toolUseContext: AttachmentFileContext,
+    successEventName: string,
+    errorEventName: string,
+    mode: 'compact' | 'at-mention',
+    options?: {
+      offset?: number
+      limit?: number
+    },
+  ) => ReturnType<typeof generateFileAttachment>
+}
+
+const defaultAtMentionedFileDeps: AtMentionedFileDeps = {
+  stat,
+  readdir,
+  generateFileAttachment: (
+    filename,
+    toolUseContext,
+    successEventName,
+    errorEventName,
+    mode,
+    options,
+  ) =>
+    generateFileAttachment(
+      filename,
+      toolUseContext as ToolUseContext,
+      successEventName,
+      errorEventName,
+      mode,
+      options,
+    ),
+}
+
 async function processAtMentionedFiles(
   input: string,
   toolUseContext: ToolUseContext,
+): Promise<Attachment[]> {
+  return processAtMentionedFilesWithDependencies(
+    input,
+    toolUseContext,
+    defaultAtMentionedFileDeps,
+  )
+}
+
+async function processAtMentionedFilesWithDependencies(
+  input: string,
+  toolUseContext: AttachmentFileContext,
+  deps: AtMentionedFileDeps,
 ): Promise<Attachment[]> {
   const files = extractAtMentionedFiles(input)
   if (files.length === 0) return []
 
   const appState = toolUseContext.getAppState()
-  const results = await Promise.all(
-    files.map(async file => {
+  const results = await mapWithConcurrency(
+    files,
+    ATTACHMENT_FILE_IO_CONCURRENCY,
+    async file => {
+      toolUseContext.abortController.signal.throwIfAborted()
       try {
         const { filename, lineStart, lineEnd } = parseAtMentionedFileLines(file)
         const absoluteFilename = expandPath(filename)
@@ -1983,10 +2082,11 @@ async function processAtMentionedFiles(
 
         // Check if it's a directory
         try {
-          const stats = await stat(absoluteFilename)
+          const stats = await deps.stat(absoluteFilename)
+          toolUseContext.abortController.signal.throwIfAborted()
           if (stats.isDirectory()) {
             try {
-              const entries = await readdir(absoluteFilename, {
+              const entries = await deps.readdir(absoluteFilename, {
                 withFileTypes: true,
               })
               const MAX_DIR_ENTRIES = 1000
@@ -2014,7 +2114,7 @@ async function processAtMentionedFiles(
           // If stat fails, continue with file logic
         }
 
-        return await generateFileAttachment(
+        return await deps.generateFileAttachment(
           absoluteFilename,
           toolUseContext,
           'tengu_at_mention_extracting_filename_success',
@@ -2025,10 +2125,13 @@ async function processAtMentionedFiles(
             limit: lineEnd && lineStart ? lineEnd - lineStart + 1 : undefined,
           },
         )
-      } catch {
+      } catch (err) {
+        if (isAbortError(err)) throw err
         logEvent('tengu_at_mention_extracting_filename_error', {})
       }
-    }),
+      return null
+    },
+    { signal: toolUseContext.abortController.signal },
   )
   return results.filter(Boolean) as Attachment[]
 }
@@ -2185,8 +2288,10 @@ export async function getChangedFiles(
   if (filePaths.length === 0) return []
 
   const appState = toolUseContext.getAppState()
-  const results = await Promise.all(
-    filePaths.map(async filePath => {
+  const results = await mapWithConcurrency(
+    filePaths,
+    ATTACHMENT_FILE_IO_CONCURRENCY,
+    async filePath => {
       const fileState = toolUseContext.readFileState.get(filePath)
       if (!fileState) return null
 
@@ -2203,6 +2308,7 @@ export async function getChangedFiles(
       }
 
       try {
+        toolUseContext.abortController.signal.throwIfAborted()
         const mtime = await getFileModificationTimeAsync(normalizedPath)
         if (mtime <= fileState.timestamp) {
           return null
@@ -2219,6 +2325,7 @@ export async function getChangedFiles(
           return null
         }
 
+        toolUseContext.abortController.signal.throwIfAborted()
         const result = await FileReadTool.call(fileInput, toolUseContext)
         // Extract only the changed section
         if (result.data.type === 'text') {
@@ -2249,6 +2356,9 @@ export async function getChangedFiles(
         // null so the map callback has no implicit-undefined path.
         return null
       } catch (err) {
+        if (isAbortError(err)) {
+          throw err
+        }
         // Evict ONLY on ENOENT (file truly deleted). Transient stat
         // failures — atomic-save races (editor writes tmp→rename and
         // stat hits the gap), EACCES churn, network-FS hiccups — must
@@ -2261,7 +2371,8 @@ export async function getChangedFiles(
         }
         return null
       }
-    }),
+    },
+    { signal: toolUseContext.abortController.signal },
   )
   return results.filter(result => result != null) as Attachment[]
 }
@@ -3129,7 +3240,10 @@ async function getLSPDiagnosticAttachments(
 }
 
 export const __test = {
+  ATTACHMENT_FILE_IO_CONCURRENCY,
   getLSPDiagnosticAttachments,
+  maybe,
+  processAtMentionedFilesWithDependencies,
 }
 
 export async function* getAttachmentMessages(

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1072,6 +1072,7 @@ async function maybe<A>(
 ): Promise<A[]> {
   const startTime = Date.now()
   try {
+    signal?.throwIfAborted()
     const result = await raceAbort(f(), signal, `Attachment ${label} timed out`)
     const duration = Date.now() - startTime
     // Log only 5% of events to reduce volume

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -119,7 +119,11 @@ import {
   createAbortController,
   createChildAbortController,
 } from './abortController.js'
-import { mapWithConcurrency, raceAbort } from './boundedAsync.js'
+import {
+  mapWithConcurrency,
+  raceAbort,
+  throwIfAborted,
+} from './boundedAsync.js'
 import { isAbortError } from './errors.js'
 import {
   getFileModificationTimeAsync,
@@ -801,20 +805,16 @@ export async function getAttachments(
     label: string,
     f: () => Promise<A[]>,
   ): Promise<A[]> => maybe(label, f)
-  const maybeTimedAttachment = <A>(
-    label: string,
-    f: () => Promise<A[]>,
-  ): Promise<A[]> => maybe(label, f, context.abortController.signal)
 
   const isMainThread = !toolUseContext.agentId
 
   // Attachments which are added in response to on user input
   const userInputAttachments = input
     ? [
-        maybeTimedAttachment('at_mentioned_files', () =>
+        maybeAttachment('at_mentioned_files', () =>
           processAtMentionedFiles(input, context),
         ),
-        maybeTimedAttachment('mcp_resources', () =>
+        maybeAttachment('mcp_resources', () =>
           processMcpResourceAttachments(input, context),
         ),
         maybeAttachment('agent_mentions', () =>
@@ -841,7 +841,7 @@ export async function getAttachments(
         skillSearchModules &&
         !options?.skipSkillDiscovery
           ? [
-              maybeTimedAttachment('skill_discovery', () =>
+              maybeAttachment('skill_discovery', () =>
                 skillSearchModules.prefetch.getTurnZeroSkillDiscovery(
                   input,
                   messages ?? [],
@@ -912,17 +912,17 @@ export async function getAttachments(
           ),
         ]
       : []),
-    maybeTimedAttachment('changed_files', () => getChangedFiles(context)),
-    maybeTimedAttachment('nested_memory', () =>
+    maybeAttachment('changed_files', () => getChangedFiles(context)),
+    maybeAttachment('nested_memory', () =>
       getNestedMemoryAttachments(context),
     ),
     // relevant_memories moved to async prefetch (startRelevantMemoryPrefetch)
-    maybeTimedAttachment('dynamic_skill', () =>
+    maybeAttachment('dynamic_skill', () =>
       getDynamicSkillAttachments(context),
     ),
     ...(shouldIncludeSkillListingAttachment(querySource)
       ? [
-          maybeTimedAttachment('skill_listing', () =>
+          maybeAttachment('skill_listing', () =>
             getSkillListingAttachments(context),
           ),
         ]
@@ -1072,7 +1072,7 @@ async function maybe<A>(
 ): Promise<A[]> {
   const startTime = Date.now()
   try {
-    signal?.throwIfAborted()
+    throwIfAborted(signal, `Attachment ${label} timed out`)
     const result = await raceAbort(f(), signal, `Attachment ${label} timed out`)
     const duration = Date.now() - startTime
     // Log only 5% of events to reduce volume
@@ -2070,7 +2070,6 @@ async function processAtMentionedFilesWithDependencies(
     files,
     ATTACHMENT_FILE_IO_CONCURRENCY,
     async file => {
-      toolUseContext.abortController.signal.throwIfAborted()
       try {
         const { filename, lineStart, lineEnd } = parseAtMentionedFileLines(file)
         const absoluteFilename = expandPath(filename)
@@ -2084,7 +2083,6 @@ async function processAtMentionedFilesWithDependencies(
         // Check if it's a directory
         try {
           const stats = await deps.stat(absoluteFilename)
-          toolUseContext.abortController.signal.throwIfAborted()
           if (stats.isDirectory()) {
             try {
               const entries = await deps.readdir(absoluteFilename, {
@@ -2126,15 +2124,13 @@ async function processAtMentionedFilesWithDependencies(
             limit: lineEnd && lineStart ? lineEnd - lineStart + 1 : undefined,
           },
         )
-      } catch (err) {
-        if (isAbortError(err)) throw err
+      } catch {
         logEvent('tengu_at_mention_extracting_filename_error', {})
       }
       return null
     },
-    { signal: toolUseContext.abortController.signal },
   )
-  return results.filter(Boolean) as Attachment[]
+  return results.filter(result => result != null) as Attachment[]
 }
 
 function processAgentMentions(
@@ -2282,8 +2278,42 @@ export async function tryReadEditedImageAttachment(
   }
 }
 
+type ChangedFileReadInput = {
+  file_path: string
+}
+
+type ChangedFileDeps = {
+  getFileModificationTime: (path: string) => Promise<number>
+  validateFileReadInput: (
+    input: ChangedFileReadInput,
+    toolUseContext: ToolUseContext,
+  ) => ReturnType<typeof FileReadTool.validateInput>
+  readFile: (
+    input: ChangedFileReadInput,
+    toolUseContext: ToolUseContext,
+  ) => ReturnType<typeof FileReadTool.call>
+  readEditedImageAttachment: (
+    path: string,
+  ) => ReturnType<typeof tryReadEditedImageAttachment>
+}
+
+const defaultChangedFileDeps: ChangedFileDeps = {
+  getFileModificationTime: getFileModificationTimeAsync,
+  validateFileReadInput: (input, context) =>
+    FileReadTool.validateInput(input, context),
+  readFile: (input, context) => FileReadTool.call(input, context),
+  readEditedImageAttachment: tryReadEditedImageAttachment,
+}
+
 export async function getChangedFiles(
   toolUseContext: ToolUseContext,
+): Promise<Attachment[]> {
+  return getChangedFilesWithDependencies(toolUseContext, defaultChangedFileDeps)
+}
+
+async function getChangedFilesWithDependencies(
+  toolUseContext: ToolUseContext,
+  deps: ChangedFileDeps,
 ): Promise<Attachment[]> {
   const filePaths = cacheKeys(toolUseContext.readFileState)
   if (filePaths.length === 0) return []
@@ -2309,8 +2339,7 @@ export async function getChangedFiles(
       }
 
       try {
-        toolUseContext.abortController.signal.throwIfAborted()
-        const mtime = await getFileModificationTimeAsync(normalizedPath)
+        const mtime = await deps.getFileModificationTime(normalizedPath)
         if (mtime <= fileState.timestamp) {
           return null
         }
@@ -2318,7 +2347,7 @@ export async function getChangedFiles(
         const fileInput = { file_path: normalizedPath }
 
         // Validate file path is valid
-        const isValid = await FileReadTool.validateInput(
+        const isValid = await deps.validateFileReadInput(
           fileInput,
           toolUseContext,
         )
@@ -2326,8 +2355,7 @@ export async function getChangedFiles(
           return null
         }
 
-        toolUseContext.abortController.signal.throwIfAborted()
-        const result = await FileReadTool.call(fileInput, toolUseContext)
+        const result = await deps.readFile(fileInput, toolUseContext)
         // Extract only the changed section
         if (result.data.type === 'text') {
           const snippet = getSnippetForTwoFileDiff(
@@ -2350,16 +2378,13 @@ export async function getChangedFiles(
         // For non-text files (images), apply the same token limit logic as
         // FileReadTool. Degrades to null on failure (see the helper's contract).
         if (result.data.type === 'image') {
-          return tryReadEditedImageAttachment(normalizedPath)
+          return deps.readEditedImageAttachment(normalizedPath)
         }
 
         // notebook / pdf / parts — no diff representation; explicitly
         // null so the map callback has no implicit-undefined path.
         return null
       } catch (err) {
-        if (isAbortError(err)) {
-          throw err
-        }
         // Evict ONLY on ENOENT (file truly deleted). Transient stat
         // failures — atomic-save races (editor writes tmp→rename and
         // stat hits the gap), EACCES churn, network-FS hiccups — must
@@ -2373,7 +2398,6 @@ export async function getChangedFiles(
         return null
       }
     },
-    { signal: toolUseContext.abortController.signal },
   )
   return results.filter(result => result != null) as Attachment[]
 }
@@ -3242,6 +3266,7 @@ async function getLSPDiagnosticAttachments(
 
 export const __test = {
   ATTACHMENT_FILE_IO_CONCURRENCY,
+  getChangedFilesWithDependencies,
   getLSPDiagnosticAttachments,
   maybe,
   processAtMentionedFilesWithDependencies,

--- a/src/utils/boundedAsync.test.ts
+++ b/src/utils/boundedAsync.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'bun:test'
+import { mapWithConcurrency, raceAbort } from './boundedAsync.js'
+
+function deferred<T = void>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('mapWithConcurrency', () => {
+  test('preserves input order while bounding active mappers', async () => {
+    let active = 0
+    let maxActive = 0
+
+    const result = await mapWithConcurrency(
+      [3, 1, 2, 0],
+      2,
+      async value => {
+        active++
+        maxActive = Math.max(maxActive, active)
+        await new Promise(resolve => setTimeout(resolve, value * 5))
+        active--
+        return value * 10
+      },
+    )
+
+    expect(result).toEqual([30, 10, 20, 0])
+    expect(maxActive).toBeLessThanOrEqual(2)
+  })
+
+  test('does not schedule every item at once', async () => {
+    const gate = deferred()
+    let started = 0
+
+    const promise = mapWithConcurrency(
+      Array.from({ length: 50 }, (_, i) => i),
+      8,
+      async value => {
+        started++
+        await gate.promise
+        return value
+      },
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(started).toBe(8)
+    gate.resolve()
+    await expect(promise).resolves.toHaveLength(50)
+  })
+
+  test('rejects invalid concurrency', async () => {
+    await expect(
+      mapWithConcurrency([1], 0, async value => value),
+    ).rejects.toThrow('concurrency must be >= 1')
+  })
+
+  test('rejects before scheduling work when signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    let started = false
+
+    await expect(
+      mapWithConcurrency(
+        [1],
+        1,
+        async value => {
+          started = true
+          return value
+        },
+        { signal: controller.signal },
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(started).toBe(false)
+  })
+})
+
+describe('raceAbort', () => {
+  test('propagates non-abort inner rejection', async () => {
+    const controller = new AbortController()
+    const error = new Error('inner failed')
+
+    try {
+      await raceAbort(Promise.reject(error), controller.signal)
+      throw new Error('expected raceAbort to reject')
+    } catch (caught) {
+      expect(caught).toBe(error)
+    }
+  })
+
+  test('does not leak unhandled rejection when signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const unhandled: unknown[] = []
+    const onUnhandled = (error: unknown): void => {
+      unhandled.push(error)
+    }
+    process.on('unhandledRejection', onUnhandled)
+
+    try {
+      const lateFailure = new Promise<string>((_, reject) => {
+        setTimeout(() => reject(new Error('late failure')), 0)
+      })
+
+      await expect(
+        raceAbort(lateFailure, controller.signal, 'already aborted'),
+      ).rejects.toMatchObject({ name: 'AbortError' })
+      await new Promise(resolve => setTimeout(resolve, 10))
+      expect(unhandled).toEqual([])
+    } finally {
+      process.off('unhandledRejection', onUnhandled)
+    }
+  })
+
+  test('rejects when signal aborts before inner promise settles', async () => {
+    const controller = new AbortController()
+    const never = new Promise<string>(() => {})
+    const raced = raceAbort(never, controller.signal, 'attachment timeout')
+
+    controller.abort()
+
+    await expect(raced).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  test('returns promise value when it settles before abort', async () => {
+    const controller = new AbortController()
+    await expect(
+      raceAbort(Promise.resolve('done'), controller.signal),
+    ).resolves.toBe('done')
+  })
+})

--- a/src/utils/boundedAsync.test.ts
+++ b/src/utils/boundedAsync.test.ts
@@ -81,6 +81,52 @@ describe('mapWithConcurrency', () => {
     expect(started).toBe(false)
   })
 
+  test('normalizes non-Error abort reasons when already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort('cancelled')
+    let started = false
+
+    await expect(
+      mapWithConcurrency(
+        [1],
+        1,
+        async value => {
+          started = true
+          return value
+        },
+        { signal: controller.signal },
+      ),
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(started).toBe(false)
+  })
+
+  test('rejects and stops queued work when signal aborts mid-flight', async () => {
+    const controller = new AbortController()
+    const gate = deferred()
+    const started: number[] = []
+
+    const promise = mapWithConcurrency(
+      [0, 1, 2, 3],
+      2,
+      async value => {
+        started.push(value)
+        await gate.promise
+        return value
+      },
+      { signal: controller.signal },
+    )
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(started).toEqual([0, 1])
+
+    controller.abort('cancelled')
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+
+    gate.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(started).toEqual([0, 1])
+  })
+
   test('stops scheduling queued items after the first mapper rejection', async () => {
     const failFirst = deferred()
     const holdSecond = deferred()

--- a/src/utils/boundedAsync.test.ts
+++ b/src/utils/boundedAsync.test.ts
@@ -80,6 +80,35 @@ describe('mapWithConcurrency', () => {
     ).rejects.toMatchObject({ name: 'AbortError' })
     expect(started).toBe(false)
   })
+
+  test('stops scheduling queued items after the first mapper rejection', async () => {
+    const failFirst = deferred()
+    const holdSecond = deferred()
+    const error = new Error('mapper failed')
+    const started: number[] = []
+
+    const promise = mapWithConcurrency([0, 1, 2, 3], 2, async value => {
+      started.push(value)
+      if (value === 0) {
+        await failFirst.promise
+        throw error
+      }
+      if (value === 1) {
+        await holdSecond.promise
+      }
+      return value
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(started).toEqual([0, 1])
+
+    failFirst.resolve()
+    await expect(promise).rejects.toBe(error)
+
+    holdSecond.resolve()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(started).toEqual([0, 1])
+  })
 })
 
 describe('raceAbort', () => {

--- a/src/utils/boundedAsync.ts
+++ b/src/utils/boundedAsync.ts
@@ -1,0 +1,85 @@
+import { AbortError } from './errors.js'
+
+type MapWithConcurrencyOptions = {
+  signal?: AbortSignal
+}
+
+function abortReason(signal: AbortSignal, message?: string): Error {
+  if (signal.reason instanceof Error) {
+    return signal.reason
+  }
+  return new AbortError(message)
+}
+
+export async function raceAbort<T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+  message?: string,
+): Promise<T> {
+  if (!signal) {
+    return promise
+  }
+  if (signal.aborted) {
+    void promise.catch(() => {})
+    throw abortReason(signal, message)
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const cleanup = (): void => {
+      signal.removeEventListener('abort', onAbort)
+    }
+    const onAbort = (): void => {
+      cleanup()
+      reject(abortReason(signal, message))
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true })
+    promise.then(
+      value => {
+        cleanup()
+        resolve(value)
+      },
+      error => {
+        cleanup()
+        reject(error)
+      },
+    )
+  })
+}
+
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>,
+  options?: MapWithConcurrencyOptions,
+): Promise<R[]> {
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error('concurrency must be >= 1')
+  }
+
+  const signal = options?.signal
+  signal?.throwIfAborted()
+
+  const results = new Array<R>(items.length)
+  let nextIndex = 0
+
+  async function worker(): Promise<void> {
+    while (true) {
+      signal?.throwIfAborted()
+      const index = nextIndex
+      nextIndex++
+      if (index >= items.length) {
+        return
+      }
+      results[index] = await mapper(items[index]!, index)
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length)
+  await raceAbort(
+    Promise.all(Array.from({ length: workerCount }, () => worker())),
+    signal,
+    'operation aborted',
+  )
+  return results
+}

--- a/src/utils/boundedAsync.ts
+++ b/src/utils/boundedAsync.ts
@@ -62,16 +62,25 @@ export async function mapWithConcurrency<T, R>(
 
   const results = new Array<R>(items.length)
   let nextIndex = 0
+  let failed = false
 
   async function worker(): Promise<void> {
     while (true) {
+      if (failed) {
+        return
+      }
       signal?.throwIfAborted()
       const index = nextIndex
       nextIndex++
       if (index >= items.length) {
         return
       }
-      results[index] = await mapper(items[index]!, index)
+      try {
+        results[index] = await mapper(items[index]!, index)
+      } catch (error) {
+        failed = true
+        throw error
+      }
     }
   }
 

--- a/src/utils/boundedAsync.ts
+++ b/src/utils/boundedAsync.ts
@@ -11,6 +11,15 @@ function abortReason(signal: AbortSignal, message?: string): Error {
   return new AbortError(message)
 }
 
+export function throwIfAborted(
+  signal: AbortSignal | undefined,
+  message?: string,
+): void {
+  if (signal?.aborted) {
+    throw abortReason(signal, message)
+  }
+}
+
 export async function raceAbort<T>(
   promise: Promise<T>,
   signal?: AbortSignal,
@@ -58,7 +67,7 @@ export async function mapWithConcurrency<T, R>(
   }
 
   const signal = options?.signal
-  signal?.throwIfAborted()
+  throwIfAborted(signal, 'operation aborted')
 
   const results = new Array<R>(items.length)
   let nextIndex = 0
@@ -69,7 +78,7 @@ export async function mapWithConcurrency<T, R>(
       if (failed) {
         return
       }
-      signal?.throwIfAborted()
+      throwIfAborted(signal, 'operation aborted')
       const index = nextIndex
       nextIndex++
       if (index >= items.length) {


### PR DESCRIPTION
## Summary

- Bound file IO fan-out in attachment and team-memory paths.
- Add a small bounded concurrency/abort helper with tests.
- Fixes #1947

## Impact

- user-facing impact: less IO pressure in large repos or large team-memory dirs; no intended behavior change.
- developer/maintainer impact: focused helper + tests for concurrency and abort behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added abort-aware bounded async utilities to limit concurrent async work and fail fast on cancellation.
  * Introduced bounded, dependency-injected attachment and team-memory sync processing.
* **Bug Fixes**
  * Prevented unsafe path traversal during team memory synchronization.
  * Ensured secret-containing items are excluded deterministically, including after secret filtering.
  * Improved cancellation behavior so aborted operations stop cleanly and propagate aborts consistently.
* **Performance**
  * Reduced load spikes by enforcing concurrency caps for filesystem-heavy attachment and sync tasks.
* **Tests**
  * Added concurrency, determinism, and performance “contract” tests for attachments, team memory sync, and bounded async helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->