### PR TITLE
test: isolate flaky smoke assertions

### DIFF
--- a/src/tools/WebFetchTool/domainCheck.test.ts
+++ b/src/tools/WebFetchTool/domainCheck.test.ts
@@ -7,9 +7,19 @@ import {
 
 const originalEnv = { ...process.env }
 const originalAxiosGet = axios.get
+const _realProvidersModule = await import(
+  `../../utils/model/providers.js?real=${Date.now()}-${Math.random()}`,
+)
+const realProviders = { ..._realProvidersModule }
 
-async function importFreshModule() {
+async function importFreshModule(isFirstPartyAnthropicProvider?: boolean) {
   mock.restore()
+  mock.module('../../utils/model/providers.js', () => ({
+    ...realProviders,
+    ...(isFirstPartyAnthropicProvider === undefined
+      ? {}
+      : { isFirstPartyAnthropicProvider: () => isFirstPartyAnthropicProvider }),
+  }))
   return import(`./utils.ts?ts=${Date.now()}-${Math.random()}`)
 }
 
@@ -23,6 +33,7 @@ afterEach(() => {
     process.env = { ...originalEnv }
     axios.get = originalAxiosGet
     mock.restore()
+    mock.module('../../utils/model/providers.js', () => realProviders)
   } finally {
     releaseSharedMutationLock()
   }
@@ -31,12 +42,6 @@ afterEach(() => {
 describe('checkDomainBlocklist', () => {
   test('returns allowed without API call in OpenAI mode', async () => {
     process.env.CLAUDE_CODE_USE_OPENAI = '1'
-    const actual = await import('../../utils/model/providers.js')
-    mock.module('../../utils/model/providers.js', () => ({
-      ...actual,
-      getAPIProvider: () => 'openai',
-      isFirstPartyAnthropicBaseUrl: () => false,
-    }))
     const getSpy = mock(() =>
       Promise.resolve({ status: 200, data: { can_fetch: true } }),
     )
@@ -51,12 +56,6 @@ describe('checkDomainBlocklist', () => {
 
   test('returns allowed without API call in Gemini mode', async () => {
     process.env.CLAUDE_CODE_USE_GEMINI = '1'
-    const actual = await import('../../utils/model/providers.js')
-    mock.module('../../utils/model/providers.js', () => ({
-      ...actual,
-      getAPIProvider: () => 'gemini',
-      isFirstPartyAnthropicBaseUrl: () => false,
-    }))
     const getSpy = mock(() =>
       Promise.resolve({ status: 200, data: { can_fetch: true } }),
     )
@@ -74,18 +73,12 @@ describe('checkDomainBlocklist', () => {
     delete process.env.CLAUDE_CODE_USE_GEMINI
     delete process.env.CLAUDE_CODE_USE_GITHUB
 
-    const actual = await import('../../utils/model/providers.js')
-    mock.module('../../utils/model/providers.js', () => ({
-      ...actual,
-      getAPIProvider: () => 'firstParty',
-      isFirstPartyAnthropicBaseUrl: () => true,
-    }))
     const getSpy = mock(() =>
       Promise.resolve({ status: 200, data: { can_fetch: true } }),
     )
     axios.get = getSpy as typeof axios.get
 
-    const { checkDomainBlocklist } = await importFreshModule()
+    const { checkDomainBlocklist } = await importFreshModule(true)
     const result = await checkDomainBlocklist('example.com')
 
     expect(result.status).toBe('allowed')

--- a/src/utils/messages/planMode.test.ts
+++ b/src/utils/messages/planMode.test.ts
@@ -1,9 +1,36 @@
-import { expect, test } from 'bun:test'
+import { afterEach, beforeEach, expect, test } from 'bun:test'
 import {
   getAutoModeInstructions,
   getPlanModeInstructions,
   wrapInSystemReminder,
 } from './planMode.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
+
+let originalPlanModeInterviewPhase: string | undefined
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/messages/planMode.test.ts')
+  // Other suites exercise the interview-phase flag. Pin this test's intended
+  // legacy full-reminder contract so cached feature-gate state cannot leak in.
+  originalPlanModeInterviewPhase =
+    process.env.CLAUDE_CODE_PLAN_MODE_INTERVIEW_PHASE
+  process.env.CLAUDE_CODE_PLAN_MODE_INTERVIEW_PHASE = 'false'
+})
+
+afterEach(() => {
+  try {
+    if (originalPlanModeInterviewPhase === undefined) {
+      delete process.env.CLAUDE_CODE_PLAN_MODE_INTERVIEW_PHASE
+    } else {
+      process.env.CLAUDE_CODE_PLAN_MODE_INTERVIEW_PHASE = originalPlanModeInterviewPhase
+    }
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
 
 test('wrapInSystemReminder wraps content in system-reminder tags', () => {
   expect(wrapInSystemReminder('hello')).toBe(


### PR DESCRIPTION
## Summary
- isolate the plan-mode legacy-reminder assertion from leaked feature-flag state
- restore the real provider module around domain-check tests while preserving OpenAI/Gemini classification coverage

## Validation
- bun test --feature=UNATTENDED_RETRY src/tools/WebFetchTool/domainCheck.test.ts src/utils/messages/planMode.test.ts --rerun-each 20
- bun run smoke
- bun run test:full (scoped tests no longer fail; existing unrelated environment/baseline failures remain)

Final reviewed SHA: 1743c5ccb9277cae38f5366497ce3dfd0c3f6f21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved test isolation for domain access checks and plan mode behavior.
  - Prevented environment settings and feature flags from leaking between tests.
  - Ensured provider behavior is reset consistently after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->