### PR TITLE
fix(query): bound per-turn latency growth in long REPL sessions (#1949)

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -674,13 +674,13 @@ compaction via the in-app `/config` command:
 
 Message-count compaction defaults to `200` messages. Select
 **Message-count compaction** to choose a different threshold (`100`, `500`, or
-`1000`), or set it to `off` to disable this proactive guard. The built-in hard
-cap remains, and an `OPENCLAUDE_MAX_ACTIVE_MESSAGES` override remains active
-when configured.
+`1000`), or set it to `off` to disable the setting's proactive guard. The
+built-in hard cap remains, and an `OPENCLAUDE_MAX_ACTIVE_MESSAGES` override
+remains active when configured.
 
 The legacy `OPENCLAUDE_MAX_ACTIVE_MESSAGES` environment variable is honored
-when the setting is unset or `off`; when both it and an explicit setting are
-present, the explicit setting takes precedence. `OPENCLAUDE_MAX_ACTIVE_MESSAGES_HARD_CAP`
+when the setting is unset or `off`. An explicit numeric setting takes
+precedence over that legacy value. `OPENCLAUDE_MAX_ACTIVE_MESSAGES_HARD_CAP`
 can override the safety cap; set it to `0` only for diagnostics.
 
 ### Long-session memory guard validation

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -672,14 +672,14 @@ compaction via the in-app `/config` command:
 /config
 ```
 
-Select **Message-count compaction** and choose a threshold (`100`, `200`, `500`,
-or `1000`). Setting it to `off` (default) leaves only the built-in hard cap.
+Message-count compaction defaults to `200` messages. Select
+**Message-count compaction** to choose a different threshold (`100`, `500`, or
+`1000`), or set it to `off` to disable this proactive guard and leave only the
+built-in hard cap.
 
-This setting is intended for power users debugging specific edge cases. Most
-users should leave it at `off`.
-
-The legacy `OPENCLAUDE_MAX_ACTIVE_MESSAGES` environment variable is still
-honored when the setting is `off`. `OPENCLAUDE_MAX_ACTIVE_MESSAGES_HARD_CAP`
+The legacy `OPENCLAUDE_MAX_ACTIVE_MESSAGES` environment variable is honored
+when the setting is unset or `off`; when both it and an explicit setting are
+present, the explicit setting takes precedence. `OPENCLAUDE_MAX_ACTIVE_MESSAGES_HARD_CAP`
 can override the safety cap; set it to `0` only for diagnostics.
 
 ### Long-session memory guard validation

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -665,7 +665,7 @@ would otherwise prevent it. Set `OPENCLAUDE_MAX_ACTIVE_MESSAGES_HARD_CAP=0`
 only when you need to suppress that safety cap for diagnostics.
 
 If you frequently resume long sessions that accumulate hundreds of small
-tool-result messages with negligible token cost, you can opt in to message-count
+tool-result messages with negligible token cost, adjust message-count
 compaction via the in-app `/config` command:
 
 ```text
@@ -674,8 +674,9 @@ compaction via the in-app `/config` command:
 
 Message-count compaction defaults to `200` messages. Select
 **Message-count compaction** to choose a different threshold (`100`, `500`, or
-`1000`), or set it to `off` to disable this proactive guard and leave only the
-built-in hard cap.
+`1000`), or set it to `off` to disable this proactive guard. The built-in hard
+cap remains, and an `OPENCLAUDE_MAX_ACTIVE_MESSAGES` override remains active
+when configured.
 
 The legacy `OPENCLAUDE_MAX_ACTIVE_MESSAGES` environment variable is honored
 when the setting is unset or `off`; when both it and an explicit setting are

--- a/scripts/system-check.test.ts
+++ b/scripts/system-check.test.ts
@@ -769,7 +769,21 @@ describe('system-check memory guard diagnostics', () => {
       ok: false,
       label: 'Auto-compact guard',
       detail:
-        'settings disabled; DISABLE_COMPACT is set; DISABLE_AUTO_COMPACT is set',
+        'settings disabled; DISABLE_COMPACT is set; DISABLE_AUTO_COMPACT is set; message-count threshold 500 remains active.',
+    })
+  })
+
+  test('reports an explicit message-count guard when token auto-compact is disabled', () => {
+    const results = buildMemoryGuardChecks({
+      autoCompactEnabled: true,
+      maxMessagesCompactionThreshold: '100',
+      env: { DISABLE_AUTO_COMPACT: '1' },
+    })
+
+    expect(results[0]).toEqual({
+      ok: false,
+      label: 'Auto-compact guard',
+      detail: 'DISABLE_AUTO_COMPACT is set; message-count threshold 100 remains active.',
     })
   })
 

--- a/scripts/system-check.test.ts
+++ b/scripts/system-check.test.ts
@@ -157,20 +157,6 @@ describe('formatReachabilityFailureDetail', () => {
     )
   })
 
