### PR TITLE
fix(stats): stop over-counting totalDays by one

### DIFF
--- a/src/utils/stats.totalDays.test.ts
+++ b/src/utils/stats.totalDays.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 import { comparePersistedDates, inclusiveCalendarDaySpan } from './stats.js'
+import type { SessionStats } from './stats.js'
+import {
+  mergeCacheWithNewStats,
+  type PersistedStatsCache,
+  STATS_CACHE_VERSION,
+} from './statsCache.js'
 
 describe('inclusiveCalendarDaySpan', () => {
   test('is 1 when both timestamps fall on the same UTC calendar day', () => {
@@ -136,12 +142,15 @@ describe('inclusiveCalendarDaySpan', () => {
   })
 
   test('accepts a UTC offset instant as well as Z', () => {
+    // 2026-07-13T23:30+05:30 is 2026-07-13T18:00Z, so these endpoints span
+    // exactly two UTC calendar days. Asserting the value rather than just
+    // "positive" means a regression back to 1 is caught.
     expect(
       inclusiveCalendarDaySpan(
         '2026-07-13T23:30:00+05:30',
         '2026-07-14T00:30:00.000Z',
       ),
-    ).toBeGreaterThan(0)
+    ).toBe(2)
   })
 
   test('returns 0 for out-of-range clock components', () => {
@@ -202,5 +211,77 @@ describe('comparePersistedDates', () => {
     expect(comparePersistedDates('not-a-date', '2026-07-13')).toBeGreaterThan(0)
     expect(comparePersistedDates('2026-07-13', 'not-a-date')).toBeLessThan(0)
     expect(comparePersistedDates('not-a-date', 'not-a-date')).toBe(0)
+  })
+})
+describe('mergeCacheWithNewStats first-session selection', () => {
+  // The cache writer is the companion to the endpoint selection above: what it
+  // stores is what a later cached /stats run reads back, and at that point
+  // there is no session list left to correct it.
+  function emptyCache(): PersistedStatsCache {
+    return {
+      version: STATS_CACHE_VERSION,
+      lastComputedDate: '2026-07-12',
+      dailyActivity: [],
+      dailyModelTokens: [],
+      modelUsage: {},
+      totalSessions: 0,
+      totalMessages: 0,
+      longestSession: null,
+      firstSessionDate: null,
+      hourCounts: {},
+      totalSpeculationTimeSavedMs: 0,
+    } as PersistedStatsCache
+  }
+
+  function session(timestamp: string): SessionStats {
+    return { sessionId: timestamp, duration: 1, messageCount: 1, timestamp }
+  }
+
+  function mergeSessions(timestamps: string[]): string | null {
+    return mergeCacheWithNewStats(
+      emptyCache(),
+      {
+        dailyActivity: [],
+        dailyModelTokens: [],
+        modelUsage: {},
+        sessionStats: timestamps.map(session),
+        hourCounts: {},
+        totalSpeculationTimeSavedMs: 0,
+      },
+      '2026-07-14',
+    ).firstSessionDate
+  }
+
+  test('stores the chronologically first session across mixed offsets', () => {
+    // +14:00 is UTC July 13, -10:00 is UTC July 14, but string order ranks them
+    // the other way round -- so the lexical pick stored the later instant and a
+    // later cached run reported one day for two UTC dates.
+    const utcJuly13 = '2026-07-14T00:00:00+14:00'
+    const utcJuly14 = '2026-07-13T23:30:00-10:00'
+    expect(mergeSessions([utcJuly14, utcJuly13])).toBe(utcJuly13)
+    expect(mergeSessions([utcJuly13, utcJuly14])).toBe(utcJuly13)
+  })
+
+  test('keeps an existing cached first date when it is genuinely earlier', () => {
+    const cache = { ...emptyCache(), firstSessionDate: '2026-07-01T00:00:00Z' }
+    const merged = mergeCacheWithNewStats(
+      cache,
+      {
+        dailyActivity: [],
+        dailyModelTokens: [],
+        modelUsage: {},
+        sessionStats: [session('2026-07-13T12:00:00.000Z')],
+        hourCounts: {},
+        totalSpeculationTimeSavedMs: 0,
+      },
+      '2026-07-14',
+    )
+    expect(merged.firstSessionDate).toBe('2026-07-01T00:00:00Z')
+  })
+
+  test('same-zone timestamps are unaffected', () => {
+    expect(
+      mergeSessions(['2026-07-13T20:00:00.000Z', '2026-07-13T01:00:00.000Z']),
+    ).toBe('2026-07-13T01:00:00.000Z')
   })
 })

--- a/src/utils/stats.totalDays.test.ts
+++ b/src/utils/stats.totalDays.test.ts
@@ -37,4 +37,20 @@ describe('inclusiveCalendarDaySpan', () => {
       ),
     ).toBe(2)
   })
+
+  test('returns 0 instead of throwing on an unparseable persisted date', () => {
+    // A same-version stats cache can carry a corrupt firstSessionDate/last date
+    // (e.g. "not-a-date"). Feeding that to toDateString → toISOString throws
+    // RangeError and aborts /stats; the helper must degrade to 0 for either end.
+    expect(() =>
+      inclusiveCalendarDaySpan('not-a-date', '2026-07-15T06:00:00.000Z'),
+    ).not.toThrow()
+    expect(
+      inclusiveCalendarDaySpan('not-a-date', '2026-07-15T06:00:00.000Z'),
+    ).toBe(0)
+    expect(
+      inclusiveCalendarDaySpan('2026-07-13T22:00:00.000Z', 'not-a-date'),
+    ).toBe(0)
+    expect(inclusiveCalendarDaySpan('not-a-date', 'also-bad')).toBe(0)
+  })
 })

