### PR TITLE
fix(openai): compress tool history on Responses requests

### DIFF
--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
@@ -11,8 +11,10 @@ import {
   convertToolsToResponsesTools,
 } from './codexShim.js'
 import { __test as webSearchToolTest } from '../../tools/WebSearchTool/WebSearchTool.js'
+import { setToolHistoryCompressionEnabledOverrideForTest } from './compressToolHistory.js'
 
 const tempDirs: string[] = []
+const originalFetch = globalThis.fetch
 const originalEnv = {
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
   OPENAI_API_BASE: process.env.OPENAI_API_BASE,
@@ -26,6 +28,7 @@ beforeEach(async () => {
 
 afterEach(() => {
   try {
+    globalThis.fetch = originalFetch
     if (originalEnv.OPENAI_BASE_URL === undefined) delete process.env.OPENAI_BASE_URL
     else process.env.OPENAI_BASE_URL = originalEnv.OPENAI_BASE_URL
 
@@ -776,6 +779,59 @@ describe('Codex request translation', () => {
       | { type: 'function_call_output'; output: string }
       | undefined
     expect(output?.output).toBe('first block\nsecond block')
+  })
+
+  test('compresses structured tool results with the Codex Responses separator', async () => {
+    setToolHistoryCompressionEnabledOverrideForTest(true)
+    try {
+      mock.restore()
+      const isolatedModulePath = './codexShim.ts?compression-test'
+      const { performCodexRequest } = await import(isolatedModulePath)
+      const messages = Array.from({ length: 30 }, (_, index) => [
+        {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: `call_${index}`, name: 'Read', input: {} }],
+        },
+        {
+          role: 'user',
+          content: [{
+            type: 'tool_result',
+            tool_use_id: `call_${index}`,
+            content: index === 16
+              ? [
+                { type: 'text', text: 'a'.repeat(1_000) },
+                { type: 'text', text: 'b'.repeat(1_500) },
+              ]
+              : 'recent',
+          }],
+        },
+      ]).flat()
+      let body: Record<string, unknown> | undefined
+      globalThis.fetch = (async (_url, init) => {
+        body = JSON.parse(String(init?.body))
+        return new Response('', { status: 200 })
+      }) as typeof globalThis.fetch
+
+      await performCodexRequest({
+        request: {
+          transport: 'codex_responses',
+          requestedModel: 'gpt-4o',
+          resolvedModel: 'gpt-4o',
+          baseUrl: 'https://api.openai.test/v1',
+        },
+        credentials: { apiKey: 'test-key', source: 'env' },
+        params: { model: 'gpt-4o', messages, max_tokens: 100 },
+        defaultHeaders: {},
+      })
+
+      const outputs = (body?.input as Array<{ type?: string; output?: string }>)
+        .filter(item => item.type === 'function_call_output')
+      expect(outputs[16]?.output).toBe(
+        `${'a'.repeat(1_000)}\n${'b'.repeat(999)}\n[…truncated 501 chars from tool history]`,
+      )
+    } finally {
+      setToolHistoryCompressionEnabledOverrideForTest(undefined)
+    }
   })
 
   test('renders tool_reference blocks from ToolSearch results as readable text', () => {

--- a/src/services/api/codexShim.test.ts
+++ b/src/services/api/codexShim.test.ts
@@ -753,6 +753,31 @@ describe('Codex request translation', () => {
     ])
   })
 
+  test('joins structured tool-result text with the Responses separator', () => {
+    const items = convertAnthropicMessagesToResponsesInput([
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'call_123', name: 'search', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{
+          type: 'tool_result',
+          tool_use_id: 'call_123',
+          content: [
+            { type: 'text', text: 'first block' },
+            { type: 'text', text: 'second block' },
+          ],
+        }],
+      },
+    ])
+
+    const output = items.find(item => item.type === 'function_call_output') as
+      | { type: 'function_call_output'; output: string }
+      | undefined
+    expect(output?.output).toBe('first block\nsecond block')
+  })
+
   test('renders tool_reference blocks from ToolSearch results as readable text', () => {
     const items = convertAnthropicMessagesToResponsesInput([
       {

--- a/src/services/api/codexShim.ts
+++ b/src/services/api/codexShim.ts
@@ -609,6 +609,9 @@ export async function performCodexRequest(options: {
       content?: unknown
     }>,
     options.request.resolvedModel,
+    // Codex Responses flattens structured tool-result text with a single
+    // newline, unlike Chat's double-newline message serialization.
+    { textBlockSeparator: '\n' },
   )
   const input = convertAnthropicMessagesToResponsesInput(compressedMessages)
   const body: Record<string, unknown> = {

--- a/src/services/api/compressToolHistory.test.ts
+++ b/src/services/api/compressToolHistory.test.ts
@@ -77,7 +77,7 @@ afterEach(() => {
 })
 
 type Block = Record<string, unknown>
-type Msg = { role: string; content: Block[] | string }
+type Msg = { role: string; content: Block[] | string; toolUseResult?: unknown }
 
 function bigText(n: number): string {
   return 'x'.repeat(n)
@@ -501,7 +501,7 @@ test('tier boundaries: 16 exchanges → 1 old + 10 mid + 5 recent', () => {
   }
 })
 
-test('only omits permission images that follow a compressed tool result', () => {
+test('preserves an independent image that follows a compressed tool result', () => {
   const inlineImage = (data: string): Block => ({
     type: 'image',
     source: { type: 'base64', media_type: 'image/png', data },
@@ -517,22 +517,52 @@ test('only omits permission images that follow a compressed tool result', () => 
       role: 'user',
       content: [
         { type: 'tool_result', tool_use_id: 'toolu_0', content: bigText(5_000) },
-        inlineImage('old-image-data'),
+        inlineImage('user-image-data'),
         ...Array.from({ length: 4 }, (_, offset) => ({
           type: 'tool_result', tool_use_id: `toolu_${offset + 1}`, content: 'recent',
         })),
         { type: 'tool_result', tool_use_id: 'toolu_5', content: 'recent' },
-        inlineImage('recent-image-data'),
       ],
     },
   ]
 
   const result = compressToolHistoryForTest(messages, 'gpt-4o')
   const content = result[1].content as Block[]
-  expect(content[1]).toEqual({
+  expect(content[1]).toEqual(inlineImage('user-image-data'))
+})
+
+test('omits a permission image that follows a compressed tool result', () => {
+  const messages = buildConversation(16, 5_000)
+  const firstResult = getResultBlock(messages[2])
+  firstResult.content = bigText(5_000)
+  messages[2] = {
+    ...messages[2],
+    toolUseResult: 'tool output',
+    content: [firstResult, {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'permission-image-data' },
+    }],
+  }
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  expect((result[2].content as Block[])[1]).toEqual({
     type: 'text', text: '[Inline image omitted from tool history]',
   })
-  expect(content.at(-1)).toEqual(inlineImage('recent-image-data'))
+})
+
+test('cleared tool results remove embedded inline image payloads', () => {
+  const messages = buildConversation(16, 5_000)
+  const firstResult = getResultBlock(messages[2])
+  firstResult.content = [
+    { type: 'text', text: '[Old tool result content cleared]' },
+    { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'a'.repeat(10_000) } },
+    { type: 'image', source: { type: 'url', url: `data:image/svg+xml,${'x'.repeat(10_000)}` } },
+  ]
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  expect(getResultBlock(result[2]).content).toEqual([
+    { type: 'text', text: '[Old tool result content cleared]' },
+  ])
 })
 
 test('large window (1M) with 30 exchanges: all untouched (recent=25 ≥ 30 - 5)', () => {

--- a/src/services/api/compressToolHistory.test.ts
+++ b/src/services/api/compressToolHistory.test.ts
@@ -271,7 +271,7 @@ test('mid tier: preserves structured-part order across multiple text blocks', ()
     source: { type: 'url', url: 'https://example.com/result.png' },
   })
   expect(content[2].text).toBe(
-    `${'b'.repeat(999)}\n[…truncated 501 chars from tool history]`,
+    `${'b'.repeat(998)}\n[…truncated 502 chars from tool history]`,
   )
   expect(content[3]).toEqual({
     type: 'tool_reference',

--- a/src/services/api/compressToolHistory.test.ts
+++ b/src/services/api/compressToolHistory.test.ts
@@ -501,6 +501,40 @@ test('tier boundaries: 16 exchanges → 1 old + 10 mid + 5 recent', () => {
   }
 })
 
+test('only omits permission images that follow a compressed tool result', () => {
+  const inlineImage = (data: string): Block => ({
+    type: 'image',
+    source: { type: 'base64', media_type: 'image/png', data },
+  })
+  const messages: Msg[] = [
+    {
+      role: 'assistant',
+      content: Array.from({ length: 6 }, (_, id) => ({
+        type: 'tool_use', id: `toolu_${id}`, name: 'Read', input: {},
+      })),
+    },
+    {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'toolu_0', content: bigText(5_000) },
+        inlineImage('old-image-data'),
+        ...Array.from({ length: 4 }, (_, offset) => ({
+          type: 'tool_result', tool_use_id: `toolu_${offset + 1}`, content: 'recent',
+        })),
+        { type: 'tool_result', tool_use_id: 'toolu_5', content: 'recent' },
+        inlineImage('recent-image-data'),
+      ],
+    },
+  ]
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  const content = result[1].content as Block[]
+  expect(content[1]).toEqual({
+    type: 'text', text: '[Inline image omitted from tool history]',
+  })
+  expect(content.at(-1)).toEqual(inlineImage('recent-image-data'))
+})
+
 test('large window (1M) with 30 exchanges: all untouched (recent=25 ≥ 30 - 5)', () => {
   // ≥500k → recent=25, mid=50. 30 exchanges → 5 mid + 25 recent. None old.
   const messages = buildConversation(30, 5_000)

--- a/src/services/api/compressToolHistory.test.ts
+++ b/src/services/api/compressToolHistory.test.ts
@@ -266,9 +266,17 @@ test('mid tier: preserves structured-part order across multiple text blocks', ()
     'tool_reference',
   ])
   expect(content[0].text).toBe('a'.repeat(1_000))
+  expect(content[1]).toEqual({
+    type: 'image',
+    source: { type: 'url', url: 'https://example.com/result.png' },
+  })
   expect(content[2].text).toBe(
     `${'b'.repeat(999)}\n[…truncated 501 chars from tool history]`,
   )
+  expect(content[3]).toEqual({
+    type: 'tool_reference',
+    tool_name: 'mcp__example',
+  })
   expect((firstResult.content as Block[])[2].text).toBe('b'.repeat(1_500))
 })
 

--- a/src/services/api/compressToolHistory.test.ts
+++ b/src/services/api/compressToolHistory.test.ts
@@ -77,7 +77,12 @@ afterEach(() => {
 })
 
 type Block = Record<string, unknown>
-type Msg = { role: string; content: Block[] | string; toolUseResult?: unknown }
+type Msg = {
+  role: string
+  content: Block[] | string
+  toolUseResult?: unknown
+  imagePermissionToolUseIds?: Array<string | null>
+}
 
 function bigText(n: number): string {
   return 'x'.repeat(n)
@@ -538,6 +543,7 @@ test('omits a permission image that follows a compressed tool result', () => {
   messages[2] = {
     ...messages[2],
     toolUseResult: 'tool output',
+    imagePermissionToolUseIds: ['toolu_0'],
     content: [firstResult, {
       type: 'image',
       source: { type: 'base64', media_type: 'image/png', data: 'permission-image-data' },
@@ -563,6 +569,102 @@ test('cleared tool results remove embedded inline image payloads', () => {
   expect(getResultBlock(result[2]).content).toEqual([
     { type: 'text', text: '[Old tool result content cleared]' },
   ])
+})
+
+test('preserves an independent image after a cleared tool result', () => {
+  const messages = buildConversation(16, 5_000)
+  const firstResult = getResultBlock(messages[2])
+  firstResult.content = '[Old tool result content cleared]'
+  const image: Block = {
+    type: 'image',
+    source: { type: 'base64', media_type: 'image/png', data: 'user-image-data' },
+  }
+  messages[2] = { ...messages[2], content: [firstResult, image] }
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  expect((result[2].content as Block[])[1]).toEqual(image)
+})
+
+test('omits a permission image after a non-compactable old tool result', () => {
+  const messages = buildConversation(16, 5_000)
+  const toolUse = (messages[1].content as Block[])[0]
+  toolUse.name = 'Task'
+  const firstResult = getResultBlock(messages[2])
+  messages[2] = {
+    ...messages[2],
+    toolUseResult: 'task output',
+    imagePermissionToolUseIds: ['toolu_0'],
+    content: [firstResult, {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'permission-image-data' },
+    }],
+  }
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  expect(getResultText(result[2])).toHaveLength(5_000)
+  expect((result[2].content as Block[])[1]).toEqual({
+    type: 'text', text: '[Inline image omitted from tool history]',
+  })
+})
+
+test('omits a subagent permission image without retaining toolUseResult', () => {
+  const messages = buildConversation(16, 5_000)
+  const toolUse = (messages[1].content as Block[])[0]
+  toolUse.name = 'Task'
+  const firstResult = getResultBlock(messages[2])
+  messages[2] = {
+    ...messages[2],
+    imagePermissionToolUseIds: ['toolu_0'],
+    content: [firstResult, {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'subagent-permission-image' },
+    }],
+  }
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  expect((result[2].content as Block[])[1]).toEqual({
+    type: 'text', text: '[Inline image omitted from tool history]',
+  })
+})
+
+test('omits a rejected-permission image from old tool history', () => {
+  const messages = buildConversation(16, 5_000)
+  const firstResult = getResultBlock(messages[2])
+  firstResult.is_error = true
+  messages[2] = {
+    ...messages[2],
+    imagePermissionToolUseIds: ['toolu_0'],
+    content: [firstResult, {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'rejected-permission-image' },
+    }],
+  }
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  expect((result[2].content as Block[])[1]).toEqual({
+    type: 'text', text: '[Inline image omitted from tool history]',
+  })
+})
+
+test('keeps permission image ownership after parallel results are hoisted', () => {
+  const messages = buildConversation(16, 5_000)
+  const firstResult = getResultBlock(messages[2])
+  const secondResult: Block = {
+    type: 'tool_result', tool_use_id: 'toolu_parallel', content: bigText(5_000),
+  }
+  messages[2] = {
+    ...messages[2],
+    imagePermissionToolUseIds: ['toolu_0'],
+    content: [firstResult, secondResult, {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'parallel-permission-image' },
+    }],
+  }
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  expect((result[2].content as Block[])[2]).toEqual({
+    type: 'text', text: '[Inline image omitted from tool history]',
+  })
 })
 
 test('large window (1M) with 30 exchanges: all untouched (recent=25 ≥ 30 - 5)', () => {

--- a/src/services/api/compressToolHistory.test.ts
+++ b/src/services/api/compressToolHistory.test.ts
@@ -243,6 +243,35 @@ test('mid tier: short content (< MID_MAX_CHARS) untouched', () => {
   }
 })
 
+test('mid tier: preserves structured-part order across multiple text blocks', () => {
+  const messages = buildConversation(10, 5_000)
+  const firstResult = getResultBlock(messages[2])
+  firstResult.content = [
+    { type: 'text', text: 'a'.repeat(1_000) },
+    {
+      type: 'image',
+      source: { type: 'url', url: 'https://example.com/result.png' },
+    },
+    { type: 'text', text: 'b'.repeat(1_500) },
+    { type: 'tool_reference', tool_name: 'mcp__example' },
+  ]
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  const content = getResultBlock(getResultMessages(result)[0]).content as Block[]
+
+  expect(content.map(part => part.type)).toEqual([
+    'text',
+    'image',
+    'text',
+    'tool_reference',
+  ])
+  expect(content[0].text).toBe('a'.repeat(1_000))
+  expect(content[2].text).toBe(
+    `${'b'.repeat(999)}\n[…truncated 501 chars from tool history]`,
+  )
+  expect((firstResult.content as Block[])[2].text).toBe('b'.repeat(1_500))
+})
+
 test('old tier: content replaced with stub [name args={...} → N chars omitted]', () => {
   // 100k → recent=5, mid=10, old=rest. 20 exchanges → 5 old + 10 mid + 5 recent.
   const messages = buildConversation(20, 5_000)
@@ -390,6 +419,17 @@ test('empty content array handled gracefully', () => {
     ...buildConversation(20, 100).slice(1),
   ]
   expect(() => compressToolHistoryForTest(messages, 'gpt-4o')).not.toThrow()
+})
+
+test('old tool_result with empty content array retains an omission stub', () => {
+  const messages = buildConversation(20, 100)
+  const firstResult = getResultBlock(messages[2])
+  firstResult.content = []
+
+  const result = compressToolHistoryForTest(messages, 'gpt-4o')
+  const text = getResultText(getResultMessages(result)[0])
+
+  expect(text).toMatch(/^\[Read args=.*→ 0 chars omitted\]$/)
 })
 
 // ---------- message shape compatibility ----------

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -96,7 +96,7 @@ function extractText(content: unknown): string {
           b?.type === 'text' && typeof b.text === 'string',
       )
       .map((b: { text?: string }) => b.text ?? '')
-      .join('\n')
+      .join('\n\n')
   }
   return ''
 }
@@ -197,7 +197,7 @@ function truncateTextContent(
     if (truncated) continue
 
     const text = (part as { text: string }).text
-    const separatorChars = sawText ? 1 : 0
+    const separatorChars = sawText ? 2 : 0
     sawText = true
     if (remaining <= separatorChars) {
       appendMarker()

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -87,7 +87,7 @@ export function setToolHistoryCompressionEnabledOverrideForTest(
   toolHistoryCompressionEnabledOverrideForTest = enabled
 }
 
-function extractText(content: unknown): string {
+function extractText(content: unknown, separator: string): string {
   if (typeof content === 'string') return content
   if (Array.isArray(content)) {
     return content
@@ -96,7 +96,7 @@ function extractText(content: unknown): string {
           b?.type === 'text' && typeof b.text === 'string',
       )
       .map((b: { text?: string }) => b.text ?? '')
-      .join('\n\n')
+      .join(separator)
   }
   return ''
 }
@@ -170,6 +170,7 @@ function truncateTextContent(
   block: ToolResultBlock,
   maxChars: number,
   originalLength: number,
+  separator: string,
 ): ToolResultBlock {
   const marker = `\n[…truncated ${originalLength - maxChars} chars from tool history]`
   if (!Array.isArray(block.content)) {
@@ -206,7 +207,7 @@ function truncateTextContent(
     if (truncated) continue
 
     const text = (part as { text: string }).text
-    const separatorChars = sawText ? 2 : 0
+    const separatorChars = sawText ? separator.length : 0
     sawText = true
     if (remaining <= separatorChars) {
       appendMarker()
@@ -236,8 +237,9 @@ function truncateTextContent(
 function buildStub(
   block: ToolResultBlock,
   toolUsesById: Map<string, ToolUseBlock>,
+  separator: string,
 ): ToolResultBlock {
-  const original = extractText(block.content)
+  const original = extractText(block.content, separator)
   const toolUse = toolUsesById.get(block.tool_use_id ?? '')
   const name = toolUse?.name ?? 'tool'
   const args = toolUse?.input
@@ -256,11 +258,12 @@ function buildStub(
 function truncateBlock(
   block: ToolResultBlock,
   maxChars: number,
+  separator: string,
 ): ToolResultBlock {
   block = omitInlineBase64Images(block)
-  const text = extractText(block.content)
+  const text = extractText(block.content, separator)
   if (text.length <= maxChars) return block
-  return truncateTextContent(block, maxChars, text.length)
+  return truncateTextContent(block, maxChars, text.length, separator)
 }
 
 function getInner(msg: AnyMessage): { role?: string; content?: unknown } {
@@ -314,7 +317,7 @@ function rewriteMessage<T extends AnyMessage>(
 // Re-compressing produces a stub over a marker (e.g. `[Read args={} → 40
 // chars omitted]`), wasteful and less informative than the canonical marker.
 function isAlreadyCleared(block: ToolResultBlock): boolean {
-  const text = extractText(block.content)
+  const text = extractText(block.content, '\n\n')
   return text === TOOL_RESULT_CLEARED_MESSAGE
 }
 
@@ -336,7 +339,10 @@ function shouldCompressBlock(
 export function compressToolHistory<T extends AnyMessage>(
   messages: T[],
   model: string,
-  options: { effectiveContextWindowSize?: number } = {},
+  options: {
+    effectiveContextWindowSize?: number
+    textBlockSeparator?: string
+  } = {},
 ): T[] {
   // Master kill-switch. Returns the original reference so callers skip a
   // defensive copy when the feature is disabled.
@@ -348,6 +354,7 @@ export function compressToolHistory<T extends AnyMessage>(
   const tiers = getTiers(
     options.effectiveContextWindowSize ?? getEffectiveContextWindowSize(model),
   )
+  const textBlockSeparator = options.textBlockSeparator ?? '\n\n'
 
   const toolResults = indexToolResults(messages)
   const total = toolResults.length
@@ -398,8 +405,8 @@ export function compressToolHistory<T extends AnyMessage>(
       const tr = block as ToolResultBlock
       if (!shouldCompressBlock(tr, toolUsesById)) return block
       return fromEnd < tiers.recent + tiers.mid
-        ? truncateBlock(tr, MID_MAX_CHARS)
-        : buildStub(tr, toolUsesById)
+        ? truncateBlock(tr, MID_MAX_CHARS, textBlockSeparator)
+        : buildStub(tr, toolUsesById, textBlockSeparator)
     })
 
     return rewriteMessage(msg, newContent)

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -97,6 +97,103 @@ function extractText(content: unknown): string {
   return ''
 }
 
+function replaceTextContent(
+  block: ToolResultBlock,
+  replacementText: string,
+): ToolResultBlock {
+  if (!Array.isArray(block.content)) {
+    return {
+      ...block,
+      content: [{ type: 'text', text: replacementText }],
+    }
+  }
+
+  let replacedText = false
+  const content = block.content.flatMap(part => {
+    if (
+      part &&
+      typeof part === 'object' &&
+      (part as { type?: string }).type === 'text'
+    ) {
+      if (replacedText) return []
+      replacedText = true
+      return [{ ...part, text: replacementText }]
+    }
+    return [part]
+  })
+
+  if (!replacedText && content.length === 0) {
+    return {
+      ...block,
+      content: [{ type: 'text', text: replacementText }],
+    }
+  }
+
+  return { ...block, content }
+}
+
+function truncateTextContent(
+  block: ToolResultBlock,
+  maxChars: number,
+  originalLength: number,
+): ToolResultBlock {
+  const marker = `\n[…truncated ${originalLength - maxChars} chars from tool history]`
+  if (!Array.isArray(block.content)) {
+    const text = typeof block.content === 'string' ? block.content : ''
+    return {
+      ...block,
+      content: [{ type: 'text', text: `${text.slice(0, maxChars)}${marker}` }],
+    }
+  }
+
+  const content: unknown[] = []
+  let remaining = maxChars
+  let sawText = false
+  let truncated = false
+  let lastTextIndex = -1
+
+  const appendMarker = (): void => {
+    const part = content[lastTextIndex] as { text?: string } | undefined
+    if (part && typeof part.text === 'string') {
+      content[lastTextIndex] = { ...part, text: `${part.text}${marker}` }
+    }
+  }
+
+  for (const part of block.content) {
+    if (
+      !part ||
+      typeof part !== 'object' ||
+      (part as { type?: string }).type !== 'text' ||
+      typeof (part as { text?: unknown }).text !== 'string'
+    ) {
+      content.push(part)
+      continue
+    }
+    if (truncated) continue
+
+    const text = (part as { text: string }).text
+    const separatorChars = sawText ? 1 : 0
+    sawText = true
+    if (remaining <= separatorChars) {
+      appendMarker()
+      truncated = true
+      continue
+    }
+
+    remaining -= separatorChars
+    const retained = text.slice(0, remaining)
+    remaining -= retained.length
+    content.push({ ...part, text: retained })
+    lastTextIndex = content.length - 1
+    if (retained.length < text.length || remaining === 0) {
+      appendMarker()
+      truncated = true
+    }
+  }
+
+  return { ...block, content }
+}
+
 // Old-tier compression strategy. Replaces content entirely with a one-line
 // metadata marker ~10× more token-efficient than a 500-char truncation AND
 // unambiguous — partial truncations can look authoritative to the model. The
@@ -112,15 +209,10 @@ function buildStub(
   const args = toolUse?.input
     ? JSON.stringify(toolUse.input).slice(0, STUB_ARGS_MAX_CHARS)
     : '{}'
-  return {
-    ...block,
-    content: [
-      {
-        type: 'text',
-        text: `[${name} args=${args} → ${original.length} chars omitted]`,
-      },
-    ],
-  }
+  return replaceTextContent(
+    block,
+    `[${name} args=${args} → ${original.length} chars omitted]`,
+  )
 }
 
 // Mid-tier compression. The trailing marker is load-bearing: without it, the
@@ -133,16 +225,7 @@ function truncateBlock(
 ): ToolResultBlock {
   const text = extractText(block.content)
   if (text.length <= maxChars) return block
-  const omitted = text.length - maxChars
-  return {
-    ...block,
-    content: [
-      {
-        type: 'text',
-        text: `${text.slice(0, maxChars)}\n[…truncated ${omitted} chars from tool history]`,
-      },
-    ],
-  }
+  return truncateTextContent(block, maxChars, text.length)
 }
 
 function getInner(msg: AnyMessage): { role?: string; content?: unknown } {

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -35,14 +35,15 @@ const MID_MAX_CHARS = 2_000
 // here keeps the stub size bounded even when callers pass oversized arguments.
 const STUB_ARGS_MAX_CHARS = 200
 
-// Inline base64 image blocks can be megabytes long. Older tool history must
-// not retain that payload merely because it is structured rather than text.
+// Inline image payloads can be megabytes long. Older tool history must not
+// retain them merely because they are structured rather than text.
 const OMITTED_INLINE_IMAGE_MARKER = '[Inline image omitted from tool history]'
 
 type AnyMessage = {
   role?: string
   message?: { role?: string; content?: unknown }
   content?: unknown
+  toolUseResult?: unknown
 }
 
 type ToolResultBlock = {
@@ -101,26 +102,23 @@ function extractText(content: unknown, separator: string): string {
   return ''
 }
 
-function isInlineBase64Image(part: unknown): boolean {
+function isInlineImagePayload(part: unknown): boolean {
   if (!part || typeof part !== 'object' || (part as { type?: string }).type !== 'image') {
     return false
   }
 
   const source = (part as { source?: { type?: string; url?: string } }).source
   return source?.type === 'base64' ||
-    (
-      source?.type === 'url' &&
-      typeof source.url === 'string' &&
-      /^data:image\/[^,]*;base64,/i.test(source.url)
-    )
+    (source?.type === 'url' && typeof source.url === 'string' &&
+      /^data:image\//i.test(source.url))
 }
 
-function omitInlineBase64Images(block: ToolResultBlock): ToolResultBlock {
+function omitInlineImagePayloads(block: ToolResultBlock): ToolResultBlock {
   if (!Array.isArray(block.content)) return block
 
   let omittedImage = false
   const content = block.content.map(part => {
-    if (isInlineBase64Image(part)) {
+    if (isInlineImagePayload(part)) {
       omittedImage = true
       return { type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }
     }
@@ -130,11 +128,17 @@ function omitInlineBase64Images(block: ToolResultBlock): ToolResultBlock {
   return omittedImage ? { ...block, content } : block
 }
 
+function sanitizeClearedBlock(block: ToolResultBlock): ToolResultBlock {
+  if (!Array.isArray(block.content)) return block
+  const content = block.content.filter(part => !isInlineImagePayload(part))
+  return content.length === block.content.length ? block : { ...block, content }
+}
+
 function replaceTextContent(
   block: ToolResultBlock,
   replacementText: string,
 ): ToolResultBlock {
-  block = omitInlineBase64Images(block)
+  block = omitInlineImagePayloads(block)
   if (!Array.isArray(block.content)) {
     return {
       ...block,
@@ -260,7 +264,7 @@ function truncateBlock(
   maxChars: number,
   separator: string,
 ): ToolResultBlock {
-  block = omitInlineBase64Images(block)
+  block = omitInlineImagePayloads(block)
   const text = extractText(block.content, separator)
   if (text.length <= maxChars) return block
   return truncateTextContent(block, maxChars, text.length, separator)
@@ -384,27 +388,25 @@ export function compressToolHistory<T extends AnyMessage>(
     if (firstPos === undefined || total - 1 - firstPos < tiers.recent) return msg
 
     const content = getInner(msg).content as unknown[]
-    // Tool execution appends permission-decision content blocks after the
-    // owning tool result. Keep an independent user image that precedes a
-    // result, but bound inline images attached to an old/mid result.
+    const ownsFollowingPermissionBlocks = msg.toolUseResult !== undefined
     let omitFollowingInlineImages = false
     const newContent = content.map((block, blockIndex) => {
-      if (isInlineBase64Image(block) && omitFollowingInlineImages) {
+      if (isInlineImagePayload(block) && omitFollowingInlineImages) {
         return { type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }
       }
 
       const pos = positions.get(blockIndex)
       if (pos === undefined) return block
-      // A new result starts a new ownership span. This matters for a large
-      // parallel batch that crosses a tier boundary: an image following a
-      // recent result must not inherit omission from an older sibling.
-      omitFollowingInlineImages = false
       const fromEnd = total - 1 - pos
       if (fromEnd < tiers.recent) return block
 
       const tr = block as ToolResultBlock
+      if (isAlreadyCleared(tr)) {
+        omitFollowingInlineImages = true
+        return sanitizeClearedBlock(tr)
+      }
       if (!shouldCompressBlock(tr, toolUsesById)) return block
-      omitFollowingInlineImages = true
+      omitFollowingInlineImages = ownsFollowingPermissionBlocks
       return fromEnd < tiers.recent + tiers.mid
         ? truncateBlock(tr, MID_MAX_CHARS, textBlockSeparator)
         : buildStub(tr, toolUsesById, textBlockSeparator)

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -101,10 +101,31 @@ function extractText(content: unknown): string {
   return ''
 }
 
+function omitInlineBase64Images(block: ToolResultBlock): ToolResultBlock {
+  if (!Array.isArray(block.content)) return block
+
+  let omittedImage = false
+  const content = block.content.map(part => {
+    if (
+      part &&
+      typeof part === 'object' &&
+      (part as { type?: string }).type === 'image' &&
+      (part as { source?: { type?: string } }).source?.type === 'base64'
+    ) {
+      omittedImage = true
+      return { type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }
+    }
+    return part
+  })
+
+  return omittedImage ? { ...block, content } : block
+}
+
 function replaceTextContent(
   block: ToolResultBlock,
   replacementText: string,
 ): ToolResultBlock {
+  block = omitInlineBase64Images(block)
   if (!Array.isArray(block.content)) {
     return {
       ...block,
@@ -114,14 +135,6 @@ function replaceTextContent(
 
   let replacedText = false
   const content = block.content.flatMap(part => {
-    if (
-      part &&
-      typeof part === 'object' &&
-      (part as { type?: string }).type === 'image' &&
-      (part as { source?: { type?: string } }).source?.type === 'base64'
-    ) {
-      return [{ type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }]
-    }
     if (
       part &&
       typeof part === 'object' &&
@@ -235,6 +248,7 @@ function truncateBlock(
   block: ToolResultBlock,
   maxChars: number,
 ): ToolResultBlock {
+  block = omitInlineBase64Images(block)
   const text = extractText(block.content)
   if (text.length <= maxChars) return block
   return truncateTextContent(block, maxChars, text.length)

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -35,6 +35,10 @@ const MID_MAX_CHARS = 2_000
 // here keeps the stub size bounded even when callers pass oversized arguments.
 const STUB_ARGS_MAX_CHARS = 200
 
+// Inline base64 image blocks can be megabytes long. Older tool history must
+// not retain that payload merely because it is structured rather than text.
+const OMITTED_INLINE_IMAGE_MARKER = '[Inline image omitted from tool history]'
+
 type AnyMessage = {
   role?: string
   message?: { role?: string; content?: unknown }
@@ -110,6 +114,14 @@ function replaceTextContent(
 
   let replacedText = false
   const content = block.content.flatMap(part => {
+    if (
+      part &&
+      typeof part === 'object' &&
+      (part as { type?: string }).type === 'image' &&
+      (part as { source?: { type?: string } }).source?.type === 'base64'
+    ) {
+      return [{ type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }]
+    }
     if (
       part &&
       typeof part === 'object' &&

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -377,7 +377,12 @@ export function compressToolHistory<T extends AnyMessage>(
     if (firstPos === undefined || total - 1 - firstPos < tiers.recent) return msg
 
     const content = getInner(msg).content as unknown[]
+    let omitSiblingInlineImages = false
     const newContent = content.map((block, blockIndex) => {
+      if (isInlineBase64Image(block) && omitSiblingInlineImages) {
+        return { type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }
+      }
+
       const pos = positions.get(blockIndex)
       if (pos === undefined) return block
       const fromEnd = total - 1 - pos
@@ -387,6 +392,7 @@ export function compressToolHistory<T extends AnyMessage>(
       if (b?.type !== 'tool_result') return block
       const tr = block as ToolResultBlock
       if (!shouldCompressBlock(tr, toolUsesById)) return block
+      omitSiblingInlineImages = true
       return fromEnd < tiers.recent + tiers.mid
         ? truncateBlock(tr, MID_MAX_CHARS)
         : buildStub(tr, toolUsesById)

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -44,6 +44,7 @@ type AnyMessage = {
   message?: { role?: string; content?: unknown }
   content?: unknown
   toolUseResult?: unknown
+  imagePermissionToolUseIds?: Array<string | null>
 }
 
 type ToolResultBlock = {
@@ -388,11 +389,21 @@ export function compressToolHistory<T extends AnyMessage>(
     if (firstPos === undefined || total - 1 - firstPos < tiers.recent) return msg
 
     const content = getInner(msg).content as unknown[]
-    const ownsFollowingPermissionBlocks = msg.toolUseResult !== undefined
-    let omitFollowingInlineImages = false
+    const pendingImagePermissionToolUseIds = [
+      ...(msg.imagePermissionToolUseIds ?? []),
+    ]
+    const omittedPermissionImageToolUseIds = new Set<string>()
     const newContent = content.map((block, blockIndex) => {
-      if (isInlineImagePayload(block) && omitFollowingInlineImages) {
-        return { type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }
+      if ((block as { type?: string })?.type === 'image') {
+        const toolUseId = pendingImagePermissionToolUseIds.shift()
+        if (
+          toolUseId &&
+          omittedPermissionImageToolUseIds.has(toolUseId) &&
+          isInlineImagePayload(block)
+        ) {
+          return { type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }
+        }
+        return block
       }
 
       const pos = positions.get(blockIndex)
@@ -401,12 +412,11 @@ export function compressToolHistory<T extends AnyMessage>(
       if (fromEnd < tiers.recent) return block
 
       const tr = block as ToolResultBlock
+      if (tr.tool_use_id) omittedPermissionImageToolUseIds.add(tr.tool_use_id)
       if (isAlreadyCleared(tr)) {
-        omitFollowingInlineImages = true
         return sanitizeClearedBlock(tr)
       }
       if (!shouldCompressBlock(tr, toolUsesById)) return block
-      omitFollowingInlineImages = ownsFollowingPermissionBlocks
       return fromEnd < tiers.recent + tiers.mid
         ? truncateBlock(tr, MID_MAX_CHARS, textBlockSeparator)
         : buildStub(tr, toolUsesById, textBlockSeparator)

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -246,18 +246,19 @@ function indexToolUses(messages: AnyMessage[]): Map<string, ToolUseBlock> {
   return map
 }
 
-function indexToolResultMessages(messages: AnyMessage[]): number[] {
-  const indices: number[] = []
+function indexToolResults(
+  messages: AnyMessage[],
+): Array<{ messageIndex: number; blockIndex: number }> {
+  const indices: Array<{ messageIndex: number; blockIndex: number }> = []
   for (let i = 0; i < messages.length; i++) {
     const inner = getInner(messages[i])
     const role = inner.role ?? messages[i].role
     const content = inner.content
-    if (
-      role === 'user' &&
-      Array.isArray(content) &&
-      content.some((b: { type?: string }) => b?.type === 'tool_result')
-    ) {
-      indices.push(i)
+    if (role !== 'user' || !Array.isArray(content)) continue
+    for (let blockIndex = 0; blockIndex < content.length; blockIndex++) {
+      if ((content[blockIndex] as { type?: string })?.type === 'tool_result') {
+        indices.push({ messageIndex: i, blockIndex })
+      }
     }
   }
   return indices
@@ -313,36 +314,45 @@ export function compressToolHistory<T extends AnyMessage>(
     options.effectiveContextWindowSize ?? getEffectiveContextWindowSize(model),
   )
 
-  const toolResultIndices = indexToolResultMessages(messages)
-  const total = toolResultIndices.length
+  const toolResults = indexToolResults(messages)
+  const total = toolResults.length
   // If every tool-result fits in the recent tier, no boundary crosses; return
   // the same reference for the same copy-elision reason.
   if (total <= tiers.recent) return messages
 
-  // O(1) lookup: messageIndex → tool-result position (0 = oldest). Replaces
-  // the naive Array.indexOf(i) that was O(n²) across the .map below.
-  const positionByIndex = new Map<number, number>()
-  for (let pos = 0; pos < toolResultIndices.length; pos++) {
-    positionByIndex.set(toolResultIndices[pos], pos)
+  // O(1) lookup within each carrier message: blockIndex → tool-result position
+  // (0 = oldest). Parallel results share a message but receive distinct tiers.
+  const positionsByMessage = new Map<number, Map<number, number>>()
+  for (let pos = 0; pos < toolResults.length; pos++) {
+    const { messageIndex, blockIndex } = toolResults[pos]
+    let positions = positionsByMessage.get(messageIndex)
+    if (!positions) {
+      positions = new Map<number, number>()
+      positionsByMessage.set(messageIndex, positions)
+    }
+    positions.set(blockIndex, pos)
   }
 
   const toolUsesById = indexToolUses(messages)
 
   return messages.map((msg, i) => {
-    const pos = positionByIndex.get(i)
-    if (pos === undefined) return msg
+    const positions = positionsByMessage.get(i)
+    if (!positions) return msg
+    const firstPos = positions.values().next().value
+    if (firstPos === undefined || total - 1 - firstPos < tiers.recent) return msg
 
-    const fromEnd = total - 1 - pos
-    if (fromEnd < tiers.recent) return msg
-
-    const inMidWindow = fromEnd < tiers.recent + tiers.mid
     const content = getInner(msg).content as unknown[]
-    const newContent = content.map(block => {
+    const newContent = content.map((block, blockIndex) => {
+      const pos = positions.get(blockIndex)
+      if (pos === undefined) return block
+      const fromEnd = total - 1 - pos
+      if (fromEnd < tiers.recent) return block
+
       const b = block as { type?: string }
       if (b?.type !== 'tool_result') return block
       const tr = block as ToolResultBlock
       if (!shouldCompressBlock(tr, toolUsesById)) return block
-      return inMidWindow
+      return fromEnd < tiers.recent + tiers.mid
         ? truncateBlock(tr, MID_MAX_CHARS)
         : buildStub(tr, toolUsesById)
     })

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -384,26 +384,27 @@ export function compressToolHistory<T extends AnyMessage>(
     if (firstPos === undefined || total - 1 - firstPos < tiers.recent) return msg
 
     const content = getInner(msg).content as unknown[]
-    const omitSiblingInlineImages = content.some((block, blockIndex) => {
-      const pos = positions.get(blockIndex)
-      if (pos === undefined || total - 1 - pos < tiers.recent) return false
-      if ((block as { type?: string })?.type !== 'tool_result') return false
-      return shouldCompressBlock(block as ToolResultBlock, toolUsesById)
-    })
+    // Tool execution appends permission-decision content blocks after the
+    // owning tool result. Keep an independent user image that precedes a
+    // result, but bound inline images attached to an old/mid result.
+    let omitFollowingInlineImages = false
     const newContent = content.map((block, blockIndex) => {
-      if (isInlineBase64Image(block) && omitSiblingInlineImages) {
+      if (isInlineBase64Image(block) && omitFollowingInlineImages) {
         return { type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }
       }
 
       const pos = positions.get(blockIndex)
       if (pos === undefined) return block
+      // A new result starts a new ownership span. This matters for a large
+      // parallel batch that crosses a tier boundary: an image following a
+      // recent result must not inherit omission from an older sibling.
+      omitFollowingInlineImages = false
       const fromEnd = total - 1 - pos
       if (fromEnd < tiers.recent) return block
 
-      const b = block as { type?: string }
-      if (b?.type !== 'tool_result') return block
       const tr = block as ToolResultBlock
       if (!shouldCompressBlock(tr, toolUsesById)) return block
+      omitFollowingInlineImages = true
       return fromEnd < tiers.recent + tiers.mid
         ? truncateBlock(tr, MID_MAX_CHARS, textBlockSeparator)
         : buildStub(tr, toolUsesById, textBlockSeparator)

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -101,17 +101,26 @@ function extractText(content: unknown): string {
   return ''
 }
 
+function isInlineBase64Image(part: unknown): boolean {
+  if (!part || typeof part !== 'object' || (part as { type?: string }).type !== 'image') {
+    return false
+  }
+
+  const source = (part as { source?: { type?: string; url?: string } }).source
+  return source?.type === 'base64' ||
+    (
+      source?.type === 'url' &&
+      typeof source.url === 'string' &&
+      /^data:image\/[^;,]+;base64,/i.test(source.url)
+    )
+}
+
 function omitInlineBase64Images(block: ToolResultBlock): ToolResultBlock {
   if (!Array.isArray(block.content)) return block
 
   let omittedImage = false
   const content = block.content.map(part => {
-    if (
-      part &&
-      typeof part === 'object' &&
-      (part as { type?: string }).type === 'image' &&
-      (part as { source?: { type?: string } }).source?.type === 'base64'
-    ) {
+    if (isInlineBase64Image(part)) {
       omittedImage = true
       return { type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }
     }

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -111,7 +111,7 @@ function isInlineBase64Image(part: unknown): boolean {
     (
       source?.type === 'url' &&
       typeof source.url === 'string' &&
-      /^data:image\/[^;,]+;base64,/i.test(source.url)
+      /^data:image\/[^,]*;base64,/i.test(source.url)
     )
 }
 

--- a/src/services/api/compressToolHistory.ts
+++ b/src/services/api/compressToolHistory.ts
@@ -377,7 +377,12 @@ export function compressToolHistory<T extends AnyMessage>(
     if (firstPos === undefined || total - 1 - firstPos < tiers.recent) return msg
 
     const content = getInner(msg).content as unknown[]
-    let omitSiblingInlineImages = false
+    const omitSiblingInlineImages = content.some((block, blockIndex) => {
+      const pos = positions.get(blockIndex)
+      if (pos === undefined || total - 1 - pos < tiers.recent) return false
+      if ((block as { type?: string })?.type !== 'tool_result') return false
+      return shouldCompressBlock(block as ToolResultBlock, toolUsesById)
+    })
     const newContent = content.map((block, blockIndex) => {
       if (isInlineBase64Image(block) && omitSiblingInlineImages) {
         return { type: 'text', text: OMITTED_INLINE_IMAGE_MARKER }
@@ -392,7 +397,6 @@ export function compressToolHistory<T extends AnyMessage>(
       if (b?.type !== 'tool_result') return block
       const tr = block as ToolResultBlock
       if (!shouldCompressBlock(tr, toolUsesById)) return block
-      omitSiblingInlineImages = true
       return fromEnd < tiers.recent + tiers.mid
         ? truncateBlock(tr, MID_MAX_CHARS)
         : buildStub(tr, toolUsesById)

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -530,6 +530,39 @@ test('FIX: 32k window tier → recent=3 keeps last 3 only', async () => {
   }
 })
 
+test('Chat compression omits old inline base64 image payloads', async () => {
+  mockState.enabled = true
+  mockState.effectiveWindow = 100_000
+  const imageData = 'a'.repeat(100_000)
+  const messages = buildLongConversation(30, 5_000)
+  messages[2] = {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_0',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: imageData,
+            },
+          },
+        ],
+      },
+    ],
+  }
+
+  const body = await captureRequestBody(messages, MID_TIER_MODEL)
+  const firstOutput = getToolMessages(body)[0]?.content
+
+  expect(firstOutput).toContain('[Inline image omitted from tool history]')
+  expect(JSON.stringify(body)).not.toContain(imageData)
+  expect(JSON.stringify(body).length).toBeLessThan(100_000)
+})
+
 test('Responses compression preserves structured history and materially reduces the payload', async () => {
   mockState.effectiveWindow = 100_000
   const messages = buildStructuredLongConversation()

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -571,6 +571,75 @@ test('Responses compression preserves structured history and materially reduces 
   expect(compressedSize).toBeLessThan(uncompressedSize * 0.5)
 })
 
+test('Responses compression preserves structured parts while compressing old and mid text', async () => {
+  mockState.enabled = true
+  mockState.effectiveWindow = 100_000
+  const messages = buildLongConversation(30, 5_000)
+  messages[2] = {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_0',
+        content: [
+          {
+            type: 'image',
+            source: { type: 'url', url: 'https://example.com/old-image.png' },
+          },
+        ],
+      },
+    ],
+  }
+  messages[4] = {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_1',
+        content: [
+          { type: 'text', text: 'Screenshot from the old result.' },
+          {
+            type: 'image',
+            source: { type: 'url', url: 'https://example.com/mixed-result.png' },
+          },
+        ],
+      },
+    ],
+  }
+  messages[32] = {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_15',
+        content: [
+          { type: 'text', text: bigText(5_000) },
+          {
+            type: 'image',
+            source: { type: 'url', url: 'https://example.com/mid-result.png' },
+          },
+        ],
+      },
+    ],
+  }
+
+  const body = await captureResponsesRequestBody(messages, MID_TIER_MODEL)
+  const outputs = new Map(
+    getResponsesFunctionOutputs(body).map(item => [item.call_id, item.output ?? '']),
+  )
+  const oldMixedOutput = outputs.get('toolu_1') ?? ''
+  const midMixedOutput = outputs.get('toolu_15') ?? ''
+
+  expect(outputs.get('toolu_0')).toBe('[Image](https://example.com/old-image.png)')
+  expect(outputs.get('toolu_0')).not.toContain('chars omitted')
+  expect(oldMixedOutput).toMatch(/^\[Read args=.*31 chars omitted\]/)
+  expect(oldMixedOutput).toContain('[Image](https://example.com/mixed-result.png)')
+  expect(oldMixedOutput.length).toBeLessThan(200)
+  expect(midMixedOutput).toContain('[…truncated 3000 chars from tool history]')
+  expect(midMixedOutput).toContain('[Image](https://example.com/mid-result.png)')
+  expect(midMixedOutput.length).toBeLessThan(2_200)
+})
+
 test('Responses local fast path preserves the uncompressed request', async () => {
   mockState.enabled = true
   mockState.effectiveWindow = 100_000

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -572,11 +572,30 @@ test('Chat compression omits old and mid-tier inline image payloads', async () =
       },
     ],
   }
+  messages[4] = {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_1',
+        content: bigText(5_000),
+      },
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: imageData,
+        },
+      },
+    ],
+  }
 
   const body = await captureRequestBody(messages, MID_TIER_MODEL)
   const toolOutputs = getToolMessages(body).map(message => message.content)
 
   expect(toolOutputs[0]).toContain('0 chars omitted')
+  expect(toolOutputs[1]).toContain('5000 chars omitted')
   expect(toolOutputs[15]).toContain('[Inline image omitted from tool history]')
   expect(JSON.stringify(body)).not.toContain(imageData)
   expect(JSON.stringify(body).length).toBeLessThan(100_000)
@@ -661,8 +680,8 @@ test('Responses compression preserves structured history and materially reduces 
     item => item.content ?? [],
   )
   expect(inputParts).toContainEqual({
-    type: 'input_image',
-    image_url: 'data:image/png;base64,aGVsbG8=',
+    type: 'input_text',
+    text: '[Inline image omitted from tool history]',
   })
   expect(inputParts).toContainEqual({
     type: 'input_text',

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, expect, test } from 'bun:test'
 import { getGlobalConfig, saveGlobalConfig } from '../../utils/config.js'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
 import { setToolHistoryCompressionEnabledOverrideForTest } from './compressToolHistory.js'
-import { createOpenAIShimClient } from './openaiShim.js'
+import { __test, createOpenAIShimClient } from './openaiShim.js'
 
 type FetchType = typeof globalThis.fetch
 const originalFetch = globalThis.fetch
@@ -14,7 +14,12 @@ const originalEnv = {
   CLAUDE_CODE_MAX_OUTPUT_TOKENS: process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS,
   OPENAI_BASE_URL: process.env.OPENAI_BASE_URL,
   OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  OPENAI_API_FORMAT: process.env.OPENAI_API_FORMAT,
   OPENAI_MODEL: process.env.OPENAI_MODEL,
+  CLAUDE_CODE_USE_GITHUB: process.env.CLAUDE_CODE_USE_GITHUB,
+  GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+  OPENCLAUDE_LOCAL_FAST_PATH: process.env.OPENCLAUDE_LOCAL_FAST_PATH,
+  OPENCODE_API_KEY: process.env.OPENCODE_API_KEY,
 }
 
 const originalConfig = {
@@ -126,6 +131,24 @@ function makeFakeResponse(): Response {
   )
 }
 
+function makeFakeResponsesResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: 'resp-1',
+      model: 'gpt-5.4',
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'done' }],
+        },
+      ],
+      usage: { input_tokens: 8, output_tokens: 2, total_tokens: 10 },
+    }),
+    { headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
 beforeEach(async () => {
   await acquireSharedMutationLock('openaiShim.compression.test.ts')
   setCompressionEnabledForTest(true)
@@ -133,6 +156,11 @@ beforeEach(async () => {
   process.env.OPENAI_BASE_URL = 'http://example.test/v1'
   process.env.OPENAI_API_KEY = 'test-key'
   delete process.env.OPENAI_MODEL
+  delete process.env.OPENAI_API_FORMAT
+  delete process.env.CLAUDE_CODE_USE_GITHUB
+  delete process.env.GITHUB_TOKEN
+  delete process.env.OPENCLAUDE_LOCAL_FAST_PATH
+  delete process.env.OPENCODE_API_KEY
 })
 
 afterEach(() => {
@@ -177,6 +205,36 @@ async function captureRequestBody(
   return captured
 }
 
+async function captureResponsesRequestBody(
+  messages: Array<{ role: string; content: unknown }>,
+  model: string,
+  options: {
+    apiFormat?: 'responses' | 'responses_compat'
+    baseUrl?: string
+  } = {},
+): Promise<Record<string, unknown>> {
+  setCompressionEnabledForTest(mockState.enabled)
+  setEffectiveWindowForTest(mockState.effectiveWindow)
+  process.env.OPENAI_API_FORMAT = options.apiFormat ?? 'responses'
+  process.env.OPENAI_BASE_URL = options.baseUrl ?? 'http://example.test/v1'
+  let captured: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    captured = JSON.parse(String(init?.body))
+    return makeFakeResponsesResponse()
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model,
+    system: 'system prompt',
+    messages,
+  })
+
+  if (!captured) throw new Error('Responses request not captured')
+  return captured
+}
+
 function getToolMessages(body: Record<string, unknown>): Array<{ content: string }> {
   const messages = body.messages as Array<{ role: string; content: string }>
   return messages.filter(m => m.role === 'tool')
@@ -190,6 +248,89 @@ function getAssistantToolCalls(body: Record<string, unknown>): unknown[] {
   return messages
     .filter(m => m.role === 'assistant' && Array.isArray(m.tool_calls))
     .flatMap(m => m.tool_calls ?? [])
+}
+
+type ResponsesInputItem = {
+  type: string
+  role?: string
+  id?: string
+  call_id?: string
+  name?: string
+  output?: string
+  content?: Array<{ type?: string; text?: string; image_url?: string }>
+}
+
+function getResponsesInput(body: Record<string, unknown>): ResponsesInputItem[] {
+  return body.input as ResponsesInputItem[]
+}
+
+function getResponsesFunctionCalls(body: Record<string, unknown>): ResponsesInputItem[] {
+  return getResponsesInput(body).filter(item => item.type === 'function_call')
+}
+
+function getResponsesFunctionOutputs(body: Record<string, unknown>): ResponsesInputItem[] {
+  return getResponsesInput(body).filter(item => item.type === 'function_call_output')
+}
+
+function buildStructuredLongConversation(resultLength = 5_000) {
+  const messages = buildLongConversation(30, resultLength)
+
+  messages[2] = {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_0',
+        content: '[Old tool result content cleared]',
+      },
+    ],
+  }
+
+  messages[33] = {
+    role: 'assistant',
+    content: [
+      { type: 'text', text: 'Checking both files.' },
+      {
+        type: 'tool_use',
+        id: 'toolu_16',
+        name: 'Read',
+        input: { file_path: '/path/to/file16.ts' },
+      },
+      { type: 'text', text: 'The second file is related.' },
+      {
+        type: 'tool_use',
+        id: 'toolu_16_extra',
+        name: 'Read',
+        input: { file_path: '/path/to/extra16.ts' },
+      },
+    ],
+  }
+  messages[34] = {
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Keep the screenshot with the results.' },
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_16',
+        content: bigText(resultLength),
+      },
+      {
+        type: 'image',
+        source: {
+          type: 'base64',
+          media_type: 'image/png',
+          data: 'aGVsbG8=',
+        },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_16_extra',
+        content: bigText(resultLength),
+      },
+    ],
+  }
+
+  return messages
 }
 
 // ============================================================================
@@ -356,4 +497,351 @@ test('FIX: 32k window tier → recent=3 keeps last 3 only', async () => {
   for (let i = 12; i <= 14; i++) {
     expect(toolMessages[i].content.length).toBe(3_000)
   }
+})
+
+test('Responses compression preserves structured history and materially reduces the payload', async () => {
+  mockState.effectiveWindow = 100_000
+  const messages = buildStructuredLongConversation()
+
+  mockState.enabled = false
+  const uncompressedBody = await captureResponsesRequestBody(messages, MID_TIER_MODEL)
+  const uncompressedOutputs = getResponsesFunctionOutputs(uncompressedBody)
+  const uncompressedByCallId = new Map(
+    uncompressedOutputs.map(item => [item.call_id, item.output ?? '']),
+  )
+  const uncompressedSize = JSON.stringify(uncompressedBody).length
+
+  expect(uncompressedBody).toHaveProperty('input')
+  expect(uncompressedBody).not.toHaveProperty('messages')
+  expect(uncompressedByCallId.get('toolu_1')).toHaveLength(5_000)
+  expect(uncompressedByCallId.get('toolu_1')).not.toContain('[…truncated')
+  expect(uncompressedByCallId.get('toolu_1')).not.toContain('chars omitted')
+
+  mockState.enabled = true
+  const compressedBody = await captureResponsesRequestBody(messages, MID_TIER_MODEL)
+  const functionCalls = getResponsesFunctionCalls(compressedBody)
+  const functionOutputs = getResponsesFunctionOutputs(compressedBody)
+  const compressedByCallId = new Map(
+    functionOutputs.map(item => [item.call_id, item.output ?? '']),
+  )
+  const compressedSize = JSON.stringify(compressedBody).length
+
+  expect(compressedBody).toHaveProperty('input')
+  expect(compressedBody).not.toHaveProperty('messages')
+  expect(functionCalls).toHaveLength(31)
+  expect(functionOutputs).toHaveLength(31)
+  expect(functionCalls.map(item => item.call_id)).toEqual(
+    functionOutputs.map(item => item.call_id),
+  )
+
+  expect(compressedByCallId.get('toolu_0')).toBe(
+    '[Old tool result content cleared]',
+  )
+  for (let i = 1; i <= 14; i++) {
+    expect(compressedByCallId.get(`toolu_${i}`)).toMatch(
+      /^\[Read args=.*chars omitted\]$/,
+    )
+  }
+  for (let i = 15; i <= 24; i++) {
+    expect(compressedByCallId.get(`toolu_${i}`)).toContain('[…truncated')
+  }
+  expect(compressedByCallId.get('toolu_16_extra')).toContain('[…truncated')
+  for (let i = 25; i <= 29; i++) {
+    expect(compressedByCallId.get(`toolu_${i}`)).toHaveLength(5_000)
+    expect(compressedByCallId.get(`toolu_${i}`)).not.toContain('[…truncated')
+    expect(compressedByCallId.get(`toolu_${i}`)).not.toContain('chars omitted')
+  }
+
+  const inputParts = getResponsesInput(compressedBody).flatMap(
+    item => item.content ?? [],
+  )
+  expect(inputParts).toContainEqual({
+    type: 'input_image',
+    image_url: 'data:image/png;base64,aGVsbG8=',
+  })
+  expect(inputParts).toContainEqual({
+    type: 'input_text',
+    text: 'Keep the screenshot with the results.',
+  })
+  expect(inputParts).toContainEqual({
+    type: 'output_text',
+    text: 'Checking both files.',
+  })
+
+  expect(compressedSize).toBeLessThan(uncompressedSize * 0.5)
+})
+
+test('Responses local fast path preserves the uncompressed request', async () => {
+  mockState.enabled = true
+  mockState.effectiveWindow = 100_000
+  const body = await captureResponsesRequestBody(
+    buildLongConversation(30, 5_000),
+    MID_TIER_MODEL,
+    { baseUrl: 'http://localhost:8000/v1' },
+  )
+  const outputs = getResponsesFunctionOutputs(body)
+
+  expect(body).toHaveProperty('input')
+  expect(body).not.toHaveProperty('messages')
+  expect(outputs).toHaveLength(30)
+  expect(outputs[0]?.output).toHaveLength(5_000)
+  expect(outputs[0]?.output).not.toContain('[…truncated')
+  expect(outputs[0]?.output).not.toContain('chars omitted')
+  expect(JSON.stringify(body).length).toBeGreaterThan(150_000)
+})
+
+test('responses_compat keeps text content types while compressing tool outputs', async () => {
+  mockState.enabled = true
+  mockState.effectiveWindow = 100_000
+  const body = await captureResponsesRequestBody(
+    buildStructuredLongConversation(),
+    MID_TIER_MODEL,
+    { apiFormat: 'responses_compat' },
+  )
+  const outputs = getResponsesFunctionOutputs(body)
+  const contentParts = getResponsesInput(body).flatMap(item => item.content ?? [])
+
+  expect(outputs.find(item => item.call_id === 'toolu_1')?.output).toContain(
+    'chars omitted',
+  )
+  expect(contentParts.some(part => part.type === 'text')).toBe(true)
+  expect(contentParts.some(part => part.type === 'input_text')).toBe(false)
+  expect(contentParts.some(part => part.type === 'output_text')).toBe(false)
+})
+
+test('Responses compression leaves histories without tool results unchanged', async () => {
+  mockState.enabled = true
+  const body = await captureResponsesRequestBody(
+    [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: [{ type: 'text', text: 'hi' }] },
+      { role: 'user', content: [{ type: 'text', text: 'continue' }] },
+    ],
+    MID_TIER_MODEL,
+  )
+
+  expect(getResponsesFunctionCalls(body)).toHaveLength(0)
+  expect(getResponsesFunctionOutputs(body)).toHaveLength(0)
+  expect(getResponsesInput(body)).toEqual([
+    {
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text: 'hello' }],
+    },
+    {
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'output_text', text: 'hi' }],
+    },
+    {
+      type: 'message',
+      role: 'user',
+      content: [{ type: 'input_text', text: 'continue' }],
+    },
+  ])
+})
+
+test('GitHub chat fallback compresses the retried Responses request', async () => {
+  mockState.enabled = true
+  mockState.effectiveWindow = 100_000
+  setCompressionEnabledForTest(true)
+  setEffectiveWindowForTest(100_000)
+  delete process.env.CLAUDE_CODE_USE_OPENAI
+  delete process.env.OPENAI_API_FORMAT
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+  process.env.OPENAI_API_KEY = 'github-test-key'
+  process.env.GITHUB_TOKEN = 'github-test-key'
+
+  const urls: string[] = []
+  let fallbackBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (input, init) => {
+    urls.push(String(input))
+    if (urls.length === 1) {
+      return new Response(
+        JSON.stringify({ error: { message: '/chat/completions not accessible' } }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } },
+      )
+    }
+    fallbackBody = JSON.parse(String(init?.body))
+    return makeFakeResponsesResponse()
+  }) as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'gpt-4o',
+    messages: buildLongConversation(30, 5_000),
+  })
+
+  expect(urls).toEqual([
+    'https://api.githubcopilot.com/chat/completions',
+    'https://api.githubcopilot.com/responses',
+  ])
+  expect(fallbackBody).toBeDefined()
+  const outputs = getResponsesFunctionOutputs(fallbackBody!)
+  expect(outputs[0]?.output).toContain('chars omitted')
+  expect(outputs[29]?.output).toHaveLength(5_000)
+})
+
+test('non-chat transports do not invoke the Chat message converter', () => {
+  const selectMessages = __test.getChatMessagesForTransport
+  const unexpectedConversion = () => {
+    throw new Error('Chat converter must stay lazy')
+  }
+
+  expect(selectMessages('responses', unexpectedConversion)).toBeUndefined()
+  expect(selectMessages('responses_compat', unexpectedConversion)).toBeUndefined()
+  expect(selectMessages('anthropic_messages', unexpectedConversion)).toBeUndefined()
+  expect(selectMessages('gemini', unexpectedConversion)).toBeUndefined()
+
+  const chatMessages = [{ role: 'user', content: 'hello' }]
+  expect(selectMessages('chat_completions', () => chatMessages)).toBe(chatMessages)
+})
+
+test('Responses conversion stays single-pass when error classification inspects images', async () => {
+  mockState.enabled = false
+  setCompressionEnabledForTest(false)
+  process.env.OPENAI_API_FORMAT = 'responses'
+  let contentReads = 0
+  let fetchCalls = 0
+  const message = {
+    role: 'user',
+    get content() {
+      contentReads++
+      if (contentReads > 1) {
+        throw new Error('Responses input was converted more than once')
+      }
+      return 'hello'
+    },
+  }
+
+  globalThis.fetch = (async () => {
+    fetchCalls++
+    return new Response('server error', { status: 500 })
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  let rejection: unknown
+  try {
+    await client.beta.messages.create({
+      model: MID_TIER_MODEL,
+      messages: [message],
+    })
+  } catch (error) {
+    rejection = error
+  }
+
+  expect(rejection).toBeDefined()
+  expect(fetchCalls).toBe(1)
+  expect(contentReads).toBe(1)
+})
+
+test('image error classification follows the serialized body for local self-healing', async () => {
+  process.env.OPENAI_BASE_URL = 'http://localhost:8000'
+  const requestUrls: string[] = []
+
+  globalThis.fetch = (async (input) => {
+    requestUrls.push(String(input))
+    if (requestUrls.length === 1) {
+      return new Response('Not Found', { status: 404 })
+    }
+    return makeFakeResponse()
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: MID_TIER_MODEL,
+    messages: [
+      { role: 'user', content: 'inspect the attachment' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'aGVsbG8=',
+            },
+          },
+        ],
+      },
+      { role: 'user', content: 'continue' },
+    ],
+  })
+
+  expect(requestUrls).toEqual([
+    'http://localhost:8000/chat/completions',
+    'http://localhost:8000/v1/chat/completions',
+  ])
+})
+
+test('image error classification follows JSON-normalized Anthropic content', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
+  process.env.OPENAI_MODEL = 'minimax-m3'
+  process.env.OPENCODE_API_KEY = 'test-opencode-key'
+
+  globalThis.fetch = (async (_input, init) => {
+    expect(String(init?.body)).toContain('"type":"image"')
+    return new Response('Not Found', { status: 404 })
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await expect(client.beta.messages.create({
+    model: 'minimax-m3',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'text',
+            text: 'placeholder',
+            toJSON() {
+              return {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: 'image/png',
+                  data: 'aGVsbG8=',
+                },
+              }
+            },
+          },
+        ],
+      },
+    ],
+  })).rejects.toThrow('openai_category=vision_not_supported')
+})
+
+test('Responses requests preserve an abort that happened before fetch', async () => {
+  process.env.OPENAI_API_FORMAT = 'responses'
+  const controller = new AbortController()
+  const abortError = new DOMException('cancelled before request', 'AbortError')
+  controller.abort(abortError)
+  let fetchCalls = 0
+
+  globalThis.fetch = (async (_input, init) => {
+    fetchCalls++
+    expect(init?.signal).toBe(controller.signal)
+    expect(init?.signal?.aborted).toBe(true)
+    throw init?.signal?.reason
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  let rejection: unknown
+  try {
+    await client.beta.messages.create(
+      {
+        model: MID_TIER_MODEL,
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+      { signal: controller.signal },
+    )
+  } catch (error) {
+    rejection = error
+  }
+
+  expect(rejection).toBe(abortError)
+  expect(fetchCalls).toBe(1)
 })

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -576,17 +576,17 @@ test('Chat compression omits old and mid-tier inline image payloads', async () =
     role: 'user',
     content: [
       {
+        type: 'tool_result',
+        tool_use_id: 'toolu_1',
+        content: bigText(5_000),
+      },
+      {
         type: 'image',
         source: {
           type: 'base64',
           media_type: 'image/png',
           data: imageData,
         },
-      },
-      {
-        type: 'tool_result',
-        tool_use_id: 'toolu_1',
-        content: bigText(5_000),
       },
     ],
   }

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -530,7 +530,7 @@ test('FIX: 32k window tier → recent=3 keeps last 3 only', async () => {
   }
 })
 
-test('Chat compression omits old inline base64 image payloads', async () => {
+test('Chat compression omits old and mid-tier inline base64 image payloads', async () => {
   mockState.enabled = true
   mockState.effectiveWindow = 100_000
   const imageData = 'a'.repeat(100_000)
@@ -554,11 +554,31 @@ test('Chat compression omits old inline base64 image payloads', async () => {
       },
     ],
   }
+  messages[32] = {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_15',
+        content: [
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: imageData,
+            },
+          },
+        ],
+      },
+    ],
+  }
 
   const body = await captureRequestBody(messages, MID_TIER_MODEL)
-  const firstOutput = getToolMessages(body)[0]?.content
+  const toolOutputs = getToolMessages(body).map(message => message.content)
 
-  expect(firstOutput).toContain('[Inline image omitted from tool history]')
+  expect(toolOutputs[0]).toContain('0 chars omitted')
+  expect(toolOutputs[15]).toContain('[Inline image omitted from tool history]')
   expect(JSON.stringify(body)).not.toContain(imageData)
   expect(JSON.stringify(body).length).toBeLessThan(100_000)
 })

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -572,25 +572,6 @@ test('Chat compression omits old and mid-tier inline image payloads', async () =
       },
     ],
   }
-  messages[4] = {
-    role: 'user',
-    content: [
-      {
-        type: 'tool_result',
-        tool_use_id: 'toolu_1',
-        content: bigText(5_000),
-      },
-      {
-        type: 'image',
-        source: {
-          type: 'base64',
-          media_type: 'image/png',
-          data: imageData,
-        },
-      },
-    ],
-  }
-
   const body = await captureRequestBody(messages, MID_TIER_MODEL)
   const toolOutputs = getToolMessages(body).map(message => message.content)
 
@@ -703,8 +684,8 @@ test('Responses compression preserves structured history and materially reduces 
     item => item.content ?? [],
   )
   expect(inputParts).toContainEqual({
-    type: 'input_text',
-    text: '[Inline image omitted from tool history]',
+    type: 'input_image',
+    image_url: 'data:image/png;base64,aGVsbG8=',
   })
   expect(inputParts).toContainEqual({
     type: 'input_text',

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -583,6 +583,28 @@ test('Chat compression omits old and mid-tier inline base64 image payloads', asy
   expect(JSON.stringify(body).length).toBeLessThan(100_000)
 })
 
+test('Chat compression bounds structured text using its serialized separators', async () => {
+  mockState.enabled = true
+  mockState.effectiveWindow = 100_000
+  const messages = buildLongConversation(10, 5_000)
+  messages[2] = {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_0',
+        content: Array.from({ length: 2_000 }, () => ({ type: 'text', text: 'x' })),
+      },
+    ],
+  }
+
+  const body = await captureRequestBody(messages, MID_TIER_MODEL)
+  const firstToolOutput = getToolMessages(body)[0]?.content ?? ''
+
+  expect(firstToolOutput).toContain('[…truncated')
+  expect(firstToolOutput.length).toBeLessThan(2_200)
+})
+
 test('Responses compression preserves structured history and materially reduces the payload', async () => {
   mockState.effectiveWindow = 100_000
   const messages = buildStructuredLongConversation()
@@ -1000,6 +1022,49 @@ test('local self-healing follows the serialized image-free Chat body', async () 
     'http://localhost:8000/v1/chat/completions',
   ])
   expect(requestBodies[0]).not.toContain('"type":"image_url"')
+  expect(requestBodies[1]).toBe(requestBodies[0])
+})
+
+test('local image requests probe alternate OpenAI-compatible endpoints before failing', async () => {
+  process.env.OPENAI_BASE_URL = 'http://localhost:8000'
+  const requestUrls: string[] = []
+  const requestBodies: string[] = []
+
+  globalThis.fetch = (async (input, init) => {
+    requestUrls.push(String(input))
+    requestBodies.push(String(init?.body))
+    if (requestUrls.length === 1) {
+      return new Response('Not Found', { status: 404 })
+    }
+    return makeFakeResponse()
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: MID_TIER_MODEL,
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'inspect the attachment' },
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'aGVsbG8=',
+            },
+          },
+        ],
+      },
+    ],
+  })
+
+  expect(requestUrls).toEqual([
+    'http://localhost:8000/chat/completions',
+    'http://localhost:8000/v1/chat/completions',
+  ])
+  expect(requestBodies[0]).toContain('"type":"image_url"')
   expect(requestBodies[1]).toBe(requestBodies[0])
 })
 

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -623,6 +623,29 @@ test('Chat compression bounds structured text using its serialized separators', 
   expect(firstToolOutput.length).toBeLessThan(2_200)
 })
 
+test('Responses compression bounds structured text using its serialized separators', async () => {
+  mockState.enabled = true
+  mockState.effectiveWindow = 100_000
+  const messages = buildLongConversation(10, 5_000)
+  messages[2] = {
+    role: 'user',
+    content: [
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_0',
+        content: Array.from({ length: 2_000 }, () => ({ type: 'text', text: 'x' })),
+      },
+    ],
+  }
+
+  const body = await captureResponsesRequestBody(messages, MID_TIER_MODEL)
+  const firstToolOutput = getResponsesFunctionOutputs(body)[0]?.output ?? ''
+
+  expect(firstToolOutput).toContain('[…truncated')
+  expect(firstToolOutput.length).toBeLessThan(2_200)
+  expect(firstToolOutput.length).toBeGreaterThan(2_000)
+})
+
 test('Responses compression preserves structured history and materially reduces the payload', async () => {
   mockState.effectiveWindow = 100_000
   const messages = buildStructuredLongConversation()

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -950,6 +950,96 @@ test('local self-healing follows the serialized image-free Chat body', async () 
   expect(requestBodies[1]).toBe(requestBodies[0])
 })
 
+test('native Ollama image requests preserve local endpoint fallback', async () => {
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434'
+  const requestUrls: string[] = []
+  const requestBodies: Array<Record<string, unknown>> = []
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input)
+    requestUrls.push(url)
+    requestBodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>)
+    if (url.includes('localhost')) {
+      return new Response('Not Found', { status: 404 })
+    }
+    return new Response(
+      JSON.stringify({
+        model: 'qwen2.5-coder:7b',
+        message: { role: 'assistant', content: 'image received' },
+        done: true,
+        done_reason: 'stop',
+        prompt_eval_count: 5,
+        eval_count: 2,
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'qwen2.5-coder:7b',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'describe the image' },
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'aGVsbG8=',
+            },
+          },
+        ],
+      },
+    ],
+  })
+
+  expect(requestUrls).toEqual([
+    'http://localhost:11434/api/chat',
+    'http://127.0.0.1:11434/api/chat',
+  ])
+  for (const requestBody of requestBodies) {
+    const messages = requestBody.messages as Array<{ images?: string[] }>
+    expect(messages[0]?.images).toEqual(['aGVsbG8='])
+  }
+})
+
+test('native Ollama image requests keep vision diagnosis after local fallbacks', async () => {
+  process.env.OPENAI_BASE_URL = 'http://localhost:11434'
+  const requestUrls: string[] = []
+  globalThis.fetch = (async input => {
+    requestUrls.push(String(input))
+    return new Response('Not Found', { status: 404 })
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await expect(client.beta.messages.create({
+    model: 'qwen2.5-coder:7b',
+    messages: [
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'describe the image' },
+          {
+            type: 'image',
+            source: {
+              type: 'base64',
+              media_type: 'image/png',
+              data: 'aGVsbG8=',
+            },
+          },
+        ],
+      },
+    ],
+  })).rejects.toThrow('openai_category=vision_not_supported')
+  expect(requestUrls).toEqual([
+    'http://localhost:11434/api/chat',
+    'http://127.0.0.1:11434/api/chat',
+  ])
+})
+
 test('image error classification follows JSON-normalized Anthropic content', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -915,10 +915,23 @@ test('GitHub chat fallback compresses the retried Responses request', async () =
     return makeFakeResponsesResponse()
   }) as FetchType
 
+  const messages = buildLongConversation(30, 5_000)
+  messages[34] = {
+    role: 'user',
+    content: [{
+      type: 'tool_result',
+      tool_use_id: 'toolu_16',
+      content: [
+        { type: 'text', text: 'a'.repeat(1_000) },
+        { type: 'text', text: 'b'.repeat(1_500) },
+      ],
+    }],
+  }
+
   const client = createOpenAIShimClient({}) as OpenAIShimClient
   await client.beta.messages.create({
     model: 'gpt-4o',
-    messages: buildLongConversation(30, 5_000),
+    messages,
   })
 
   expect(urls).toEqual([
@@ -927,7 +940,9 @@ test('GitHub chat fallback compresses the retried Responses request', async () =
   ])
   expect(fallbackBody).toBeDefined()
   const outputs = getResponsesFunctionOutputs(fallbackBody!)
-  expect(outputs[0]?.output).toContain('chars omitted')
+  expect(outputs[16]?.output).toBe(
+    `${'a'.repeat(1_000)}\n${'b'.repeat(999)}\n[…truncated 501 chars from tool history]`,
+  )
   expect(outputs[29]?.output).toHaveLength(5_000)
 })
 

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -698,6 +698,43 @@ test('non-chat transports do not invoke the Chat message converter', () => {
   expect(selectMessages('chat_completions', () => chatMessages)).toBe(chatMessages)
 })
 
+test('Anthropic and Gemini transports do not invoke tool history compression', () => {
+  const selectMessages = __test.getCompressedMessagesForTransport
+  const rawMessages = [{ role: 'user', content: 'hello' }]
+  const compressedMessages = [{ role: 'user', content: 'compressed' }]
+  let compressionCalls = 0
+  const compress = () => {
+    compressionCalls++
+    return compressedMessages
+  }
+
+  expect(selectMessages('anthropic_messages', rawMessages, compress)).toBe(rawMessages)
+  expect(selectMessages('gemini', rawMessages, compress)).toBe(rawMessages)
+  expect(compressionCalls).toBe(0)
+
+  expect(selectMessages('responses', rawMessages, compress)).toBe(compressedMessages)
+  expect(selectMessages('responses_compat', rawMessages, compress)).toBe(compressedMessages)
+  expect(selectMessages('chat_completions', rawMessages, compress)).toBe(compressedMessages)
+  expect(compressionCalls).toBe(3)
+})
+
+test('Gemini image detection requires an image MIME type', () => {
+  const containsImages = __test.requestBodyContainsImages
+
+  expect(containsImages({
+    contents: [{ parts: [{ inlineData: { mimeType: 'image/png', data: 'aGVsbG8=' } }] }],
+  })).toBe(true)
+  expect(containsImages({
+    contents: [{ parts: [{ fileData: { mimeType: 'image/jpeg', fileUri: 'gs://bucket/image.jpg' } }] }],
+  })).toBe(true)
+  expect(containsImages({
+    contents: [{ parts: [{ inlineData: { mimeType: 'audio/wav', data: 'aGVsbG8=' } }] }],
+  })).toBe(false)
+  expect(containsImages({
+    contents: [{ parts: [{ fileData: { mimeType: 'application/pdf', fileUri: 'gs://bucket/file.pdf' } }] }],
+  })).toBe(false)
+})
+
 test('Responses conversion stays single-pass when error classification inspects images', async () => {
   mockState.enabled = false
   setCompressionEnabledForTest(false)
@@ -736,12 +773,14 @@ test('Responses conversion stays single-pass when error classification inspects 
   expect(contentReads).toBe(1)
 })
 
-test('image error classification follows the serialized body for local self-healing', async () => {
+test('local self-healing follows the serialized image-free Chat body', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:8000'
   const requestUrls: string[] = []
+  const requestBodies: string[] = []
 
-  globalThis.fetch = (async (input) => {
+  globalThis.fetch = (async (input, init) => {
     requestUrls.push(String(input))
+    requestBodies.push(String(init?.body))
     if (requestUrls.length === 1) {
       return new Response('Not Found', { status: 404 })
     }
@@ -774,6 +813,8 @@ test('image error classification follows the serialized body for local self-heal
     'http://localhost:8000/chat/completions',
     'http://localhost:8000/v1/chat/completions',
   ])
+  expect(requestBodies[0]).not.toContain('"type":"image_url"')
+  expect(requestBodies[1]).toBe(requestBodies[0])
 })
 
 test('image error classification follows JSON-normalized Anthropic content', async () => {

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -530,7 +530,7 @@ test('FIX: 32k window tier → recent=3 keeps last 3 only', async () => {
   }
 })
 
-test('Chat compression omits old and mid-tier inline base64 image payloads', async () => {
+test('Chat compression omits old and mid-tier inline image payloads', async () => {
   mockState.enabled = true
   mockState.effectiveWindow = 100_000
   const imageData = 'a'.repeat(100_000)
@@ -545,9 +545,8 @@ test('Chat compression omits old and mid-tier inline base64 image payloads', asy
           {
             type: 'image',
             source: {
-              type: 'base64',
-              media_type: 'image/png',
-              data: imageData,
+              type: 'url',
+              url: `data:image/png;base64,${imageData}`,
             },
           },
         ],

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -546,7 +546,7 @@ test('Chat compression omits old and mid-tier inline image payloads', async () =
             type: 'image',
             source: {
               type: 'url',
-              url: `data:image/png;base64,${imageData}`,
+              url: `data:image/png;charset=utf-8;base64,${imageData}`,
             },
           },
         ],

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -114,6 +114,37 @@ function buildLongConversation(numExchanges: number, resultLength = 5_000) {
   return out
 }
 
+function buildParallelToolConversation(
+  numBatches: number,
+  batchSize: number,
+  resultLength = 5_000,
+) {
+  const out: Array<{ role: string; content: unknown }> = [
+    { role: 'user', content: 'start the parallel work' },
+  ]
+  for (let batch = 0; batch < numBatches; batch++) {
+    const firstId = batch * batchSize
+    out.push({
+      role: 'assistant',
+      content: Array.from({ length: batchSize }, (_, offset) => ({
+        type: 'tool_use',
+        id: `toolu_${firstId + offset}`,
+        name: 'Read',
+        input: { file_path: `/path/to/file${firstId + offset}.ts` },
+      })),
+    })
+    out.push({
+      role: 'user',
+      content: Array.from({ length: batchSize }, (_, offset) => ({
+        type: 'tool_result',
+        tool_use_id: `toolu_${firstId + offset}`,
+        content: bigText(resultLength),
+      })),
+    })
+  }
+  return out
+}
+
 function makeFakeResponse(): Response {
   return new Response(
     JSON.stringify({
@@ -537,12 +568,12 @@ test('Responses compression preserves structured history and materially reduces 
   expect(compressedByCallId.get('toolu_0')).toBe(
     '[Old tool result content cleared]',
   )
-  for (let i = 1; i <= 14; i++) {
+  for (let i = 1; i <= 15; i++) {
     expect(compressedByCallId.get(`toolu_${i}`)).toMatch(
       /^\[Read args=.*chars omitted\]$/,
     )
   }
-  for (let i = 15; i <= 24; i++) {
+  for (let i = 16; i <= 24; i++) {
     expect(compressedByCallId.get(`toolu_${i}`)).toContain('[…truncated')
   }
   expect(compressedByCallId.get('toolu_16_extra')).toContain('[…truncated')
@@ -569,6 +600,38 @@ test('Responses compression preserves structured history and materially reduces 
   })
 
   expect(compressedSize).toBeLessThan(uncompressedSize * 0.5)
+})
+
+test('Responses compression assigns tiers per parallel tool result', async () => {
+  mockState.enabled = true
+  mockState.effectiveWindow = 100_000
+  const messages = buildParallelToolConversation(5, 6)
+
+  const body = await captureResponsesRequestBody(messages, MID_TIER_MODEL)
+  const functionCalls = getResponsesFunctionCalls(body)
+  const functionOutputs = getResponsesFunctionOutputs(body)
+  const outputs = new Map(
+    functionOutputs.map(item => [item.call_id, item.output ?? '']),
+  )
+
+  expect(functionCalls).toHaveLength(30)
+  expect(functionOutputs).toHaveLength(30)
+  expect(functionCalls.map(item => item.call_id)).toEqual(
+    functionOutputs.map(item => item.call_id),
+  )
+  for (let i = 0; i < 15; i++) {
+    expect(outputs.get(`toolu_${i}`)).toMatch(
+      /^\[Read args=.*5000 chars omitted\]$/,
+    )
+  }
+  for (let i = 15; i < 25; i++) {
+    expect(outputs.get(`toolu_${i}`)).toContain(
+      '[…truncated 3000 chars from tool history]',
+    )
+  }
+  for (let i = 25; i < 30; i++) {
+    expect(outputs.get(`toolu_${i}`)).toHaveLength(5_000)
+  }
 })
 
 test('Responses compression preserves structured parts while compressing old and mid text', async () => {
@@ -767,7 +830,7 @@ test('non-chat transports do not invoke the Chat message converter', () => {
   expect(selectMessages('chat_completions', () => chatMessages)).toBe(chatMessages)
 })
 
-test('Anthropic and Gemini transports do not invoke tool history compression', () => {
+test('only OpenAI-compatible transports invoke tool history compression', () => {
   const selectMessages = __test.getCompressedMessagesForTransport
   const rawMessages = [{ role: 'user', content: 'hello' }]
   const compressedMessages = [{ role: 'user', content: 'compressed' }]
@@ -779,6 +842,7 @@ test('Anthropic and Gemini transports do not invoke tool history compression', (
 
   expect(selectMessages('anthropic_messages', rawMessages, compress)).toBe(rawMessages)
   expect(selectMessages('gemini', rawMessages, compress)).toBe(rawMessages)
+  expect(selectMessages('future_transport', rawMessages, compress)).toBe(rawMessages)
   expect(compressionCalls).toBe(0)
 
   expect(selectMessages('responses', rawMessages, compress)).toBe(compressedMessages)

--- a/src/services/api/openaiShim.compression.test.ts
+++ b/src/services/api/openaiShim.compression.test.ts
@@ -576,17 +576,17 @@ test('Chat compression omits old and mid-tier inline image payloads', async () =
     role: 'user',
     content: [
       {
-        type: 'tool_result',
-        tool_use_id: 'toolu_1',
-        content: bigText(5_000),
-      },
-      {
         type: 'image',
         source: {
           type: 'base64',
           media_type: 'image/png',
           data: imageData,
         },
+      },
+      {
+        type: 'tool_result',
+        tool_use_id: 'toolu_1',
+        content: bigText(5_000),
       },
     ],
   }

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -4326,7 +4326,10 @@ class OpenAIShimMessages {
       rawMessages,
       () => fastPath.skipToolHistoryCompression
         ? rawMessages
-        : compressToolHistory(rawMessages, request.resolvedModel),
+        : compressToolHistory(rawMessages, request.resolvedModel, {
+          textBlockSeparator:
+            effectiveTransport === 'chat_completions' ? '\n\n' : '\n',
+        }),
     )
     const useNativeOllamaChat =
       effectiveTransport === 'chat_completions' &&

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1269,6 +1269,67 @@ function ensureTextPartForImageContent(
   return [{ type: 'text', text: 'Image attached.' }, ...parts]
 }
 
+function contentBlocksContainImages(content: unknown): boolean {
+  if (!Array.isArray(content)) return false
+
+  return content.some(block => {
+    if (!block || typeof block !== 'object') return false
+    const record = block as Record<string, unknown>
+    if (
+      record.type === 'image' ||
+      record.type === 'image_url' ||
+      record.type === 'input_image'
+    ) {
+      return true
+    }
+    return record.type === 'tool_result' && contentBlocksContainImages(record.content)
+  })
+}
+
+function requestBodyContainsImages(
+  payload: Record<string, unknown> | undefined,
+): boolean {
+  if (!payload) return false
+
+  const messages = payload.messages
+  if (
+    Array.isArray(messages) &&
+    messages.some(message => {
+      if (!message || typeof message !== 'object') return false
+      const record = message as Record<string, unknown>
+      return (
+        contentBlocksContainImages(record.content) ||
+        (Array.isArray(record.images) && record.images.length > 0)
+      )
+    })
+  ) {
+    return true
+  }
+
+  const input = payload.input
+  if (
+    Array.isArray(input) &&
+    input.some(item =>
+      item &&
+      typeof item === 'object' &&
+      contentBlocksContainImages((item as Record<string, unknown>).content),
+    )
+  ) {
+    return true
+  }
+
+  const contents = payload.contents
+  return Array.isArray(contents) && contents.some(item => {
+    if (!item || typeof item !== 'object') return false
+    const parts = (item as Record<string, unknown>).parts
+    return Array.isArray(parts) && parts.some(part =>
+      part &&
+      typeof part === 'object' &&
+      ('inlineData' in part || 'fileData' in part),
+    )
+  })
+}
+
 function joinTextContentParts(parts: OpenAIContentPart[]): string {
   return parts.map(part => part.type === 'text' ? part.text : '').join('')
 }
@@ -1789,6 +1850,13 @@ function convertMessages(
   }
 
   return coalesced
+}
+
+function getChatMessagesForTransport<T>(
+  transport: string,
+  convert: () => T,
+): T | undefined {
+  return transport === 'chat_completions' ? convert() : undefined
 }
 
 /**
@@ -4243,14 +4311,17 @@ class OpenAIShimMessages {
       !shimConfig.endpointPath &&
       isDirectLocalOllamaEndpoint(request.baseUrl) &&
       isLikelyOllamaEndpoint(request.baseUrl)
-    const openaiMessages = convertMessages(compressedMessages, params.system, {
-      preserveReasoningContent: shimConfig.preserveReasoningContent,
-      reasoningContentFallback: shimConfig.reasoningContentFallback,
-      preserveGeminiThoughtSignature: shouldPreserveGeminiThoughtSignature(
-        request.resolvedModel,
-        request.baseUrl,
-      ),
-    })
+    const openaiMessages = getChatMessagesForTransport(
+      effectiveTransport,
+      () => convertMessages(compressedMessages, params.system, {
+        preserveReasoningContent: shimConfig.preserveReasoningContent,
+        reasoningContentFallback: shimConfig.reasoningContentFallback,
+        preserveGeminiThoughtSignature: shouldPreserveGeminiThoughtSignature(
+          request.resolvedModel,
+          request.baseUrl,
+        ),
+      }),
+    )
 
     const reasoningControl = resolveModelReasoningControl(request.resolvedModel, {
       routeId: runtimeShimContext.routeId,
@@ -4281,7 +4352,7 @@ class OpenAIShimMessages {
 
     const body: Record<string, unknown> = {
       model: request.resolvedModel,
-      messages: openaiMessages,
+      ...(openaiMessages ? { messages: openaiMessages } : {}),
       stream: params.stream ?? false,
       store: false,
     }
@@ -4417,17 +4488,20 @@ class OpenAIShimMessages {
     }
 
     let omitResponsesTools = false
+    let responsesInput: ReturnType<
+      typeof convertAnthropicMessagesToResponsesInput
+    > | undefined
+    const getResponsesInput = () => {
+      responsesInput ??= convertAnthropicMessagesToResponsesInput(
+        compressedMessages,
+        effectiveTransport === 'responses_compat',
+      )
+      return responsesInput
+    }
     const buildResponsesBody = (): Record<string, unknown> => {
       const responsesBody: Record<string, unknown> = {
         model: request.resolvedModel,
-        input: convertAnthropicMessagesToResponsesInput(
-          params.messages as Array<{
-            role?: string
-            message?: { role?: string; content?: unknown }
-            content?: unknown
-          }>,
-          effectiveTransport === 'responses_compat',
-        ),
+        input: getResponsesInput(),
         stream: params.stream ?? false,
         store: false,
       }
@@ -4960,23 +5034,34 @@ class OpenAIShimMessages {
       return false
     }
 
-    const bodyContainsImages = (): boolean => {
-      if (request.transport === 'responses') {
-        const responsesBody = buildResponsesBody()
-        const input = responsesBody.input as Array<Record<string, unknown>> | undefined
-        if (!Array.isArray(input)) return false
-        return input.some(item => {
-          const content = item.content as Array<Record<string, unknown>> | undefined
-          return Array.isArray(content) && content.some(part => part.type === 'input_image')
-        })
+    let serializedBody = ''
+    let imageClassificationCache:
+      | { serializedBody: string; hasImages: boolean }
+      | undefined
+    const bodyContainsImages = (
+      bodyToInspect = serializedBody,
+    ): boolean => {
+      if (imageClassificationCache?.serializedBody === bodyToInspect) {
+        return imageClassificationCache.hasImages
       }
-      const messages = body.messages as Array<Record<string, unknown>> | undefined
-      if (!Array.isArray(messages)) return false
-      return messages.some(msg => {
-        const content = msg.content
-        if (!Array.isArray(content)) return false
-        return content.some((part: Record<string, unknown>) => part.type === 'image_url')
-      })
+
+      let hasImages = false
+      try {
+        const payload = JSON.parse(bodyToInspect)
+        if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+          hasImages = requestBodyContainsImages(
+            payload as Record<string, unknown>,
+          )
+        }
+      } catch {
+        // Request serialization already succeeded before this error path.
+      }
+
+      imageClassificationCache = {
+        serializedBody: bodyToInspect,
+        hasImages,
+      }
+      return hasImages
     }
 
     // WHY: byte-identity required for implicit prefix caching in
@@ -5020,7 +5105,7 @@ class OpenAIShimMessages {
         ? JSON.stringify(payload)
         : stableStringifyJson(payload)
     }
-    let serializedBody = serializeBody()
+    serializedBody = serializeBody()
 
     const refreshSerializedBody = (): void => {
       serializedBody = serializeBody()
@@ -5257,6 +5342,7 @@ class OpenAIShimMessages {
         if (errorBody.includes('/chat/completions') || errorBody.includes('not accessible')) {
           const responsesUrl = `${request.baseUrl}/responses`
           const responsesBody = buildResponsesBody()
+          const responsesSerializedBody = stableStringifyJson(responsesBody)
 
           let responsesResponse!: Response
           try {
@@ -5265,7 +5351,7 @@ class OpenAIShimMessages {
               {
                 method: 'POST',
                 headers,
-                body: stableStringifyJson(responsesBody),
+                body: responsesSerializedBody,
               },
             )
           } catch (error) {
@@ -5301,7 +5387,7 @@ class OpenAIShimMessages {
           const responsesFailure = classifyOpenAIHttpFailure({
             status: responsesResponse.status,
             body: responsesErrorBody,
-            hasImages: bodyContainsImages(),
+            hasImages: bodyContainsImages(responsesSerializedBody),
           })
           let responsesErrorResponse: object | undefined
           try { responsesErrorResponse = JSON.parse(responsesErrorBody) } catch { /* raw text */ }
@@ -5553,6 +5639,7 @@ export function createOpenAIShimClient(options: {
 export const __test = {
   convertMessages,
   getApiTimeoutMs,
+  getChatMessagesForTransport,
   getStreamIdleTimeoutMs,
   readWithIdleTimeout,
   StreamIdleTimeoutError,

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -5026,6 +5026,7 @@ class OpenAIShimMessages {
     let activeBaseUrl = request.baseUrl
     let requestUrl = buildRequestUrl(activeBaseUrl)
     const attemptedLocalBaseUrls = new Set<string>([activeBaseUrl])
+    const attemptedLocalRequestUrls = new Set<string>([requestUrl])
     let didRetryWithoutTools = false
     let didRetryWithoutToolStream = false
     let retryCredentialLease: CredentialLease | null = null
@@ -5040,10 +5041,16 @@ class OpenAIShimMessages {
           continue
         }
 
-        const previousUrl = requestUrl
         attemptedLocalBaseUrls.add(candidateBaseUrl)
+        const candidateRequestUrl = buildRequestUrl(candidateBaseUrl)
+        if (attemptedLocalRequestUrls.has(candidateRequestUrl)) {
+          continue
+        }
+
+        const previousUrl = requestUrl
+        attemptedLocalRequestUrls.add(candidateRequestUrl)
         activeBaseUrl = candidateBaseUrl
-        requestUrl = buildRequestUrl(activeBaseUrl)
+        requestUrl = candidateRequestUrl
 
         logForDebugging(
           `[OpenAIShim] self-heal retry reason=${reason} method=POST from=${redactUrlForDiagnostics(previousUrl)} to=${redactUrlForDiagnostics(requestUrl)} model=${request.resolvedModel}`,
@@ -5483,9 +5490,16 @@ class OpenAIShimMessages {
         }
       }
 
+      const shouldRetryLocalEndpoint404 =
+        failure.category === 'endpoint_not_found' ||
+        (
+          useNativeOllamaChat &&
+          response.status === 404 &&
+          failure.category === 'vision_not_supported'
+        )
       if (
         isLocal &&
-        failure.category === 'endpoint_not_found' &&
+        shouldRetryLocalEndpoint404 &&
         promoteNextLocalBaseUrl('endpoint_not_found')
       ) {
         continue

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -4516,9 +4516,20 @@ class OpenAIShimMessages {
     let responsesInput: ReturnType<
       typeof convertAnthropicMessagesToResponsesInput
     > | undefined
+    let responsesMessages: typeof compressedMessages | undefined
     const getResponsesInput = () => {
+      // GitHub can reject a Chat request and retry it through Responses. That
+      // retry must budget structured text with the Responses separator rather
+      // than reusing the Chat-compressed form (which uses a double newline).
+      responsesMessages ??= effectiveTransport === 'chat_completions'
+        ? fastPath.skipToolHistoryCompression
+          ? rawMessages
+          : compressToolHistory(rawMessages, request.resolvedModel, {
+            textBlockSeparator: '\n',
+          })
+        : compressedMessages
       responsesInput ??= convertAnthropicMessagesToResponsesInput(
-        compressedMessages,
+        responsesMessages,
         effectiveTransport === 'responses_compat',
       )
       return responsesInput

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1322,11 +1322,17 @@ function requestBodyContainsImages(
   return Array.isArray(contents) && contents.some(item => {
     if (!item || typeof item !== 'object') return false
     const parts = (item as Record<string, unknown>).parts
-    return Array.isArray(parts) && parts.some(part =>
-      part &&
-      typeof part === 'object' &&
-      ('inlineData' in part || 'fileData' in part),
-    )
+    return Array.isArray(parts) && parts.some(part => {
+      if (!part || typeof part !== 'object') return false
+      const record = part as Record<string, unknown>
+      return ['inlineData', 'fileData'].some(key => {
+        const data = record[key]
+        if (!data || typeof data !== 'object') return false
+        const mimeType = (data as Record<string, unknown>).mimeType
+        return typeof mimeType === 'string' &&
+          mimeType.trim().toLowerCase().startsWith('image/')
+      })
+    })
   })
 }
 
@@ -1857,6 +1863,16 @@ function getChatMessagesForTransport<T>(
   convert: () => T,
 ): T | undefined {
   return transport === 'chat_completions' ? convert() : undefined
+}
+
+function getCompressedMessagesForTransport<T>(
+  transport: string,
+  rawMessages: T,
+  compress: () => T,
+): T {
+  return transport === 'anthropic_messages' || transport === 'gemini'
+    ? rawMessages
+    : compress()
 }
 
 /**
@@ -4283,9 +4299,6 @@ class OpenAIShimMessages {
       message?: { role?: string; content?: unknown }
       content?: unknown
     }>
-    const compressedMessages = fastPath.skipToolHistoryCompression
-      ? rawMessages
-      : compressToolHistory(rawMessages, request.resolvedModel)
     const runtimeShimContext = resolveOpenAIShimRuntimeContext({
       processEnv: requestProcessEnv,
       baseUrl: request.baseUrl,
@@ -4306,6 +4319,13 @@ class OpenAIShimMessages {
         : shimConfig.endpointPath?.startsWith('/models/gemini-')
           ? 'gemini'
           : request.transport
+    const compressedMessages = getCompressedMessagesForTransport(
+      effectiveTransport,
+      rawMessages,
+      () => fastPath.skipToolHistoryCompression
+        ? rawMessages
+        : compressToolHistory(rawMessages, request.resolvedModel),
+    )
     const useNativeOllamaChat =
       effectiveTransport === 'chat_completions' &&
       !shimConfig.endpointPath &&
@@ -5053,8 +5073,13 @@ class OpenAIShimMessages {
             payload as Record<string, unknown>,
           )
         }
-      } catch {
-        // Request serialization already succeeded before this error path.
+      } catch (error) {
+        // Request serialization already succeeded before this error path, so
+        // parsing should only fail if a future caller passes a different body.
+        logForDebugging(
+          `[OpenAIShim] failed to inspect serialized request body for images: ${error instanceof Error ? error.message : String(error)}`,
+          { level: 'warn' },
+        )
       }
 
       imageClassificationCache = {
@@ -5640,6 +5665,8 @@ export const __test = {
   convertMessages,
   getApiTimeoutMs,
   getChatMessagesForTransport,
+  getCompressedMessagesForTransport,
+  requestBodyContainsImages,
   getStreamIdleTimeoutMs,
   readWithIdleTimeout,
   StreamIdleTimeoutError,

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1870,9 +1870,11 @@ function getCompressedMessagesForTransport<T>(
   rawMessages: T,
   compress: () => T,
 ): T {
-  return transport === 'anthropic_messages' || transport === 'gemini'
-    ? rawMessages
-    : compress()
+  return transport === 'chat_completions' ||
+    transport === 'responses' ||
+    transport === 'responses_compat'
+    ? compress()
+    : rawMessages
 }
 
 /**

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -5493,7 +5493,6 @@ class OpenAIShimMessages {
       const shouldRetryLocalEndpoint404 =
         failure.category === 'endpoint_not_found' ||
         (
-          useNativeOllamaChat &&
           response.status === 404 &&
           failure.category === 'vision_not_supported'
         )

--- a/src/services/tools/toolExecution.ts
+++ b/src/services/tools/toolExecution.ts
@@ -1299,6 +1299,7 @@ export async function checkPermissionsAndCallTool(
         content: messageContent,
         imagePasteIds: rejectImageIds,
         toolUseResult: `Error: ${errorMessage}`,
+        imagePermissionToolUseIds: rejectImageIds?.map(() => toolUseID),
         sourceToolAssistantUUID: assistantMessage.uuid,
       }),
     })
@@ -1637,6 +1638,7 @@ export async function checkPermissionsAndCallTool(
             toolUseContext.agentId && !toolUseContext.preserveToolUseResults
               ? undefined
               : toolUseResult,
+          imagePermissionToolUseIds: allowImageIds?.map(() => toolUseID),
           mcpMeta: toolUseContext.agentId ? undefined : mcpMeta,
           sourceToolAssistantUUID: assistantMessage.uuid,
         }),

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -116,6 +116,8 @@ export interface UserMessage<C = string | ContentBlockParam[]> {
   }
   /** Matches the tool's `Output` type for tool_result messages. */
   toolUseResult?: unknown
+  /** Per-image tool-result owner; null marks an independent user image. */
+  imagePermissionToolUseIds?: Array<string | null>
   /** Internal marker for synthetic tool_result messages created by agent step limits. */
   isAgentStepLimitToolResult?: boolean
   /** MCP protocol metadata passed through to SDK consumers. */

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1632,35 +1632,35 @@ export function normalizeMessagesForAPI(
                 typesToStrip,
               )
             } else {
-            const content = normalizedMessage.message.content
-            if (Array.isArray(content)) {
-              let imageIndex = 0
-              const imageOwners: Array<string | null> = []
-              const filtered = content.filter(block => {
-                const keep = !typesToStrip.has(block.type)
-                if (block.type === 'image') {
-                  const owner = normalizedMessage.imagePermissionToolUseIds?.[imageIndex++] ?? null
-                  if (keep) imageOwners.push(owner)
+              const content = normalizedMessage.message.content
+              if (Array.isArray(content)) {
+                let imageIndex = 0
+                const imageOwners: Array<string | null> = []
+                const filtered = content.filter(block => {
+                  const keep = !typesToStrip.has(block.type)
+                  if (block.type === 'image') {
+                    const owner = normalizedMessage.imagePermissionToolUseIds?.[imageIndex++] ?? null
+                    if (keep) imageOwners.push(owner)
+                  }
+                  return keep
+                })
+                if (filtered.length === 0) {
+                  // All content blocks were stripped; skip this message entirely
+                  return
                 }
-                return keep
-              })
-              if (filtered.length === 0) {
-                // All content blocks were stripped; skip this message entirely
-                return
-              }
-              if (filtered.length < content.length) {
-                normalizedMessage = {
-                  ...normalizedMessage,
-                  message: {
-                    ...normalizedMessage.message,
-                    content: filtered,
-                  },
-                  imagePermissionToolUseIds:
-                    imageOwners.length > 0 ? imageOwners : undefined,
+                if (filtered.length < content.length) {
+                  normalizedMessage = {
+                    ...normalizedMessage,
+                    message: {
+                      ...normalizedMessage.message,
+                      content: filtered,
+                    },
+                    imagePermissionToolUseIds:
+                      imageOwners.length > 0 ? imageOwners : undefined,
+                  }
+                }
               }
             }
-            }
-          }
           }
 
           // Server renders tool_reference expansion as <functions>...</functions>

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1420,9 +1420,18 @@ export function normalizeMessagesForAPI(
   ): UserMessage => {
     const content = message.message.content
     if (!Array.isArray(content)) return message
+    let imageIndex = 0
+    const imageOwners: Array<string | null> = []
+    for (const block of content) {
+      if (block.type !== 'image') continue
+      const owner = message.imagePermissionToolUseIds?.[imageIndex++] ?? null
+      if (!types.has(block.type)) imageOwners.push(owner)
+    }
     const filtered = stripTargetsFromContent(content, types)
     return {
       ...message,
+      imagePermissionToolUseIds:
+        imageOwners.length > 0 ? imageOwners : undefined,
       message: {
         ...message.message,
         content: filtered.length > 0
@@ -1626,41 +1635,10 @@ export function normalizeMessagesForAPI(
           // the problematic content on every subsequent API call.
           const typesToStrip = stripTargets.get(normalizedMessage.uuid)
           if (typesToStrip) {
-            if (!normalizedMessage.isMeta) {
-              normalizedMessage = stripMediaFromUserMessage(
-                normalizedMessage,
-                typesToStrip,
-              )
-            } else {
-              const content = normalizedMessage.message.content
-              if (Array.isArray(content)) {
-                let imageIndex = 0
-                const imageOwners: Array<string | null> = []
-                const filtered = content.filter(block => {
-                  const keep = !typesToStrip.has(block.type)
-                  if (block.type === 'image') {
-                    const owner = normalizedMessage.imagePermissionToolUseIds?.[imageIndex++] ?? null
-                    if (keep) imageOwners.push(owner)
-                  }
-                  return keep
-                })
-                if (filtered.length === 0) {
-                  // All content blocks were stripped; skip this message entirely
-                  return
-                }
-                if (filtered.length < content.length) {
-                  normalizedMessage = {
-                    ...normalizedMessage,
-                    message: {
-                      ...normalizedMessage.message,
-                      content: filtered,
-                    },
-                    imagePermissionToolUseIds:
-                      imageOwners.length > 0 ? imageOwners : undefined,
-                  }
-                }
-              }
-            }
+            normalizedMessage = stripMediaFromUserMessage(
+              normalizedMessage,
+              typesToStrip,
+            )
           }
 
           // Server renders tool_reference expansion as <functions>...</functions>

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -1626,10 +1626,41 @@ export function normalizeMessagesForAPI(
           // the problematic content on every subsequent API call.
           const typesToStrip = stripTargets.get(normalizedMessage.uuid)
           if (typesToStrip) {
-            normalizedMessage = stripMediaFromUserMessage(
-              normalizedMessage,
-              typesToStrip,
-            )
+            if (!normalizedMessage.isMeta) {
+              normalizedMessage = stripMediaFromUserMessage(
+                normalizedMessage,
+                typesToStrip,
+              )
+            } else {
+            const content = normalizedMessage.message.content
+            if (Array.isArray(content)) {
+              let imageIndex = 0
+              const imageOwners: Array<string | null> = []
+              const filtered = content.filter(block => {
+                const keep = !typesToStrip.has(block.type)
+                if (block.type === 'image') {
+                  const owner = normalizedMessage.imagePermissionToolUseIds?.[imageIndex++] ?? null
+                  if (keep) imageOwners.push(owner)
+                }
+                return keep
+              })
+              if (filtered.length === 0) {
+                // All content blocks were stripped; skip this message entirely
+                return
+              }
+              if (filtered.length < content.length) {
+                normalizedMessage = {
+                  ...normalizedMessage,
+                  message: {
+                    ...normalizedMessage.message,
+                    content: filtered,
+                  },
+                  imagePermissionToolUseIds:
+                    imageOwners.length > 0 ? imageOwners : undefined,
+              }
+            }
+            }
+          }
           }
 
           // Server renders tool_reference expansion as <functions>...</functions>
@@ -1896,6 +1927,7 @@ export function mergeUserMessagesAndToolResults(
   const currentContent = normalizeUserTextContent(b.message.content)
   return {
     ...a,
+    imagePermissionToolUseIds: mergeImagePermissionToolUseIds(a, b),
     message: {
       ...a.message,
       content: hoistToolResults(
@@ -1903,6 +1935,20 @@ export function mergeUserMessagesAndToolResults(
       ),
     },
   }
+}
+
+function mergeImagePermissionToolUseIds(
+  a: UserMessage,
+  b: UserMessage,
+): Array<string | null> | undefined {
+  const getImageOwners = (message: UserMessage): Array<string | null> => {
+    if (message.imagePermissionToolUseIds) return message.imagePermissionToolUseIds
+    const content = message.message.content
+    if (!Array.isArray(content)) return []
+    return content.filter(block => block.type === 'image').map(() => null)
+  }
+  const ids = [...getImageOwners(a), ...getImageOwners(b)]
+  return ids.length > 0 ? ids : undefined
 }
 
 export function mergeAssistantMessages(
@@ -1952,6 +1998,7 @@ export function mergeUserMessages(a: UserMessage, b: UserMessage): UserMessage {
     if (isSnipRuntimeEnabled()) {
       return {
         ...a,
+        imagePermissionToolUseIds: mergeImagePermissionToolUseIds(a, b),
         isMeta: a.isMeta && b.isMeta ? (true as const) : undefined,
         isCollapseSummary,
         uuid: a.isMeta ? b.uuid : a.uuid,
@@ -1966,6 +2013,7 @@ export function mergeUserMessages(a: UserMessage, b: UserMessage): UserMessage {
   }
   return {
     ...a,
+    imagePermissionToolUseIds: mergeImagePermissionToolUseIds(a, b),
     isCollapseSummary,
     // Preserve the non-meta message's uuid so snip ids (derived from uuid)
     // stay stable across API calls (meta messages like system context get fresh uuids each call)
@@ -2159,11 +2207,12 @@ export function mergeUserContentBlocks(
     return [...a, ...b]
   }
 
-  // Universal smoosh (gated): fold all non-tool_result block types (text,
-  // image, document, search_result) into tool_result.content. tool_result
-  // blocks stay as siblings (hoisted later by hoistToolResults).
-  const toSmoosh = b.filter(x => x.type !== 'tool_result')
+  // Universal smoosh (gated): fold textual/document siblings into the result,
+  // but keep images top-level. Compression must retain their provenance so an
+  // independent attachment is never mistaken for tool-result payload.
+  const toSmoosh = b.filter(x => x.type !== 'tool_result' && x.type !== 'image')
   const toolResults = b.filter(x => x.type === 'tool_result')
+  const images = b.filter(x => x.type === 'image')
   if (toSmoosh.length === 0) {
     return [...a, ...b]
   }
@@ -2174,7 +2223,7 @@ export function mergeUserContentBlocks(
     return [...a, ...b]
   }
 
-  return [...a.slice(0, -1), smooshed, ...toolResults]
+  return [...a.slice(0, -1), smooshed, ...toolResults, ...images]
 }
 
 // Sometimes the API returns empty messages (eg. "\n\n"). We need to filter these out,

--- a/src/utils/messages/apiTransform.test.ts
+++ b/src/utils/messages/apiTransform.test.ts
@@ -361,6 +361,19 @@ describe('appendMessageTagToUserMessage', () => {
     const blocks = merged.message.content as any[]
     expect(blocks.filter(b => b.type === 'tool_result').length).toBe(2)
   })
+
+  test('merging tool-result siblings keeps permission attachment ownership', () => {
+    const resultA = createUserMessage({
+      content: [{ type: 'tool_result', tool_use_id: 'tu-A', content: 'a' }],
+    })
+    const resultB = createUserMessage({
+      content: [{ type: 'tool_result', tool_use_id: 'tu-B', content: 'b' }],
+      imagePermissionToolUseIds: ['tu-B'],
+    })
+
+    expect(mergeUserMessages(resultA, resultB).imagePermissionToolUseIds)
+      .toEqual(['tu-B'])
+  })
 })
 
 describe('API cleanup transforms', () => {

--- a/src/utils/messages/factories.ts
+++ b/src/utils/messages/factories.ts
@@ -202,6 +202,7 @@ export function createUserMessage({
   isCollapseSummary,
   summarizeMetadata,
   toolUseResult,
+  imagePermissionToolUseIds,
   isAgentStepLimitToolResult,
   mcpMeta,
   uuid,
@@ -218,6 +219,7 @@ export function createUserMessage({
   isCompactSummary?: boolean
   isCollapseSummary?: boolean
   toolUseResult?: unknown // Matches tool's `Output` type
+  imagePermissionToolUseIds?: Array<string | null>
   isAgentStepLimitToolResult?: boolean
   /** MCP protocol metadata to pass through to SDK consumers (never sent to model) */
   mcpMeta?: {
@@ -259,6 +261,7 @@ export function createUserMessage({
     uuid: (uuid as UUID | undefined) || randomUUID(),
     timestamp: timestamp ?? new Date().toISOString(),
     toolUseResult,
+    imagePermissionToolUseIds,
     isAgentStepLimitToolResult,
     mcpMeta,
     imagePasteIds,

--- a/src/utils/messages/normalize.test.ts
+++ b/src/utils/messages/normalize.test.ts
@@ -39,6 +39,26 @@ function expectEquivalent(messages: Message[]): void {
   expect(normalizeMessagesCached(messages)).toEqual(normalizeMessages(messages))
 }
 
+describe('normalizeMessages', () => {
+  test('keeps each split permission image paired with its own tool result', () => {
+    const message = withUuid(createUserMessage({
+      content: [
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'one' } },
+        { type: 'text', text: 'between images' },
+        { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'two' } },
+      ],
+      imagePermissionToolUseIds: ['toolu_one', 'toolu_two'],
+    }))
+
+    const normalized = normalizeMessages([message])
+    expect(normalized.map(item => item.imagePermissionToolUseIds)).toEqual([
+      ['toolu_one'],
+      undefined,
+      ['toolu_two'],
+    ])
+  })
+})
+
 describe('normalizeMessagesCached', () => {
   test('matches normalizeMessages for single-block messages', () => {
     expectEquivalent([user('hi'), assistant('hello'), user('bye')])

--- a/src/utils/messages/normalize.ts
+++ b/src/utils/messages/normalize.ts
@@ -33,6 +33,7 @@ function createNormalizedUserBlockMessage({
     uuid,
     timestamp: source.timestamp,
     toolUseResult: source.toolUseResult,
+    imagePermissionToolUseIds: source.imagePermissionToolUseIds,
     mcpMeta: source.mcpMeta,
     imagePasteIds,
     origin: source.origin,

--- a/src/utils/messages/normalize.ts
+++ b/src/utils/messages/normalize.ts
@@ -13,11 +13,13 @@ function createNormalizedUserBlockMessage({
   source,
   content,
   imagePasteIds,
+  imagePermissionToolUseIds,
   uuid,
 }: {
   source: UserMessage
   content: ContentBlockParam[]
   imagePasteIds?: number[]
+  imagePermissionToolUseIds?: Array<string | null>
   uuid: UUID
 }): UserMessage {
   return {
@@ -33,7 +35,7 @@ function createNormalizedUserBlockMessage({
     uuid,
     timestamp: source.timestamp,
     toolUseResult: source.toolUseResult,
-    imagePermissionToolUseIds: source.imagePermissionToolUseIds,
+    imagePermissionToolUseIds,
     mcpMeta: source.mcpMeta,
     imagePasteIds,
     origin: source.origin,
@@ -122,11 +124,15 @@ export function normalizeMessages(messages: Message[]): NormalizedMessage[] {
             isImage && message.imagePasteIds
               ? message.imagePasteIds[imageIndex]
               : undefined
+          const imageOwner =
+            isImage ? message.imagePermissionToolUseIds?.[imageIndex] : undefined
           if (isImage) imageIndex++
           return createNormalizedUserBlockMessage({
             source: message,
             content: [_],
             imagePasteIds: imageId !== undefined ? [imageId] : undefined,
+            imagePermissionToolUseIds:
+              imageOwner !== undefined ? [imageOwner] : undefined,
             uuid: isNewChain ? deriveUUID(message.uuid, index) : message.uuid,
           }) as NormalizedMessage
         })


### PR DESCRIPTION
## Summary

- Compress old tool-result history before building generic Responses and compatibility requests, matching the existing Chat Completions behavior.
- Avoid constructing discarded Chat messages for Responses, Anthropic Messages, and Gemini transports.
- Cache converted Responses input per request so retries and GitHub endpoint fallback reuse the same immutable conversion.

## Impact

- Reduces the structured 30-exchange fixture from 156,657 to 55,115 serialized characters, a 64.8% reduction.
- Keeps native Ollama on the Chat-shaped conversion path while leaving custom Anthropic Messages and Gemini request bodies uncompressed.
- Preserves tool pairing, URL-backed structured tool-result images, reasoning fields, compatibility content types, local fast-path behavior, stable serialization, retry behavior, and abort propagation.

## Testing

- Focused API and compressor suite with Responses, compatibility, Chat, fallback, local fast-path, structured-image, tool-pairing, and abort coverage: 322 passed, 0 failed.
- `bun run typecheck`
- `bun run typecheck:type-tests`
- `bun run build`
- `bun run smoke`
- `git diff --check`
- `bun run security:pr-scan`
- `bun run check` remains nonzero on existing repository-wide baseline failures; comparison found no branch-only failures.

Provider paths exercised include generic Responses, `responses_compat`, GitHub Chat-to-Responses fallback, local fast-path requests, native Ollama Chat, Anthropic Messages overrides, and Gemini overrides.

## Notes

- Compression tier policy and configuration defaults are unchanged.
- Old eligible tool results retain the existing intentionally lossy compression behavior.
- Image-related failure classification uses the exact serialized payload and runs only on the error path.
- The branch was refreshed additively with current `main`; adjacent PRs #1869, #1940, and #1614 remained open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool-history compression for Responses/OpenAI-compatible requests, maintaining `function_call`/`function_call_output` alignment across tiering, truncation/stubbing, and parallel tool batches.
  * Strengthened image handling across transports: more accurate image detection from outgoing payloads, correct inline/permission image omission & sanitization, improved multimodal behavior, and more reliable retry/fallback—including proper abort propagation and vision-not-supported handling.
  * Adjusted Codex tool-result text serialization to match the expected newline format.
* **Tests**
  * Expanded Requests/Responses and image/multimodal edge-case coverage, including retry/fallback ordering and structured tool-result formatting assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
