### PR TITLE
fix(resume): read the session tag from its own entry, not a tool's tag input

### DIFF
--- a/src/utils/sessionStorage.liteTag.test.ts
+++ b/src/utils/sessionStorage.liteTag.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { readLiteMetadata } from './sessionStorage.js'
+import { LITE_READ_BUF_SIZE } from './sessionStoragePortable.js'
+
+/** Write a session JSONL to a temp file and read its lite metadata back. */
+async function readMetadata(lines: string[]) {
+  const dir = mkdtempSync(join(tmpdir(), 'lite-tag-'))
+  const file = join(dir, 'session.jsonl')
+  try {
+    writeFileSync(file, lines.join('\n') + '\n')
+    const size = statSync(file).size
+    return await readLiteMetadata(file, size, Buffer.alloc(LITE_READ_BUF_SIZE))
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+const USER_LINE =
+  '{"type":"user","message":{"role":"user","content":"hi"},"cwd":"/work/app"}'
+
+// A tool call carrying a `tag` parameter — Docker image tags, git tags and
+// cloud resource tags all look like this. It is stored as literal nested JSON
+// inside the assistant entry, and is appended *after* the tag entry.
+const TOOL_USE_WITH_TAG_INPUT =
+  '{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"mcp__docker__push_image","input":{"image":"myapp","tag":"v1.2.3"}}]}}'
+
+describe('readLiteMetadata tag extraction', () => {
+  test('reads the session tag, not a tag parameter from a later tool call', async () => {
+    // The tail scan is a raw substring search, so an unscoped lookup returned
+    // the *last* "tag":"..." in the window — the tool's value — which surfaced
+    // a phantom tag tab in /resume and misfiled the session away from its own.
+    const meta = await readMetadata([
+      USER_LINE,
+      '{"type":"tag","tag":"backend","sessionId":"S1"}',
+      TOOL_USE_WITH_TAG_INPUT,
+    ])
+    expect(meta.tag).toBe('backend')
+  })
+
+  test('does not invent a tag for an untagged session', async () => {
+    const meta = await readMetadata([USER_LINE, TOOL_USE_WITH_TAG_INPUT])
+    expect(meta.tag).toBeUndefined()
+  })
+
+  test('treats a cleared tag as untagged', async () => {
+    // tagSession(id, null) writes tag:"" to clear.
+    const meta = await readMetadata([
+      USER_LINE,
+      '{"type":"tag","tag":"backend","sessionId":"S1"}',
+      '{"type":"tag","tag":"","sessionId":"S1"}',
+    ])
+    expect(meta.tag).toBeUndefined()
+  })
+
+  test('uses the most recent tag entry', async () => {
+    const meta = await readMetadata([
+      USER_LINE,
+      '{"type":"tag","tag":"backend","sessionId":"S1"}',
+      '{"type":"tag","tag":"frontend","sessionId":"S1"}',
+    ])
+    expect(meta.tag).toBe('frontend')
+  })
+})

--- a/src/utils/sessionStorage.ts
+++ b/src/utils/sessionStorage.ts
@@ -5226,7 +5226,8 @@ async function getLogsWithoutIndex(
  *
  * Accepts a shared buffer to avoid per-file allocation overhead.
  */
-async function readLiteMetadata(
+// exported for testing
+export async function readLiteMetadata(
   filePath: string,
   fileSize: number,
   buf: Buffer,
@@ -5265,7 +5266,15 @@ async function readLiteMetadata(
     extractLastJsonStringField(tail, 'aiTitle') ??
     extractLastJsonStringField(head, 'aiTitle')
   const summary = extractLastJsonStringField(tail, 'summary')
-  const tag = extractLastJsonStringField(tail, 'tag')
+  // Type-scope tag extraction to the {"type":"tag"} JSONL line to avoid
+  // collision with tool_use inputs containing a `tag` parameter (git tag,
+  // Docker tags, cloud resource tags). Those are nested inside an assistant
+  // entry appended after the tag entry, so an unscoped tail scan returns the
+  // tool's value. Mirrors listSessionsImpl.ts:132 and sessionStorage.ts:782.
+  const tagLine = tail.split('\n').findLast(l => l.startsWith('{"type":"tag"'))
+  const tag = tagLine
+    ? extractLastJsonStringField(tagLine, 'tag') || undefined
+    : undefined
   const gitBranch =
     extractLastJsonStringField(tail, 'gitBranch') ??
     extractJsonStringField(head, 'gitBranch')


### PR DESCRIPTION
### Problem
`readLiteMetadata` extracts the session tag with an unscoped scan of the raw 64KB tail:

```ts
const tag = extractLastJsonStringField(tail, 'tag')
```

That is a substring search, not a JSON parse, so **any** nested `"tag":"..."` in the tail window matches. A `tool_use` input carrying a `tag` parameter — Docker image tags, git tags, cloud resource tags — is stored as literal JSON inside an assistant entry, and tool calls are appended *after* the `{"type":"tag"}` entry. Since last-occurrence wins, the tool's value reliably beats the real tag.

### Repro
```
{"type":"tag","tag":"backend","sessionId":"S1"}
{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"mcp__docker__push_image","input":{"image":"myapp","tag":"v1.2.3"}}]}}
```
| | tag |
|---|---|
| **actual** | `"v1.2.3"` |
| **expected** | `"backend"` |

An untagged session that merely ran such a tool also acquires a tag it never had.

### This is an oversight, not a deliberate divergence
The codebase's other two tag readers already type-scope for exactly this reason, with comments naming this collision:

- `sessionStorage.ts:782` — `tailLines.findLast(l => l.startsWith('{"type":"tag"'))`
- `listSessionsImpl.ts:132` — *"Type-scope tag extraction to the `{"type":"tag"}` JSONL line to avoid collision with tool_use inputs containing a `tag` parameter (git tag, Docker tags, cloud resource tags)."*

And `sessionBranch` **in this same function** is already type-scoped via `SESSION_BRANCH_ENTRY_PREFIX`. `readLiteMetadata` is the third reader and simply missed it.

### Reachability
`readLiteMetadata` → `enrichLog` (sets `tag: meta.tag`) → `enrichLogs` → `loadSameRepoMessageLogsProgressive` / `loadAllProjectsMessageLogsProgressive` → `ResumeConversation.tsx` → `LogSelector.tsx`.

That `log.tag` drives the **/resume** picker: `getUniqueTags()` builds the tag filter bar, `log.tag === tagFilter` filters by tab, and the tag feeds /resume search text. User-visible effect: a phantom `#v1.2.3` tab appears, and the genuinely-tagged session disappears from its own `#backend` tab and can't be found by searching its real tag.

### Fix
Mirror `listSessionsImpl.ts:132` — scope to the top-level `{"type":"tag"}` line before extracting.

### Tests
New `sessionStorage.liteTag.test.ts` drives the real function against a temp JSONL: the tag entry wins over a later tool `tag` input; an untagged session stays untagged; a cleared tag (`tag:""`) reads as untagged; the most recent tag entry wins. Three of the four fail on the current code. `readLiteMetadata` had no direct coverage, so it is exported for testing, following the existing `// exported for testing` convention in this file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session tags being incorrectly extracted from nested tool payloads.
  * Session metadata now uses the most recent explicit tag entry.
  * Cleared or missing tags are correctly reported as unset.

* **Tests**
  * Added coverage for tagged, untagged, cleared, and multiple-tag sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->