--- a/src/utils/stats.totalDays.test.ts
+++ b/src/utils/stats.totalDays.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'bun:test'
+import { inclusiveCalendarDaySpan } from './stats.js'
+
+describe('inclusiveCalendarDaySpan', () => {
+  test('is 1 when both timestamps fall on the same UTC calendar day', () => {
+    // Two sessions on the same day (01:00 and 20:00 UTC). The old
+    // Math.ceil(rawGap) + 1 rounded the 19h partial day up to 1 and then added
+    // 1, reporting 2 total days for a single active day.
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T01:00:00.000Z',
+        '2026-07-13T20:00:00.000Z',
+      ),
+    ).toBe(1)
+  })
+
+  test('counts calendar days inclusively across a multi-day span', () => {
+    // 2026-07-13 .. 2026-07-15 inclusive = 3 days, regardless of time of day.
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T22:00:00.000Z',
+        '2026-07-15T06:00:00.000Z',
+      ),
+    ).toBe(3)
+  })
+
+  test('is 1 for identical timestamps', () => {
+    const t = '2026-07-13T12:00:00.000Z'
+    expect(inclusiveCalendarDaySpan(t, t)).toBe(1)
+  })
+
+  test('counts exactly two days for adjacent calendar days', () => {
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T23:59:59.000Z',
+        '2026-07-14T00:00:01.000Z',
+      ),
+    ).toBe(2)
+  })
+})

--- a/src/utils/stats.totalDays.test.ts
+++ b/src/utils/stats.totalDays.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { inclusiveCalendarDaySpan } from './stats.js'
+import { comparePersistedDates, inclusiveCalendarDaySpan } from './stats.js'
 
 describe('inclusiveCalendarDaySpan', () => {
   test('is 1 when both timestamps fall on the same UTC calendar day', () => {
@@ -142,5 +142,65 @@ describe('inclusiveCalendarDaySpan', () => {
         '2026-07-14T00:30:00.000Z',
       ),
     ).toBeGreaterThan(0)
+  })
+
+  test('returns 0 for out-of-range clock components', () => {
+    // Date.parse normalizes T24:00:00 to midnight the next day, so a corrupt
+    // persisted timestamp would shift the span by a day rather than take the
+    // documented 0 fallback.
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T24:00:00.000Z',
+        '2026-07-14T00:00:00.000Z',
+      ),
+    ).toBe(0)
+    for (const bad of [
+      '2026-07-13T25:00:00.000Z',
+      '2026-07-13T12:60:00.000Z',
+      '2026-07-13T12:00:60.000Z',
+      '2026-07-13T12:00:00+24:00',
+      '2026-07-13T12:00:00+05:60',
+    ]) {
+      expect(inclusiveCalendarDaySpan(bad, '2026-07-15T06:00:00.000Z')).toBe(0)
+    }
+  })
+})
+
+describe('comparePersistedDates', () => {
+  test('orders offset instants by the moment they denote, not by string', () => {
+    // 2026-07-13T23:30:00-10:00 is 2026-07-14T09:30Z; 2026-07-14T00:00:00+14:00
+    // is 2026-07-13T10:00Z. String order gets this exactly backwards, so the
+    // later instant was selected as firstSessionDate and the span collapsed to
+    // 0 for two sessions occupying different UTC days.
+    const earlier = '2026-07-14T00:00:00+14:00'
+    const later = '2026-07-13T23:30:00-10:00'
+    // String order puts the chronologically earlier instant last -- that
+    // inversion is the bug.
+    expect(earlier > later).toBe(true)
+    expect(comparePersistedDates(earlier, later)).toBeLessThan(0)
+    expect(comparePersistedDates(later, earlier)).toBeGreaterThan(0)
+    // Selected chronologically, the pair spans UTC July 13 and 14.
+    expect(inclusiveCalendarDaySpan(earlier, later)).toBe(2)
+  })
+
+  test('orders same-zone instants and bare date keys', () => {
+    expect(
+      comparePersistedDates(
+        '2026-07-13T01:00:00.000Z',
+        '2026-07-13T20:00:00.000Z',
+      ),
+    ).toBeLessThan(0)
+    expect(comparePersistedDates('2026-07-13', '2026-07-15')).toBeLessThan(0)
+    const same = '2026-07-13T12:00:00.000Z'
+    expect(comparePersistedDates(same, same)).toBe(0)
+  })
+
+  test('stays deterministic when a value is not parseable', () => {
+    // The span helper rejects corrupt values separately; selection must still
+    // be total and stable rather than depending on NaN comparisons.
+    // Falls back to string order, which is at least total and antisymmetric.
+    expect(comparePersistedDates('not-a-date', '2026-07-13')).toBeGreaterThan(0)
+    expect(comparePersistedDates('2026-07-13', 'not-a-date')).toBeLessThan(0)
+    expect(comparePersistedDates('not-a-date', 'not-a-date')).toBe(0)
   })
 })

--- a/src/utils/stats.totalDays.test.ts
+++ b/src/utils/stats.totalDays.test.ts
@@ -284,4 +284,27 @@ describe('mergeCacheWithNewStats first-session selection', () => {
       mergeSessions(['2026-07-13T20:00:00.000Z', '2026-07-13T01:00:00.000Z']),
     ).toBe('2026-07-13T01:00:00.000Z')
   })
+
+  test('replaces a corrupt cached first date that lexical order never heals', () => {
+    // A persisted seed like "1" is unparseable and sorts lexically BEFORE every
+    // real timestamp, so comparePersistedDates alone never displaces it -- the
+    // corruption (and the wrong totalDays it drives) survives every later run.
+    // The NaN guard treats it as absent so the first valid session date wins.
+    for (const corrupt of ['1', '0000', 'not-a-date']) {
+      const cache = { ...emptyCache(), firstSessionDate: corrupt }
+      const merged = mergeCacheWithNewStats(
+        cache,
+        {
+          dailyActivity: [],
+          dailyModelTokens: [],
+          modelUsage: {},
+          sessionStats: [session('2026-07-13T12:00:00.000Z')],
+          hourCounts: {},
+          totalSpeculationTimeSavedMs: 0,
+        },
+        '2026-07-14',
+      )
+      expect(merged.firstSessionDate).toBe('2026-07-13T12:00:00.000Z')
+    }
+  })
 })

