### PR TITLE
fix(cache): use a monotonic clock for conversation-cache LRU recency

### DIFF
--- a/src/utils/conversationCache.test.ts
+++ b/src/utils/conversationCache.test.ts
@@ -45,9 +45,29 @@ describe('conversationCache', () => {
       cache.get('a') // access 'a' to update order
       cache.set('c', [{ role: 'user', content: 'c' }])
       cache.set('d', [{ role: 'user', content: 'd' }]) // should evict 'b'
-      
+
       expect(cache.get('b')).toBeUndefined()
       expect(cache.get('a')).toBeDefined()
+    })
+
+    it('keeps a freshly-set entry once the cache is saturated', () => {
+      // Fill to capacity, then bump the two older keys with gets. Once the cache
+      // is full the recency clock must keep advancing; deriving it from map size
+      // makes every touch tie at ~maxSize, so the just-inserted 'd' looks older
+      // than the bumped 'b'/'c' and gets wrongly evicted on the next insert.
+      cache.set('a', [{ role: 'user', content: 'a' }])
+      cache.set('b', [{ role: 'user', content: 'b' }])
+      cache.set('c', [{ role: 'user', content: 'c' }])
+      cache.get('b')
+      cache.get('c')
+      cache.set('d', [{ role: 'user', content: 'd' }]) // evicts 'a' (true LRU)
+      cache.set('e', [{ role: 'user', content: 'e' }]) // must evict 'b', not 'd'
+
+      expect(cache.get('a')).toBeUndefined()
+      expect(cache.get('b')).toBeUndefined()
+      expect(cache.get('d')).toBeDefined()
+      expect(cache.get('c')).toBeDefined()
+      expect(cache.get('e')).toBeDefined()
     })
   })
 

--- a/src/utils/conversationCache.ts
+++ b/src/utils/conversationCache.ts
@@ -22,6 +22,12 @@ export class ConversationCache {
   private cache = new Map<string, CacheEntry<CacheMessage[]>>()
   private accessOrder = new Map<string, number>()
   private evictions = 0
+  // Monotonic logical clock for recency. Must never decrease, so it can't be
+  // derived from `accessOrder.size` — that plateaus at ~maxSize once the cache
+  // is full (and drops on delete), which makes a freshly-set entry tie or even
+  // rank older than entries a prior get already bumped, so evictLRU discards the
+  // most-recently-touched key instead of the least.
+  private accessClock = 0
 
   private readonly maxSize: number
   private readonly ttlMs: number
@@ -49,7 +55,7 @@ export class ConversationCache {
       timestamp: Date.now(),
       hits: 0,
     })
-    this.accessOrder.set(key, this.accessOrder.size)
+    this.accessOrder.set(key, ++this.accessClock)
   }
 
   get(key: string): CacheMessage[] | undefined {
@@ -62,7 +68,7 @@ export class ConversationCache {
     }
 
     entry.hits++
-    this.accessOrder.set(key, this.accessOrder.size)
+    this.accessOrder.set(key, ++this.accessClock)
     return entry.value
   }
 


### PR DESCRIPTION
### Problem
`ConversationCache.evictLRU()` evicts the entry with the smallest recorded access order, but that order is stamped with `this.accessOrder.size`:

```ts
this.accessOrder.set(key, this.accessOrder.size) // in both set() and get()
```

`Map.size` is **not a monotonic clock** — it plateaus at `~maxSize` once the cache is full and *decreases* on delete. While the cache is still filling this happens to look right, but after it saturates every `set`/`get` stamps roughly the same value. A freshly-inserted key (stamped after an eviction shrank the map) can end up ranked **below** older keys that a prior `get` bumped to the plateau value, so the next insert evicts the *most*-recently-touched entry instead of the least.

### Repro (maxSize = 3)
```
set a, b, c        // full
get b; get c       // bump b, c
set d              // evicts a  (correct)
set e              // evicts d  ← BUG (d is the newest; should evict b)
```

### Impact
`sessionHistory.ts` creates this cache with `maxSize: 50` for conversation-history pages. Past 50 cached sessions, eviction stops following LRU and can drop the page a caller is actively paging through, forcing a needless refetch (and inflating the eviction count).

### Fix
Stamp recency from a dedicated counter that only ever increases (`++this.accessClock`), independent of map size. Small, self-contained.

### Test
Added a saturated-cache case that bumps the two older keys and asserts the just-inserted entry survives the next eviction (`b` is evicted, `d` kept). Fails on the old code, passes with the fix; the existing suite is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation cache eviction to consistently remove the least recently used entries.
  * Preserved accurate recency ordering when cached conversations are accessed repeatedly and the cache reaches capacity.

* **Tests**
  * Added coverage for complex access and eviction sequences to verify true least-recently-used behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->