### PR TITLE
fix: prevent Ctrl-C feedback from freezing prompt input

### DIFF
--- a/src/components/PromptInput/HistorySearchInput.test.tsx
+++ b/src/components/PromptInput/HistorySearchInput.test.tsx
@@ -1,0 +1,107 @@
+import { PassThrough } from 'node:stream'
+import { expect, test } from 'bun:test'
+import { useEffect } from 'react'
+import { createRoot, useInput } from '../../ink.js'
+import { AppStateProvider } from '../../state/AppState.js'
+import HistorySearchInput from './HistorySearchInput.js'
+
+function createTestStreams(): {
+  stdout: PassThrough
+  stdin: PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+} {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough() as PassThrough & {
+    isTTY: boolean
+    setRawMode: (mode: boolean) => void
+    ref: () => void
+    unref: () => void
+  }
+
+  stdin.isTTY = true
+  stdin.setRawMode = () => {}
+  stdin.ref = () => {}
+  stdin.unref = () => {}
+  ;(stdout as unknown as { columns: number }).columns = 80
+
+  return { stdout, stdin }
+}
+
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (condition()) return
+    await Bun.sleep(5)
+  }
+  throw new Error(`Timed out waiting for ${description}`)
+}
+
+test('stops consuming input when its hidden parent disables focus', async () => {
+  const { stdout, stdin } = createTestStreams()
+  const changes: string[] = []
+  const dispatchedInputs: string[] = []
+  let committedToken = 0
+  let unmounted = false
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  function InputDispatchProbe(): null {
+    useInput(input => dispatchedInputs.push(input))
+    useEffect(() => () => {
+      unmounted = true
+    }, [])
+    return null
+  }
+
+  function CommitProbe({ token }: { token: number }): null {
+    useEffect(() => {
+      committedToken = token
+    }, [token])
+    return null
+  }
+
+  const onChange = (nextValue: string) => changes.push(nextValue)
+  const render = (value: string, focus: boolean, token: number) =>
+    root.render(
+      <AppStateProvider>
+        <HistorySearchInput
+          value={value}
+          onChange={onChange}
+          historyFailedMatch={false}
+          focus={focus}
+        />
+        <InputDispatchProbe />
+        <CommitProbe token={token} />
+      </AppStateProvider>,
+    )
+
+  render('', true, 1)
+  await waitFor(() => committedToken === 1, 'focused commit')
+  stdin.write('a')
+  await waitFor(
+    () => changes.includes('a') && dispatchedInputs.includes('a'),
+    'focused input dispatch',
+  )
+
+  render('a', false, 2)
+  await waitFor(() => committedToken === 2, 'unfocused commit')
+  stdin.write('b')
+  await waitFor(() => dispatchedInputs.includes('b'), 'unfocused input dispatch')
+  expect(changes).toEqual(['a'])
+
+  root.unmount()
+  await waitFor(() => unmounted, 'input probe cleanup')
+  stdin.end()
+  stdout.end()
+})