--- a/src/utils/stats.totalDays.test.ts
+++ b/src/utils/stats.totalDays.test.ts
@@ -24,6 +24,44 @@ describe('inclusiveCalendarDaySpan', () => {
     ).toBe(3)
   })
 
+  test('does not add a day when the later session is later in the day', () => {
+    // The canonical off-by-one: the raw gap is 1.5 days, so the old
+    // Math.ceil(gap) + 1 rounded up to 2 and then added the inclusive +1,
+    // reporting 3 for a 2-calendar-day span. Unlike the spans above, this case
+    // separates the two formulas, so it fails if the off-by-one comes back.
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T06:00:00.000Z',
+        '2026-07-14T18:00:00.000Z',
+      ),
+    ).toBe(2)
+  })
+
+  test('counts a longer non-midnight span by calendar day', () => {
+    // Raw gap 3.5 days: old formula gave ceil(3.5) + 1 = 5, correct is 4.
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T06:00:00.000Z',
+        '2026-07-16T18:00:00.000Z',
+      ),
+    ).toBe(4)
+  })
+
+  test('accepts bare dailyActivity date keys', () => {
+    // lastSessionDate can be derived from dailyActivity, which stores YYYY-MM-DD.
+    expect(inclusiveCalendarDaySpan('2026-07-13', '2026-07-15')).toBe(3)
+  })
+
+  test('returns 0 for parseable but malformed persisted dates', () => {
+    // Date.parse accepts all of these, silently producing a misleading span:
+    // "2026-07" -> Jul 1, "2026" -> Jan 1, "123" -> year 0123, and a
+    // non-ISO locale format. None is a shape this pipeline ever persists.
+    for (const bad of ['2026-07', '2026', '123', '01/01/2026']) {
+      expect(inclusiveCalendarDaySpan(bad, '2026-07-15T06:00:00.000Z')).toBe(0)
+      expect(inclusiveCalendarDaySpan('2026-07-13T06:00:00.000Z', bad)).toBe(0)
+    }
+  })
+
   test('is 1 for identical timestamps', () => {
     const t = '2026-07-13T12:00:00.000Z'
     expect(inclusiveCalendarDaySpan(t, t)).toBe(1)

--- a/src/utils/stats.totalDays.test.ts
+++ b/src/utils/stats.totalDays.test.ts
@@ -109,4 +109,38 @@ describe('inclusiveCalendarDaySpan', () => {
     // Leap 2024: a real day, spans inclusively to March 1.
     expect(inclusiveCalendarDaySpan('2024-02-29', '2024-03-01')).toBe(2)
   })
+
+  test('rejects timestamps that are not one of the two persisted shapes', () => {
+    // Space-delimited: Date.parse would read this as host-local time, so the
+    // span would depend on the machine's timezone instead of falling back to 0.
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13 23:30:00',
+        '2026-07-14T00:30:00.000Z',
+      ),
+    ).toBe(0)
+    // ISO shape with no zone designator is equally ambiguous.
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T23:30:00',
+        '2026-07-14T00:30:00.000Z',
+      ),
+    ).toBe(0)
+    // Trailing junk after a valid instant.
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T23:30:00.000Zjunk',
+        '2026-07-14T00:30:00.000Z',
+      ),
+    ).toBe(0)
+  })
+
+  test('accepts a UTC offset instant as well as Z', () => {
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T23:30:00+05:30',
+        '2026-07-14T00:30:00.000Z',
+      ),
+    ).toBeGreaterThan(0)
+  })
 })

--- a/src/utils/stats.totalDays.test.ts
+++ b/src/utils/stats.totalDays.test.ts
@@ -91,4 +91,22 @@ describe('inclusiveCalendarDaySpan', () => {
     ).toBe(0)
     expect(inclusiveCalendarDaySpan('not-a-date', 'also-bad')).toBe(0)
   })
+
+  test('returns 0 for impossible calendar dates instead of normalizing them', () => {
+    // Date.parse rolls 2026-02-30 over to March 2, so a date-shaped-prefix
+    // guard alone would fabricate a span (this exact pair returned 1) instead
+    // of taking the documented 0 fallback.
+    expect(inclusiveCalendarDaySpan('2026-02-30', '2026-03-02')).toBe(0)
+    expect(inclusiveCalendarDaySpan('2026-07-13', '2026-13-01')).toBe(0)
+    expect(inclusiveCalendarDaySpan('2026-00-10', '2026-07-13')).toBe(0)
+    expect(inclusiveCalendarDaySpan('2026-07-00', '2026-07-13')).toBe(0)
+    expect(inclusiveCalendarDaySpan('2026-04-31', '2026-05-01')).toBe(0)
+  })
+
+  test('rejects February 29 only in non-leap years', () => {
+    // Non-leap 2026: impossible, must not normalize to March 1.
+    expect(inclusiveCalendarDaySpan('2026-02-29', '2026-03-01')).toBe(0)
+    // Leap 2024: a real day, spans inclusively to March 1.
+    expect(inclusiveCalendarDaySpan('2024-02-29', '2024-03-01')).toBe(2)
+  })
 })

--- a/src/utils/stats.totalDays.test.ts
+++ b/src/utils/stats.totalDays.test.ts
@@ -141,6 +141,33 @@ describe('inclusiveCalendarDaySpan', () => {
     ).toBe(0)
   })
 
