### PR TITLE
test(websearch): stabilize Brave timeout coverage

### DIFF
--- a/src/tools/WebSearchTool/providers/brave.test.ts
+++ b/src/tools/WebSearchTool/providers/brave.test.ts
@@ -1,10 +1,12 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../../../test/sharedMutationLock.js'
 
 import { braveProvider } from './brave.ts'
+
+await acquireSharedMutationLock('WebSearchTool/providers/brave.test.ts')
 
 const originalEnv = {
   BRAVE_API_KEY: process.env.BRAVE_API_KEY,
@@ -29,20 +31,16 @@ function expectSignalAbort(signal: AbortSignal | undefined): Promise<void> {
   })
 }
 
-beforeEach(async () => {
-  await acquireSharedMutationLock('WebSearchTool/providers/brave.test.ts')
+afterEach(() => {
+  for (const [k, v] of Object.entries(originalEnv)) {
+    if (v === undefined) delete process.env[k]
+    else process.env[k] = v
+  }
+  globalThis.fetch = originalFetch
 })
 
-afterEach(() => {
-  try {
-    for (const [k, v] of Object.entries(originalEnv)) {
-      if (v === undefined) delete process.env[k]
-      else process.env[k] = v
-    }
-    globalThis.fetch = originalFetch
-  } finally {
-    releaseSharedMutationLock()
-  }
+afterAll(() => {
+  releaseSharedMutationLock()
 })
 
 describe('braveProvider isConfigured', () => {


### PR DESCRIPTION
## Summary

- Acquire the Brave provider test's shared global-mutation lock during module setup instead of its per-test hook.
- Snapshot and restore `process.env` and `globalThis.fetch` only while owning that lock.
- Keep queued lock time outside Bun's individual five-second test deadline, while preserving the one-second provider-timeout and abort assertions.

## Why

PR #1939's Node 22 smoke run failed the target test at 5936.95ms, then passed when that job was retried without a code change. The asynchronous `beforeEach` lock wait was included in the test's deadline; a roughly five-second queue wait plus the deliberate one-second provider timeout caused the flake.

## Validation

- `bun test src/tools/WebSearchTool/providers/brave.test.ts` (10 pass)
- Serialized neighboring WebSearch provider tests (96 pass)
- Concurrent Brave/provider probes (39 pass; 14 pass; 10 pass)
- `bun run test:full`: all Brave tests pass, including the target at ~1.00s. It retains the 24 unrelated failures reproduced unchanged on clean upstream main.
- `git diff --check`

## Notes

The complete baseline failures are the stale startup-provider override, PowerShell/git commit-governance, and full-plan-instructions cases; they reproduce identically from upstream main. `security:pr-scan` is not reported because it compares against the stale fork-origin baseline and scans unrelated upstream history.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and cleanup for web search provider tests.
  * Ensured shared test resources are acquired and released consistently across the test suite.
  * Simplified restoration of environment variables and network request behavior between tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->