--- a/src/components/PromptInput/HistorySearchInput.tsx
+++ b/src/components/PromptInput/HistorySearchInput.tsx
@@ -7,13 +7,15 @@ type Props = {
   value: string;
   onChange: (value: string) => void;
   historyFailedMatch: boolean;
+  focus: boolean;
 };
 function HistorySearchInput(t0) {
-  const $ = _c(9);
+  const $ = _c(10);
   const {
     value,
     onChange,
-    historyFailedMatch
+    historyFailedMatch,
+    focus
   } = t0;
   const t1 = historyFailedMatch ? "no matching prompt:" : "search prompts:";
   let t2;
@@ -26,23 +28,24 @@ function HistorySearchInput(t0) {
   }
   const t3 = stringWidth(value) + 1;
   let t4;
-  if ($[2] !== onChange || $[3] !== t3 || $[4] !== value) {
-    t4 = <TextInput value={value} onChange={onChange} cursorOffset={value.length} onChangeCursorOffset={_temp} columns={t3} focus={true} showCursor={true} multiline={false} dimColor={true} />;
-    $[2] = onChange;
-    $[3] = t3;
-    $[4] = value;
-    $[5] = t4;
+  if ($[2] !== focus || $[3] !== onChange || $[4] !== t3 || $[5] !== value) {
+    t4 = <TextInput value={value} onChange={onChange} cursorOffset={value.length} onChangeCursorOffset={_temp} columns={t3} focus={focus} showCursor={true} multiline={false} dimColor={true} />;
+    $[2] = focus;
+    $[3] = onChange;
+    $[4] = t3;
+    $[5] = value;
+    $[6] = t4;
   } else {
-    t4 = $[5];
+    t4 = $[6];
   }
   let t5;
-  if ($[6] !== t2 || $[7] !== t4) {
+  if ($[7] !== t2 || $[8] !== t4) {
     t5 = <Box gap={1}>{t2}{t4}</Box>;
-    $[6] = t2;
-    $[7] = t4;
-    $[8] = t5;
+    $[7] = t2;
+    $[8] = t4;
+    $[9] = t5;
   } else {
-    t5 = $[8];
+    t5 = $[9];
   }
   return t5;
 }

--- a/src/components/PromptInput/KeepMounted.test.tsx
+++ b/src/components/PromptInput/KeepMounted.test.tsx
@@ -11,9 +11,23 @@ function createTestStdout(): NodeJS.WriteStream {
   return stdout as unknown as NodeJS.WriteStream
 }
 
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (condition()) return
+    await Bun.sleep(5)
+  }
+  throw new Error(`Timed out waiting for ${description}`)
+}
+
 test('keeps children mounted while visibility changes', async () => {
   let mounts = 0
   let unmounts = 0
+  let committedToken = 0
   const stdout = createTestStdout() as unknown as PassThrough
   let output = ''
   stdout.on('data', chunk => {
@@ -30,32 +44,55 @@ test('keeps children mounted while visibility changes', async () => {
     return <Text>persistent child</Text>
   }
 
+  function CommitProbe({ token }: { token: number }): null {
+    useEffect(() => {
+      committedToken = token
+    }, [token])
+    return null
+  }
+
   const root = await createRoot({
     stdout: stdout as unknown as NodeJS.WriteStream,
     patchConsole: false,
   })
-  const render = (hidden: boolean) =>
+  const render = (hidden: boolean, token: number) =>
     root.render(
-      <KeepMounted hidden={hidden}>
-        <Probe />
-      </KeepMounted>,
+      <>
+        <KeepMounted hidden={hidden}>
+          <Probe />
+        </KeepMounted>
+        <CommitProbe token={token} />
+      </>,
     )
 
-  render(false)
-  await Bun.sleep(10)
+  render(false, 1)
+  await waitFor(
+    () =>
+      committedToken === 1 &&
+      mounts === 1 &&
+      stripAnsi(output).includes('persistent child'),
+    'initial mount',
+  )
   expect(stripAnsi(output)).toContain('persistent child')
 
   output = ''
-  render(true)
-  await Bun.sleep(10)
+  render(true, 2)
+  await waitFor(() => committedToken === 2, 'hidden commit')
   const hiddenFrame = stripAnsi(output).replaceAll('\r', '').replaceAll('\n', '')
   expect(hiddenFrame).toBe('')
 
-  render(false)
+  render(false, 3)
+  await waitFor(
+    () =>
+      committedToken === 3 && stripAnsi(output).includes('persistent child'),
+    'visible commit',
+  )
+  expect(stripAnsi(output)).toContain('persistent child')
 
   expect(mounts).toBe(1)
   expect(unmounts).toBe(0)
 
   root.unmount()
+  await waitFor(() => unmounts === 1, 'unmount cleanup')
   expect(unmounts).toBe(1)
 })

--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -111,6 +111,7 @@ import { BackgroundTasksDialog } from '../tasks/BackgroundTasksDialog.js';
 import { countVisibleBackgroundTasks, shouldHideTasksFooter } from '../tasks/taskStatusUtils.js';
 import { TeamsDialog } from '../teams/TeamsDialog.js';
 import VimTextInput from '../VimTextInput.js';
+import { applyHistorySearchActiveState } from './footerVisibility.js';
 import { detectModeEntry, getModeFromInput, getValueFromInput } from './inputModes.js';
 import { FOOTER_TEMPORARY_STATUS_TIMEOUT, Notifications } from './Notifications.js';
 import PromptInputFooter from './PromptInputFooter.js';
@@ -357,6 +358,9 @@ function PromptInput({
     }
     return toolPermissionContext;
   }, [viewedTeammate, toolPermissionContext]);
+  const setHistorySearchActive = useCallback((active: boolean) => {
+    applyHistorySearchActiveState(active, setHelpOpen, setIsSearchingHistory);
+  }, [setHelpOpen, setIsSearchingHistory]);
   const {
     historyQuery,
     setHistoryQuery,
@@ -365,7 +369,7 @@ function PromptInput({
   } = useHistorySearch(entry => {
     setPastedContents(entry.pastedContents);
     void onSubmit(entry.display);
-  }, input, trackAndSetInput, setCursorOffset, cursorOffset, onModeChange, mode, isSearchingHistory, setIsSearchingHistory, setPastedContents, pastedContents);
+  }, input, trackAndSetInput, setCursorOffset, cursorOffset, onModeChange, mode, isSearchingHistory, setHistorySearchActive, setPastedContents, pastedContents);
   // Counter for paste IDs (shared between images and text).
   // Compute initial value once from existing messages (for --continue/--resume).
   // useRef(fn()) evaluates fn() on every render and discards the result after

--- a/src/components/PromptInput/PromptInputFooter.test.tsx
+++ b/src/components/PromptInput/PromptInputFooter.test.tsx
@@ -10,6 +10,7 @@ import {
 const guardsPass = {
   isPromptMode: true,
   isShort: false,
+  hideRegularFooter: false,
   exitMessageShown: false,
   isPasting: false,
 }
@@ -51,6 +52,7 @@ describe('resolveFooterStatusLine', () => {
   for (const [name, guards] of [
     ['non-prompt mode', { ...guardsPass, isPromptMode: false }],
     ['short fullscreen', { ...guardsPass, isShort: true }],
+    ['inline suggestions or help', { ...guardsPass, hideRegularFooter: true }],
     ['exit message showing', { ...guardsPass, exitMessageShown: true }],
     ['paste in progress', { ...guardsPass, isPasting: true }],
   ] as const) {

--- a/src/components/PromptInput/PromptInputFooter.tsx
+++ b/src/components/PromptInput/PromptInputFooter.tsx
@@ -21,6 +21,7 @@ import { BuiltinStatusLine, builtinStatusLineShouldDisplay } from '../BuiltinSta
 import { useCoordinatorTaskCount } from '../CoordinatorAgentStatus.js';
 import { getLastAssistantMessageId, StatusLine, statusLineShouldDisplay } from '../StatusLine.js';
 import { Notifications } from './Notifications.js';
+import { resolveFooterOverlay, resolveTransientFooterMessage } from './footerVisibility.js';
 import { KeepMounted } from './KeepMounted.js';
 import { PromptInputFooterLeftSide } from './PromptInputFooterLeftSide.js';
 import { PromptInputFooterSuggestions, type SuggestionItem } from './PromptInputFooterSuggestions.js';
@@ -28,18 +29,20 @@ import { PromptInputHelpMenu } from './PromptInputHelpMenu.js';
 /**
  * Which status line, if any, the footer renders below the prompt: the
  * configured custom command wins over the built-in one, and neither renders
- * when the row's guards fail (non-prompt mode, short fullscreen, exit
- * message showing, paste in progress). The `? for shortcuts` hint is
+ * when the row's guards fail (non-prompt mode, short fullscreen, inline
+ * suggestions/help, exit message showing, or paste in progress). The
+ * `? for shortcuts` hint is
  * suppressed only when this returns non-null, so the hint never disappears
  * in states where no status line actually renders.
  */
 export function resolveFooterStatusLine(settings: ReadonlySettings, guards: {
   isPromptMode: boolean;
   isShort: boolean;
+  hideRegularFooter: boolean;
   exitMessageShown: boolean;
   isPasting: boolean;
 }, config?: Parameters<typeof builtinStatusLineShouldDisplay>[1]): 'custom' | 'builtin' | null {
-  if (!guards.isPromptMode || guards.isShort || guards.exitMessageShown || guards.isPasting) return null;
+  if (!guards.isPromptMode || guards.isShort || guards.hideRegularFooter || resolveTransientFooterMessage(guards) !== null) return null;
   if (statusLineShouldDisplay(settings)) return 'custom';
   if (builtinStatusLineShouldDisplay(settings, config)) return 'builtin';
   return null;
@@ -49,6 +52,7 @@ export function resolveConfiguredFooterStatusLine(settings: ReadonlySettings): '
   return resolveFooterStatusLine(settings, {
     isPromptMode: true,
     isShort: false,
+    hideRegularFooter: false,
     exitMessageShown: false,
     isPasting: false
   });
@@ -159,6 +163,12 @@ function PromptInputFooter({
   // has terminal scrollback to absorb overflow, so we never hide StatusLine there.
   const isFullscreen = isFullscreenEnvEnabled();
   const isShort = isFullscreen && rows < 24;
+  const footerOverlay = resolveFooterOverlay({
+    hasInlineSuggestions: suggestions.length > 0 && !isFullscreen,
+    helpOpen,
+    isSearching
+  });
+  const hideRegularFooter = footerOverlay !== null;
 
   // Pill highlights when tasks is the active footer item AND no specific
   // agent row is selected. When coordinatorTaskIndex >= 0 the pointer has
@@ -172,6 +182,7 @@ function PromptInputFooter({
   const footerStatusLine = resolveFooterStatusLine(settings, {
     isPromptMode: mode === 'prompt',
     isShort,
+    hideRegularFooter,
     exitMessageShown: exitMessage.show,
     isPasting
   });
@@ -192,16 +203,14 @@ function PromptInputFooter({
     maxColumnWidth
   } : null, [isFullscreen, suggestions, selectedSuggestion, maxColumnWidth]);
   useSetPromptOverlay(overlayData);
-  const showInlineSuggestions = suggestions.length > 0 && !isFullscreen;
-  const hideRegularFooter = showInlineSuggestions || helpOpen;
   return <>
       <KeepMounted hidden={hideRegularFooter}>
         <Box flexDirection={isNarrow ? 'column' : 'row'} justifyContent={isNarrow ? 'flex-start' : 'space-between'} paddingX={2} gap={isNarrow ? 0 : 1}>
           <Box flexDirection="column" flexShrink={isNarrow ? 0 : 1}>
           <KeepMounted hidden={footerStatusLine === null}>
-            {configuredFooterStatusLine === 'custom' ? <StatusLine messagesRef={messagesRef} lastAssistantMessageId={lastAssistantMessageId} vimMode={vimMode} /> : configuredFooterStatusLine === 'builtin' ? <BuiltinStatusLine messagesRef={messagesRef} lastAssistantMessageId={lastAssistantMessageId} /> : null}
+            {configuredFooterStatusLine === 'custom' ? <StatusLine active={footerStatusLine === 'custom'} messagesRef={messagesRef} lastAssistantMessageId={lastAssistantMessageId} vimMode={vimMode} /> : configuredFooterStatusLine === 'builtin' ? <BuiltinStatusLine messagesRef={messagesRef} lastAssistantMessageId={lastAssistantMessageId} /> : null}
           </KeepMounted>
-          <PromptInputFooterLeftSide exitMessage={exitMessage} vimMode={vimMode} mode={mode} toolPermissionContext={toolPermissionContext} suppressHint={suppressHint} isLoading={isLoading} tasksSelected={pillSelected} teamsSelected={teamsSelected} teammateFooterIndex={teammateFooterIndex} tmuxSelected={tmuxSelected} isPasting={isPasting} isSearching={isSearching} historyQuery={historyQuery} setHistoryQuery={setHistoryQuery} historyFailedMatch={historyFailedMatch} onOpenTasksDialog={onOpenTasksDialog} />
+          <PromptInputFooterLeftSide active={!hideRegularFooter} exitMessage={exitMessage} vimMode={vimMode} mode={mode} toolPermissionContext={toolPermissionContext} suppressHint={suppressHint} isLoading={isLoading} tasksSelected={pillSelected} teamsSelected={teamsSelected} teammateFooterIndex={teammateFooterIndex} tmuxSelected={tmuxSelected} isPasting={isPasting} isSearching={isSearching} historyQuery={historyQuery} setHistoryQuery={setHistoryQuery} historyFailedMatch={historyFailedMatch} onOpenTasksDialog={onOpenTasksDialog} />
           </Box>
           <Box flexShrink={1} gap={1}>
           {isFullscreen ? null : <Notifications apiKeyStatus={apiKeyStatus} autoUpdaterResult={autoUpdaterResult} debug={debug} isAutoUpdating={isAutoUpdating} verbose={verbose} messages={messages} onAutoUpdaterResult={onAutoUpdaterResult} onChangeIsUpdating={onChangeIsUpdating} ideSelection={ideSelection} mcpClients={mcpClients} isInputWrapped={isInputWrapped} isNarrow={isNarrow} />}
@@ -209,9 +218,9 @@ function PromptInputFooter({
           </Box>
         </Box>
       </KeepMounted>
-      {showInlineSuggestions ? <Box paddingX={2} paddingY={0}>
+      {footerOverlay === 'suggestions' ? <Box paddingX={2} paddingY={0}>
           <PromptInputFooterSuggestions suggestions={suggestions} selectedSuggestion={selectedSuggestion} maxColumnWidth={maxColumnWidth} />
-        </Box> : helpOpen ? <PromptInputHelpMenu dimColor={true} fixedWidth={true} paddingX={2} /> : null}
+        </Box> : footerOverlay === 'help' ? <PromptInputHelpMenu dimColor={true} fixedWidth={true} paddingX={2} /> : null}
     </>;
 }
 export default memo(PromptInputFooter);

--- a/src/components/PromptInput/PromptInputFooterLeftSide.test.ts
+++ b/src/components/PromptInput/PromptInputFooterLeftSide.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  applyHistorySearchActiveState,
+  resolveFooterOverlay,
+  resolveRegularFooterActive,
+  resolveTransientFooterMessage,
+  resolveVisibleTransientFooterMessage,
+} from './footerVisibility.js'
+
+describe('applyHistorySearchActiveState', () => {
+  it('closes help before activating history search', () => {
+    const transitions: string[] = []
+    applyHistorySearchActiveState(
+      true,
+      open => transitions.push(`help:${open}`),
+      active => transitions.push(`search:${active}`),
+    )
+    expect(transitions).toEqual(['help:false', 'search:true'])
+  })
+
+  it('does not change help when history search ends', () => {
+    const transitions: string[] = []
+    applyHistorySearchActiveState(
+      false,
+      open => transitions.push(`help:${open}`),
+      active => transitions.push(`search:${active}`),
+    )
+    expect(transitions).toEqual(['search:false'])
+  })
+})
+
+describe('resolveFooterOverlay', () => {
+  it('lets history search replace help and inline suggestions', () => {
+    expect(
+      resolveFooterOverlay({
+        hasInlineSuggestions: true,
+        helpOpen: true,
+        isSearching: true,
+      }),
+    ).toBeNull()
+  })
+
+  it('shows suggestions before help outside history search', () => {
+    expect(
+      resolveFooterOverlay({
+        hasInlineSuggestions: true,
+        helpOpen: true,
+        isSearching: false,
+      }),
+    ).toBe('suggestions')
+    expect(
+      resolveFooterOverlay({
+        hasInlineSuggestions: false,
+        helpOpen: true,
+        isSearching: false,
+      }),
+    ).toBe('help')
+  })
+})
+
+describe('resolveTransientFooterMessage', () => {
+  it('shows transient feedback outside history search', () => {
+    expect(
+      resolveTransientFooterMessage({
+        exitMessageShown: true,
+        isPasting: false,
+      }),
+    ).toBe('exit')
+    expect(
+      resolveTransientFooterMessage({
+        exitMessageShown: false,
+        isPasting: true,
+      }),
+    ).toBe('paste')
+  })
+
+  it('lets history search replace pending transient feedback', () => {
+    expect(
+      resolveVisibleTransientFooterMessage({
+        isSearching: true,
+        exitMessageShown: true,
+        isPasting: false,
+      }),
+    ).toBeNull()
+  })
+
+  it('prioritizes exit feedback when paste feedback is also active', () => {
+    expect(
+      resolveTransientFooterMessage({
+        exitMessageShown: true,
+        isPasting: true,
+      }),
+    ).toBe('exit')
+  })
+})
+
+describe('resolveRegularFooterActive', () => {
+  it('requires both parent visibility and no transient message', () => {
+    expect(
+      resolveRegularFooterActive({
+        parentActive: true,
+        transientMessage: null,
+      }),
+    ).toBe(true)
+    expect(
+      resolveRegularFooterActive({
+        parentActive: false,
+        transientMessage: null,
+      }),
+    ).toBe(false)
+    expect(
+      resolveRegularFooterActive({
+        parentActive: true,
+        transientMessage: 'exit',
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/components/PromptInput/PromptInputFooterLeftSide.tsx
+++ b/src/components/PromptInput/PromptInputFooterLeftSide.tsx
@@ -39,6 +39,8 @@ import { useHasSelection, useSelection } from '../../ink/hooks/use-selection.js'
 import { getGlobalConfig, saveGlobalConfig } from '../../utils/config.js';
 import { getPlatform } from '../../utils/platform.js';
 import { PrBadge } from '../PrBadge.js';
+import { resolveRegularFooterActive, resolveVisibleTransientFooterMessage } from './footerVisibility.js';
+import { KeepMounted } from './KeepMounted.js';
 
 // Dead code elimination: conditional import for proactive mode
 /* eslint-disable @typescript-eslint/no-require-imports */
@@ -48,6 +50,7 @@ const NO_OP_SUBSCRIBE = (_cb: () => void) => () => {};
 const NULL = () => null;
 const MAX_VOICE_HINT_SHOWS = 3;
 type Props = {
+  active: boolean;
   exitMessage: {
     show: boolean;
     key?: string;
@@ -69,15 +72,19 @@ type Props = {
   historyFailedMatch: boolean;
   onOpenTasksDialog?: (taskId?: string) => void;
 };
-function ProactiveCountdown() {
-  const $ = _c(7);
+function ProactiveCountdown({
+  active
+}: {
+  active: boolean;
+}) {
+  const $ = _c(8);
   const nextTickAt = useSyncExternalStore(proactiveModule?.subscribeToProactiveChanges ?? NO_OP_SUBSCRIBE, proactiveModule?.getNextTickAt ?? NULL, NULL);
   const [remainingSeconds, setRemainingSeconds] = useState<number | null>(null);
   let t0;
   let t1;
-  if ($[0] !== nextTickAt) {
+  if ($[0] !== active || $[1] !== nextTickAt) {
     t0 = () => {
-      if (nextTickAt === null) {
+      if (!active || nextTickAt === null) {
         setRemainingSeconds(null);
         return;
       }
@@ -89,13 +96,14 @@ function ProactiveCountdown() {
       const interval = setInterval(update, 1000);
       return () => clearInterval(interval);
     };
-    t1 = [nextTickAt];
-    $[0] = nextTickAt;
-    $[1] = t0;
-    $[2] = t1;
+    t1 = [active, nextTickAt];
+    $[0] = active;
+    $[1] = nextTickAt;
+    $[2] = t0;
+    $[3] = t1;
   } else {
-    t0 = $[1];
-    t1 = $[2];
+    t0 = $[2];
+    t1 = $[3];
   }
   useEffect(t0, t1);
   if (remainingSeconds === null) {
@@ -103,28 +111,29 @@ function ProactiveCountdown() {
   }
   const t2 = remainingSeconds * 1000;
   let t3;
-  if ($[3] !== t2) {
+  if ($[4] !== t2) {
     t3 = formatDuration(t2, {
       mostSignificantOnly: true
     });
-    $[3] = t2;
-    $[4] = t3;
+    $[4] = t2;
+    $[5] = t3;
   } else {
-    t3 = $[4];
+    t3 = $[5];
   }
   let t4;
-  if ($[5] !== t3) {
+  if ($[6] !== t3) {
     t4 = <Text dimColor={true}>waiting{" "}{t3}</Text>;
-    $[5] = t3;
-    $[6] = t4;
+    $[6] = t3;
+    $[7] = t4;
   } else {
-    t4 = $[6];
+    t4 = $[7];
   }
   return t4;
 }
 export function PromptInputFooterLeftSide(t0) {
-  const $ = _c(27);
+  const $ = _c(29);
   const {
+    active,
     exitMessage,
     vimMode,
     mode,
@@ -135,14 +144,20 @@ export function PromptInputFooterLeftSide(t0) {
     teamsSelected,
     tmuxSelected,
     teammateFooterIndex,
-    isPasting,
+    isPasting = false,
     isSearching,
     historyQuery,
     setHistoryQuery,
     historyFailedMatch,
     onOpenTasksDialog
   } = t0;
-  if (exitMessage.show) {
+  let transientMessage: React.ReactNode = null;
+  const transientMessageType = resolveVisibleTransientFooterMessage({
+    isSearching,
+    exitMessageShown: exitMessage.show,
+    isPasting
+  });
+  if (transientMessageType === 'exit') {
     let t1;
     if ($[0] !== exitMessage.key) {
       t1 = <Text dimColor={true} key="exit-message">Press {exitMessage.key} again to exit</Text>;
@@ -151,9 +166,8 @@ export function PromptInputFooterLeftSide(t0) {
     } else {
       t1 = $[1];
     }
-    return t1;
-  }
-  if (isPasting) {
+    transientMessage = t1;
+  } else if (transientMessageType === 'paste') {
     let t1;
     if ($[2] === Symbol.for("react.memo_cache_sentinel")) {
       t1 = <Text dimColor={true} key="pasting-message">Pasting text…</Text>;
@@ -161,7 +175,7 @@ export function PromptInputFooterLeftSide(t0) {
     } else {
       t1 = $[2];
     }
-    return t1;
+    transientMessage = t1;
   }
   let t1;
   if ($[3] !== isSearching || $[4] !== vimMode) {
@@ -174,52 +188,61 @@ export function PromptInputFooterLeftSide(t0) {
   }
   const showVim = t1;
   let t2;
-  if ($[6] !== historyFailedMatch || $[7] !== historyQuery || $[8] !== isSearching || $[9] !== setHistoryQuery) {
-    t2 = isSearching && <HistorySearchInput value={historyQuery} onChange={setHistoryQuery} historyFailedMatch={historyFailedMatch} />;
+  const isRegularFooterActive = resolveRegularFooterActive({
+    parentActive: active,
+    transientMessage: transientMessageType
+  });
+  if ($[6] !== historyFailedMatch || $[7] !== historyQuery || $[8] !== isRegularFooterActive || $[9] !== isSearching || $[10] !== setHistoryQuery) {
+    t2 = isSearching && <HistorySearchInput value={historyQuery} onChange={setHistoryQuery} historyFailedMatch={historyFailedMatch} focus={isRegularFooterActive} />;
     $[6] = historyFailedMatch;
     $[7] = historyQuery;
-    $[8] = isSearching;
-    $[9] = setHistoryQuery;
-    $[10] = t2;
+    $[8] = isRegularFooterActive;
+    $[9] = isSearching;
+    $[10] = setHistoryQuery;
+    $[11] = t2;
   } else {
-    t2 = $[10];
+    t2 = $[11];
   }
   let t3;
-  if ($[11] !== showVim) {
+  if ($[12] !== showVim) {
     t3 = showVim ? <Text dimColor={true} key="vim-insert">-- INSERT --</Text> : null;
-    $[11] = showVim;
-    $[12] = t3;
+    $[12] = showVim;
+    $[13] = t3;
   } else {
-    t3 = $[12];
+    t3 = $[13];
   }
   const t4 = !suppressHint && !showVim;
   let t5;
-  if ($[13] !== isLoading || $[14] !== mode || $[15] !== onOpenTasksDialog || $[16] !== t4 || $[17] !== tasksSelected || $[18] !== teammateFooterIndex || $[19] !== teamsSelected || $[20] !== tmuxSelected || $[21] !== toolPermissionContext) {
-    t5 = <ModeIndicator mode={mode} toolPermissionContext={toolPermissionContext} showHint={t4} isLoading={isLoading} tasksSelected={tasksSelected} teamsSelected={teamsSelected} teammateFooterIndex={teammateFooterIndex} onOpenTasksDialog={onOpenTasksDialog} />;
-    $[13] = isLoading;
-    $[14] = mode;
-    $[15] = onOpenTasksDialog;
-    $[16] = t4;
-    $[17] = tasksSelected;
-    $[18] = teammateFooterIndex;
-    $[19] = teamsSelected;
-    $[20] = tmuxSelected;
-    $[21] = toolPermissionContext;
-    $[22] = t5;
+  if ($[14] !== isRegularFooterActive || $[15] !== isLoading || $[16] !== mode || $[17] !== onOpenTasksDialog || $[18] !== t4 || $[19] !== tasksSelected || $[20] !== teammateFooterIndex || $[21] !== teamsSelected || $[22] !== tmuxSelected || $[23] !== toolPermissionContext) {
+    t5 = <ModeIndicator mode={mode} toolPermissionContext={toolPermissionContext} showHint={t4} isLoading={isLoading} tasksSelected={tasksSelected} teamsSelected={teamsSelected} teammateFooterIndex={teammateFooterIndex} onOpenTasksDialog={onOpenTasksDialog} active={isRegularFooterActive} />;
+    $[14] = isRegularFooterActive;
+    $[15] = isLoading;
+    $[16] = mode;
+    $[17] = onOpenTasksDialog;
+    $[18] = t4;
+    $[19] = tasksSelected;
+    $[20] = teammateFooterIndex;
+    $[21] = teamsSelected;
+    $[22] = tmuxSelected;
+    $[23] = toolPermissionContext;
+    $[24] = t5;
   } else {
-    t5 = $[22];
+    t5 = $[24];
   }
   let t6;
-  if ($[23] !== t2 || $[24] !== t3 || $[25] !== t5) {
+  if ($[25] !== t2 || $[26] !== t3 || $[27] !== t5) {
     t6 = <Box justifyContent="flex-start" gap={1}>{t2}{t3}{t5}</Box>;
-    $[23] = t2;
-    $[24] = t3;
-    $[25] = t5;
-    $[26] = t6;
+    $[25] = t2;
+    $[26] = t3;
+    $[27] = t5;
+    $[28] = t6;
   } else {
-    t6 = $[26];
+    t6 = $[28];
   }
-  return t6;
+  return <>
+    <KeepMounted hidden={transientMessage !== null}>{t6}</KeepMounted>
+    {transientMessage}
+  </>;
 }
 type ModeIndicatorProps = {
   mode: PromptInputMode;
@@ -230,6 +253,7 @@ type ModeIndicatorProps = {
   teamsSelected: boolean;
   teammateFooterIndex?: number;
   onOpenTasksDialog?: (taskId?: string) => void;
+  active: boolean;
 };
 function ModeIndicator({
   mode,
@@ -239,7 +263,8 @@ function ModeIndicator({
   tasksSelected,
   teamsSelected,
   teammateFooterIndex,
-  onOpenTasksDialog
+  onOpenTasksDialog,
+  active
 }: ModeIndicatorProps): React.ReactNode {
   const {
     columns
@@ -255,7 +280,7 @@ function ModeIndicator({
   const viewingAgentTaskId = useAppState(s_2 => s_2.viewingAgentTaskId);
   const expandedView = useAppState(s_3 => s_3.expandedView);
   const showSpinnerTree = expandedView === 'teammates';
-  const prStatus = usePrStatus(isLoading, isPrStatusEnabled());
+  const prStatus = usePrStatus(isLoading, active && isPrStatusEnabled());
   const nextTickAt = useSyncExternalStore(proactiveModule?.subscribeToProactiveChanges ?? NO_OP_SUBSCRIBE, proactiveModule?.getNextTickAt ?? NULL, NULL);
   // biome-ignore lint/correctness/useHookAtTopLevel: feature() is a compile-time constant
   const voiceEnabled = feature('VOICE_MODE') ? useVoiceEnabled() : false;
@@ -290,7 +315,7 @@ function ModeIndicator({
   const voiceHintIncrementedRef = feature('VOICE_MODE') ? useRef(false) : null;
   useEffect(() => {
     if (feature('VOICE_MODE')) {
-      if (!voiceEnabled || !voiceHintUnderCap) return;
+      if (!active || !voiceEnabled || !voiceHintUnderCap) return;
       if (voiceHintIncrementedRef?.current) return;
       if (voiceHintIncrementedRef) voiceHintIncrementedRef.current = true;
       const newCount = (getGlobalConfig().voiceFooterHintSeenCount ?? 0) + 1;
@@ -302,7 +327,7 @@ function ModeIndicator({
         };
       });
     }
-  }, [voiceEnabled, voiceHintUnderCap]);
+  }, [active, voiceEnabled, voiceHintUnderCap]);
   const isKillAgentsConfirmShowing = useAppState(s_7 => s_7.notifications.current?.key === 'kill-agents-confirm');
 
   // Derive team info from teamContext (no filesystem I/O needed)
@@ -372,7 +397,7 @@ function ModeIndicator({
         <KeyboardShortcutHint shortcut={escShortcut} action="return to team lead" />
       </Text>);
   } else if ((feature('PROACTIVE') || feature('KAIROS')) && hasNextTick) {
-    parts.push(<ProactiveCountdown key="proactive" />);
+    parts.push(<ProactiveCountdown key="proactive" active={active} />);
   } else if (!hasTeammatePills && showHint) {
     parts.push(...hintParts);
   }

--- a/src/components/PromptInput/footerVisibility.ts
+++ b/src/components/PromptInput/footerVisibility.ts
@@ -1,0 +1,52 @@
+export type TransientFooterMessage = 'exit' | 'paste' | null
+export type FooterOverlay = 'suggestions' | 'help' | null
+
+/** Keeps help keybindings from remaining active behind inline history search. */
+export function applyHistorySearchActiveState(
+  active: boolean,
+  setHelpOpen: (open: boolean) => void,
+  setIsSearching: (active: boolean) => void,
+): void {
+  if (active) setHelpOpen(false)
+  setIsSearching(active)
+}
+
+/** History search owns the footer while active; otherwise suggestions beat help. */
+export function resolveFooterOverlay(options: {
+  hasInlineSuggestions: boolean
+  helpOpen: boolean
+  isSearching: boolean
+}): FooterOverlay {
+  if (options.isSearching) return null
+  if (options.hasInlineSuggestions) return 'suggestions'
+  if (options.helpOpen) return 'help'
+  return null
+}
+
+/** Resolves exit/paste precedence shared by footer visibility consumers. */
+export function resolveTransientFooterMessage(options: {
+  exitMessageShown: boolean
+  isPasting: boolean
+}): TransientFooterMessage {
+  if (options.exitMessageShown) return 'exit'
+  if (options.isPasting) return 'paste'
+  return null
+}
+
+/** Lets history search replace transient feedback in the footer's left side. */
+export function resolveVisibleTransientFooterMessage(options: {
+  isSearching: boolean
+  exitMessageShown: boolean
+  isPasting: boolean
+}): TransientFooterMessage {
+  if (options.isSearching) return null
+  return resolveTransientFooterMessage(options)
+}
+
+/** Regular footer effects run only while both visibility layers are active. */
+export function resolveRegularFooterActive(options: {
+  parentActive: boolean
+  transientMessage: TransientFooterMessage
+}): boolean {
+  return options.parentActive && options.transientMessage === null
+}

--- a/src/components/StatusLine.active.test.tsx
+++ b/src/components/StatusLine.active.test.tsx
@@ -1,0 +1,255 @@
+import { PassThrough } from 'node:stream'
+import { afterAll, expect, jest, test } from 'bun:test'
+import { type RefObject, useEffect, useLayoutEffect } from 'react'
+import {
+  getSessionTrustAccepted,
+  setSessionTrustAccepted,
+} from '../bootstrap/state.js'
+import { createRoot } from '../ink.js'
+import {
+  AppStateProvider,
+  type AppState,
+  getDefaultAppState,
+  useSetAppState,
+} from '../state/AppState.js'
+import type { Message } from '../types/message.js'
+import type { StatusLineCommandInput } from '../types/statusLine.js'
+import type { executeStatusLineCommand } from '../utils/hooks.js'
+import { StatusLine } from './StatusLine.js'
+
+type MacroGlobal = typeof globalThis & { MACRO?: { VERSION: string } }
+const macroGlobal = globalThis as MacroGlobal
+const originalMacro = macroGlobal.MACRO
+macroGlobal.MACRO = {
+  VERSION: 'test-version',
+}
+afterAll(() => {
+  if (originalMacro === undefined) delete macroGlobal.MACRO
+  else macroGlobal.MACRO = originalMacro
+})
+
+type PendingExecution = {
+  input: StatusLineCommandInput
+  signal: AbortSignal
+  resolve: (value: string | undefined) => void
+}
+
+function assistantMessage(id: string): Message {
+  return {
+    type: 'assistant',
+    uuid: id,
+    timestamp: '2026-07-14T00:00:00.000Z',
+    message: {
+      id,
+      type: 'message',
+      role: 'assistant',
+      model: 'test-model',
+      content: [{ type: 'text', text: 'test' }],
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    },
+  } as Message
+}
+
+async function waitFor(
+  condition: () => boolean,
+  description: string,
+  timeoutMs = 1000,
+): Promise<void> {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (condition()) return
+    await Bun.sleep(5)
+  }
+  throw new Error(`Timed out waiting for ${description}`)
+}
+
+function CommitProbe({
+  token,
+  onCommit,
+  onLayoutCommit,
+}: {
+  token: number
+  onCommit: (token: number) => void
+  onLayoutCommit: (token: number) => void
+}): null {
+  useLayoutEffect(() => {
+    onLayoutCommit(token)
+  }, [onLayoutCommit, token])
+  useEffect(() => {
+    onCommit(token)
+  }, [onCommit, token])
+  return null
+}
+
+test('cancels hidden statusline work and refreshes once reactivated', async () => {
+  const stdout = new PassThrough()
+  ;(stdout as unknown as { columns: number }).columns = 80
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    patchConsole: false,
+  })
+  const originalTrust = getSessionTrustAccepted()
+  const calls: PendingExecution[] = []
+  const commits: number[] = []
+  const layoutCommits: Array<{ token: number; commandAborted: boolean }> = []
+  let updateAppState: ReturnType<typeof useSetAppState> | undefined
+  const messagesRef: RefObject<Message[]> = { current: [] }
+  const initialState: AppState = {
+    ...getDefaultAppState(),
+    settings: {
+      statusLine: { type: 'command', command: 'test-statusline' },
+    },
+  }
+  let latestState = initialState
+  const executeCommand: typeof executeStatusLineCommand = async (
+    input,
+    signal,
+  ) =>
+    new Promise(resolve => {
+      expect(signal).toBeInstanceOf(AbortSignal)
+      const pending = { input, signal: signal!, resolve }
+      calls.push(pending)
+      signal?.addEventListener('abort', () => resolve(undefined), { once: true })
+    })
+  const onCommit = (token: number) => commits.push(token)
+  const onLayoutCommit = (token: number) => {
+    layoutCommits.push({
+      token,
+      commandAborted: calls[0]?.signal.aborted ?? false,
+    })
+  }
+  function StateController(): null {
+    const setAppState = useSetAppState()
+    useEffect(() => {
+      updateAppState = setAppState
+    }, [setAppState])
+    return null
+  }
+  const render = (
+    active: boolean,
+    lastAssistantMessageId: string | null,
+    token: number,
+  ) => {
+    messagesRef.current = lastAssistantMessageId
+      ? [assistantMessage(lastAssistantMessageId)]
+      : []
+    root.render(
+      <AppStateProvider
+        initialState={initialState}
+        onChangeAppState={({ newState }) => {
+          latestState = newState
+        }}
+      >
+        <StatusLine
+          active={active}
+          executeCommand={executeCommand}
+          messagesRef={messagesRef}
+          lastAssistantMessageId={lastAssistantMessageId}
+        />
+        <CommitProbe
+          token={token}
+          onCommit={onCommit}
+          onLayoutCommit={onLayoutCommit}
+        />
+        <StateController />
+      </AppStateProvider>,
+    )
+  }
+
+  setSessionTrustAccepted(true)
+  try {
+    render(true, null, 1)
+    await waitFor(
+      () => calls.length === 1 && updateAppState !== undefined,
+      'initial statusline execution and state controller',
+    )
+
+    render(false, null, 2)
+    await waitFor(() => commits.includes(2), 'inactive commit')
+    expect(layoutCommits.find(commit => commit.token === 2)?.commandAborted).toBe(
+      true,
+    )
+    expect(calls[0]!.signal.aborted).toBe(true)
+
+    await Bun.sleep(10)
+    render(true, null, 3)
+    await waitFor(() => calls.length === 2, 'refresh after aborted execution')
+    calls[1]!.resolve('refreshed-after-abort')
+    await waitFor(
+      () => latestState.statusLineText === 'refreshed-after-abort',
+      'statusline text after aborted execution',
+    )
+
+    render(false, null, 4)
+    await waitFor(() => commits.includes(4), 'second inactive commit')
+
+    render(false, 'message-while-hidden', 5)
+    await waitFor(() => commits.includes(5), 'hidden state-change commit')
+    expect(calls).toHaveLength(2)
+
+    render(true, 'message-while-hidden', 6)
+    await waitFor(() => calls.length === 3, 'reactivation refresh')
+    calls[2]!.resolve('reactivated')
+    await waitFor(
+      () => latestState.statusLineText === 'reactivated',
+      'reactivated statusline text',
+    )
+
+    updateAppState!(prev => ({
+      ...prev,
+      settings: { ...prev.settings, outputStyle: 'Explanatory' },
+    }))
+    await waitFor(() => calls.length === 4, 'output-style refresh')
+    expect(calls[3]!.input.output_style.name).toBe('Explanatory')
+    calls[3]!.resolve('output-style')
+    await waitFor(
+      () => latestState.statusLineText === 'output-style',
+      'output-style statusline text',
+    )
+
+    const addedDirectory = '/tmp/statusline-added-directory'
+    updateAppState!(prev => ({
+      ...prev,
+      toolPermissionContext: {
+        ...prev.toolPermissionContext,
+        additionalWorkingDirectories: new Map([
+          ...prev.toolPermissionContext.additionalWorkingDirectories,
+          [addedDirectory, { path: addedDirectory, source: 'session' as const }],
+        ]),
+      },
+    }))
+    await waitFor(() => calls.length === 5, 'workspace-directory refresh')
+    expect(calls[4]!.input.workspace.added_dirs).toContain(addedDirectory)
+    calls[4]!.resolve('workspace-directory')
+    await waitFor(
+      () => latestState.statusLineText === 'workspace-directory',
+      'workspace-directory statusline text',
+    )
+
+    const setTimeoutSpy = jest.spyOn(globalThis, 'setTimeout')
+    const clearTimeoutSpy = jest.spyOn(globalThis, 'clearTimeout')
+    render(true, 'debounced-message', 7)
+    await waitFor(
+      () => setTimeoutSpy.mock.calls.some(call => call[1] === 300),
+      'debounced statusline timer',
+    )
+    const timerIndex = setTimeoutSpy.mock.calls.findIndex(call => call[1] === 300)
+    const timer = setTimeoutSpy.mock.results[timerIndex]!.value
+
+    render(false, 'debounced-message', 8)
+    await waitFor(() => commits.includes(8), 'timer cancellation commit')
+    expect(clearTimeoutSpy).toHaveBeenCalledWith(timer)
+  } finally {
+    jest.restoreAllMocks()
+    root.unmount()
+    stdout.end()
+    setSessionTrustAccepted(originalTrust)
+  }
+})

--- a/src/components/StatusLine.test.ts
+++ b/src/components/StatusLine.test.ts
@@ -3,6 +3,7 @@ import { resetStateForTests } from '../cost-tracker.js'
 import { getUnreportedSessionUsage } from '../utils/tokens.js'
 import {
   buildStatusLineCommandInput,
+  resolveStatusLineUpdateAction,
   resolveStatusLineTokenTotals,
 } from './StatusLine.js'
 import type { AssistantMessage, Message } from '../types/message.js'
@@ -67,6 +68,32 @@ describe('resolveStatusLineTokenTotals', () => {
       totalOutputTokens: 320,
       totalTokensAreEstimated: true,
     })
+  })
+})
+
+describe('resolveStatusLineUpdateAction', () => {
+  it('cancels pending work and records a refresh when hidden', () => {
+    expect(resolveStatusLineUpdateAction({ active: false, hasRun: true, needsRefresh: false, stateChanged: false, commandChanged: false, hasPendingUpdate: true })).toEqual({ action: 'cancel', needsRefresh: true })
+  })
+
+  it('runs once when first activated with pending changes', () => {
+    expect(resolveStatusLineUpdateAction({ active: true, hasRun: false, needsRefresh: true, stateChanged: true, commandChanged: false, hasPendingUpdate: false })).toEqual({ action: 'run' })
+  })
+
+  it('runs immediately when reactivated after hidden changes', () => {
+    expect(resolveStatusLineUpdateAction({ active: true, hasRun: true, needsRefresh: true, stateChanged: false, commandChanged: false, hasPendingUpdate: false })).toEqual({ action: 'run' })
+  })
+
+  it('debounces ordinary visible state changes', () => {
+    expect(resolveStatusLineUpdateAction({ active: true, hasRun: true, needsRefresh: false, stateChanged: true, commandChanged: false, hasPendingUpdate: false })).toEqual({ action: 'schedule' })
+  })
+
+  it('does nothing when active and nothing changed', () => {
+    expect(resolveStatusLineUpdateAction({ active: true, hasRun: true, needsRefresh: false, stateChanged: false, commandChanged: false, hasPendingUpdate: false })).toEqual({ action: 'none' })
+  })
+
+  it('runs immediately when the statusline command changes', () => {
+    expect(resolveStatusLineUpdateAction({ active: true, hasRun: true, needsRefresh: false, stateChanged: false, commandChanged: true, hasPendingUpdate: false })).toEqual({ action: 'run' })
   })
 })
 

--- a/src/components/StatusLine.tsx
+++ b/src/components/StatusLine.tsx
@@ -1,6 +1,6 @@
 import { feature } from 'bun:bundle';
 import * as React from 'react';
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { logEvent } from 'src/services/analytics/index.js';
 import { useAppState, useSetAppState } from 'src/state/AppState.js';
 import type { PermissionMode } from 'src/utils/permissions/PermissionMode.js';
@@ -55,6 +55,41 @@ export function resolveStatusLineTokenTotals(
     totalInputTokens: totalInputTokens + unreportedSessionUsage.input_tokens,
     totalOutputTokens: totalOutputTokens + unreportedSessionUsage.output_tokens,
     totalTokensAreEstimated: true,
+  };
+}
+
+/** Resolves the next statusline side effect for the current visibility transition. */
+export function resolveStatusLineUpdateAction(options: {
+  active: boolean;
+  hasRun: boolean;
+  needsRefresh: boolean;
+  stateChanged: boolean;
+  commandChanged: boolean;
+  hasPendingUpdate: boolean;
+}): {
+  action: 'cancel';
+  needsRefresh: boolean;
+} | {
+  action: 'run' | 'schedule' | 'none';
+} {
+  if (!options.active) {
+    return {
+      action: 'cancel',
+      needsRefresh: options.needsRefresh || options.stateChanged || options.commandChanged || options.hasPendingUpdate
+    };
+  }
+  if (!options.hasRun || options.needsRefresh || options.commandChanged) {
+    return {
+      action: 'run'
+    };
+  }
+  if (options.stateChanged) {
+    return {
+      action: 'schedule'
+    };
+  }
+  return {
+    action: 'none'
   };
 }
 
@@ -160,6 +195,8 @@ type Props = {
   messagesRef: React.RefObject<Message[]>;
   lastAssistantMessageId: string | null;
   vimMode?: VimMode;
+  active?: boolean;
+  executeCommand?: typeof executeStatusLineCommand;
 };
 export function getLastAssistantMessageId(messages: Message[]): string | null {
   return getLastAssistantMessage(messages)?.uuid ?? null;
@@ -167,7 +204,9 @@ export function getLastAssistantMessageId(messages: Message[]): string | null {
 function StatusLineInner({
   messagesRef,
   lastAssistantMessageId,
-  vimMode
+  vimMode,
+  active = true,
+  executeCommand = executeStatusLineCommand
 }: Props): React.ReactNode {
   const abortControllerRef = useRef<AbortController | undefined>(undefined);
   const permissionMode = useAppState(s => s.toolPermissionContext.mode);
@@ -194,6 +233,15 @@ function StatusLineInner({
   addedDirsRef.current = additionalWorkingDirectories;
   const mainLoopModelRef = useRef(mainLoopModel);
   mainLoopModelRef.current = mainLoopModel;
+  const activeRef = useRef(active);
+  const needsRefreshRef = useRef(false);
+  useLayoutEffect(() => {
+    activeRef.current = active;
+    if (!active && abortControllerRef.current !== undefined) {
+      needsRefreshRef.current = true;
+      abortControllerRef.current.abort();
+    }
+  }, [active]);
 
   // Track previous state to detect changes and cache expensive calculations
   const previousStateRef = useRef<{
@@ -202,12 +250,16 @@ function StatusLineInner({
     permissionMode: PermissionMode;
     vimMode: VimMode | undefined;
     mainLoopModel: ModelName;
+    outputStyle: ReadonlySettings['outputStyle'];
+    additionalWorkingDirectories: typeof additionalWorkingDirectories;
   }>({
     messageId: null,
     exceeds200kTokens: false,
     permissionMode,
     vimMode,
-    mainLoopModel
+    mainLoopModel,
+    outputStyle: settings?.outputStyle,
+    additionalWorkingDirectories
   });
 
   // Debounce timer ref
@@ -215,16 +267,22 @@ function StatusLineInner({
 
   // True when the next invocation should log its result (first run or after settings reload)
   const logNextResultRef = useRef(true);
+  const hasRunRef = useRef(false);
+  const statusLineCommand = settings?.statusLine?.command;
+  const previousStatusLineCommandRef = useRef(statusLineCommand);
 
   // Stable update function — reads latest values from refs
   const doUpdate = useCallback(async () => {
+    if (!activeRef.current) {
+      needsRefreshRef.current = true;
+      return;
+    }
     // Cancel any in-flight requests
     abortControllerRef.current?.abort();
     const controller = new AbortController();
     abortControllerRef.current = controller;
     const msgs = messagesRef.current;
     const logResult = logNextResultRef.current;
-    logNextResultRef.current = false;
     try {
       let exceeds200kTokens = previousStateRef.current.exceeds200kTokens;
 
@@ -236,8 +294,9 @@ function StatusLineInner({
         previousStateRef.current.exceeds200kTokens = exceeds200kTokens;
       }
       const statusInput = buildStatusLineCommandInput(permissionModeRef.current, exceeds200kTokens, settingsRef.current, msgs, Array.from(addedDirsRef.current.keys()), mainLoopModelRef.current, vimModeRef.current);
-      const text = await executeStatusLineCommand(statusInput, controller.signal, undefined, logResult);
+      const text = await executeCommand(statusInput, controller.signal, undefined, logResult);
       if (!controller.signal.aborted) {
+        if (logResult) logNextResultRef.current = false;
         setAppState(prev => {
           if (prev.statusLineText === text) return prev;
           return {
@@ -248,11 +307,28 @@ function StatusLineInner({
       }
     } catch {
       // Silently ignore errors in status line updates
+    } finally {
+      if (abortControllerRef.current === controller) {
+        abortControllerRef.current = undefined;
+      }
     }
-  }, [messagesRef, setAppState]);
+  }, [executeCommand, messagesRef, setAppState]);
+
+  const cancelPendingUpdate = useCallback(() => {
+    if (debounceTimerRef.current !== undefined) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = undefined;
+    }
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = undefined;
+  }, []);
 
   // Stable debounced schedule function — no deps, uses refs
   const scheduleUpdate = useCallback(() => {
+    if (!activeRef.current) {
+      needsRefreshRef.current = true;
+      return;
+    }
     if (debounceTimerRef.current !== undefined) {
       clearTimeout(debounceTimerRef.current);
     }
@@ -262,29 +338,42 @@ function StatusLineInner({
     }, 300, debounceTimerRef, doUpdate);
   }, [doUpdate]);
 
-  // Only trigger update when assistant message, permission mode, vim mode, or model actually changes
+  // Single state-machine effect for initial activation, visibility changes,
+  // input changes, and command hot reload. Keeping these transitions together
+  // avoids correctness depending on effect declaration order.
   useEffect(() => {
-    if (lastAssistantMessageId !== previousStateRef.current.messageId || permissionMode !== previousStateRef.current.permissionMode || vimMode !== previousStateRef.current.vimMode || mainLoopModel !== previousStateRef.current.mainLoopModel) {
-      // Don't update messageId here — let doUpdate handle it so
-      // exceeds200kTokens is recalculated with the latest messages
-      previousStateRef.current.permissionMode = permissionMode;
-      previousStateRef.current.vimMode = vimMode;
-      previousStateRef.current.mainLoopModel = mainLoopModel;
-      scheduleUpdate();
-    }
-  }, [lastAssistantMessageId, permissionMode, vimMode, mainLoopModel, scheduleUpdate]);
+    const stateChanged = lastAssistantMessageId !== previousStateRef.current.messageId || permissionMode !== previousStateRef.current.permissionMode || vimMode !== previousStateRef.current.vimMode || mainLoopModel !== previousStateRef.current.mainLoopModel || settings?.outputStyle !== previousStateRef.current.outputStyle || additionalWorkingDirectories !== previousStateRef.current.additionalWorkingDirectories;
+    const commandChanged = statusLineCommand !== previousStatusLineCommandRef.current;
+    previousStateRef.current.permissionMode = permissionMode;
+    previousStateRef.current.vimMode = vimMode;
+    previousStateRef.current.mainLoopModel = mainLoopModel;
+    previousStateRef.current.outputStyle = settings?.outputStyle;
+    previousStateRef.current.additionalWorkingDirectories = additionalWorkingDirectories;
+    previousStatusLineCommandRef.current = statusLineCommand;
+    if (commandChanged) logNextResultRef.current = true;
 
-  // When the statusLine command changes (hot reload), log the next result
-  const statusLineCommand = settings?.statusLine?.command;
-  const isFirstSettingsRender = useRef(true);
-  useEffect(() => {
-    if (isFirstSettingsRender.current) {
-      isFirstSettingsRender.current = false;
+    const transition = resolveStatusLineUpdateAction({
+      active,
+      hasRun: hasRunRef.current,
+      needsRefresh: needsRefreshRef.current,
+      stateChanged,
+      commandChanged,
+      hasPendingUpdate: debounceTimerRef.current !== undefined || abortControllerRef.current !== undefined
+    });
+    if (transition.action === 'cancel') {
+      needsRefreshRef.current = transition.needsRefresh;
+      cancelPendingUpdate();
       return;
     }
-    logNextResultRef.current = true;
-    void doUpdate();
-  }, [statusLineCommand, doUpdate]);
+    needsRefreshRef.current = false;
+    if (transition.action === 'run') {
+      cancelPendingUpdate();
+      hasRunRef.current = true;
+      void doUpdate();
+      return;
+    }
+    if (transition.action === 'schedule') scheduleUpdate();
+  }, [active, lastAssistantMessageId, permissionMode, vimMode, mainLoopModel, settings?.outputStyle, additionalWorkingDirectories, statusLineCommand, cancelPendingUpdate, doUpdate, scheduleUpdate]);
 
   // Separate effect for logging on mount
   useEffect(() => {
@@ -319,18 +408,14 @@ function StatusLineInner({
     // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
   }, []); // Only run once on mount - settings stable for initial logging
 
-  // Initial update on mount + cleanup on unmount
+  // Cleanup on unmount
   useEffect(() => {
-    void doUpdate();
     return () => {
-      abortControllerRef.current?.abort();
-      if (debounceTimerRef.current !== undefined) {
-        clearTimeout(debounceTimerRef.current);
-      }
+      cancelPendingUpdate();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
     // biome-ignore lint/correctness/useExhaustiveDependencies: intentional
-  }, []); // Only run once on mount, not when doUpdate changes
+  }, [cancelPendingUpdate]);
 
   // Get padding from settings or default to 0
   const paddingX = settings?.statusLine?.padding ?? 0;

--- a/src/tools/WebSearchTool/providers/brave.test.ts
+++ b/src/tools/WebSearchTool/providers/brave.test.ts
@@ -121,20 +121,24 @@ describe('braveProvider search', () => {
     await expect(braveProvider.search({ query: 'q' })).rejects.toThrow(/429/)
   })
 
-  test('rejects when the provider-level timeout elapses', async () => {
-    process.env.WEB_SEARCH_TIMEOUT_SEC = '1'
+  test(
+    'rejects when the provider-level timeout elapses',
+    async () => {
+      process.env.WEB_SEARCH_TIMEOUT_SEC = '1'
 
-    let signalAborted: Promise<void> | undefined
-    globalThis.fetch = (async (_input: any, init: any) => {
-      signalAborted = expectSignalAbort(init?.signal as AbortSignal | undefined)
-      return new Promise<Response>(() => undefined)
-    }) as typeof fetch
+      let signalAborted: Promise<void> | undefined
+      globalThis.fetch = (async (_input: any, init: any) => {
+        signalAborted = expectSignalAbort(init?.signal as AbortSignal | undefined)
+        return new Promise<Response>(() => undefined)
+      }) as typeof fetch
 
-    await expect(braveProvider.search({ query: 'q' })).rejects.toThrow(
-      /Brave search timed out/,
-    )
-    await expect(signalAborted).resolves.toBeUndefined()
-  })
+      await expect(braveProvider.search({ query: 'q' })).rejects.toThrow(
+        /Brave search timed out/,
+      )
+      await expect(signalAborted).resolves.toBeUndefined()
+    },
+    { timeout: 10_000 },
+  )
 
   test('rejects when the response body stalls after headers arrive', async () => {
     process.env.WEB_SEARCH_TIMEOUT_SEC = '1'


### PR DESCRIPTION
## Summary

- Keep the regular prompt footer mounted through transient Ctrl-C and paste feedback so stateful footer components do not remount during the transition.
- Pause custom statusline commands and hidden footer side effects while the regular footer is inactive, then refresh once when it becomes active again.
- Disable hidden history-search input focus and let Ctrl-R history search replace pending transient feedback so invisible inputs cannot capture or drop typed characters.

This fixes the short prompt freeze described in #1962, where keystrokes entered during a Ctrl-C footer transition were delayed and appeared together after statusline work completed.

Fixes #1962

## Impact

- user-facing impact: Ctrl-C and paste feedback no longer trigger custom statusline work or expensive footer polling while hidden, and prompt/history input remains responsive through the transition.
- developer/maintainer impact: Adds explicit active-state contracts for statusline, proactive countdown, PR polling, voice-hint work, and history-search focus, with focused lifecycle and input-routing tests. No dependencies, provider behavior, or runtime requirements change.

## Testing

- [x] `bun run build` via `bun run check`
- [x] `bun run smoke` via `bun run check`
- [x] `bun run check` on both `origin/main` and this branch; both reported the same 92 existing failure cases (`main`: 6682 pass / 2 skip / 92 fail, `fix`: 6689 pass / 2 skip / 92 fail)
- [x] focused tests: `bun test src/components/PromptInput/PromptInputFooterLeftSide.test.ts src/components/PromptInput/HistorySearchInput.test.tsx src/components/PromptInput/KeepMounted.test.tsx src/components/PromptInput/PromptInputFooter.test.tsx src/components/StatusLine.test.ts` (25 pass / 0 fail)
- [x] `bun run typecheck`
- [x] `bun run typecheck:type-tests`
- [x] `bun run security:pr-scan`
- [x] `bun run doctor:runtime`

## Notes

- provider/model path tested: Not applicable; this changes only prompt footer lifecycle and input handling.
- screenshots attached: None; the fix changes transient input responsiveness and background lifecycle behavior without changing the terminal layout or static presentation.
- follow-up work or known limitations: None for the reported Ctrl-C freeze.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved footer visibility and status-line behavior across history search, inline suggestions, and help, with consistent transient message precedence (exit before paste) and proper suppression during search.
  * Prevented unnecessary regular-footer resets while transient feedback is active.
  * Updated Status Line to suspend/cancel background work while inactive and reliably resume on reactivation.
  * Made History Search input focus controllable via a new `focus` setting.
* **Tests**
  * Added/expanded tests for footer resolution, mounting behavior, History Search focus/consumption, and deterministic Status Line active/inactive transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->