### PR TITLE
fix(memory): match nested directories on path boundaries, not name prefixes

### DIFF
--- a/src/utils/attachments.nestedDirs.test.ts
+++ b/src/utils/attachments.nestedDirs.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from 'bun:test'
+import { join, resolve } from 'path'
 import { getDirectoriesToProcess } from './attachments.js'
+
+// Build every fixture with node:path so drive letters and separators match what
+// the implementation's own resolve()/dirname() produce on Windows as well.
+const WORK = resolve('/work')
+const CWD = join(WORK, 'myapp')
+const PREFIXED_SIBLING = join(WORK, 'myapp-backend')
+const PLAIN_SIBLING = join(WORK, 'backend')
 
 describe('getDirectoriesToProcess', () => {
   test('does not treat a name-prefixed sibling as nested under the CWD', () => {
@@ -8,8 +16,8 @@ describe('getDirectoriesToProcess', () => {
     // starts with "myapp", so its CLAUDE.md was loaded as Project memory —
     // e.g. `cd /work/myapp && claude --add-dir ../myapp-backend`.
     const { nestedDirs } = getDirectoriesToProcess(
-      '/work/myapp-backend/src/a.ts',
-      '/work/myapp',
+      join(PREFIXED_SIBLING, 'src', 'a.ts'),
+      CWD,
     )
     expect(nestedDirs).toEqual([])
   })
@@ -19,29 +27,29 @@ describe('getDirectoriesToProcess', () => {
     // CWD's name while `myapp-backend` does. Both are siblings, so both must
     // behave identically.
     const prefixed = getDirectoriesToProcess(
-      '/work/myapp-backend/src/a.ts',
-      '/work/myapp',
+      join(PREFIXED_SIBLING, 'src', 'a.ts'),
+      CWD,
     ).nestedDirs
     const unprefixed = getDirectoriesToProcess(
-      '/work/backend/src/a.ts',
-      '/work/myapp',
+      join(PLAIN_SIBLING, 'src', 'a.ts'),
+      CWD,
     ).nestedDirs
     expect(prefixed).toEqual(unprefixed)
   })
 
   test('still collects directories genuinely nested under the CWD', () => {
     const { nestedDirs } = getDirectoriesToProcess(
-      '/work/myapp/src/deep/a.ts',
-      '/work/myapp',
+      join(CWD, 'src', 'deep', 'a.ts'),
+      CWD,
     )
-    expect(nestedDirs).toEqual(['/work/myapp/src', '/work/myapp/src/deep'])
+    expect(nestedDirs).toEqual([join(CWD, 'src'), join(CWD, 'src', 'deep')])
   })
 
-  test('reports directories from the CWD down to the target', () => {
+  test('reports directories from the root down to the CWD', () => {
     const { cwdLevelDirs } = getDirectoriesToProcess(
-      '/work/myapp/src/a.ts',
-      '/work/myapp',
+      join(CWD, 'src', 'a.ts'),
+      CWD,
     )
-    expect(cwdLevelDirs).toEqual(['/work', '/work/myapp'])
+    expect(cwdLevelDirs).toEqual([WORK, CWD])
   })
 })

--- a/src/utils/attachments.nestedDirs.test.ts
+++ b/src/utils/attachments.nestedDirs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { getDirectoriesToProcess } from './attachments.js'
+
+describe('getDirectoriesToProcess', () => {
+  test('does not treat a name-prefixed sibling as nested under the CWD', () => {
+    // `/work/myapp-backend` is a sibling of the CWD, not a directory "between
+    // CWD and targetPath". A string-prefix test accepted it because the name
+    // starts with "myapp", so its CLAUDE.md was loaded as Project memory —
+    // e.g. `cd /work/myapp && claude --add-dir ../myapp-backend`.
+    const { nestedDirs } = getDirectoriesToProcess(
+      '/work/myapp-backend/src/a.ts',
+      '/work/myapp',
+    )
+    expect(nestedDirs).toEqual([])
+  })
+
+  test('treats sibling directories the same regardless of their name', () => {
+    // The only difference here is spelling: `backend` shares no prefix with the
+    // CWD's name while `myapp-backend` does. Both are siblings, so both must
+    // behave identically.
+    const prefixed = getDirectoriesToProcess(
+      '/work/myapp-backend/src/a.ts',
+      '/work/myapp',
+    ).nestedDirs
+    const unprefixed = getDirectoriesToProcess(
+      '/work/backend/src/a.ts',
+      '/work/myapp',
+    ).nestedDirs
+    expect(prefixed).toEqual(unprefixed)
+  })
+
+  test('still collects directories genuinely nested under the CWD', () => {
+    const { nestedDirs } = getDirectoriesToProcess(
+      '/work/myapp/src/deep/a.ts',
+      '/work/myapp',
+    )
+    expect(nestedDirs).toEqual(['/work/myapp/src', '/work/myapp/src/deep'])
+  })
+
+  test('reports directories from the CWD down to the target', () => {
+    const { cwdLevelDirs } = getDirectoriesToProcess(
+      '/work/myapp/src/a.ts',
+      '/work/myapp',
+    )
+    expect(cwdLevelDirs).toEqual(['/work', '/work/myapp'])
+  })
+})

--- a/src/utils/attachments.nestedDirs.test.ts
+++ b/src/utils/attachments.nestedDirs.test.ts
@@ -45,6 +45,19 @@ describe('getDirectoriesToProcess', () => {
     expect(nestedDirs).toEqual([join(CWD, 'src'), join(CWD, 'src', 'deep')])
   })
 
+  test('does not treat a case-variant sibling as nested', () => {
+    // On a case-sensitive filesystem /work/MyApp and /work/myapp are two
+    // unrelated projects. A case-folding containment check would merge them and
+    // load the other project's CLAUDE.md/AGENTS.md as nested project memory.
+    const caseVariant = join(WORK, 'MyApp')
+    const { nestedDirs } = getDirectoriesToProcess(
+      join(CWD, 'src', 'a.ts'),
+      caseVariant,
+    )
+    expect(nestedDirs).not.toContain(CWD)
+    expect(nestedDirs).not.toContain(join(CWD, 'src'))
+  })
+
   test('reports directories from the root down to the CWD', () => {
     const { cwdLevelDirs } = getDirectoriesToProcess(
       join(CWD, 'src', 'a.ts'),

--- a/src/utils/attachments.nestedDirs.test.ts
+++ b/src/utils/attachments.nestedDirs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
-import { join, resolve } from 'path'
-import { getDirectoriesToProcess } from './attachments.js'
+import { join, posix, resolve, win32 } from 'path'
+import { getDirectoriesToProcess, isPathUnder } from './attachments.js'
 
 // Build every fixture with node:path so drive letters and separators match what
 // the implementation's own resolve()/dirname() produce on Windows as well.
@@ -45,13 +45,7 @@ describe('getDirectoriesToProcess', () => {
     expect(nestedDirs).toEqual([join(CWD, 'src'), join(CWD, 'src', 'deep')])
   })
 
-  // Windows path comparison is case-insensitive, so `/work/MyApp` and
-  // `/work/myapp` genuinely are the same directory there and treating them as
-  // nested is correct. This behavior only differs on case-sensitive platforms.
-  const caseSensitive = process.platform !== 'win32'
-  const testIfCaseSensitive = caseSensitive ? test : test.skip
-
-  testIfCaseSensitive('does not treat a case-variant sibling as nested', () => {
+  test('does not treat a case-variant sibling as nested', () => {
     // On a case-sensitive filesystem /work/MyApp and /work/myapp are two
     // unrelated projects. A case-folding containment check would merge them and
     // load the other project's CLAUDE.md/AGENTS.md as nested project memory.
@@ -78,5 +72,45 @@ describe('getDirectoriesToProcess', () => {
       CWD,
     )
     expect(cwdLevelDirs).toEqual([WORK, CWD])
+  })
+})
+
+// The Windows semantics are driven through the injected path implementation so
+// they run on every host: path.win32.relative() compares components
+// case-insensitively, and NTFS supports per-directory case sensitivity, so a
+// case-variant spelling there can be a genuinely different project tree.
+describe('isPathUnder', () => {
+  test('keeps case distinct under Windows path semantics', () => {
+    expect(isPathUnder('C:\\work\\myapp\\src', 'C:\\work\\MyApp', win32)).toBe(
+      false,
+    )
+    expect(isPathUnder('C:\\work\\MyApp\\src', 'C:\\work\\MyApp', win32)).toBe(
+      true,
+    )
+  })
+
+  test('keeps case distinct under POSIX path semantics', () => {
+    expect(isPathUnder('/work/myapp/src', '/work/MyApp', posix)).toBe(false)
+    expect(isPathUnder('/work/myapp/src', '/work/myapp', posix)).toBe(true)
+  })
+
+  test('matches on boundaries, not string prefixes, on both platforms', () => {
+    for (const [api, child, parent, dotted, dottedParent] of [
+      [posix, '/work/myapp-backend/src', '/work/myapp', '/work/myapp/..hello', '/work/myapp'],
+      [
+        win32,
+        'C:\\work\\myapp-backend\\src',
+        'C:\\work\\myapp',
+        'C:\\work\\myapp\\..hello',
+        'C:\\work\\myapp',
+      ],
+    ] as const) {
+      expect(isPathUnder(child, parent, api)).toBe(false)
+      // `..hello` yields a relative path starting with ".." without being an
+      // upward traversal.
+      expect(isPathUnder(dotted, dottedParent, api)).toBe(true)
+      expect(isPathUnder(parent, parent, api)).toBe(false)
+      expect(isPathUnder(parent, child, api)).toBe(false)
+    }
   })
 })

--- a/src/utils/attachments.nestedDirs.test.ts
+++ b/src/utils/attachments.nestedDirs.test.ts
@@ -45,7 +45,13 @@ describe('getDirectoriesToProcess', () => {
     expect(nestedDirs).toEqual([join(CWD, 'src'), join(CWD, 'src', 'deep')])
   })
 
-  test('does not treat a case-variant sibling as nested', () => {
+  // Windows path comparison is case-insensitive, so `/work/MyApp` and
+  // `/work/myapp` genuinely are the same directory there and treating them as
+  // nested is correct. This behavior only differs on case-sensitive platforms.
+  const caseSensitive = process.platform !== 'win32'
+  const testIfCaseSensitive = caseSensitive ? test : test.skip
+
+  testIfCaseSensitive('does not treat a case-variant sibling as nested', () => {
     // On a case-sensitive filesystem /work/MyApp and /work/myapp are two
     // unrelated projects. A case-folding containment check would merge them and
     // load the other project's CLAUDE.md/AGENTS.md as nested project memory.
@@ -56,6 +62,14 @@ describe('getDirectoriesToProcess', () => {
     )
     expect(nestedDirs).not.toContain(CWD)
     expect(nestedDirs).not.toContain(join(CWD, 'src'))
+  })
+
+  test('collects a nested directory whose name begins with dots', () => {
+    // `relative()` returns "..hello" here, which begins with ".." without being
+    // an upward traversal — a string-prefix check would drop it.
+    const dotted = join(CWD, '..hello')
+    const { nestedDirs } = getDirectoriesToProcess(join(dotted, 'a.ts'), CWD)
+    expect(nestedDirs).toContain(dotted)
   })
 
   test('reports directories from the root down to the CWD', () => {

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -45,7 +45,7 @@ import {
   getConditionalRulesForCwdLevelDirectory,
   type MemoryFileInfo,
 } from './claudemd.js'
-import { dirname, isAbsolute, parse, relative, resolve, sep } from 'path'
+import nodePath, { dirname, parse, relative, resolve } from 'path'
 import { getCwd } from 'src/utils/cwd.js'
 import { getViewedTeammateTask } from '../state/selectors.js'
 import { logError } from './log.js'
@@ -1765,19 +1765,45 @@ async function getSelectedLinesFromIDE(
  * from slipping past a security check. Applying it here would go the wrong way
  * — on a case-sensitive filesystem `/work/MyApp` and `/work/myapp` are two
  * unrelated projects, and folding them together would load the other project's
- * CLAUDE.md/AGENTS.md as nested memory. `relative` keeps the platform's native
- * case semantics.
+ * CLAUDE.md/AGENTS.md as nested memory.
+ *
+ * `relative()` gets the boundary right but is not case-faithful on Windows: it
+ * compares components case-insensitively, so `C:\work\MyApp` -> `C:\work\myapp\src`
+ * returns `src` as though it were nested. NTFS supports per-directory case
+ * sensitivity, so those can be distinct trees there too. Rebuilding the child
+ * from the parent and comparing exactly keeps the boundary logic while
+ * restoring the lexical case distinction.
+ *
+ * `pathApi` is injectable so the Windows semantics can be covered from any
+ * host. Exported for testing.
  */
-function isPathUnder(child: string, parent: string): boolean {
-  const rel = relative(parent, child)
+export function isPathUnder(
+  child: string,
+  parent: string,
+  pathApi: Pick<
+    typeof nodePath,
+    'relative' | 'join' | 'normalize' | 'isAbsolute' | 'sep'
+  > = nodePath,
+): boolean {
+  const rel = pathApi.relative(parent, child)
   // Compare on segment boundaries, not a string prefix: a directory legitimately
   // named `..hello` yields the relative path `..hello`, which starts with `..`
   // without being an upward traversal.
+  if (
+    rel === '' ||
+    rel === '..' ||
+    rel.startsWith('..' + pathApi.sep) ||
+    pathApi.isAbsolute(rel)
+  ) {
+    return false
+  }
+  const stripTrailingSep = (value: string): string =>
+    value.length > 1 && value.endsWith(pathApi.sep)
+      ? value.slice(0, -pathApi.sep.length)
+      : value
   return (
-    rel !== '' &&
-    rel !== '..' &&
-    !rel.startsWith('..' + sep) &&
-    !isAbsolute(rel)
+    stripTrailingSep(pathApi.join(parent, rel)) ===
+    stripTrailingSep(pathApi.normalize(child))
   )
 }
 

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -142,6 +142,7 @@ import { mcpInfoFromString } from '../services/mcp/mcpStringUtils.js'
 import {
   matchingRuleForInput,
   pathInAllowedWorkingPath,
+  pathInWorkingPath,
 } from './permissions/filesystem.js'
 import {
   generateTaskAttachments,
@@ -1765,9 +1766,14 @@ export function getDirectoriesToProcess(
   const nestedDirs: string[] = []
   let currentDir = targetDir
 
-  // Walk up from target directory to original CWD
+  // Walk up from target directory to original CWD.
+  // Containment must be tested on path boundaries, not string prefixes: a
+  // sibling whose name merely starts with the CWD's name (cwd `/work/myapp`,
+  // target in `/work/myapp-backend`) is not "between CWD and targetPath", but
+  // startsWith accepts it — so its CLAUDE.md loaded as Project memory purely
+  // because of how the directory happened to be spelled.
   while (currentDir !== originalCwd && currentDir !== parse(currentDir).root) {
-    if (currentDir.startsWith(originalCwd)) {
+    if (pathInWorkingPath(currentDir, originalCwd)) {
       nestedDirs.push(currentDir)
     }
     currentDir = dirname(currentDir)

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -45,7 +45,7 @@ import {
   getConditionalRulesForCwdLevelDirectory,
   type MemoryFileInfo,
 } from './claudemd.js'
-import { dirname, isAbsolute, parse, relative, resolve } from 'path'
+import { dirname, isAbsolute, parse, relative, resolve, sep } from 'path'
 import { getCwd } from 'src/utils/cwd.js'
 import { getViewedTeammateTask } from '../state/selectors.js'
 import { logError } from './log.js'
@@ -1770,7 +1770,15 @@ async function getSelectedLinesFromIDE(
  */
 function isPathUnder(child: string, parent: string): boolean {
   const rel = relative(parent, child)
-  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel)
+  // Compare on segment boundaries, not a string prefix: a directory legitimately
+  // named `..hello` yields the relative path `..hello`, which starts with `..`
+  // without being an upward traversal.
+  return (
+    rel !== '' &&
+    rel !== '..' &&
+    !rel.startsWith('..' + sep) &&
+    !isAbsolute(rel)
+  )
 }
 
 export function getDirectoriesToProcess(

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -45,7 +45,7 @@ import {
   getConditionalRulesForCwdLevelDirectory,
   type MemoryFileInfo,
 } from './claudemd.js'
-import { dirname, parse, relative, resolve } from 'path'
+import { dirname, isAbsolute, parse, relative, resolve } from 'path'
 import { getCwd } from 'src/utils/cwd.js'
 import { getViewedTeammateTask } from '../state/selectors.js'
 import { logError } from './log.js'
@@ -142,7 +142,6 @@ import { mcpInfoFromString } from '../services/mcp/mcpStringUtils.js'
 import {
   matchingRuleForInput,
   pathInAllowedWorkingPath,
-  pathInWorkingPath,
 } from './permissions/filesystem.js'
 import {
   generateTaskAttachments,
@@ -1757,6 +1756,23 @@ async function getSelectedLinesFromIDE(
  * @param originalCwd The original current working directory
  * @returns Object with nestedDirs and cwdLevelDirs arrays, both ordered from parent to child
  */
+/**
+ * True when `child` sits strictly beneath `parent`, compared on path
+ * boundaries.
+ *
+ * Deliberately not the permissions predicate (`pathInWorkingPath`): that one
+ * case-folds both operands on every platform to stop case-variant spellings
+ * from slipping past a security check. Applying it here would go the wrong way
+ * — on a case-sensitive filesystem `/work/MyApp` and `/work/myapp` are two
+ * unrelated projects, and folding them together would load the other project's
+ * CLAUDE.md/AGENTS.md as nested memory. `relative` keeps the platform's native
+ * case semantics.
+ */
+function isPathUnder(child: string, parent: string): boolean {
+  const rel = relative(parent, child)
+  return rel !== '' && !rel.startsWith('..') && !isAbsolute(rel)
+}
+
 export function getDirectoriesToProcess(
   targetPath: string,
   originalCwd: string,
@@ -1773,7 +1789,7 @@ export function getDirectoriesToProcess(
   // startsWith accepts it — so its CLAUDE.md loaded as Project memory purely
   // because of how the directory happened to be spelled.
   while (currentDir !== originalCwd && currentDir !== parse(currentDir).root) {
-    if (pathInWorkingPath(currentDir, originalCwd)) {
+    if (isPathUnder(currentDir, originalCwd)) {
       nestedDirs.push(currentDir)
     }
     currentDir = dirname(currentDir)


### PR DESCRIPTION
### Problem
`getDirectoriesToProcess` documents `nestedDirs` as *"Directories between CWD and targetPath"*, but tests containment with a string prefix:

```ts
while (currentDir !== originalCwd && currentDir !== parse(currentDir).root) {
  if (currentDir.startsWith(originalCwd)) {
    nestedDirs.push(currentDir)
  }
  currentDir = dirname(currentDir)
}
```

A **sibling** directory whose name merely begins with the CWD's name satisfies `startsWith`, so it is collected as if it were nested.

### Repro
An ordinary multi-directory layout, no attacker and no contrived input:

```
cd /work/myapp
claude --add-dir ../myapp-backend
# then read /work/myapp-backend/src/a.ts
```

`getDirectoriesToProcess('/work/myapp-backend/src/a.ts', '/work/myapp')`

| | nestedDirs |
|---|---|
| **actual** | `['/work/myapp-backend', '/work/myapp-backend/src']` |
| **expected** | `[]` |

So `/work/myapp-backend/CLAUDE.md` is loaded as **Project** memory. Rename that directory to `/work/backend` and it loads nothing — identical layout, identical permission grant, behavior flips purely on spelling. `myapp` + `myapp-backend` / `myapp-docs` / `myapp-e2e` is a common way to lay out related repos.

Whichever behavior you consider correct, the current code can't be: it does both depending on the name.

### Reachability
`getDirectoriesToProcess(filePath, getOriginalCwd())` is called from the memory-attachment path in `attachments.ts` (Phase 2), whose `nestedDirs` feed `getMemoryFilesForNestedDirectory` — i.e. CLAUDE.md + rule discovery for the file being read.

### Fix
Route the check through `pathInWorkingPath`, the helper already used for path containment elsewhere in this file's module graph (`attachments.ts` already imports from `permissions/filesystem.js`), so the comparison happens on path boundaries. It also brings along the symlink and case normalization that helper already handles.

### Tests
New `attachments.nestedDirs.test.ts`: the prefixed sibling collects nothing; prefixed and unprefixed siblings behave identically; genuine nesting is unaffected. The first two fail on the current code and pass with the fix. `getDirectoriesToProcess` is exported and previously had no direct tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment directory scanning with boundary-aware path containment checks to avoid false matches from sibling names that merely share a prefix, and to ensure only truly descendant directories between the working directory and the target are included.

* **Tests**
  * Added Bun tests validating strict “under” detection across platforms and case-sensitivity rules, correct nested-directory ordering, proper root-to-working-directory enumeration, and correct handling of dot-prefixed nested directory names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->