-  test('reports explicit off without a legacy message-count override', () => {
-    const results = buildMemoryGuardChecks({
-      autoCompactEnabled: true,
-      maxMessagesCompactionThreshold: 'off',
-      env: {},
-    })
-
-    expect(results).toContainEqual({
-      ok: true,
-      label: 'Auto-compact guard',
-      detail: `Enabled; message-count threshold off; hard cap ${DEFAULT_MAX_ACTIVE_MESSAGES_HARD_CAP}.`,
-    })
-  })
-
   test('redacts credentials and sensitive query parameters in endpoint details', () => {
     const detail = formatReachabilityFailureDetail(
       'http://user:pass@localhost:11434/v1/models?token=abc123&mode=test',
@@ -672,6 +658,20 @@ describe('system-check WebSearch diagnostics', () => {
 })
 
 describe('system-check memory guard diagnostics', () => {
+  test('reports explicit off without a legacy message-count override', () => {
+    const results = buildMemoryGuardChecks({
+      autoCompactEnabled: true,
+      maxMessagesCompactionThreshold: 'off',
+      env: {},
+    })
+
+    expect(results).toContainEqual({
+      ok: true,
+      label: 'Auto-compact guard',
+      detail: `Enabled; message-count threshold off; hard cap ${DEFAULT_MAX_ACTIVE_MESSAGES_HARD_CAP}.`,
+    })
+  })
+
   test('reports the effective default auto-compact and hard-cap guards', () => {
     const results = buildMemoryGuardChecks({
       autoCompactEnabled: true,

--- a/scripts/system-check.test.ts
+++ b/scripts/system-check.test.ts
@@ -787,6 +787,20 @@ describe('system-check memory guard diagnostics', () => {
     })
   })
 
+  test('does not report the unset default as active when auto-compact is disabled', () => {
+    const results = buildMemoryGuardChecks({
+      autoCompactEnabled: true,
+      maxMessagesCompactionThreshold: undefined,
+      env: { DISABLE_AUTO_COMPACT: '1' },
+    })
+
+    expect(results[0]).toEqual({
+      ok: false,
+      label: 'Auto-compact guard',
+      detail: 'DISABLE_AUTO_COMPACT is set',
+    })
+  })
+
   test('fails when active-message hard cap is explicitly disabled', () => {
     const results = buildMemoryGuardChecks({
       autoCompactEnabled: true,

--- a/scripts/system-check.test.ts
+++ b/scripts/system-check.test.ts
@@ -658,7 +658,7 @@ describe('system-check WebSearch diagnostics', () => {
 })
 
 describe('system-check memory guard diagnostics', () => {
-  test('reports safe default auto-compact and hard-cap guards', () => {
+  test('reports the effective default auto-compact and hard-cap guards', () => {
     const results = buildMemoryGuardChecks({
       autoCompactEnabled: true,
       maxMessagesCompactionThreshold: undefined,
@@ -668,7 +668,7 @@ describe('system-check memory guard diagnostics', () => {
     expect(results).toContainEqual({
       ok: true,
       label: 'Auto-compact guard',
-      detail: `Enabled; message-count threshold off; hard cap ${DEFAULT_MAX_ACTIVE_MESSAGES_HARD_CAP}.`,
+      detail: `Enabled; message-count threshold 200; hard cap ${DEFAULT_MAX_ACTIVE_MESSAGES_HARD_CAP}.`,
     })
     expect(results).toContainEqual({
       ok: true,
@@ -677,6 +677,36 @@ describe('system-check memory guard diagnostics', () => {
     })
     expect(results.find(result => result.label === 'Memory pressure guard'))
       .toMatchObject({ ok: true })
+  })
+
+  test('reports the legacy message-count override when the setting is unset or off', () => {
+    for (const maxMessagesCompactionThreshold of [undefined, 'off']) {
+      const results = buildMemoryGuardChecks({
+        autoCompactEnabled: true,
+        maxMessagesCompactionThreshold,
+        env: { OPENCLAUDE_MAX_ACTIVE_MESSAGES: '500' },
+      })
+
+      expect(results).toContainEqual({
+        ok: true,
+        label: 'Auto-compact guard',
+        detail: `Enabled; message-count threshold 500; hard cap ${DEFAULT_MAX_ACTIVE_MESSAGES_HARD_CAP}.`,
+      })
+    }
+  })
+
+  test('reports an explicit message-count setting ahead of the legacy override', () => {
+    const results = buildMemoryGuardChecks({
+      autoCompactEnabled: true,
+      maxMessagesCompactionThreshold: '100',
+      env: { OPENCLAUDE_MAX_ACTIVE_MESSAGES: '500' },
+    })
+
+    expect(results).toContainEqual({
+      ok: true,
+      label: 'Auto-compact guard',
+      detail: `Enabled; message-count threshold 100; hard cap ${DEFAULT_MAX_ACTIVE_MESSAGES_HARD_CAP}.`,
+    })
   })
 
   test('falls back to the default hard cap when the override is malformed', () => {

--- a/scripts/system-check.test.ts
+++ b/scripts/system-check.test.ts
@@ -157,6 +157,20 @@ describe('formatReachabilityFailureDetail', () => {
     )
   })
 
+  test('reports explicit off without a legacy message-count override', () => {
+    const results = buildMemoryGuardChecks({
+      autoCompactEnabled: true,
+      maxMessagesCompactionThreshold: 'off',
+      env: {},
+    })
+
+    expect(results).toContainEqual({
+      ok: true,
+      label: 'Auto-compact guard',
+      detail: `Enabled; message-count threshold off; hard cap ${DEFAULT_MAX_ACTIVE_MESSAGES_HARD_CAP}.`,
+    })
+  })
+
   test('redacts credentials and sensitive query parameters in endpoint details', () => {
     const detail = formatReachabilityFailureDetail(
       'http://user:pass@localhost:11434/v1/models?token=abc123&mode=test',

--- a/scripts/system-check.ts
+++ b/scripts/system-check.ts
@@ -131,6 +131,17 @@ export function buildMemoryGuardChecks(
           input.maxMessagesCompactionThreshold,
         )
   const memoryBudget = parsePositiveInteger(env.OPENCLAUDE_MAX_MEMORY_MB) || 1536
+  const hasIndependentMessageCountGuard =
+    configuredLimit !== 'off' &&
+    (!autoCompactAvailable ||
+      input.maxMessagesCompactionThreshold !== undefined ||
+      legacyLimit > 0)
+  const autoCompactDisabledReason =
+    [
+      input.autoCompactEnabled ? undefined : 'settings disabled',
+      disableCompact ? 'DISABLE_COMPACT is set' : undefined,
+      disableAutoCompact ? 'DISABLE_AUTO_COMPACT is set' : undefined,
+    ].filter(Boolean).join('; ') || 'Disabled by configuration.'
 
   results.push(
     autoCompactAvailable
@@ -140,12 +151,10 @@ export function buildMemoryGuardChecks(
         )
       : fail(
           'Auto-compact guard',
-          [
-            input.autoCompactEnabled ? undefined : 'settings disabled',
-            disableCompact ? 'DISABLE_COMPACT is set' : undefined,
-            disableAutoCompact ? 'DISABLE_AUTO_COMPACT is set' : undefined,
-          ].filter(Boolean).join('; ') ||
-            'Disabled by configuration.',
+          autoCompactDisabledReason +
+            (hasIndependentMessageCountGuard
+              ? `; message-count threshold ${configuredLimit} remains active.`
+              : ''),
         ),
   )
 

--- a/scripts/system-check.ts
+++ b/scripts/system-check.ts
@@ -36,6 +36,7 @@ import {
   DEFAULT_MAX_ACTIVE_MESSAGES_HARD_CAP,
   getMaxActiveMessagesHardCap,
 } from '../src/utils/maxActiveMessages.js'
+import { normalizeMaxMessagesCompactionThreshold } from '../src/utils/config.js'
 import {
   getAvailableProviders,
   getProviderChain,
@@ -120,19 +121,22 @@ export function buildMemoryGuardChecks(
     input.autoCompactEnabled && !disableCompact && !disableAutoCompact
   const hardCapOverride = env.OPENCLAUDE_MAX_ACTIVE_MESSAGES_HARD_CAP
   const hardCap = getMaxActiveMessagesHardCap(env)
-  const configuredLimit =
-    input.maxMessagesCompactionThreshold &&
-    input.maxMessagesCompactionThreshold !== 'off'
-      ? input.maxMessagesCompactionThreshold
-      : undefined
   const legacyLimit = parsePositiveInteger(env.OPENCLAUDE_MAX_ACTIVE_MESSAGES)
+  const configuredLimit =
+    ((input.maxMessagesCompactionThreshold === undefined ||
+      input.maxMessagesCompactionThreshold === 'off') &&
+      legacyLimit > 0)
+      ? legacyLimit
+      : normalizeMaxMessagesCompactionThreshold(
+          input.maxMessagesCompactionThreshold,
+        )
   const memoryBudget = parsePositiveInteger(env.OPENCLAUDE_MAX_MEMORY_MB) || 1536
 
   results.push(
     autoCompactAvailable
       ? pass(
           'Auto-compact guard',
-          `Enabled; message-count threshold ${configuredLimit ?? (legacyLimit > 0 ? legacyLimit : 'off')}; hard cap ${hardCap === 0 ? 'disabled' : hardCap}.`,
+          `Enabled; message-count threshold ${configuredLimit}; hard cap ${hardCap === 0 ? 'disabled' : hardCap}.`,
         )
       : fail(
           'Auto-compact guard',

--- a/scripts/system-check.ts
+++ b/scripts/system-check.ts
@@ -36,7 +36,10 @@ import {
   DEFAULT_MAX_ACTIVE_MESSAGES_HARD_CAP,
   getMaxActiveMessagesHardCap,
 } from '../src/utils/maxActiveMessages.js'
-import { normalizeMaxMessagesCompactionThreshold } from '../src/utils/config.js'
+import {
+  isValidMaxMessagesCompactionThreshold,
+  normalizeMaxMessagesCompactionThreshold,
+} from '../src/utils/config.js'
 import {
   getAvailableProviders,
   getProviderChain,
@@ -130,12 +133,20 @@ export function buildMemoryGuardChecks(
       : normalizeMaxMessagesCompactionThreshold(
           input.maxMessagesCompactionThreshold,
         )
+  const hasExplicitMessageCountGuard =
+    input.maxMessagesCompactionThreshold !== undefined &&
+    isValidMaxMessagesCompactionThreshold(
+      input.maxMessagesCompactionThreshold,
+    ) &&
+    input.maxMessagesCompactionThreshold !== 'off'
+  const hasLegacyMessageCountGuard =
+    (input.maxMessagesCompactionThreshold === undefined ||
+      input.maxMessagesCompactionThreshold === 'off') &&
+    legacyLimit > 0
   const memoryBudget = parsePositiveInteger(env.OPENCLAUDE_MAX_MEMORY_MB) || 1536
   const hasIndependentMessageCountGuard =
     configuredLimit !== 'off' &&
-    (!autoCompactAvailable ||
-      input.maxMessagesCompactionThreshold !== undefined ||
-      legacyLimit > 0)
+    (hasExplicitMessageCountGuard || hasLegacyMessageCountGuard)
   const autoCompactDisabledReason =
     [
       input.autoCompactEnabled ? undefined : 'settings disabled',

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -480,15 +480,6 @@ export function canBatchWith(
   )
 }
 
-// Default per-prompt turn cap for the interactive REPL main thread.
-// Without a hard cap the while(true) tool-use loop in query.ts can spin for
-// dozens of sequential tool round-trips within a single prompt, each appending
-// tool_use/tool_result pairs and re-issuing a full-context API call — producing
-// the non-linear latency growth described in issue #1949. The --max-turns flag
-// still overrides this for headless/print mode; the SDK API contract is
-// unchanged (SDK callers pass their own maxTurns).
-export const DEFAULT_REPL_MAX_TURNS = 50
-
 export async function runHeadless(
   inputPrompt: string | AsyncIterable<string>,
   getAppState: () => AppState,

--- a/src/cli/print.ts
+++ b/src/cli/print.ts
@@ -480,6 +480,15 @@ export function canBatchWith(
   )
 }
 
+// Default per-prompt turn cap for the interactive REPL main thread.
+// Without a hard cap the while(true) tool-use loop in query.ts can spin for
+// dozens of sequential tool round-trips within a single prompt, each appending
+// tool_use/tool_result pairs and re-issuing a full-context API call — producing
+// the non-linear latency growth described in issue #1949. The --max-turns flag
+// still overrides this for headless/print mode; the SDK API contract is
+// unchanged (SDK callers pass their own maxTurns).
+export const DEFAULT_REPL_MAX_TURNS = 50
+
 export async function runHeadless(
   inputPrompt: string | AsyncIterable<string>,
   getAppState: () => AppState,

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -294,7 +294,7 @@ export function Config({
   }, {
     id: 'maxMessagesCompactionThreshold',
     label: 'Message-count compaction',
-    value: globalConfig.maxMessagesCompactionThreshold ?? 'off',
+    value: normalizeMaxMessagesCompactionThreshold(globalConfig.maxMessagesCompactionThreshold),
     options: [...MAX_MESSAGES_COMPACTION_THRESHOLDS],
     type: 'enum' as const,
     onChange(maxMessagesCompactionThreshold: string) {
@@ -1242,7 +1242,7 @@ export function Config({
       formattedChanges.push(`${globalConfig.autoCompactEnabled ? 'Enabled' : 'Disabled'} auto-compact`);
     }
     if (globalConfig.maxMessagesCompactionThreshold !== initialConfig.current.maxMessagesCompactionThreshold) {
-      const threshold = globalConfig.maxMessagesCompactionThreshold ?? 'off';
+      const threshold = normalizeMaxMessagesCompactionThreshold(globalConfig.maxMessagesCompactionThreshold);
       formattedChanges.push(threshold === 'off' ? 'Disabled message-count compaction' : `Set message-count compaction to ${threshold}`);
     }
     if (globalConfig.toolHistoryCompressionEnabled !== initialConfig.current.toolHistoryCompressionEnabled) {

--- a/src/components/messages/AttachmentMessage.tsx
+++ b/src/components/messages/AttachmentMessage.tsx
@@ -121,6 +121,10 @@ export function AttachmentMessage({
 
   // eslint-disable-next-line @typescript-eslint/switch-exhaustiveness-check -- teammate_mailbox/skill_discovery handled before switch
   switch (attachment.type) {
+    case 'max_turns_reached':
+      return <Line>
+          <Text color="warning">Reached the maximum number of turns ({attachment.maxTurns}).</Text>
+        </Line>;
     case 'directory':
       return <Line>
           Listed directory <Text bold>{attachment.displayPath + sep}</Text>

--- a/src/components/messages/nullRenderingAttachments.ts
+++ b/src/components/messages/nullRenderingAttachments.ts
@@ -43,7 +43,6 @@ const NULL_RENDERING_TYPES = [
   'token_usage',
   'ultrathink_effort',
   'ultracode_mode',
-  'max_turns_reached',
   'task_reminder',
   'auto_mode',
   'auto_mode_exit',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2789,9 +2789,10 @@ async function run(): Promise<CommanderCommand> {
       }
       logSessionTelemetry();
       profileCheckpoint('before_print_import');
-      const {
-        runHeadless
-      } = await import('src/cli/print.js');
+       const {
+         runHeadless,
+         DEFAULT_REPL_MAX_TURNS,
+       } = await import('src/cli/print.js');
       profileCheckpoint('after_print_import');
       void runHeadless(inputPrompt, () => headlessStore.getState(), headlessStore.setState, commandsHeadless, tools, sdkMcpConfigs, agentDefinitions.activeAgents, {
         continue: options.continue,
@@ -2803,7 +2804,14 @@ async function run(): Promise<CommanderCommand> {
         permissionPromptToolName: options.permissionPromptTool,
         allowedTools,
         thinkingConfig,
-        maxTurns: options.maxTurns,
+        // Cap the interactive REPL main thread at a bounded default number of
+        // turns per prompt so a single prompt cannot spin indefinitely in the
+        // while(true) tool-use loop (issue #1949). Headless/print mode (where
+        // inputPrompt is provided) keeps the previous behavior where only the
+        // --max-turns flag bounds it. The SDK API contract is unchanged.
+        maxTurns:
+          options.maxTurns ??
+          (inputPrompt ? undefined : DEFAULT_REPL_MAX_TURNS),
         maxBudgetUsd: options.maxBudgetUsd,
         taskBudget: options.taskBudget ? {
           total: options.taskBudget

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -853,9 +853,10 @@ async function getInputPrompt(prompt: string, inputFormat: 'text' | 'stream-json
   }
   return prompt;
 }
-// Default per-prompt turn cap for the interactive REPL main thread. Headless
-// and SDK callers keep their existing explicit maxTurns contracts.
-const DEFAULT_REPL_MAX_TURNS = 50
+// query() enforces its limit after completing a tool-use turn (`>` rather than
+// `>=`), so 49 permits exactly 50 interactive tool-use turns. Headless and SDK
+// callers keep their existing explicit maxTurns contracts.
+const DEFAULT_REPL_MAX_TURNS = 49
 
 async function run(): Promise<CommanderCommand> {
   profileCheckpoint('run_function_start');

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -853,11 +853,6 @@ async function getInputPrompt(prompt: string, inputFormat: 'text' | 'stream-json
   }
   return prompt;
 }
-// query() enforces its limit after completing a tool-use turn (`>` rather than
-// `>=`), so 49 permits exactly 50 interactive tool-use turns. Headless and SDK
-// callers keep their existing explicit maxTurns contracts.
-const DEFAULT_REPL_MAX_TURNS = 49
-
 async function run(): Promise<CommanderCommand> {
   profileCheckpoint('run_function_start');
 
@@ -3051,7 +3046,6 @@ async function run(): Promise<CommanderCommand> {
       systemPrompt,
       appendSystemPrompt,
       thinkingConfig,
-      maxTurns: DEFAULT_REPL_MAX_TURNS,
     };
 
     // Shared context for processResumedConversation calls

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -853,6 +853,10 @@ async function getInputPrompt(prompt: string, inputFormat: 'text' | 'stream-json
   }
   return prompt;
 }
+// Default per-prompt turn cap for the interactive REPL main thread. Headless
+// and SDK callers keep their existing explicit maxTurns contracts.
+const DEFAULT_REPL_MAX_TURNS = 50
+
 async function run(): Promise<CommanderCommand> {
   profileCheckpoint('run_function_start');
 
@@ -2789,10 +2793,9 @@ async function run(): Promise<CommanderCommand> {
       }
       logSessionTelemetry();
       profileCheckpoint('before_print_import');
-       const {
-         runHeadless,
-         DEFAULT_REPL_MAX_TURNS,
-       } = await import('src/cli/print.js');
+      const {
+        runHeadless
+      } = await import('src/cli/print.js');
       profileCheckpoint('after_print_import');
       void runHeadless(inputPrompt, () => headlessStore.getState(), headlessStore.setState, commandsHeadless, tools, sdkMcpConfigs, agentDefinitions.activeAgents, {
         continue: options.continue,
@@ -2804,14 +2807,7 @@ async function run(): Promise<CommanderCommand> {
         permissionPromptToolName: options.permissionPromptTool,
         allowedTools,
         thinkingConfig,
-        // Cap the interactive REPL main thread at a bounded default number of
-        // turns per prompt so a single prompt cannot spin indefinitely in the
-        // while(true) tool-use loop (issue #1949). Headless/print mode (where
-        // inputPrompt is provided) keeps the previous behavior where only the
-        // --max-turns flag bounds it. The SDK API contract is unchanged.
-        maxTurns:
-          options.maxTurns ??
-          (inputPrompt ? undefined : DEFAULT_REPL_MAX_TURNS),
+        maxTurns: options.maxTurns,
         maxBudgetUsd: options.maxBudgetUsd,
         taskBudget: options.taskBudget ? {
           total: options.taskBudget
@@ -3053,7 +3049,8 @@ async function run(): Promise<CommanderCommand> {
       strictMcpConfig,
       systemPrompt,
       appendSystemPrompt,
-      thinkingConfig
+      thinkingConfig,
+      maxTurns: DEFAULT_REPL_MAX_TURNS,
     };
 
     // Shared context for processResumedConversation calls

--- a/src/query.ts
+++ b/src/query.ts
@@ -76,6 +76,7 @@ import {
 import {
   getMaxActiveMessagesHardCap,
   isAboveMaxActiveMessagesLimit,
+  parseMaxActiveMessagesLimit,
   resolveMaxActiveMessagesLimit,
 } from './utils/maxActiveMessages.js'
 /* eslint-disable @typescript-eslint/no-require-imports */
@@ -126,6 +127,7 @@ import {
 import { AGENT_STEP_LIMIT_TOOL_RESULT_PREFIX } from './query/agentStepLimit.js'
 import { buildQueryConfig } from './query/config.js'
 import {
+  MAX_MESSAGES_COMPACTION_THRESHOLDS,
   getGlobalConfig,
   normalizeMaxMessagesCompactionThreshold,
 } from './utils/config.js'
@@ -816,14 +818,24 @@ async function* queryLoop(
       querySource !== 'compact' && querySource !== 'session_memory'
     // An unset UI setting keeps the legacy environment override. Without that
     // override, enforce the new effective 200-message default.
+    const hasValidLegacyActiveMessageLimit =
+      parseMaxActiveMessagesLimit(process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES) > 0
     const maxMessagesLimitSetting =
       configuredMaxMessagesCompactionThreshold === undefined &&
-      process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES !== undefined
+      hasValidLegacyActiveMessageLimit
         ? undefined
         : maxMessagesCompactionThreshold
     const hasExplicitMessageCountThreshold =
       configuredMaxMessagesCompactionThreshold !== undefined &&
+      MAX_MESSAGES_COMPACTION_THRESHOLDS.includes(
+        configuredMaxMessagesCompactionThreshold,
+      ) &&
       configuredMaxMessagesCompactionThreshold !== 'off'
+    const hasActiveMessageLimitOverride =
+      hasExplicitMessageCountThreshold ||
+      ((configuredMaxMessagesCompactionThreshold === undefined ||
+        configuredMaxMessagesCompactionThreshold === 'off') &&
+        hasValidLegacyActiveMessageLimit)
     const activeMessageLimit = canForceCompact
       ? resolveMaxActiveMessagesLimit(
           maxMessagesLimitSetting,
@@ -834,7 +846,7 @@ async function* queryLoop(
       if (
         isAboveMaxActiveMessagesLimit(messagesForQuery.length, activeMessageLimit) &&
         (isAutoCompactEnabled() ||
-          hasExplicitMessageCountThreshold ||
+          hasActiveMessageLimitOverride ||
           isAboveMaxActiveMessagesLimit(
             messagesForQuery.length,
             getMaxActiveMessagesHardCap(),
@@ -1181,6 +1193,14 @@ async function* queryLoop(
     // cooling down or otherwise exhausted and context or message count is still
     // over the safety threshold, block immediately with a clear message instead
     // of burning an oversized API call.
+    const isAboveActiveMessageHardCap = isAboveMaxActiveMessagesLimit(
+      messagesForQuery.length,
+      getMaxActiveMessagesHardCap(),
+    )
+    const shouldEnforceActiveMessageLimit =
+      (!collapseOwnsIt && isAutoCompactEnabled()) ||
+      hasActiveMessageLimitOverride ||
+      isAboveActiveMessageHardCap
     if (
       tracking?.consecutiveFailures !== undefined &&
       tracking.consecutiveFailures >=
@@ -1199,13 +1219,7 @@ async function* queryLoop(
         isAboveMaxActiveMessagesLimit(
           messagesForQuery.length,
           activeMessageLimit,
-        ) &&
-        (isAutoCompactEnabled() ||
-          hasExplicitMessageCountThreshold ||
-          isAboveMaxActiveMessagesLimit(
-            messagesForQuery.length,
-            getMaxActiveMessagesHardCap(),
-          ))
+        ) && shouldEnforceActiveMessageLimit
       const isAboveBreakerThreshold =
         isAboveAutoCompactThreshold ||
         ((circuitBreakerActive === true || circuitBreakerTripped === true) &&
@@ -1233,16 +1247,11 @@ async function* queryLoop(
     }
 
     if (
+      shouldEnforceActiveMessageLimit &&
       isAboveMaxActiveMessagesLimit(
         messagesForQuery.length,
         activeMessageLimit,
-      ) &&
-      (isAutoCompactEnabled() ||
-        hasExplicitMessageCountThreshold ||
-        isAboveMaxActiveMessagesLimit(
-          messagesForQuery.length,
-          getMaxActiveMessagesHardCap(),
-        ))
+      )
     ) {
       yield createAssistantAPIErrorMessage({
         content:

--- a/src/query.ts
+++ b/src/query.ts
@@ -814,9 +814,16 @@ async function* queryLoop(
     // compaction and forcing would deadlock via recursive autocompaction.
     const canForceCompact =
       querySource !== 'compact' && querySource !== 'session_memory'
+    // An unset UI setting keeps the legacy environment override. Without that
+    // override, enforce the new effective 200-message default.
+    const maxMessagesLimitSetting =
+      configuredMaxMessagesCompactionThreshold === undefined &&
+      process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES !== undefined
+        ? undefined
+        : maxMessagesCompactionThreshold
     const activeMessageLimit = canForceCompact
       ? resolveMaxActiveMessagesLimit(
-          configuredMaxMessagesCompactionThreshold,
+          maxMessagesLimitSetting,
           process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES,
         )
       : 0

--- a/src/query.ts
+++ b/src/query.ts
@@ -74,6 +74,7 @@ import {
   startRelevantMemoryPrefetch,
 } from './utils/attachments.js'
 import {
+  getMaxActiveMessagesHardCap,
   isAboveMaxActiveMessagesLimit,
   resolveMaxActiveMessagesLimit,
 } from './utils/maxActiveMessages.js'
@@ -815,16 +816,18 @@ async function* queryLoop(
       querySource !== 'compact' && querySource !== 'session_memory'
     const activeMessageLimit = canForceCompact
       ? resolveMaxActiveMessagesLimit(
-          maxMessagesCompactionThreshold,
+          configuredMaxMessagesCompactionThreshold,
           process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES,
         )
       : 0
     if (canForceCompact) {
       if (
-        isAboveMaxActiveMessagesLimit(
-          messagesForQuery.length,
-          activeMessageLimit,
-        )
+        isAboveMaxActiveMessagesLimit(messagesForQuery.length, activeMessageLimit) &&
+        (isAutoCompactEnabled() ||
+          isAboveMaxActiveMessagesLimit(
+            messagesForQuery.length,
+            getMaxActiveMessagesHardCap(),
+          ))
       ) {
         tracking = {
           ...(tracking ?? { compacted: false, turnId: '', turnCounter: 0 }),

--- a/src/query.ts
+++ b/src/query.ts
@@ -129,6 +129,7 @@ import { buildQueryConfig } from './query/config.js'
 import {
   MAX_MESSAGES_COMPACTION_THRESHOLDS,
   getGlobalConfig,
+  isValidMaxMessagesCompactionThreshold,
   normalizeMaxMessagesCompactionThreshold,
 } from './utils/config.js'
 import { productionDeps, type QueryDeps } from './query/deps.js'
@@ -827,9 +828,7 @@ async function* queryLoop(
         : maxMessagesCompactionThreshold
     const hasExplicitMessageCountThreshold =
       configuredMaxMessagesCompactionThreshold !== undefined &&
-      MAX_MESSAGES_COMPACTION_THRESHOLDS.includes(
-        configuredMaxMessagesCompactionThreshold,
-      ) &&
+      isValidMaxMessagesCompactionThreshold(configuredMaxMessagesCompactionThreshold) &&
       configuredMaxMessagesCompactionThreshold !== 'off'
     const hasActiveMessageLimitOverride =
       hasExplicitMessageCountThreshold ||

--- a/src/query.ts
+++ b/src/query.ts
@@ -1201,6 +1201,7 @@ async function* queryLoop(
           activeMessageLimit,
         ) &&
         (isAutoCompactEnabled() ||
+          hasExplicitMessageCountThreshold ||
           isAboveMaxActiveMessagesLimit(
             messagesForQuery.length,
             getMaxActiveMessagesHardCap(),

--- a/src/query.ts
+++ b/src/query.ts
@@ -821,6 +821,9 @@ async function* queryLoop(
       process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES !== undefined
         ? undefined
         : maxMessagesCompactionThreshold
+    const hasExplicitMessageCountThreshold =
+      configuredMaxMessagesCompactionThreshold !== undefined &&
+      configuredMaxMessagesCompactionThreshold !== 'off'
     const activeMessageLimit = canForceCompact
       ? resolveMaxActiveMessagesLimit(
           maxMessagesLimitSetting,
@@ -831,6 +834,7 @@ async function* queryLoop(
       if (
         isAboveMaxActiveMessagesLimit(messagesForQuery.length, activeMessageLimit) &&
         (isAutoCompactEnabled() ||
+          hasExplicitMessageCountThreshold ||
           isAboveMaxActiveMessagesLimit(
             messagesForQuery.length,
             getMaxActiveMessagesHardCap(),
@@ -1233,6 +1237,7 @@ async function* queryLoop(
         activeMessageLimit,
       ) &&
       (isAutoCompactEnabled() ||
+        hasExplicitMessageCountThreshold ||
         isAboveMaxActiveMessagesLimit(
           messagesForQuery.length,
           getMaxActiveMessagesHardCap(),

--- a/src/query.ts
+++ b/src/query.ts
@@ -1191,14 +1191,21 @@ async function* queryLoop(
         tokenUsage,
         model,
       )
+      const isAboveActiveMessageSafetyLimit =
+        isAboveMaxActiveMessagesLimit(
+          messagesForQuery.length,
+          activeMessageLimit,
+        ) &&
+        (isAutoCompactEnabled() ||
+          isAboveMaxActiveMessagesLimit(
+            messagesForQuery.length,
+            getMaxActiveMessagesHardCap(),
+          ))
       const isAboveBreakerThreshold =
         isAboveAutoCompactThreshold ||
         ((circuitBreakerActive === true || circuitBreakerTripped === true) &&
           tokenUsage >= getAutoCompactThreshold(model)) ||
-        isAboveMaxActiveMessagesLimit(
-          messagesForQuery.length,
-          activeMessageLimit,
-        )
+        isAboveActiveMessageSafetyLimit
       if (isAboveBreakerThreshold) {
         const nowMs = Date.now()
         const retryDelayMs =
@@ -1221,7 +1228,15 @@ async function* queryLoop(
     }
 
     if (
-      isAboveMaxActiveMessagesLimit(messagesForQuery.length, activeMessageLimit)
+      isAboveMaxActiveMessagesLimit(
+        messagesForQuery.length,
+        activeMessageLimit,
+      ) &&
+      (isAutoCompactEnabled() ||
+        isAboveMaxActiveMessagesLimit(
+          messagesForQuery.length,
+          getMaxActiveMessagesHardCap(),
+        ))
     ) {
       yield createAssistantAPIErrorMessage({
         content:

--- a/src/query/autoCompactCooldown.test.ts
+++ b/src/query/autoCompactCooldown.test.ts
@@ -368,6 +368,15 @@ test('default active-message hard cap forces compaction', async () => {
   expect(seenTracking[0]?.forceReason).toBe('message-count')
 })
 
+test('unset message threshold forces compaction at the 200-message default', async () => {
+  const { terminal, callModel, seenTracking } =
+    await runMessageCountHardCapQuery(manySmallMessages(201))
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(callModel).toHaveBeenCalledTimes(1)
+  expect(seenTracking[0]?.forceReason).toBe('message-count')
+})
+
 test('disabled auto-compact leaves the default message threshold inactive', async () => {
   process.env.DISABLE_AUTO_COMPACT = '1'
 

--- a/src/query/autoCompactCooldown.test.ts
+++ b/src/query/autoCompactCooldown.test.ts
@@ -388,6 +388,21 @@ test('disabled auto-compact leaves the default message threshold inactive', asyn
   expect(seenTracking[0]?.forceReason).toBeUndefined()
 })
 
+test('disabled auto-compact preserves an explicit message threshold', async () => {
+  saveGlobalConfig(current => ({
+    ...current,
+    maxMessagesCompactionThreshold: '100',
+  }))
+  process.env.DISABLE_AUTO_COMPACT = '1'
+
+  const { terminal, callModel, seenTracking } =
+    await runMessageCountHardCapQuery(manySmallMessages(101))
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(callModel).toHaveBeenCalledTimes(1)
+  expect(seenTracking[0]?.forceReason).toBe('message-count')
+})
+
 test('long-session smoke keeps repeated over-cap turns bounded before provider calls', async () => {
   const seenProviderMessageCounts: number[] = []
   const seenTracking: Array<AutoCompactTrackingState | undefined> = []

--- a/src/query/autoCompactCooldown.test.ts
+++ b/src/query/autoCompactCooldown.test.ts
@@ -440,6 +440,13 @@ test('invalid active-message hard cap override keeps default safety cap', async 
 })
 
 test('explicit zero active-message hard cap override disables safety cap', async () => {
+  // Isolate the hard-cap override: with the 200-message-count default active,
+  // a 1001-message history would otherwise force message-count compaction, so
+  // disable message-count compaction explicitly to test only the hard cap.
+  saveGlobalConfig(current => ({
+    ...current,
+    maxMessagesCompactionThreshold: 'off',
+  }))
   process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES_HARD_CAP = '0'
 
   const { terminal, callModel, seenTracking } =

--- a/src/query/autoCompactCooldown.test.ts
+++ b/src/query/autoCompactCooldown.test.ts
@@ -377,7 +377,34 @@ test('unset message threshold forces compaction at the 200-message default', asy
   expect(seenTracking[0]?.forceReason).toBe('message-count')
 })
 
+test('invalid legacy message threshold keeps the 200-message default', async () => {
+  process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES = 'not-a-number'
+
+  const { terminal, callModel, seenTracking } =
+    await runMessageCountHardCapQuery(manySmallMessages(201))
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(callModel).toHaveBeenCalledTimes(1)
+  expect(seenTracking[0]?.forceReason).toBe('message-count')
+})
+
 test('disabled auto-compact leaves the default message threshold inactive', async () => {
+  process.env.DISABLE_AUTO_COMPACT = '1'
+
+  const { terminal, callModel, seenTracking } =
+    await runMessageCountHardCapQuery(manySmallMessages(201))
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(callModel).toHaveBeenCalledTimes(1)
+  expect(seenTracking[0]?.forceReason).toBeUndefined()
+})
+
+test('disabled auto-compact ignores an invalid persisted message threshold', async () => {
+  saveGlobalConfig(current => ({
+    ...current,
+    maxMessagesCompactionThreshold:
+      'not-a-threshold' as MaxMessagesCompactionThreshold,
+  }))
   process.env.DISABLE_AUTO_COMPACT = '1'
 
   const { terminal, callModel, seenTracking } =
@@ -394,6 +421,34 @@ test('disabled auto-compact preserves an explicit message threshold', async () =
     maxMessagesCompactionThreshold: '100',
   }))
   process.env.DISABLE_AUTO_COMPACT = '1'
+
+  const { terminal, callModel, seenTracking } =
+    await runMessageCountHardCapQuery(manySmallMessages(101))
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(callModel).toHaveBeenCalledTimes(1)
+  expect(seenTracking[0]?.forceReason).toBe('message-count')
+})
+
+test('disabled auto-compact preserves a legacy message threshold', async () => {
+  process.env.DISABLE_AUTO_COMPACT = '1'
+  process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES = '100'
+
+  const { terminal, callModel, seenTracking } =
+    await runMessageCountHardCapQuery(manySmallMessages(101))
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(callModel).toHaveBeenCalledTimes(1)
+  expect(seenTracking[0]?.forceReason).toBe('message-count')
+})
+
+test('explicit off preserves a legacy message threshold', async () => {
+  saveGlobalConfig(current => ({
+    ...current,
+    maxMessagesCompactionThreshold: 'off',
+  }))
+  process.env.DISABLE_AUTO_COMPACT = '1'
+  process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES = '100'
 
   const { terminal, callModel, seenTracking } =
     await runMessageCountHardCapQuery(manySmallMessages(101))

--- a/src/query/autoCompactCooldown.test.ts
+++ b/src/query/autoCompactCooldown.test.ts
@@ -368,6 +368,17 @@ test('default active-message hard cap forces compaction', async () => {
   expect(seenTracking[0]?.forceReason).toBe('message-count')
 })
 
+test('disabled auto-compact leaves the default message threshold inactive', async () => {
+  process.env.DISABLE_AUTO_COMPACT = '1'
+
+  const { terminal, callModel, seenTracking } =
+    await runMessageCountHardCapQuery(manySmallMessages(201))
+
+  expect(terminal.reason).toBe('max_turns')
+  expect(callModel).toHaveBeenCalledTimes(1)
+  expect(seenTracking[0]?.forceReason).toBeUndefined()
+})
+
 test('long-session smoke keeps repeated over-cap turns bounded before provider calls', async () => {
   const seenProviderMessageCounts: number[] = []
   const seenTracking: Array<AutoCompactTrackingState | undefined> = []

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -568,6 +568,9 @@ function summarizeActiveOperations(snapshot: QueryActiveOperationSnapshot): stri
 function logQueryLifecycle(event: string, context: QueryLifecycleContext, extras = ''): void {
   logForDebugging(formatQueryLifecycleLogMessage(event, context, extras));
 }
+// Default per-prompt cap for every local interactive REPL entrypoint. Headless
+// and SDK callers retain their explicit maxTurns contracts.
+const DEFAULT_REPL_MAX_TURNS = 50
 export type Props = {
   commands: Command[];
   debug: boolean;
@@ -648,7 +651,7 @@ export function REPL({
   sshSession,
   thinkingConfig,
   fallbackModel,
-  maxTurns
+  maxTurns = DEFAULT_REPL_MAX_TURNS
 }: Props): React.ReactNode {
   const isRemoteSession = !!remoteSessionConfig;
 
@@ -2811,6 +2814,7 @@ export function REPL({
           canUseTool,
           toolUseContext,
           fallbackModel,
+          maxTurns,
           querySource: getQuerySourceForREPL(),
           autoCompactTracking: getAutoCompactTrackingForSession(backgroundSessionId),
           onAutoCompactTrackingChange: tracking => {
@@ -2822,7 +2826,7 @@ export function REPL({
         agentDefinition: mainThreadAgentDefinition
       });
     })();
-  }, [abortController, mainLoopModel, toolPermissionContext, mainThreadAgentDefinition, getToolUseContext, customSystemPrompt, appendSystemPrompt, canUseTool, setAppState, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, fallbackModel]);
+  }, [abortController, mainLoopModel, toolPermissionContext, mainThreadAgentDefinition, getToolUseContext, customSystemPrompt, appendSystemPrompt, canUseTool, setAppState, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, fallbackModel, maxTurns]);
   const {
     handleBackgroundSession
   } = useSessionBackgrounding({

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -616,6 +616,8 @@ export type Props = {
   thinkingConfig: ThinkingConfig;
   // Model to fallback to when primary model returns overloaded errors (529)
   fallbackModel?: string;
+  // Bound a single interactive prompt's sequential tool-use turns.
+  maxTurns?: number;
 };
 export type Screen = 'prompt' | 'transcript';
 export function REPL({
@@ -645,7 +647,8 @@ export function REPL({
   directConnectConfig,
   sshSession,
   thinkingConfig,
-  fallbackModel
+  fallbackModel,
+  maxTurns
 }: Props): React.ReactNode {
   const isRemoteSession = !!remoteSessionConfig;
 
@@ -3040,6 +3043,7 @@ export function REPL({
       toolUseContext,
       querySource: getQuerySourceForREPL(),
       fallbackModel,
+      maxTurns,
       autoCompactTracking: queryAutoCompactTracking,
       onAutoCompactTrackingChange: tracking => {
         if (setAutoCompactTrackingForSessionIfUnchanged(querySessionId, expectedAutoCompactTracking, tracking)) {
@@ -3065,7 +3069,7 @@ export function REPL({
 
     // Signal that a query turn has completed successfully
     await onTurnComplete?.(messagesRef.current);
-  }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard]);
+  }, [initialMcpClients, resetLoadingState, getToolUseContext, toolPermissionContext, setAppState, customSystemPrompt, onTurnComplete, appendSystemPrompt, canUseTool, mainThreadAgentDefinition, onQueryEvent, sessionTitle, titleDisabled, maxTurns, getAutoCompactTrackingForSession, setAutoCompactTrackingForSession, setAutoCompactTrackingForSessionIfUnchanged, queryGuard]);
   const onQuery = useCallback(async (newMessages: MessageType[], abortController: AbortController, shouldQuery: boolean, additionalAllowedTools: string[], mainLoopModelParam: string, onBeforeQueryCallback?: (input: string, newMessages: MessageType[]) => Promise<boolean>, input?: string, effort?: EffortValue): Promise<void | false> => {
     // If this is a teammate, mark them as active when starting a turn
     if (isAgentSwarmsEnabled()) {

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -38,6 +38,7 @@ import { logForDebugging } from '../utils/debug.js';
 import { QueryGuard } from '../utils/QueryGuard.js';
 import { getQueryGuardOptionsFromEnv } from '../utils/queryGuardConfig.js';
 import { QueryLifecycleOperationTracker, formatQueryLifecycleAbortSignalReason, formatQueryLifecycleLogMessage, getQueryTerminalReason, type QueryActiveOperationSnapshot, type QueryGuardTimeoutInfo, type QueryLifecycleContext, type QueryTerminalReason } from '../utils/queryLifecycle.js';
+import { resolveReplMaxTurns } from './replMaxTurns.js';
 import { createCombinedAbortSignal } from '../utils/combinedAbortSignal.js';
 import { isEnvTruthy } from '../utils/envUtils.js';
 import { formatTokens, truncateToWidth } from '../utils/format.js';
@@ -570,7 +571,6 @@ function logQueryLifecycle(event: string, context: QueryLifecycleContext, extras
 }
 // Default per-prompt cap for every local interactive REPL entrypoint. Headless
 // and SDK callers retain their explicit maxTurns contracts.
-const DEFAULT_REPL_MAX_TURNS = 50
 export type Props = {
   commands: Command[];
   debug: boolean;
@@ -651,8 +651,9 @@ export function REPL({
   sshSession,
   thinkingConfig,
   fallbackModel,
-  maxTurns = DEFAULT_REPL_MAX_TURNS
+  maxTurns: maxTurnsProp
 }: Props): React.ReactNode {
+  const maxTurns = resolveReplMaxTurns(maxTurnsProp)
   const isRemoteSession = !!remoteSessionConfig;
 
   // Env-var gates hoisted to mount-time — isEnvTruthy does toLowerCase+trim+

--- a/src/screens/ResumeConversation.tsx
+++ b/src/screens/ResumeConversation.tsx
@@ -56,6 +56,7 @@ type Props = {
   filterByPr?: boolean | number | string;
   thinkingConfig: ThinkingConfig;
   fallbackModel?: string;
+  maxTurns?: number;
   onTurnComplete?: (messages: Message[]) => void | Promise<void>;
 };
 export function ResumeConversation({
@@ -78,6 +79,7 @@ export function ResumeConversation({
   filterByPr,
   thinkingConfig,
   fallbackModel,
+  maxTurns,
   onTurnComplete
 }: Props): React.ReactNode {
   const {
@@ -286,7 +288,7 @@ export function ResumeConversation({
     return <CrossProjectMessage command={crossProjectCommand} />;
   }
   if (resumeData) {
-    return <REPL debug={debug} commands={commands} initialTools={initialTools} initialMessages={resumeData.messages} initialFileHistorySnapshots={resumeData.fileHistorySnapshots} initialContentReplacements={resumeData.contentReplacements} initialAgentName={resumeData.agentName} initialAgentColor={resumeData.agentColor} mcpClients={mcpClients} dynamicMcpConfig={dynamicMcpConfig} strictMcpConfig={strictMcpConfig} systemPrompt={systemPrompt} appendSystemPrompt={appendSystemPrompt} mainThreadAgentDefinition={resumeData.mainThreadAgentDefinition} baseMainLoopModel={baseMainLoopModel} hasExplicitModelOverride={hasExplicitModelOverride} autoConnectIdeFlag={autoConnectIdeFlag} disableSlashCommands={disableSlashCommands} thinkingConfig={thinkingConfig} fallbackModel={fallbackModel} onTurnComplete={onTurnComplete} />;
+    return <REPL debug={debug} commands={commands} initialTools={initialTools} initialMessages={resumeData.messages} initialFileHistorySnapshots={resumeData.fileHistorySnapshots} initialContentReplacements={resumeData.contentReplacements} initialAgentName={resumeData.agentName} initialAgentColor={resumeData.agentColor} mcpClients={mcpClients} dynamicMcpConfig={dynamicMcpConfig} strictMcpConfig={strictMcpConfig} systemPrompt={systemPrompt} appendSystemPrompt={appendSystemPrompt} mainThreadAgentDefinition={resumeData.mainThreadAgentDefinition} baseMainLoopModel={baseMainLoopModel} hasExplicitModelOverride={hasExplicitModelOverride} autoConnectIdeFlag={autoConnectIdeFlag} disableSlashCommands={disableSlashCommands} thinkingConfig={thinkingConfig} fallbackModel={fallbackModel} maxTurns={maxTurns} onTurnComplete={onTurnComplete} />;
   }
   if (loading) {
     return <Box>

--- a/src/screens/replMaxTurns.ts
+++ b/src/screens/replMaxTurns.ts
@@ -1,0 +1,5 @@
+export const DEFAULT_REPL_MAX_TURNS = 50
+
+export function resolveReplMaxTurns(maxTurns?: number): number {
+  return maxTurns ?? DEFAULT_REPL_MAX_TURNS
+}

--- a/src/screens/replMaxTurnsProp.test.ts
+++ b/src/screens/replMaxTurnsProp.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const testDir = import.meta.dirname
+
+function readSource(filename: string): string {
+  return readFileSync(join(testDir, filename), 'utf8')
+}
+
+function readMainSource(): string {
+  return readFileSync(join(testDir, '..', 'main.tsx'), 'utf8')
+}
+
+describe('interactive REPL max-turn cap', () => {
+  test('main session config supplies the REPL-only default', () => {
+    const source = readMainSource()
+    expect(source).toContain('const DEFAULT_REPL_MAX_TURNS = 50')
+    expect(source).toContain('maxTurns: DEFAULT_REPL_MAX_TURNS')
+  })
+
+  test('REPL forwards maxTurns to its foreground query', () => {
+    const source = readSource('REPL.tsx')
+    expect(source).toContain('maxTurns?: number')
+    const match = source.match(
+      /query\(\s*\{[\s\S]*?maxTurns,[\s\S]*?\}\s*\)/,
+    )
+    expect(match).not.toBeNull()
+  })
+})

--- a/src/screens/replMaxTurnsProp.test.ts
+++ b/src/screens/replMaxTurnsProp.test.ts
@@ -8,15 +8,11 @@ function readSource(filename: string): string {
   return readFileSync(join(testDir, filename), 'utf8')
 }
 
-function readMainSource(): string {
-  return readFileSync(join(testDir, '..', 'main.tsx'), 'utf8')
-}
-
 describe('interactive REPL max-turn cap', () => {
-  test('main session config supplies the REPL-only default', () => {
-    const source = readMainSource()
-    expect(source).toContain('const DEFAULT_REPL_MAX_TURNS = 49')
-    expect(source).toContain('maxTurns: DEFAULT_REPL_MAX_TURNS')
+  test('REPL supplies the local interactive default', () => {
+    const source = readSource('REPL.tsx')
+    expect(source).toContain('const DEFAULT_REPL_MAX_TURNS = 50')
+    expect(source).toContain('maxTurns = DEFAULT_REPL_MAX_TURNS')
   })
 
   test('REPL forwards maxTurns to its foreground query', () => {
@@ -34,5 +30,12 @@ describe('interactive REPL max-turn cap', () => {
     const replIdx = source.indexOf('<REPL')
     const replEnd = source.indexOf('/>', replIdx)
     expect(source.slice(replIdx, replEnd)).toContain('maxTurns={maxTurns}')
+  })
+
+  test('backgrounded REPL queries retain maxTurns', () => {
+    const source = readSource('REPL.tsx')
+    const backgroundIdx = source.indexOf('startBackgroundSession({')
+    const backgroundEnd = source.indexOf('description: terminalTitle', backgroundIdx)
+    expect(source.slice(backgroundIdx, backgroundEnd)).toContain('maxTurns,')
   })
 })

--- a/src/screens/replMaxTurnsProp.test.ts
+++ b/src/screens/replMaxTurnsProp.test.ts
@@ -15,7 +15,7 @@ function readMainSource(): string {
 describe('interactive REPL max-turn cap', () => {
   test('main session config supplies the REPL-only default', () => {
     const source = readMainSource()
-    expect(source).toContain('const DEFAULT_REPL_MAX_TURNS = 50')
+    expect(source).toContain('const DEFAULT_REPL_MAX_TURNS = 49')
     expect(source).toContain('maxTurns: DEFAULT_REPL_MAX_TURNS')
   })
 
@@ -26,5 +26,13 @@ describe('interactive REPL max-turn cap', () => {
       /query\(\s*\{[\s\S]*?maxTurns,[\s\S]*?\}\s*\)/,
     )
     expect(match).not.toBeNull()
+  })
+
+  test('resume picker forwards maxTurns to the REPL', () => {
+    const source = readSource('ResumeConversation.tsx')
+    expect(source).toContain('maxTurns?: number')
+    const replIdx = source.indexOf('<REPL')
+    const replEnd = source.indexOf('/>', replIdx)
+    expect(source.slice(replIdx, replEnd)).toContain('maxTurns={maxTurns}')
   })
 })

--- a/src/screens/replMaxTurnsProp.test.ts
+++ b/src/screens/replMaxTurnsProp.test.ts
@@ -1,41 +1,13 @@
 import { describe, expect, test } from 'bun:test'
-import { readFileSync } from 'node:fs'
-import { join } from 'node:path'
-
-const testDir = import.meta.dirname
-
-function readSource(filename: string): string {
-  return readFileSync(join(testDir, filename), 'utf8')
-}
+import { DEFAULT_REPL_MAX_TURNS, resolveReplMaxTurns } from './replMaxTurns.js'
 
 describe('interactive REPL max-turn cap', () => {
-  test('REPL supplies the local interactive default', () => {
-    const source = readSource('REPL.tsx')
-    expect(source).toContain('const DEFAULT_REPL_MAX_TURNS = 50')
-    expect(source).toContain('maxTurns = DEFAULT_REPL_MAX_TURNS')
+  test('supplies the local interactive default at runtime', () => {
+    expect(DEFAULT_REPL_MAX_TURNS).toBe(50)
+    expect(resolveReplMaxTurns()).toBe(50)
   })
 
-  test('REPL forwards maxTurns to its foreground query', () => {
-    const source = readSource('REPL.tsx')
-    expect(source).toContain('maxTurns?: number')
-    const match = source.match(
-      /query\(\s*\{[\s\S]*?maxTurns,[\s\S]*?\}\s*\)/,
-    )
-    expect(match).not.toBeNull()
-  })
-
-  test('resume picker forwards maxTurns to the REPL', () => {
-    const source = readSource('ResumeConversation.tsx')
-    expect(source).toContain('maxTurns?: number')
-    const replIdx = source.indexOf('<REPL')
-    const replEnd = source.indexOf('/>', replIdx)
-    expect(source.slice(replIdx, replEnd)).toContain('maxTurns={maxTurns}')
-  })
-
-  test('backgrounded REPL queries retain maxTurns', () => {
-    const source = readSource('REPL.tsx')
-    const backgroundIdx = source.indexOf('startBackgroundSession({')
-    const backgroundEnd = source.indexOf('description: terminalTitle', backgroundIdx)
-    expect(source.slice(backgroundIdx, backgroundEnd)).toContain('maxTurns,')
+  test('preserves an explicit interactive cap at runtime', () => {
+    expect(resolveReplMaxTurns(7)).toBe(7)
   })
 })

--- a/src/screens/replMaxTurnsProp.test.ts
+++ b/src/screens/replMaxTurnsProp.test.ts
@@ -1,5 +1,28 @@
 import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { DEFAULT_REPL_MAX_TURNS, resolveReplMaxTurns } from './replMaxTurns.js'
+
+const screenDir = import.meta.dirname
+
+function readScreen(name: string): string {
+  return readFileSync(join(screenDir, name), 'utf8')
+}
+
+function objectBody(source: string, marker: RegExp): string {
+  const match = source.match(marker)
+  expect(match).not.toBeNull()
+  const start = match!.index! + match![0].length - 1
+  let depth = 0
+  for (let index = start; index < source.length; index++) {
+    if (source[index] === '{') depth++
+    if (source[index] === '}') {
+      depth--
+      if (depth === 0) return source.slice(start, index + 1)
+    }
+  }
+  throw new Error(`Unclosed object after ${marker}`)
+}
 
 describe('interactive REPL max-turn cap', () => {
   test('supplies the local interactive default at runtime', () => {
@@ -9,5 +32,21 @@ describe('interactive REPL max-turn cap', () => {
 
   test('preserves an explicit interactive cap at runtime', () => {
     expect(resolveReplMaxTurns(7)).toBe(7)
+  })
+
+  test('passes the resolved cap to foreground and background queries', () => {
+    const source = readScreen('REPL.tsx')
+    const foreground = objectBody(source, /for await \(const event of query\(\{/)
+    const background = objectBody(source, /queryParams:\s*\{/)
+
+    expect(foreground).toContain('maxTurns,')
+    expect(background).toContain('maxTurns,')
+  })
+
+  test('passes the cap from the resume selector into REPL', () => {
+    const source = readScreen('ResumeConversation.tsx')
+    const repl = source.slice(source.indexOf('<REPL'), source.indexOf('/>', source.indexOf('<REPL')) + 2)
+
+    expect(repl).toContain('maxTurns={maxTurns}')
   })
 })

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -243,6 +243,16 @@ describe('getAutoCompactThreshold', () => {
       restoreEnv()
     }
   })
+
+  test('keeps the floor buffer for constrained context windows', async () => {
+    process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = '30000'
+    process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS = '20000'
+    const { getAutoCompactThreshold } = await importAutoCompact()
+
+    // The effective window is floor-raised to 33k in this configuration.
+    // Selecting the 30k buffer here would compact after only 3k tokens.
+    expect(getAutoCompactThreshold('claude-sonnet-4')).toBe(20_000)
+  })
 })
 
 describe('getAutoCompactFailureCooldownMs', () => {

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -253,6 +253,30 @@ describe('getAutoCompactThreshold', () => {
     // Selecting the 30k buffer here would compact after only 3k tokens.
     expect(getAutoCompactThreshold('claude-sonnet-4')).toBe(20_000)
   })
+
+  test('keeps compaction and warning thresholds usable across mid-sized windows', async () => {
+    process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = '64000'
+    const { calculateTokenWarningState, getAutoCompactThreshold } =
+      await importAutoCompact()
+
+    // The effective window is 44k. Do not consume so much headroom that the
+    // 20k warning/error buffer makes a fresh conversation immediately warn.
+    expect(getAutoCompactThreshold('claude-sonnet-4')).toBe(30_000)
+    expect(
+      calculateTokenWarningState(0, 'claude-sonnet-4').isAboveWarningThreshold,
+    ).toBe(false)
+  })
+
+  test('does not lower the threshold when a configured window grows', async () => {
+    const { getAutoCompactThreshold } = await importAutoCompact()
+
+    process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = '62999'
+    const smallerWindowThreshold = getAutoCompactThreshold('claude-sonnet-4')
+    process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW = '63000'
+    const largerWindowThreshold = getAutoCompactThreshold('claude-sonnet-4')
+
+    expect(largerWindowThreshold).toBeGreaterThanOrEqual(smallerWindowThreshold)
+  })
 })
 
 describe('getAutoCompactFailureCooldownMs', () => {

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -179,7 +179,7 @@ describe('getEffectiveContextWindowSize', () => {
     try {
       const effective = getEffectiveContextWindowSize('some-unknown-3p-model')
       expect(effective).toBeGreaterThan(0)
-      // 21k = CAPPED_DEFAULT_MAX_TOKENS (8k) + AUTOCOMPACT_BUFFER_TOKENS (13k).
+      // 21k = CAPPED_DEFAULT_MAX_TOKENS (8k) + AUTOCOMPACT_FLOOR_BUFFER_TOKENS (13k).
       // Covers the anti-regression intent of issue #635 without assuming
       // the GrowthBook flag state.
       expect(effective).toBeGreaterThanOrEqual(21_000)

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -49,8 +49,12 @@ export function getEffectiveContextWindowSize(model: string): number {
 
   // Floor: effective context must be at least the summary reservation plus a
   // usable buffer. If it goes lower, the auto-compact threshold becomes
-  // negative and fires on every message (issue #635).
-  const autocompactBuffer = 13_000 // must match AUTOCOMPACT_BUFFER_TOKENS
+  // negative and fires on every message (issue #635). This floor buffer is
+  // intentionally decoupled from AUTOCOMPACT_BUFFER_TOKENS: the latter is the
+  // (larger) threshold buffer used by getAutoCompactThreshold(), while this
+  // stays at the conservative 13k so getEffectiveContextWindowSize() —
+  // also consumed by tool-history compression — is unchanged (issue #1949).
+  const autocompactBuffer = AUTOCOMPACT_FLOOR_BUFFER_TOKENS
   const effectiveContext = contextWindow - reservedTokensForSummary
   return Math.max(effectiveContext, reservedTokensForSummary + autocompactBuffer)
 }
@@ -74,7 +78,20 @@ export type AutoCompactTrackingState = {
   forceReason?: 'memory-pressure' | 'message-count'
 }
 
-export const AUTOCOMPACT_BUFFER_TOKENS = 13_000
+// Threshold buffer: auto-compact fires when token usage reaches this far below
+// the effective context window. Bumped from 13_000 -> 30_000 so compaction runs
+// earlier and with less accumulated history, bounding per-turn latency growth
+// in a single session (issue #1949). Kept below the effective-context floor
+// (AUTOCOMPACT_FLOOR_BUFFER_TOKENS) for large-context models; for small-context
+// models getAutoCompactThreshold() falls back to the floor buffer so the
+// threshold can never go negative (issue #635).
+export const AUTOCOMPACT_BUFFER_TOKENS = 30_000
+
+// Conservative floor buffer for getEffectiveContextWindowSize(). Must guarantee
+// a non-negative auto-compact threshold for small-context models, so it stays at
+// the pre-#1949 value of 13_000 and is decoupled from AUTOCOMPACT_BUFFER_TOKENS.
+const AUTOCOMPACT_FLOOR_BUFFER_TOKENS = 13_000
+
 export const WARNING_THRESHOLD_BUFFER_TOKENS = 20_000
 export const ERROR_THRESHOLD_BUFFER_TOKENS = 20_000
 export const MANUAL_COMPACT_BUFFER_TOKENS = 3_000
@@ -170,8 +187,16 @@ export function resolveAutoCompactCircuitBreakerState(args: {
 export function getAutoCompactThreshold(model: string): number {
   const effectiveContextWindow = getEffectiveContextWindowSize(model)
 
-  const autocompactThreshold =
-    effectiveContextWindow - AUTOCOMPACT_BUFFER_TOKENS
+  // Use the larger 30k buffer (issue #1949) when the context is big enough to
+  // afford it, so auto-compact fires earlier. For small-context models the 30k
+  // buffer would make the threshold negative — firing auto-compact on every
+  // message (issue #635) — so fall back to the 13k floor buffer there, keeping
+  // the pre-#1949 behavior.
+  const buffer =
+    effectiveContextWindow - AUTOCOMPACT_BUFFER_TOKENS >= 0
+      ? AUTOCOMPACT_BUFFER_TOKENS
+      : AUTOCOMPACT_FLOOR_BUFFER_TOKENS
+  const autocompactThreshold = effectiveContextWindow - buffer
 
   // Override for easier testing of autocompact
   const envPercent = process.env.CLAUDE_AUTOCOMPACT_PCT_OVERRIDE

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -187,13 +187,13 @@ export function resolveAutoCompactCircuitBreakerState(args: {
 export function getAutoCompactThreshold(model: string): number {
   const effectiveContextWindow = getEffectiveContextWindowSize(model)
 
-  // Use the larger 30k buffer (issue #1949) when the context is big enough to
-  // afford it, so auto-compact fires earlier. For small-context models the 30k
-  // buffer would make the threshold negative — firing auto-compact on every
-  // message (issue #635) — so fall back to the 13k floor buffer there, keeping
-  // the pre-#1949 behavior.
+  // Use the larger 30k buffer (issue #1949) only when it still leaves the
+  // previous 13k usable threshold. getEffectiveContextWindowSize() can be
+  // floor-raised for small contexts, so checking only for a non-negative
+  // threshold would otherwise compact after just a few thousand tokens.
   const buffer =
-    effectiveContextWindow - AUTOCOMPACT_BUFFER_TOKENS >= 0
+    effectiveContextWindow - AUTOCOMPACT_BUFFER_TOKENS >=
+    AUTOCOMPACT_FLOOR_BUFFER_TOKENS
       ? AUTOCOMPACT_BUFFER_TOKENS
       : AUTOCOMPACT_FLOOR_BUFFER_TOKENS
   const autocompactThreshold = effectiveContextWindow - buffer

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -187,15 +187,18 @@ export function resolveAutoCompactCircuitBreakerState(args: {
 export function getAutoCompactThreshold(model: string): number {
   const effectiveContextWindow = getEffectiveContextWindowSize(model)
 
-  // Use the larger 30k buffer (issue #1949) only when it still leaves the
-  // previous 13k usable threshold. getEffectiveContextWindowSize() can be
-  // floor-raised for small contexts, so checking only for a non-negative
-  // threshold would otherwise compact after just a few thousand tokens.
-  const buffer =
-    effectiveContextWindow - AUTOCOMPACT_BUFFER_TOKENS >=
-    AUTOCOMPACT_FLOOR_BUFFER_TOKENS
-      ? AUTOCOMPACT_BUFFER_TOKENS
-      : AUTOCOMPACT_FLOOR_BUFFER_TOKENS
+  // Increase the buffer gradually between the old 13k and new 30k values.
+  // This keeps the threshold monotonic and preserves the 20k warning/error
+  // headroom consumed by calculateTokenWarningState(). A direct switch would
+  // make a one-token window increase cause an earlier compact, and can make
+  // the warning threshold negative for mid-sized context windows.
+  const buffer = Math.min(
+    AUTOCOMPACT_BUFFER_TOKENS,
+    Math.max(
+      AUTOCOMPACT_FLOOR_BUFFER_TOKENS,
+      effectiveContextWindow - AUTOCOMPACT_BUFFER_TOKENS,
+    ),
+  )
   const autocompactThreshold = effectiveContextWindow - buffer
 
   // Override for easier testing of autocompact

--- a/src/utils/analyzeContext.ts
+++ b/src/utils/analyzeContext.ts
@@ -10,7 +10,7 @@ import { getCommandName } from '../commands.js'
 import { getSystemContext } from '../context.js'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../services/analytics/growthbook.js'
 import {
-  AUTOCOMPACT_BUFFER_TOKENS,
+  getAutoCompactThreshold,
   getEffectiveContextWindowSize,
   isAutoCompactEnabled,
   MANUAL_COMPACT_BUFFER_TOKENS,
@@ -1056,7 +1056,7 @@ export async function analyzeContextUsage(
   // Check if autocompact is enabled and calculate threshold
   const isAutoCompact = isAutoCompactEnabled()
   const autoCompactThreshold = isAutoCompact
-    ? getEffectiveContextWindowSize(model) - AUTOCOMPACT_BUFFER_TOKENS
+    ? getAutoCompactThreshold(model)
     : undefined
 
   // Create categories

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -197,12 +197,18 @@ export const MAX_MESSAGES_COMPACTION_THRESHOLDS = [
 export type MaxMessagesCompactionThreshold =
   (typeof MAX_MESSAGES_COMPACTION_THRESHOLDS)[number]
 
-export function normalizeMaxMessagesCompactionThreshold(
+export function isValidMaxMessagesCompactionThreshold(
   value: unknown,
-): MaxMessagesCompactionThreshold {
+): value is MaxMessagesCompactionThreshold {
   return MAX_MESSAGES_COMPACTION_THRESHOLDS.includes(
     value as MaxMessagesCompactionThreshold,
   )
+}
+
+export function normalizeMaxMessagesCompactionThreshold(
+  value: unknown,
+): MaxMessagesCompactionThreshold {
+  return isValidMaxMessagesCompactionThreshold(value)
     ? (value as MaxMessagesCompactionThreshold)
     : '200'
 }
@@ -1156,9 +1162,7 @@ function migrateConfigFields(config: GlobalConfig): GlobalConfig {
   const { maxMessagesCompactionThreshold, ...restConfig } = config
   const hasValidMaxMessagesCompactionThreshold =
     maxMessagesCompactionThreshold !== undefined &&
-    MAX_MESSAGES_COMPACTION_THRESHOLDS.includes(
-      maxMessagesCompactionThreshold as MaxMessagesCompactionThreshold,
-    )
+    isValidMaxMessagesCompactionThreshold(maxMessagesCompactionThreshold)
   const normalizedConfig = {
     ...restConfig,
     ...(!hasValidMaxMessagesCompactionThreshold

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -681,7 +681,7 @@ export type GlobalConfig = {
   logoColor?: string
 
   // Message-count-based compaction threshold. Set via /config.
-  // 'off' = disabled (default). Otherwise, one of '100', '200', '500', '1000'.
+  // 'off' = disabled. Otherwise, one of '100', '200', '500', '1000'.
   // When enabled, triggers forced compaction if the message count exceeds the
   // chosen threshold, regardless of token usage.
   maxMessagesCompactionThreshold?: MaxMessagesCompactionThreshold

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1154,9 +1154,14 @@ registerCleanup(async () => {
  */
 function migrateConfigFields(config: GlobalConfig): GlobalConfig {
   const { maxMessagesCompactionThreshold, ...restConfig } = config
+  const hasValidMaxMessagesCompactionThreshold =
+    maxMessagesCompactionThreshold !== undefined &&
+    MAX_MESSAGES_COMPACTION_THRESHOLDS.includes(
+      maxMessagesCompactionThreshold as MaxMessagesCompactionThreshold,
+    )
   const normalizedConfig = {
     ...restConfig,
-    ...(maxMessagesCompactionThreshold === undefined
+    ...(!hasValidMaxMessagesCompactionThreshold
       ? {}
       : {
           maxMessagesCompactionThreshold:

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -204,7 +204,7 @@ export function normalizeMaxMessagesCompactionThreshold(
     value as MaxMessagesCompactionThreshold,
   )
     ? (value as MaxMessagesCompactionThreshold)
-    : 'off'
+    : '200'
 }
 
 export type OutputStyle = string
@@ -741,8 +741,9 @@ function createDefaultGlobalConfig(): GlobalConfig {
     openaiAdditionalModelOptionsCacheByProfile: {},
     knowledgeGraphEnabled: true,
     // Omitted by default so callers can distinguish "unset" from an explicit
-    // persisted "off"; normalizeMaxMessagesCompactionThreshold keeps the
-    // effective default disabled.
+    // persisted "off"; normalizeMaxMessagesCompactionThreshold resolves an
+    // unset value to the effective default of '200' (message-count compaction
+    // enabled at 200 messages) to bound per-turn latency growth (issue #1949).
   }
   return config
 }

--- a/src/utils/maxActiveMessages.test.ts
+++ b/src/utils/maxActiveMessages.test.ts
@@ -36,6 +36,7 @@ test('explicit zero hard cap disables only the hard cap', () => {
   expect(isAboveMaxActiveMessagesLimit(1001)).toBe(false)
   expect(resolveMaxActiveMessagesLimit('100', undefined)).toBe(100)
   expect(resolveMaxActiveMessagesLimit('off', '5')).toBe(5)
+  expect(resolveMaxActiveMessagesLimit(undefined, '5')).toBe(5)
 })
 
 test('configured and hard cap combine by choosing the tighter positive limit', () => {

--- a/src/utils/maxActiveMessages.ts
+++ b/src/utils/maxActiveMessages.ts
@@ -31,11 +31,11 @@ export function getMaxActiveMessagesHardCap(
 }
 
 export function resolveMaxActiveMessagesLimit(
-  configSetting: string,
+  configSetting: string | undefined,
   envSetting: string | undefined,
 ): number {
   const configuredLimit =
-    configSetting !== 'off'
+    configSetting !== undefined && configSetting !== 'off'
       ? parseMaxActiveMessagesLimit(configSetting)
       : parseMaxActiveMessagesLimit(envSetting)
   const hardCap = getMaxActiveMessagesHardCap()

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -3123,6 +3123,7 @@ You have exited auto mode. The user may now want to interact more directly. You 
     case 'hook_system_message':
     case 'structured_output':
     case 'hook_permission_decision':
+    case 'max_turns_reached':
       return []
   }
 

--- a/src/utils/swarm/inProcessRunner.ts
+++ b/src/utils/swarm/inProcessRunner.ts
@@ -23,7 +23,10 @@ import {
   type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS,
   logEvent,
 } from '../../services/analytics/index.js'
-import { getAutoCompactThreshold } from '../../services/compact/autoCompact.js'
+import {
+  getAutoCompactThreshold,
+  isAutoCompactEnabled,
+} from '../../services/compact/autoCompact.js'
 import {
   buildPostCompactMessages,
   compactConversation,
@@ -70,12 +73,14 @@ import { count } from '../array.js'
 import { logForDebugging } from '../debug.js'
 import { cloneFileStateCache } from '../fileStateCache.js'
 import {
+  getMaxActiveMessagesHardCap,
   parseMaxActiveMessagesLimit,
   resolveMaxActiveMessagesLimit,
   shouldCompactActiveMessageHistory,
 } from '../maxActiveMessages.js'
 import {
   getGlobalConfig,
+  isValidMaxMessagesCompactionThreshold,
   normalizeMaxMessagesCompactionThreshold,
 } from '../config.js'
 import {
@@ -1114,12 +1119,26 @@ export async function runInProcessTeammate(
       const legacyMessageThreshold = parseMaxActiveMessagesLimit(
         process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES,
       )
-      const activeMessageLimit = resolveMaxActiveMessagesLimit(
-        configuredMessageThreshold === undefined && legacyMessageThreshold > 0
-          ? undefined
-          : normalizeMaxMessagesCompactionThreshold(configuredMessageThreshold),
-        process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES,
-      )
+      const hasExplicitMessageCountThreshold =
+        configuredMessageThreshold !== undefined &&
+        isValidMaxMessagesCompactionThreshold(configuredMessageThreshold) &&
+        configuredMessageThreshold !== 'off'
+      const hasLegacyMessageCountThreshold =
+        (configuredMessageThreshold === undefined ||
+          configuredMessageThreshold === 'off') &&
+        legacyMessageThreshold > 0
+      const shouldApplyMessageCountThreshold =
+        isAutoCompactEnabled() ||
+        hasExplicitMessageCountThreshold ||
+        hasLegacyMessageCountThreshold
+      const activeMessageLimit = shouldApplyMessageCountThreshold
+        ? resolveMaxActiveMessagesLimit(
+            configuredMessageThreshold === undefined && legacyMessageThreshold > 0
+              ? undefined
+              : normalizeMaxMessagesCompactionThreshold(configuredMessageThreshold),
+            process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES,
+          )
+        : getMaxActiveMessagesHardCap()
       const tokenThreshold = getAutoCompactThreshold(
         toolUseContext.options.mainLoopModel,
       )

--- a/src/utils/swarm/inProcessRunner.ts
+++ b/src/utils/swarm/inProcessRunner.ts
@@ -70,9 +70,14 @@ import { count } from '../array.js'
 import { logForDebugging } from '../debug.js'
 import { cloneFileStateCache } from '../fileStateCache.js'
 import {
-  getMaxActiveMessagesHardCap,
+  parseMaxActiveMessagesLimit,
+  resolveMaxActiveMessagesLimit,
   shouldCompactActiveMessageHistory,
 } from '../maxActiveMessages.js'
+import {
+  getGlobalConfig,
+  normalizeMaxMessagesCompactionThreshold,
+} from '../config.js'
 import {
   SUBAGENT_REJECT_MESSAGE,
   SUBAGENT_REJECT_MESSAGE_WITH_REASON_PREFIX,
@@ -1104,7 +1109,17 @@ export async function runInProcessTeammate(
       // Check if compaction is needed before building context
       let contextMessages = allMessages
       const tokenCount = tokenCountWithEstimation(allMessages)
-      const activeMessageHardCap = getMaxActiveMessagesHardCap()
+      const configuredMessageThreshold =
+        getGlobalConfig().maxMessagesCompactionThreshold
+      const legacyMessageThreshold = parseMaxActiveMessagesLimit(
+        process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES,
+      )
+      const activeMessageLimit = resolveMaxActiveMessagesLimit(
+        configuredMessageThreshold === undefined && legacyMessageThreshold > 0
+          ? undefined
+          : normalizeMaxMessagesCompactionThreshold(configuredMessageThreshold),
+        process.env.OPENCLAUDE_MAX_ACTIVE_MESSAGES,
+      )
       const tokenThreshold = getAutoCompactThreshold(
         toolUseContext.options.mainLoopModel,
       )
@@ -1113,7 +1128,7 @@ export async function runInProcessTeammate(
           messageCount: allMessages.length,
           tokenCount,
           tokenThreshold,
-          activeMessageLimit: activeMessageHardCap,
+          activeMessageLimit,
         })
       ) {
         logForDebugging(

--- a/src/utils/swarm/inProcessRunner.ts
+++ b/src/utils/swarm/inProcessRunner.ts
@@ -74,9 +74,9 @@ import { logForDebugging } from '../debug.js'
 import { cloneFileStateCache } from '../fileStateCache.js'
 import {
   getMaxActiveMessagesHardCap,
+  isAboveMaxActiveMessagesLimit,
   parseMaxActiveMessagesLimit,
   resolveMaxActiveMessagesLimit,
-  shouldCompactActiveMessageHistory,
 } from '../maxActiveMessages.js'
 import {
   getGlobalConfig,
@@ -1142,14 +1142,13 @@ export async function runInProcessTeammate(
       const tokenThreshold = getAutoCompactThreshold(
         toolUseContext.options.mainLoopModel,
       )
-      if (
-        shouldCompactActiveMessageHistory({
-          messageCount: allMessages.length,
-          tokenCount,
-          tokenThreshold,
-          activeMessageLimit,
-        })
-      ) {
+      const shouldCompactForTokens =
+        isAutoCompactEnabled() && tokenCount > tokenThreshold
+      const shouldCompactForMessages = isAboveMaxActiveMessagesLimit(
+        allMessages.length,
+        activeMessageLimit,
+      )
+      if (shouldCompactForTokens || shouldCompactForMessages) {
         logForDebugging(
           `[inProcessRunner] ${identity.agentId} compacting history (${tokenCount} tokens, ${allMessages.length} messages)`,
         )


### PR DESCRIPTION
## Summary

Fixes #1949 — the progressive latency regression where consecutive prompts in a single REPL session grow non-linearly (1st prompt fast, 2nd ~10s, 3rd 10+ min) due to unbounded message accumulation with no proactive compaction and no per-prompt turn cap on the main thread.

Implements the three **immediate (no API contract change)** fixes from the issue:

1. **Cap `maxTurns` on the interactive REPL main thread** (`DEFAULT_REPL_MAX_TURNS = 50`). The interactive REPL now bounds a single prompt to 50 tool-use turns, preventing the `while(true)` loop in `query.ts` from spinning for dozens of sequential round-trips. Headless/print mode keeps its existing behavior (only the `--max-turns` flag bounds it), and the SDK API contract is unchanged — SDK callers pass their own `maxTurns`.
2. **Default `maxMessagesCompactionThreshold` to `'200'`** (was `'off'`). Message-count compaction now runs well before the context window fills. An explicit `'off'` still disables it. The Settings UI was updated to reflect the effective default.
3. **Lower the auto-compact threshold buffer `13_000 → 30_000`** so compaction fires earlier with less accumulated history. The effective-context *floor* buffer is deliberately kept at `13_000` and `getAutoCompactThreshold()` falls back to it for small-context models, so the threshold can never go negative (no re-introduction of the #635 infinite-compact bug).

## Notes / scope

The issue also lists three *structural follow-ups* (inter-turn `tool_result` pruning in `QueryEngine.submitMessage`, configurable `agentStepLimit` on the main thread, per-tool execution timeouts). Those are intentionally left for a follow-up PR as they are larger behavior changes; this PR keeps to the safe, contract-preserving fixes.

## Validation

- `bun run typecheck` — clean
- `bun run build` / `bun run smoke` — clean
- Full `bun test` suite — **0 new failures** vs. the clean `main` baseline (94 pre-existing failures, all environment/provider-related and unrelated).
- Specifically verified: `src/services/compact/autoCompact.test.ts`, `src/query/autoCompactCooldown.test.ts`, `src/services/api/openaiShim.compression.test.ts` all pass.

### Test changes

- `autoCompactCooldown.test.ts`: the "explicit zero active-message hard cap override" test now disables message-count compaction explicitly so it isolates the hard-cap override behavior (the new `200` default would otherwise force compaction for its 1001-message history).
- `autoCompact.test.ts`: corrected an outdated constant reference in a comment (floor buffer, not the threshold buffer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive sessions now cap sequential tool-use turns at **50** by default (including resumed and background sessions).
  * Hitting the turn limit shows a clear **warning**.
  * Message-count compaction defaults to **200**, with thresholds **100**, **500**, or **1000** (and **Off** to disable proactive compaction).

* **Bug Fixes**
  * Improved compatibility and precedence between message-count compaction and the legacy active-message limit override.
  * Refined auto-compaction behavior for smaller context windows.
  * Improved attachment handling, including a dedicated warning when max turns are reached.

* **Documentation**
  * Updated advanced setup guidance for message-count compaction behavior, defaults, disabling, and precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->