+  test('accepts valid ISO spellings the ingestion path persists', () => {
+    // processSessionFiles stores whatever original string `new Date(...)`
+    // accepted, so seconds may be omitted and a numeric offset may drop its
+    // colon. Narrowing the validator to require both counted the session in
+    // dailyActivity yet returned a 0 span, so /stats read zero total days for
+    // genuine multi-day activity.
+    expect(
+      inclusiveCalendarDaySpan('2026-07-13T12:00Z', '2026-07-14T12:00Z'),
+    ).toBe(2)
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T12:00:00+0000',
+        '2026-07-15T00:00:00+0000',
+      ),
+    ).toBe(3)
+    // Second-less form with an offset, and fractional seconds, both accepted.
+    expect(
+      inclusiveCalendarDaySpan('2026-07-13T23:30+05:30', '2026-07-14T00:30Z'),
+    ).toBe(2)
+    expect(
+      inclusiveCalendarDaySpan(
+        '2026-07-13T00:00:00.5Z',
+        '2026-07-13T23:00:00.250Z',
+      ),
+    ).toBe(1)
+  })
+
   test('accepts a UTC offset instant as well as Z', () => {
     // 2026-07-13T23:30+05:30 is 2026-07-13T18:00Z, so these endpoints span
     // exactly two UTC calendar days. Asserting the value rather than just

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -870,14 +870,21 @@ export function inclusiveCalendarDaySpan(
 }
 
 /**
- * The two shapes this pipeline actually persists: a full ISO instant (from
- * `session.timestamp`) or a bare `dailyActivity` date key. Anything else is
- * corruption. `Date.parse` alone is far too lenient to detect it — "2026-07",
- * "2026", "123" and "01/01/2026" all parse to real dates, so a truncated or
- * foreign-format value would silently yield a plausible-but-wrong span instead
- * of being rejected.
+ * The two shapes this pipeline actually persists: a bare `dailyActivity` date
+ * key, or a complete timezone-qualified ISO instant (from `session.timestamp`).
+ * Anything else is corruption. `Date.parse` alone is far too lenient to detect
+ * it — "2026-07", "2026", "123" and "01/01/2026" all parse to real dates, so a
+ * truncated or foreign-format value would silently yield a
+ * plausible-but-wrong span instead of being rejected.
+ *
+ * The match is anchored at both ends and the zone designator is required. A
+ * space-delimited "2026-07-13 23:30:00" is neither shape, and `Date.parse`
+ * would read it as a host-local time — making the computed span depend on the
+ * machine's timezone (2 under UTC, 1 under America/Los_Angeles) rather than
+ * falling back to 0 for corrupt input.
  */
-const PERSISTED_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}(?:[T ]|$)/
+const PERSISTED_DATE_PATTERN =
+  /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))?$/
 
 function parsePersistedDateMs(value: string): number {
   if (!PERSISTED_DATE_PATTERN.test(value)) {

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -855,18 +855,35 @@ export function inclusiveCalendarDaySpan(
   firstIso: string,
   lastIso: string,
 ): number {
-  const firstMs = Date.parse(firstIso)
-  const lastMs = Date.parse(lastIso)
-  // A persisted cache can carry a structurally-valid but unparseable date (e.g.
-  // "not-a-date"). Passing that to `new Date(...).toISOString()` throws
-  // RangeError, which would abort the whole `/stats` render, so bail out to the
-  // same 0 the callers already use when an endpoint is missing.
+  const firstMs = parsePersistedDateMs(firstIso)
+  const lastMs = parsePersistedDateMs(lastIso)
+  // A persisted cache can carry a corrupt date. Passing that to
+  // `new Date(...).toISOString()` throws RangeError, which would abort the whole
+  // `/stats` render, so bail out to the same 0 the callers already use when an
+  // endpoint is missing.
   if (Number.isNaN(firstMs) || Number.isNaN(lastMs)) {
     return 0
   }
   const firstDay = new Date(toDateString(new Date(firstMs))).getTime()
   const lastDay = new Date(toDateString(new Date(lastMs))).getTime()
   return Math.round((lastDay - firstDay) / (1000 * 60 * 60 * 24)) + 1
+}
+
+/**
+ * The two shapes this pipeline actually persists: a full ISO instant (from
+ * `session.timestamp`) or a bare `dailyActivity` date key. Anything else is
+ * corruption. `Date.parse` alone is far too lenient to detect it — "2026-07",
+ * "2026", "123" and "01/01/2026" all parse to real dates, so a truncated or
+ * foreign-format value would silently yield a plausible-but-wrong span instead
+ * of being rejected.
+ */
+const PERSISTED_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}(?:[T ]|$)/
+
+function parsePersistedDateMs(value: string): number {
+  if (!PERSISTED_DATE_PATTERN.test(value)) {
+    return NaN
+  }
+  return Date.parse(value)
 }
 
 function calculateStreaks(dailyActivity: DailyActivity[]): StreakInfo {

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -855,8 +855,17 @@ export function inclusiveCalendarDaySpan(
   firstIso: string,
   lastIso: string,
 ): number {
-  const firstDay = new Date(toDateString(new Date(firstIso))).getTime()
-  const lastDay = new Date(toDateString(new Date(lastIso))).getTime()
+  const firstMs = Date.parse(firstIso)
+  const lastMs = Date.parse(lastIso)
+  // A persisted cache can carry a structurally-valid but unparseable date (e.g.
+  // "not-a-date"). Passing that to `new Date(...).toISOString()` throws
+  // RangeError, which would abort the whole `/stats` render, so bail out to the
+  // same 0 the callers already use when an endpoint is missing.
+  if (Number.isNaN(firstMs) || Number.isNaN(lastMs)) {
+    return 0
+  }
+  const firstDay = new Date(toDateString(new Date(firstMs))).getTime()
+  const lastDay = new Date(toDateString(new Date(lastMs))).getTime()
   return Math.round((lastDay - firstDay) / (1000 * 60 * 60 * 24)) + 1
 }
 

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -883,6 +883,22 @@ function parsePersistedDateMs(value: string): number {
   if (!PERSISTED_DATE_PATTERN.test(value)) {
     return NaN
   }
+  // A date-shaped prefix is not enough: Date.parse silently normalizes
+  // impossible calendar values (2026-02-30 parses as March 2), which would turn
+  // a corrupt persisted date into a fabricated span instead of the 0 fallback.
+  // Validate the spelled components against the real calendar, leap years
+  // included.
+  const year = Number(value.slice(0, 4))
+  const month = Number(value.slice(5, 7))
+  const day = Number(value.slice(8, 10))
+  if (month < 1 || month > 12) {
+    return NaN
+  }
+  // With a 1-based month, day 0 of the next month is this month's last day.
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+  if (day < 1 || day > daysInMonth) {
+    return NaN
+  }
   return Date.parse(value)
 }
 

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -15,14 +15,21 @@ import { jsonParse } from './slowOperations.js'
 import {
   getTodayDateString,
   getYesterdayDateString,
+  comparePersistedDates,
   isDateBefore,
   loadStatsCache,
   mergeCacheWithNewStats,
   type PersistedStatsCache,
   saveStatsCache,
+  parsePersistedDateMs,
   toDateString,
   withStatsCacheLock,
 } from './statsCache.js'
+
+// Re-exported so the persisted-date helpers stay reachable from the stats
+// surface; they live in statsCache.js because the cache writer needs them too
+// and this module already depends on that one.
+export { comparePersistedDates }
 
 export type DailyActivity = {
   date: string // YYYY-MM-DD format
@@ -879,88 +886,6 @@ export function inclusiveCalendarDaySpan(
   const firstDay = new Date(toDateString(new Date(firstMs))).getTime()
   const lastDay = new Date(toDateString(new Date(lastMs))).getTime()
   return Math.round((lastDay - firstDay) / (1000 * 60 * 60 * 24)) + 1
-}
-
-/**
- * The two shapes this pipeline actually persists: a bare `dailyActivity` date
- * key, or a complete timezone-qualified ISO instant (from `session.timestamp`).
- * Anything else is corruption. `Date.parse` alone is far too lenient to detect
- * it — "2026-07", "2026", "123" and "01/01/2026" all parse to real dates, so a
- * truncated or foreign-format value would silently yield a
- * plausible-but-wrong span instead of being rejected.
- *
- * The match is anchored at both ends and the zone designator is required. A
- * space-delimited "2026-07-13 23:30:00" is neither shape, and `Date.parse`
- * would read it as a host-local time — making the computed span depend on the
- * machine's timezone (2 under UTC, 1 under America/Los_Angeles) rather than
- * falling back to 0 for corrupt input.
- */
-const PERSISTED_DATE_PATTERN =
-  /^\d{4}-\d{2}-\d{2}(?:T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-](\d{2}):(\d{2})))?$/
-
-function parsePersistedDateMs(value: string): number {
-  const match = PERSISTED_DATE_PATTERN.exec(value)
-  if (!match) {
-    return NaN
-  }
-  // The clock components need the same treatment as the calendar ones below.
-  // `Date.parse` normalizes an out-of-range time instead of rejecting it, so
-  // "2026-07-13T24:00:00.000Z" becomes midnight on July 14 -- a corrupt
-  // persisted timestamp silently shifting the span by a day rather than
-  // falling back to 0.
-  const [, hour, minute, second, offsetHour, offsetMinute] = match
-  if (hour !== undefined) {
-    if (Number(hour) > 23 || Number(minute) > 59 || Number(second) > 59) {
-      return NaN
-    }
-  }
-  if (offsetHour !== undefined) {
-    if (Number(offsetHour) > 23 || Number(offsetMinute) > 59) {
-      return NaN
-    }
-  }
-  // A date-shaped prefix is not enough: Date.parse silently normalizes
-  // impossible calendar values (2026-02-30 parses as March 2), which would turn
-  // a corrupt persisted date into a fabricated span instead of the 0 fallback.
-  // Validate the spelled components against the real calendar, leap years
-  // included.
-  const year = Number(value.slice(0, 4))
-  const month = Number(value.slice(5, 7))
-  const day = Number(value.slice(8, 10))
-  if (month < 1 || month > 12) {
-    return NaN
-  }
-  // With a 1-based month, day 0 of the next month is this month's last day.
-  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
-  if (day < 1 || day > daysInMonth) {
-    return NaN
-  }
-  return Date.parse(value)
-}
-
-/**
- * Chronological ordering for the persisted date shapes, for picking the first
- * and last session out of a set.
- *
- * These endpoints cannot be compared as strings. An offset-qualified instant
- * does not sort lexicographically by the moment it denotes:
- * "2026-07-13T23:30:00-10:00" is later than "2026-07-14T00:00:00+14:00", but
- * sorts earlier, so it would be picked as the first endpoint and the span would
- * come out as 0 for two sessions that occupy different UTC days.
- *
- * Falls back to string order only when a value is not parseable, which keeps
- * the selection deterministic for a corrupt cache -- the span helper rejects it
- * separately.
- *
- * Exported for testing.
- */
-export function comparePersistedDates(a: string, b: string): number {
-  const aMs = parsePersistedDateMs(a)
-  const bMs = parsePersistedDateMs(b)
-  if (Number.isNaN(aMs) || Number.isNaN(bMs)) {
-    return a < b ? -1 : a > b ? 1 : 0
-  }
-  return aMs - bMs
 }
 
 function calculateStreaks(dailyActivity: DailyActivity[]): StreakInfo {

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -554,12 +554,17 @@ function cacheToStats(
   }
 
   // Find first/last session dates
+  // Seeded from the persisted cache, which can hold a corrupt firstSessionDate.
+  // An unparseable seed that sorts lexically before real timestamps would never
+  // be displaced by comparePersistedDates, locking in a wrong totalDays. Treat
+  // it as absent so a valid session date takes over.
   let firstSessionDate = cache.firstSessionDate
   let lastSessionDate: string | null = null
   if (todayStats) {
     for (const session of todayStats.sessionStats) {
       if (
         !firstSessionDate ||
+        Number.isNaN(parsePersistedDateMs(firstSessionDate)) ||
         comparePersistedDates(session.timestamp, firstSessionDate) < 0
       ) {
         firstSessionDate = session.timestamp

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -551,10 +551,16 @@ function cacheToStats(
   let lastSessionDate: string | null = null
   if (todayStats) {
     for (const session of todayStats.sessionStats) {
-      if (!firstSessionDate || session.timestamp < firstSessionDate) {
+      if (
+        !firstSessionDate ||
+        comparePersistedDates(session.timestamp, firstSessionDate) < 0
+      ) {
         firstSessionDate = session.timestamp
       }
-      if (!lastSessionDate || session.timestamp > lastSessionDate) {
+      if (
+        !lastSessionDate ||
+        comparePersistedDates(session.timestamp, lastSessionDate) > 0
+      ) {
         lastSessionDate = session.timestamp
       }
     }
@@ -768,10 +774,16 @@ function processedStatsToClaudeCodeStats(
   let firstSessionDate: string | null = null
   let lastSessionDate: string | null = null
   for (const session of stats.sessionStats) {
-    if (!firstSessionDate || session.timestamp < firstSessionDate) {
+    if (
+      !firstSessionDate ||
+      comparePersistedDates(session.timestamp, firstSessionDate) < 0
+    ) {
       firstSessionDate = session.timestamp
     }
-    if (!lastSessionDate || session.timestamp > lastSessionDate) {
+    if (
+      !lastSessionDate ||
+      comparePersistedDates(session.timestamp, lastSessionDate) > 0
+    ) {
       lastSessionDate = session.timestamp
     }
   }
@@ -884,11 +896,28 @@ export function inclusiveCalendarDaySpan(
  * falling back to 0 for corrupt input.
  */
 const PERSISTED_DATE_PATTERN =
-  /^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2}))?$/
+  /^\d{4}-\d{2}-\d{2}(?:T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-](\d{2}):(\d{2})))?$/
 
 function parsePersistedDateMs(value: string): number {
-  if (!PERSISTED_DATE_PATTERN.test(value)) {
+  const match = PERSISTED_DATE_PATTERN.exec(value)
+  if (!match) {
     return NaN
+  }
+  // The clock components need the same treatment as the calendar ones below.
+  // `Date.parse` normalizes an out-of-range time instead of rejecting it, so
+  // "2026-07-13T24:00:00.000Z" becomes midnight on July 14 -- a corrupt
+  // persisted timestamp silently shifting the span by a day rather than
+  // falling back to 0.
+  const [, hour, minute, second, offsetHour, offsetMinute] = match
+  if (hour !== undefined) {
+    if (Number(hour) > 23 || Number(minute) > 59 || Number(second) > 59) {
+      return NaN
+    }
+  }
+  if (offsetHour !== undefined) {
+    if (Number(offsetHour) > 23 || Number(offsetMinute) > 59) {
+      return NaN
+    }
   }
   // A date-shaped prefix is not enough: Date.parse silently normalizes
   // impossible calendar values (2026-02-30 parses as March 2), which would turn
@@ -907,6 +936,31 @@ function parsePersistedDateMs(value: string): number {
     return NaN
   }
   return Date.parse(value)
+}
+
+/**
+ * Chronological ordering for the persisted date shapes, for picking the first
+ * and last session out of a set.
+ *
+ * These endpoints cannot be compared as strings. An offset-qualified instant
+ * does not sort lexicographically by the moment it denotes:
+ * "2026-07-13T23:30:00-10:00" is later than "2026-07-14T00:00:00+14:00", but
+ * sorts earlier, so it would be picked as the first endpoint and the span would
+ * come out as 0 for two sessions that occupy different UTC days.
+ *
+ * Falls back to string order only when a value is not parseable, which keeps
+ * the selection deterministic for a corrupt cache -- the span helper rejects it
+ * separately.
+ *
+ * Exported for testing.
+ */
+export function comparePersistedDates(a: string, b: string): number {
+  const aMs = parsePersistedDateMs(a)
+  const bMs = parsePersistedDateMs(b)
+  if (Number.isNaN(aMs) || Number.isNaN(bMs)) {
+    return a < b ? -1 : a > b ? 1 : 0
+  }
+  return aMs - bMs
 }
 
 function calculateStreaks(dailyActivity: DailyActivity[]): StreakInfo {

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -580,11 +580,7 @@ function cacheToStats(
 
   const totalDays =
     firstSessionDate && lastSessionDate
-      ? Math.ceil(
-          (new Date(lastSessionDate).getTime() -
-            new Date(firstSessionDate).getTime()) /
-            (1000 * 60 * 60 * 24),
-        ) + 1
+      ? inclusiveCalendarDaySpan(firstSessionDate, lastSessionDate)
       : 0
 
   const totalSpeculationTimeSavedMs =
@@ -803,11 +799,7 @@ function processedStatsToClaudeCodeStats(
   // Total days in range
   const totalDays =
     firstSessionDate && lastSessionDate
-      ? Math.ceil(
-          (new Date(lastSessionDate).getTime() -
-            new Date(firstSessionDate).getTime()) /
-            (1000 * 60 * 60 * 24),
-        ) + 1
+      ? inclusiveCalendarDaySpan(firstSessionDate, lastSessionDate)
       : 0
 
   const result: ClaudeCodeStats = {
@@ -849,6 +841,23 @@ function getNextDay(dateStr: string): string {
   const date = new Date(dateStr)
   date.setDate(date.getDate() + 1)
   return toDateString(date)
+}
+
+/**
+ * Inclusive count of calendar days spanned by two ISO timestamps, on the same
+ * UTC-date basis as activeDays/dailyActivity (via toDateString). The endpoints
+ * are full timestamps, so diffing them raw and Math.ceil-ing rounds any partial
+ * day up to a whole one; adding 1 for inclusivity then double-counts it (a
+ * single active day would report 2). Snap both ends to their date first so the
+ * gap is an exact multiple of 24h before adding the inclusive +1.
+ */
+export function inclusiveCalendarDaySpan(
+  firstIso: string,
+  lastIso: string,
+): number {
+  const firstDay = new Date(toDateString(new Date(firstIso))).getTime()
+  const lastDay = new Date(toDateString(new Date(lastIso))).getTime()
+  return Math.round((lastDay - firstDay) / (1000 * 60 * 60 * 24)) + 1
 }
 
 function calculateStreaks(dailyActivity: DailyActivity[]): StreakInfo {

--- a/src/utils/statsCache.ts
+++ b/src/utils/statsCache.ts
@@ -353,10 +353,17 @@ export function mergeCacheWithNewStats(
     }
   }
 
-  // Find first session date
+  // Find first session date. Compared chronologically, not lexically: an
+  // offset-qualified timestamp does not sort by the instant it denotes, and
+  // this value is what a later cached run reads back. There is no session list
+  // to correct it at that point, so a wrong first date here reports one total
+  // day for activity that spans two UTC dates.
   let firstSessionDate = existingCache.firstSessionDate
   for (const session of newStats.sessionStats) {
-    if (!firstSessionDate || session.timestamp < firstSessionDate) {
+    if (
+      !firstSessionDate ||
+      comparePersistedDates(session.timestamp, firstSessionDate) < 0
+    ) {
       firstSessionDate = session.timestamp
     }
   }
@@ -431,4 +438,86 @@ export function getYesterdayDateString(): string {
  */
 export function isDateBefore(date1: string, date2: string): boolean {
   return date1 < date2
+}
+
+/**
+ * The two shapes this pipeline actually persists: a bare `dailyActivity` date
+ * key, or a complete timezone-qualified ISO instant (from `session.timestamp`).
+ * Anything else is corruption. `Date.parse` alone is far too lenient to detect
+ * it — "2026-07", "2026", "123" and "01/01/2026" all parse to real dates, so a
+ * truncated or foreign-format value would silently yield a
+ * plausible-but-wrong span instead of being rejected.
+ *
+ * The match is anchored at both ends and the zone designator is required. A
+ * space-delimited "2026-07-13 23:30:00" is neither shape, and `Date.parse`
+ * would read it as a host-local time — making the computed span depend on the
+ * machine's timezone (2 under UTC, 1 under America/Los_Angeles) rather than
+ * falling back to 0 for corrupt input.
+ */
+const PERSISTED_DATE_PATTERN =
+  /^\d{4}-\d{2}-\d{2}(?:T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-](\d{2}):(\d{2})))?$/
+
+export function parsePersistedDateMs(value: string): number {
+  const match = PERSISTED_DATE_PATTERN.exec(value)
+  if (!match) {
+    return NaN
+  }
+  // The clock components need the same treatment as the calendar ones below.
+  // `Date.parse` normalizes an out-of-range time instead of rejecting it, so
+  // "2026-07-13T24:00:00.000Z" becomes midnight on July 14 -- a corrupt
+  // persisted timestamp silently shifting the span by a day rather than
+  // falling back to 0.
+  const [, hour, minute, second, offsetHour, offsetMinute] = match
+  if (hour !== undefined) {
+    if (Number(hour) > 23 || Number(minute) > 59 || Number(second) > 59) {
+      return NaN
+    }
+  }
+  if (offsetHour !== undefined) {
+    if (Number(offsetHour) > 23 || Number(offsetMinute) > 59) {
+      return NaN
+    }
+  }
+  // A date-shaped prefix is not enough: Date.parse silently normalizes
+  // impossible calendar values (2026-02-30 parses as March 2), which would turn
+  // a corrupt persisted date into a fabricated span instead of the 0 fallback.
+  // Validate the spelled components against the real calendar, leap years
+  // included.
+  const year = Number(value.slice(0, 4))
+  const month = Number(value.slice(5, 7))
+  const day = Number(value.slice(8, 10))
+  if (month < 1 || month > 12) {
+    return NaN
+  }
+  // With a 1-based month, day 0 of the next month is this month's last day.
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+  if (day < 1 || day > daysInMonth) {
+    return NaN
+  }
+  return Date.parse(value)
+}
+
+/**
+ * Chronological ordering for the persisted date shapes, for picking the first
+ * and last session out of a set.
+ *
+ * These endpoints cannot be compared as strings. An offset-qualified instant
+ * does not sort lexicographically by the moment it denotes:
+ * "2026-07-13T23:30:00-10:00" is later than "2026-07-14T00:00:00+14:00", but
+ * sorts earlier, so it would be picked as the first endpoint and the span would
+ * come out as 0 for two sessions that occupy different UTC days.
+ *
+ * Falls back to string order only when a value is not parseable, which keeps
+ * the selection deterministic for a corrupt cache -- the span helper rejects it
+ * separately.
+ *
+ * Exported for testing.
+ */
+export function comparePersistedDates(a: string, b: string): number {
+  const aMs = parsePersistedDateMs(a)
+  const bMs = parsePersistedDateMs(b)
+  if (Number.isNaN(aMs) || Number.isNaN(bMs)) {
+    return a < b ? -1 : a > b ? 1 : 0
+  }
+  return aMs - bMs
 }

--- a/src/utils/statsCache.ts
+++ b/src/utils/statsCache.ts
@@ -358,10 +358,16 @@ export function mergeCacheWithNewStats(
   // this value is what a later cached run reads back. There is no session list
   // to correct it at that point, so a wrong first date here reports one total
   // day for activity that spans two UTC dates.
+  // The seed comes from a previously persisted cache and may itself be corrupt.
+  // A garbage seed that sorts lexically before every real timestamp (e.g. "1")
+  // is never displaced by comparePersistedDates alone, so the corruption -- and
+  // the wrong totalDays it produces -- persists across every later run. Treat an
+  // unparseable seed as absent so the first valid session date replaces it.
   let firstSessionDate = existingCache.firstSessionDate
   for (const session of newStats.sessionStats) {
     if (
       !firstSessionDate ||
+      Number.isNaN(parsePersistedDateMs(firstSessionDate)) ||
       comparePersistedDates(session.timestamp, firstSessionDate) < 0
     ) {
       firstSessionDate = session.timestamp

--- a/src/utils/statsCache.ts
+++ b/src/utils/statsCache.ts
@@ -454,28 +454,41 @@ export function isDateBefore(date1: string, date2: string): boolean {
  * truncated or foreign-format value would silently yield a
  * plausible-but-wrong span instead of being rejected.
  *
- * The match is anchored at both ends and the zone designator is required. A
- * space-delimited "2026-07-13 23:30:00" is neither shape, and `Date.parse`
- * would read it as a host-local time — making the computed span depend on the
- * machine's timezone (2 under UTC, 1 under America/Los_Angeles) rather than
- * falling back to 0 for corrupt input.
+ * The match is anchored at both ends and, once a time is present, a zone
+ * designator is required. A space-delimited "2026-07-13 23:30:00" is neither
+ * shape, and `Date.parse` would read it as a host-local time — making the
+ * computed span depend on the machine's timezone (2 under UTC, 1 under
+ * America/Los_Angeles) rather than falling back to 0 for corrupt input.
+ *
+ * What it must NOT do is narrow the timestamp contract the ingestion path
+ * already accepts. `processSessionFiles` persists whatever original string
+ * `new Date(...)` accepted, and SDK callers may supply their own, so valid ISO
+ * spellings reach this validator: seconds are optional (`T12:00Z`) and a numeric
+ * offset may omit its colon (`+0000`). Rejecting those would count the session
+ * in `dailyActivity` yet return a 0 span, so `/stats` reads zero total days for
+ * real multi-day activity. The seconds group and the offset colon are therefore
+ * optional here.
  */
 const PERSISTED_DATE_PATTERN =
-  /^\d{4}-\d{2}-\d{2}(?:T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?(?:Z|[+-](\d{2}):(\d{2})))?$/
+  /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?(?:Z|[+-](\d{2}):?(\d{2})))?$/
 
 export function parsePersistedDateMs(value: string): number {
   const match = PERSISTED_DATE_PATTERN.exec(value)
   if (!match) {
     return NaN
   }
+  const [, yearStr, monthStr, dayStr, hour, minute, second, offsetHour, offsetMinute] =
+    match
   // The clock components need the same treatment as the calendar ones below.
   // `Date.parse` normalizes an out-of-range time instead of rejecting it, so
   // "2026-07-13T24:00:00.000Z" becomes midnight on July 14 -- a corrupt
   // persisted timestamp silently shifting the span by a day rather than
   // falling back to 0.
-  const [, hour, minute, second, offsetHour, offsetMinute] = match
   if (hour !== undefined) {
-    if (Number(hour) > 23 || Number(minute) > 59 || Number(second) > 59) {
+    if (Number(hour) > 23 || Number(minute) > 59) {
+      return NaN
+    }
+    if (second !== undefined && Number(second) > 59) {
       return NaN
     }
   }
@@ -487,16 +500,20 @@ export function parsePersistedDateMs(value: string): number {
   // A date-shaped prefix is not enough: Date.parse silently normalizes
   // impossible calendar values (2026-02-30 parses as March 2), which would turn
   // a corrupt persisted date into a fabricated span instead of the 0 fallback.
-  // Validate the spelled components against the real calendar, leap years
-  // included.
-  const year = Number(value.slice(0, 4))
-  const month = Number(value.slice(5, 7))
-  const day = Number(value.slice(8, 10))
+  // Validate the spelled components against the real calendar. Use the explicit
+  // leap rule rather than `Date.UTC(year, ...)`, which maps years 0-99 to
+  // 1900-1999 and would judge year 0000's Feb 29 inconsistently with the
+  // Date.parse this returns.
+  const year = Number(yearStr)
+  const month = Number(monthStr)
+  const day = Number(dayStr)
   if (month < 1 || month > 12) {
     return NaN
   }
-  // With a 1-based month, day 0 of the next month is this month's last day.
-  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate()
+  const isLeap = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0
+  const daysInMonth = [31, isLeap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][
+    month - 1
+  ]
   if (day < 1 || day > daysInMonth) {
     return NaN
   }


### PR DESCRIPTION
### Problem
The `/stats` "active X of **Y** days" denominator (`totalDays`) diffed the first and last session **ISO timestamps** raw, ran `Math.ceil` over the millisecond gap, then added 1:

```ts
Math.ceil((new Date(lastSessionDate).getTime() - new Date(firstSessionDate).getTime()) / (1000*60*60*24)) + 1
```

`firstSessionDate`/`lastSessionDate` are full timestamps, so `ceil` rounds any sub-day remainder up to a whole day and the `+1` double-counts it:
- all activity on a **single calendar day** → `totalDays = 2` (so 1 active day shows as 50%, not 100%),
- every span that isn't an exact 24h multiple is one day too long.

`activeDays`/`dailyActivity` count distinct UTC calendar days via `toDateString`, so the denominator drifts off the numerator's basis.

### Reachability
`aggregateClaudeCodeStatsForRange('7d'|'30d')` → `processedStatsToClaudeCodeStats`, and `aggregateClaudeCodeStats` → `cacheToStats`, both compute this; surfaced in `src/components/Stats.tsx`.

### Fix
Extract `inclusiveCalendarDaySpan`, which snaps both endpoints to their UTC date (`toDateString`, same basis as `activeDays`) before differencing, so the gap is an exact multiple of 24h and the inclusive `+1` is correct. Use it at both sites.

### Test
`inclusiveCalendarDaySpan` unit tests: same-day → 1 (was 2), 3-calendar-day span → 3, identical timestamps → 1, adjacent days → 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stats calculations to use an inclusive UTC calendar-day count, improving same-day and midnight-crossing behavior.
  * Improved first/last session selection to use persisted-date-aware chronological comparisons across mixed timestamp formats and UTC offsets.
  * Hardened persisted-date parsing and comparisons so malformed, impossible, or corrupted values can’t corrupt results.

* **Tests**
  * Added Bun coverage for inclusive UTC span counting, off-by-one and leap-year edge cases, strict persisted-date validation, and deterministic persisted-date ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->