### PR TITLE
test: restore global mock isolation

### DIFF
--- a/src/components/ProviderManager.test.tsx
+++ b/src/components/ProviderManager.test.tsx
@@ -13,10 +13,14 @@ import {
 } from '../test/sharedMutationLock.js'
 
 type SettingsModule = typeof import('../utils/settings/settings.js')
+type ProviderStartupOverridesModule = typeof import('../utils/providerStartupOverrides.js')
 
 const actualSettingsModule = (await import(
   `../utils/settings/settings.ts?providerManagerSettingsActual=${Date.now()}-${Math.random()}`
 )) as SettingsModule
+const actualProviderStartupOverridesModule = (await import(
+  `../utils/providerStartupOverrides.ts?providerManagerStartupOverridesActual=${Date.now()}-${Math.random()}`
+)) as ProviderStartupOverridesModule
 
 const SYNC_START = '\x1B[?2026h'
 const SYNC_END = '\x1B[?2026l'
@@ -574,6 +578,7 @@ afterEach(() => {
   try {
     mock.restore()
     mock.module('../utils/settings/settings.js', () => actualSettingsModule)
+    mock.module('../utils/providerStartupOverrides.js', () => actualProviderStartupOverridesModule)
 
     for (const [key, value] of Object.entries(ORIGINAL_ENV)) {
       if (value === undefined) {

--- a/src/services/tips/sponsoredTips.test.ts
+++ b/src/services/tips/sponsoredTips.test.ts
@@ -1,4 +1,6 @@
 import { afterAll, describe, expect, mock, test } from 'bun:test'
+import * as actualConfig from '../../utils/config.js'
+import * as actualSettings from '../../utils/settings/settings.js'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
@@ -34,6 +36,8 @@ mock.module('../../utils/config.js', () => ({
 afterAll(() => {
   try {
     mock.restore()
+    mock.module('../../utils/settings/settings.js', () => actualSettings)
+    mock.module('../../utils/config.js', () => actualConfig)
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/services/tips/tipScheduler.test.ts
+++ b/src/services/tips/tipScheduler.test.ts
@@ -3,7 +3,11 @@ import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
+import * as actualAnalytics from '../analytics/index.js'
+import * as actualConfig from '../../utils/config.js'
+import * as actualSettings from '../../utils/settings/settings.js'
 import type { Tip } from './types.js'
+import * as actualTipRegistry from './tipRegistry.js'
 
 const settingsRef: {
   value: {
@@ -49,6 +53,10 @@ mock.module('../analytics/index.js', () => ({
 afterAll(() => {
   try {
     mock.restore()
+    mock.module('../../utils/settings/settings.js', () => actualSettings)
+    mock.module('../../utils/config.js', () => actualConfig)
+    mock.module('./tipRegistry.js', () => actualTipRegistry)
+    mock.module('../analytics/index.js', () => actualAnalytics)
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/utils/attribution.test.ts
+++ b/src/utils/attribution.test.ts
@@ -17,78 +17,6 @@ import type { SettingsJson } from './settings/types.js'
 
 const actualSettings = { ...realSettings }
 
-function restoredGovernancePolicyModule() {
-  const getForbiddenCommitMessagePatterns = (): string[] => {
-    const patterns: string[] = []
-    const sourceNames = [
-      'userSettings',
-      'projectSettings',
-      'localSettings',
-      'policySettings',
-      'flagSettings',
-    ]
-    for (const source of sourceNames) {
-      const sourcePatterns =
-        actualSettings.getSettingsForSource(source as never)?.git
-          ?.forbiddenCommitMessagePatterns ?? []
-      for (const pattern of sourcePatterns) {
-        if (!patterns.includes(pattern)) {
-          patterns.push(pattern)
-        }
-      }
-    }
-    return patterns
-  }
-
-  const findForbiddenCommitMessagePattern = (message: string): string | null => {
-    const normalizedMessage = message.toLocaleLowerCase()
-    for (const pattern of getForbiddenCommitMessagePatterns()) {
-      if (pattern && normalizedMessage.includes(pattern.toLocaleLowerCase())) {
-        return pattern
-      }
-    }
-    return null
-  }
-
-  const sourceHasGitFlag = (
-    key: 'addAICoAuthor' | 'addGeneratedWithFooter',
-    value: boolean,
-  ): boolean =>
-    [
-      'userSettings',
-      'projectSettings',
-      'localSettings',
-      'policySettings',
-      'flagSettings',
-    ].some(
-      source =>
-        actualSettings.getSettingsForSource(source as never)?.git?.[key] ===
-        value,
-    )
-
-  return {
-    getGitAttributionOptIns: () => {
-      const git = actualSettings.getInitialSettings().git
-      return {
-        addAICoAuthor: git?.addAICoAuthor === true,
-        addGeneratedWithFooter: git?.addGeneratedWithFooter === true,
-      }
-    },
-    isGeneratedCommitAttributionBlocked: () =>
-      sourceHasGitFlag('addAICoAuthor', false),
-    isGeneratedPrAttributionBlocked: () =>
-      sourceHasGitFlag('addGeneratedWithFooter', false),
-    isGitAttributionBlocked: () =>
-      sourceHasGitFlag('addAICoAuthor', false) ||
-      sourceHasGitFlag('addGeneratedWithFooter', false),
-    getForbiddenCommitMessagePatterns,
-    findForbiddenCommitMessagePattern,
-    isMemoryWriteApprovalRequired: () =>
-      actualSettings.getInitialSettings().memory?.requireApprovalBeforeWrite !==
-      false,
-  }
-}
-
 let getAttributionTexts: (typeof import('./attribution.js'))['getAttributionTexts']
 let getDefaultCommitCoAuthorEmail: (typeof import('./attribution.js'))[
   'getDefaultCommitCoAuthorEmail'
@@ -218,25 +146,6 @@ beforeEach(async () => {
     getSettings_DEPRECATED: () => testSettings,
     getSettingsForSource: () => testSettings,
   }))
-  mock.module('./governancePolicy.js', () => ({
-    getGitAttributionOptIns: () => ({
-      addAICoAuthor: testSettings.git?.addAICoAuthor === true,
-      addGeneratedWithFooter:
-        testSettings.git?.addGeneratedWithFooter === true,
-    }),
-    isGeneratedCommitAttributionBlocked: () =>
-      testSettings.git?.addAICoAuthor === false,
-    isGeneratedPrAttributionBlocked: () =>
-      testSettings.git?.addGeneratedWithFooter === false,
-    isGitAttributionBlocked: () =>
-      testSettings.git?.addAICoAuthor === false ||
-      testSettings.git?.addGeneratedWithFooter === false,
-    getForbiddenCommitMessagePatterns: () =>
-      testSettings.git?.forbiddenCommitMessagePatterns ?? [],
-    findForbiddenCommitMessagePattern: () => null,
-    isMemoryWriteApprovalRequired: () =>
-      testSettings.memory?.requireApprovalBeforeWrite !== false,
-  }))
   const attribution = await import(
     `./attribution.ts?attributionTest=${Date.now()}-${Math.random()}`
   )
@@ -253,8 +162,9 @@ afterEach(() => {
   testSettings = {}
   setClientType(originalClientType)
   setMainLoopModelOverride(originalMainLoopModelOverride)
+  mock.module('./model/model.js', () => actualModel)
+  mock.module('./model/providers.js', () => actualProviders)
   mock.module('./settings/settings.js', () => actualSettings)
-  mock.module('./governancePolicy.js', restoredGovernancePolicyModule)
   restoreEnv()
 })
 

--- a/src/utils/providerStartupOverrides.test.ts
+++ b/src/utils/providerStartupOverrides.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, mock, test } from 'bun:test'
 
-import { clearStartupProviderOverrides } from './providerStartupOverrides.js'
+async function importStartupOverridesForTest() {
+  return import(
+    `./providerStartupOverrides.ts?startupOverridesTest=${Date.now()}-${Math.random()}`
+  )
+}
 
 describe('clearStartupProviderOverrides', () => {
-  test('removes stale provider env from user settings and global config env', () => {
+  test('removes stale provider env from user settings and global config env', async () => {
+    const { clearStartupProviderOverrides } = await importStartupOverridesForTest()
     const updateUserSettings = mock(() => ({ error: null }))
     const saveConfig = mock((updater: (current: {
       env: Record<string, string>


### PR DESCRIPTION
## Summary
- restore the real provider-startup module after ProviderManager tests
- remove attribution's process-global governance mock and restore its model mocks
- restore real settings, config, registry, and analytics modules after sponsored-tip tests
- import the provider-startup module under a nonce so its regression test is independent of prior test mocks

## Scope
Targets four serial smoke-test isolation defects only. This does not overlap #1978 or #1979.

## Validation
- bun test --feature=UNATTENDED_RETRY src/components/ProviderManager.test.tsx src/utils/providerStartupOverrides.test.ts src/utils/attribution.test.ts src/services/tips/sponsoredTips.test.ts src/services/tips/tipScheduler.test.ts
- bun run smoke
- git diff --check

Reviewed AGENTS.md and CONTRIBUTING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and cleanup across provider, settings, configuration, analytics, attribution, and sponsored tips test suites.
  * Ensured mocked modules are reliably restored to their real implementations after tests complete.
  * Updated provider override tests to load fresh module instances and verify stale environment settings are cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->