### PR TITLE
test: seal mock.module leaks in awaySummary and diff smoke tests

### DIFF
--- a/src/services/awaySummary.test.ts
+++ b/src/services/awaySummary.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, expect, mock, test } from 'bun:test'
+import { afterAll, beforeAll, beforeEach, expect, mock, test } from 'bun:test'
+import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
 import type {
   AssistantMessage,
   Message,
@@ -27,15 +28,41 @@ const queryModelWithoutStreamingMock = mock(
   },
 )
 
-mock.module('./api/claude.js', () => ({
-  queryModelWithoutStreaming: queryModelWithoutStreamingMock,
-}))
+// These stubs are registered in beforeAll (NOT at module load) and torn down in
+// afterAll so the shared bun:test process loads the REAL ./api/claude.js and
+// ./SessionMemory/sessionMemoryUtils.js for every other test file at startup.
+//
+// bun evaluates all test files' module-level imports up front and caches the
+// resolved modules. A module-level mock.module() here would therefore leak the
+// incomplete stubs into every downstream importer of these modules (claude.js
+// alone has ~22 importers) and break unrelated files in the smoke suite
+// depending on run order — the classic flaky "smoke" defect. Registering the
+// stub only for the lifetime of this suite (beforeAll → afterAll) keeps the
+// subject's import of the stubbed module isolated to this file.
+// Bun's bun:test types declare mock.module() as returning void | Promise<void>
+// and do not model the returned MockModule, so we capture the handle with an
+// explicit cast. The returned object exposes unmock(), which is the documented
+// teardown for a module mock (there is no mock.restoreModule()).
+type MockModuleHandle = { unmock: () => void | Promise<void> }
+let claudeModuleMock: MockModuleHandle | undefined
+let sessionMemoryModuleMock: MockModuleHandle | undefined
+let generateAwaySummary: Awaited<
+  typeof import('./awaySummary.js')
+>['generateAwaySummary']
 
-mock.module('./SessionMemory/sessionMemoryUtils.js', () => ({
-  getSessionMemoryContent: mock(async () => null),
-}))
-
-const { generateAwaySummary } = await import('./awaySummary.js')
+beforeAll(async () => {
+  await acquireSharedMutationLock('services/awaySummary.test.ts')
+  claudeModuleMock = mock.module('./api/claude.js', () => ({
+    queryModelWithoutStreaming: queryModelWithoutStreamingMock,
+  })) as unknown as MockModuleHandle
+  sessionMemoryModuleMock = mock.module(
+    './SessionMemory/sessionMemoryUtils.js',
+    () => ({
+      getSessionMemoryContent: mock(async () => null),
+    }),
+  ) as unknown as MockModuleHandle
+  ;({ generateAwaySummary } = await import('./awaySummary.js'))
+})
 
 const RECENT_WINDOW_FOR_TEST = 30
 
@@ -78,6 +105,15 @@ function capturedConversationBeforeRecapPrompt(): (UserMessage | AssistantMessag
 beforeEach(() => {
   capturedMessages = null
   queryModelWithoutStreamingMock.mockClear()
+})
+
+afterAll(() => {
+  try {
+    claudeModuleMock?.unmock()
+    sessionMemoryModuleMock?.unmock()
+  } finally {
+    releaseSharedMutationLock()
+  }
 })
 
 test('generateAwaySummary does not start its recent projection with an orphan tool_result', async () => {

--- a/src/services/awaySummary.test.ts
+++ b/src/services/awaySummary.test.ts
@@ -63,6 +63,10 @@ beforeAll(async () => {
     }))
     ;({ generateAwaySummary } = await import('./awaySummary.js'))
   } catch (error) {
+    mock.module('./api/claude.js', () => ({ ...realClaudeModule }))
+    mock.module('./SessionMemory/sessionMemoryUtils.js', () => ({
+      ...realSessionMemoryUtilsModule,
+    }))
     releaseSharedMutationLock()
     hasSharedMutationLock = false
     throw error

--- a/src/services/awaySummary.test.ts
+++ b/src/services/awaySummary.test.ts
@@ -49,16 +49,24 @@ const realSessionMemoryUtilsModule = await import(
 let generateAwaySummary: Awaited<
   typeof import('./awaySummary.js')
 >['generateAwaySummary']
+let hasSharedMutationLock = false
 
 beforeAll(async () => {
   await acquireSharedMutationLock('services/awaySummary.test.ts')
-  mock.module('./api/claude.js', () => ({
-    queryModelWithoutStreaming: queryModelWithoutStreamingMock,
-  }))
-  mock.module('./SessionMemory/sessionMemoryUtils.js', () => ({
-    getSessionMemoryContent: mock(async () => null),
-  }))
-  ;({ generateAwaySummary } = await import('./awaySummary.js'))
+  hasSharedMutationLock = true
+  try {
+    mock.module('./api/claude.js', () => ({
+      queryModelWithoutStreaming: queryModelWithoutStreamingMock,
+    }))
+    mock.module('./SessionMemory/sessionMemoryUtils.js', () => ({
+      getSessionMemoryContent: mock(async () => null),
+    }))
+    ;({ generateAwaySummary } = await import('./awaySummary.js'))
+  } catch (error) {
+    releaseSharedMutationLock()
+    hasSharedMutationLock = false
+    throw error
+  }
 })
 
 const RECENT_WINDOW_FOR_TEST = 30
@@ -105,6 +113,9 @@ beforeEach(() => {
 })
 
 afterAll(() => {
+  if (!hasSharedMutationLock) {
+    return
+  }
   try {
     mock.module('./api/claude.js', () => ({ ...realClaudeModule }))
     mock.module('./SessionMemory/sessionMemoryUtils.js', () => ({
@@ -112,6 +123,7 @@ afterAll(() => {
     }))
   } finally {
     releaseSharedMutationLock()
+    hasSharedMutationLock = false
   }
 })
 

--- a/src/services/awaySummary.test.ts
+++ b/src/services/awaySummary.test.ts
@@ -28,6 +28,13 @@ const queryModelWithoutStreamingMock = mock(
   },
 )
 
+const realClaudeModule = await import(
+  `./api/claude.js?real=${Date.now()}-${Math.random()}`
+)
+const realSessionMemoryUtilsModule = await import(
+  `./SessionMemory/sessionMemoryUtils.js?real=${Date.now()}-${Math.random()}`
+)
+
 // These stubs are registered in beforeAll (NOT at module load) and torn down in
 // afterAll so the shared bun:test process loads the REAL ./api/claude.js and
 // ./SessionMemory/sessionMemoryUtils.js for every other test file at startup.
@@ -39,28 +46,18 @@ const queryModelWithoutStreamingMock = mock(
 // depending on run order — the classic flaky "smoke" defect. Registering the
 // stub only for the lifetime of this suite (beforeAll → afterAll) keeps the
 // subject's import of the stubbed module isolated to this file.
-// Bun's bun:test types declare mock.module() as returning void | Promise<void>
-// and do not model the returned MockModule, so we capture the handle with an
-// explicit cast. The returned object exposes unmock(), which is the documented
-// teardown for a module mock (there is no mock.restoreModule()).
-type MockModuleHandle = { unmock: () => void | Promise<void> }
-let claudeModuleMock: MockModuleHandle | undefined
-let sessionMemoryModuleMock: MockModuleHandle | undefined
 let generateAwaySummary: Awaited<
   typeof import('./awaySummary.js')
 >['generateAwaySummary']
 
 beforeAll(async () => {
   await acquireSharedMutationLock('services/awaySummary.test.ts')
-  claudeModuleMock = mock.module('./api/claude.js', () => ({
+  mock.module('./api/claude.js', () => ({
     queryModelWithoutStreaming: queryModelWithoutStreamingMock,
-  })) as unknown as MockModuleHandle
-  sessionMemoryModuleMock = mock.module(
-    './SessionMemory/sessionMemoryUtils.js',
-    () => ({
-      getSessionMemoryContent: mock(async () => null),
-    }),
-  ) as unknown as MockModuleHandle
+  }))
+  mock.module('./SessionMemory/sessionMemoryUtils.js', () => ({
+    getSessionMemoryContent: mock(async () => null),
+  }))
   ;({ generateAwaySummary } = await import('./awaySummary.js'))
 })
 
@@ -109,8 +106,10 @@ beforeEach(() => {
 
 afterAll(() => {
   try {
-    claudeModuleMock?.unmock()
-    sessionMemoryModuleMock?.unmock()
+    mock.module('./api/claude.js', () => ({ ...realClaudeModule }))
+    mock.module('./SessionMemory/sessionMemoryUtils.js', () => ({
+      ...realSessionMemoryUtilsModule,
+    }))
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -14,6 +14,16 @@ import {
 import type { Message } from '../../types/message.js'
 import * as realConfig from '../../utils/config.js'
 
+const realContext = await import(
+  `../../utils/context.js?real=${Date.now()}-${Math.random()}`
+)
+const realErrors = await import(
+  `../../utils/errors.js?real=${Date.now()}-${Math.random()}`
+)
+const realTokens = await import(
+  `../../utils/tokens.js?real=${Date.now()}-${Math.random()}`
+)
+
 const USER_ABORT_MESSAGE = 'API Error: Request was aborted.'
 
 type ImportAutoCompactOptions = {
@@ -22,6 +32,11 @@ type ImportAutoCompactOptions = {
 }
 
 async function importAutoCompact(options: ImportAutoCompactOptions = {}) {
+  // compact.test.ts uses process-global module stubs. Re-register the real
+  // dependencies this standalone suite needs before importing autoCompact.
+  mock.module('../../utils/context.js', () => ({ ...realContext }))
+  mock.module('../../utils/errors.js', () => ({ ...realErrors }))
+  mock.module('../../utils/tokens.js', () => ({ ...realTokens }))
   mock.module('../../utils/config.js', () => ({
     ...realConfig,
     getGlobalConfig: () => ({ autoCompactEnabled: true }),

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -31,6 +31,7 @@ const realSessionMemoryCompact = await import(
 )
 
 const USER_ABORT_MESSAGE = 'API Error: Request was aborted.'
+let hasSharedMutationLock = false
 
 type ImportAutoCompactOptions = {
   compactConversation?: ReturnType<typeof mock>
@@ -111,14 +112,24 @@ function restoreEnv(): void {
 
 beforeEach(async () => {
   await acquireSharedMutationLock('services/compact/autoCompact.test.ts')
-  delete process.env.DISABLE_COMPACT
-  delete process.env.DISABLE_AUTO_COMPACT
-  delete process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
-  delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW
-  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  hasSharedMutationLock = true
+  try {
+    delete process.env.DISABLE_COMPACT
+    delete process.env.DISABLE_AUTO_COMPACT
+    delete process.env.CLAUDE_CODE_MAX_CONTEXT_TOKENS
+    delete process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW
+    delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  } catch (error) {
+    releaseSharedMutationLock()
+    hasSharedMutationLock = false
+    throw error
+  }
 })
 
 afterEach(async () => {
+  if (!hasSharedMutationLock) {
+    return
+  }
   try {
     mock.restore()
     restoreEnv()
@@ -132,6 +143,7 @@ afterEach(async () => {
     }))
   } finally {
     releaseSharedMutationLock()
+    hasSharedMutationLock = false
   }
 })
 

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -23,6 +23,12 @@ const realErrors = await import(
 const realTokens = await import(
   `../../utils/tokens.js?real=${Date.now()}-${Math.random()}`
 )
+const realCompact = await import(
+  `./compact.js?real=${Date.now()}-${Math.random()}`
+)
+const realSessionMemoryCompact = await import(
+  `./sessionMemoryCompact.js?real=${Date.now()}-${Math.random()}`
+)
 
 const USER_ABORT_MESSAGE = 'API Error: Request was aborted.'
 
@@ -112,10 +118,18 @@ beforeEach(async () => {
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
 })
 
-afterEach(() => {
+afterEach(async () => {
   try {
     mock.restore()
     restoreEnv()
+    mock.module('../../utils/context.js', () => ({ ...realContext }))
+    mock.module('../../utils/errors.js', () => ({ ...realErrors }))
+    mock.module('../../utils/tokens.js', () => ({ ...realTokens }))
+    mock.module('../../utils/config.js', () => ({ ...realConfig }))
+    mock.module('./compact.js', () => ({ ...realCompact }))
+    mock.module('./sessionMemoryCompact.js', () => ({
+      ...realSessionMemoryCompact,
+    }))
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -81,6 +81,60 @@ const _realClaudeApiModule = await import(
 const _realGrowthBookModule = await import(
   `../analytics/growthbook.js?real=${Date.now()}-${Math.random()}`
 )
+const _realContextModule = await import(
+  `../../utils/context.js?real=${Date.now()}-${Math.random()}`
+)
+const _realErrorsModule = await import(
+  `../../utils/errors.js?real=${Date.now()}-${Math.random()}`
+)
+const _realTokensModule = await import(
+  `../../utils/tokens.js?real=${Date.now()}-${Math.random()}`
+)
+
+const COMPACT_STUB_MODULES = [
+  '../analytics/growthbook.js',
+  '../analytics/index.js',
+  '../api/claude.js',
+  '../api/errors.js',
+  '../api/promptCacheBreakDetection.js',
+  '../api/withRetry.js',
+  '../tokenEstimation.js',
+  '../../bootstrap/state.js',
+  '../../tools/FileReadTool/FileReadTool.js',
+  '../../tools/FileReadTool/prompt.js',
+  '../../tools/ToolSearchTool/ToolSearchTool.js',
+  '../../utils/attachments.js',
+  '../../utils/auth.js',
+  '../../utils/config.js',
+  '../../utils/context.js',
+  '../../utils/contextAnalysis.js',
+  '../../utils/debug.js',
+  '../../utils/errors.js',
+  '../../utils/fileStateCache.js',
+  '../../utils/forkedAgent.js',
+  '../../utils/hooks.js',
+  '../../utils/log.js',
+  '../../utils/memory/types.js',
+  '../../utils/messages.js',
+  '../../utils/messages/systemFactories.js',
+  '../../utils/model/model.js',
+  '../../utils/model/modelSupportOverrides.js',
+  '../../utils/path.js',
+  '../../utils/plans.js',
+  '../../utils/projectInstructions.js',
+  '../../utils/sessionActivity.js',
+  '../../utils/sessionStart.js',
+  '../../utils/sessionStorage.js',
+  '../../utils/settings/settings.js',
+  '../../utils/sleep.js',
+  '../../utils/slowOperations.js',
+  '../../utils/systemPromptType.js',
+  '../../utils/task/diskOutput.js',
+  '../../utils/tokens.js',
+  '../../utils/toolSearch.js',
+  './grouping.js',
+  './prompt.js',
+] as const
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -644,6 +698,12 @@ afterEach(() => {
 afterAll(async () => {
   mock.restore()
   clearProviderEnv()
+  for (const specifier of COMPACT_STUB_MODULES) {
+    const realModule = await import(
+      `${specifier}?real=${Date.now()}-${Math.random()}`
+    )
+    mock.module(specifier, () => ({ ...realModule }))
+  }
   // The compact test registers many mock.module() stubs that persist
   // process-wide. Restore the real implementations so downstream test files
   // (goal controller, runAgent routing, BashTool) get correct behaviour.
@@ -683,6 +743,25 @@ afterAll(async () => {
   mock.module('../tokenEstimation.js', () => ({ ..._realTokenEstimationModule }))
   mock.module('../api/claude.js', () => ({ ..._realClaudeApiModule }))
   mock.module('../analytics/growthbook.js', () => ({ ..._realGrowthBookModule }))
+  mock.module('../../utils/context.js', () => ({ ..._realContextModule }))
+  mock.module('../../utils/errors.js', () => ({ ..._realErrorsModule }))
+  mock.module('../../utils/tokens.js', () => ({ ..._realTokensModule }))
+  // Keep the cleanup load-bearing: these modules are consumed by standalone
+  // auto-compact tests when this file happens to run first in the smoke suite.
+  const [restoredContext, restoredErrors, restoredTokens] = await Promise.all([
+    import('../../utils/context.js'),
+    import('../../utils/errors.js'),
+    import('../../utils/tokens.js'),
+  ])
+  expect(restoredContext.getContextWindowForModel).toBe(
+    _realContextModule.getContextWindowForModel,
+  )
+  expect(restoredErrors.hasExactErrorMessage).toBe(
+    _realErrorsModule.hasExactErrorMessage,
+  )
+  expect(restoredTokens.tokenCountWithEstimation).toBe(
+    _realTokensModule.tokenCountWithEstimation,
+  )
   // projectInstructions: the stub above replaces the whole module with only
   // getProjectInstructionFilePaths, so every other export becomes undefined.
   // Downstream CLAUDE.md discovery in runAgent.routing.test.ts then crashes in

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -9,6 +9,8 @@ import {
   test,
 } from 'bun:test'
 import { randomUUID } from 'crypto'
+import { tmpdir } from 'os'
+import { join } from 'path'
 
 import {
   acquireSharedMutationLock,
@@ -83,6 +85,10 @@ const _realErrorsModule = await import(
 )
 const _realTokensModule = await import(
   `../../utils/tokens.js?real=${Date.now()}-${Math.random()}`
+)
+const compactTestTaskOutputPath = join(
+  tmpdir(),
+  `openclaude-compact-test-${process.pid}-${randomUUID()}`,
 )
 
 const COMPACT_STUB_MODULES = [
@@ -619,7 +625,7 @@ function registerCommonCompactStubs(options: CompactMockOptions = {}) {
 
   // --- Task output (DEFENSIVE) ---
   mock.module('../../utils/task/diskOutput.js', () => ({
-    getTaskOutputPath: mock(() => '/tmp/task'),
+    getTaskOutputPath: mock(() => compactTestTaskOutputPath),
   }))
 
   // --- Errors (DEFENSIVE) ---
@@ -810,10 +816,10 @@ async function restoreCompactTestMocks() {
   mock.module('../../utils/projectInstructions.js', () => ({
     ..._realProjectInstructionsModule,
   }))
-  // Clean up the stale /tmp/task symlink left by the mock path.
+  // Clean up only the unique test-owned path returned by the mock above.
   try {
     const { unlink } = await import('fs/promises')
-    await unlink('/tmp/task').catch(() => {})
+    await unlink(compactTestTaskOutputPath).catch(() => {})
   } catch {}
 }
 

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -72,6 +72,15 @@ const _realConfigModule = await import(
 const _realProjectInstructionsModule = await import(
   `../../utils/projectInstructions.js?real=${Date.now()}-${Math.random()}`
 )
+const _realTokenEstimationModule = await import(
+  `../tokenEstimation.js?real=${Date.now()}-${Math.random()}`
+)
+const _realClaudeApiModule = await import(
+  `../api/claude.js?real=${Date.now()}-${Math.random()}`
+)
+const _realGrowthBookModule = await import(
+  `../analytics/growthbook.js?real=${Date.now()}-${Math.random()}`
+)
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -669,6 +678,11 @@ afterAll(async () => {
   mock.module('../../utils/auth.js', () => ({ ..._realAuthModule }))
   mock.module('../../utils/path.js', () => ({ ..._realPathModule }))
   mock.module('../../utils/config.js', () => ({ ..._realConfigModule }))
+  // These compact-only stubs affect the standalone microcompact and
+  // auto-compact tests that run later in the serialized smoke suite.
+  mock.module('../tokenEstimation.js', () => ({ ..._realTokenEstimationModule }))
+  mock.module('../api/claude.js', () => ({ ..._realClaudeApiModule }))
+  mock.module('../analytics/growthbook.js', () => ({ ..._realGrowthBookModule }))
   // projectInstructions: the stub above replaces the whole module with only
   // getProjectInstructionFilePaths, so every other export becomes undefined.
   // Downstream CLAUDE.md discovery in runAgent.routing.test.ts then crashes in

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -131,6 +131,7 @@ const COMPACT_STUB_MODULES = [
   './prompt.js',
 ] as const
 let realCompactStubModules: Map<string, object> | undefined
+let hasSharedMutationLock = false
 
 async function captureRealCompactStubModules(): Promise<Map<string, object>> {
   if (!realCompactStubModules) {
@@ -686,6 +687,7 @@ async function importCompact(options: CompactMockOptions = {}) {
 
 beforeEach(async () => {
   await acquireSharedMutationLock('services/compact/compact.test.ts')
+  hasSharedMutationLock = true
   try {
     await captureRealCompactStubModules()
     mock.module('../../utils/model/providers.js', () => ({
@@ -694,15 +696,20 @@ beforeEach(async () => {
     clearProviderEnv()
   } catch (error) {
     releaseSharedMutationLock()
+    hasSharedMutationLock = false
     throw error
   }
 })
 
 afterEach(async () => {
+  if (!hasSharedMutationLock) {
+    return
+  }
   try {
     await restoreCompactTestMocks()
   } finally {
     releaseSharedMutationLock()
+    hasSharedMutationLock = false
   }
 })
 

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -748,10 +748,20 @@ afterAll(async () => {
   mock.module('../../utils/tokens.js', () => ({ ..._realTokensModule }))
   // Keep the cleanup load-bearing: these modules are consumed by standalone
   // auto-compact tests when this file happens to run first in the smoke suite.
-  const [restoredContext, restoredErrors, restoredTokens] = await Promise.all([
+  const [
+    restoredContext,
+    restoredErrors,
+    restoredTokens,
+    restoredTokenEstimation,
+    restoredClaudeApi,
+    restoredGrowthBook,
+  ] = await Promise.all([
     import('../../utils/context.js'),
     import('../../utils/errors.js'),
     import('../../utils/tokens.js'),
+    import('../tokenEstimation.js'),
+    import('../api/claude.js'),
+    import('../analytics/growthbook.js'),
   ])
   expect(restoredContext.getContextWindowForModel).toBe(
     _realContextModule.getContextWindowForModel,
@@ -761,6 +771,15 @@ afterAll(async () => {
   )
   expect(restoredTokens.tokenCountWithEstimation).toBe(
     _realTokensModule.tokenCountWithEstimation,
+  )
+  expect(restoredTokenEstimation.roughTokenCountEstimation).toBe(
+    _realTokenEstimationModule.roughTokenCountEstimation,
+  )
+  expect(restoredClaudeApi.getMaxOutputTokensForModel).toBe(
+    _realClaudeApiModule.getMaxOutputTokensForModel,
+  )
+  expect(restoredGrowthBook.getFeatureValue_CACHED_MAY_BE_STALE).toBe(
+    _realGrowthBookModule.getFeatureValue_CACHED_MAY_BE_STALE,
   )
   // projectInstructions: the stub above replaces the whole module with only
   // getProjectInstructionFilePaths, so every other export becomes undefined.

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -130,16 +130,23 @@ const COMPACT_STUB_MODULES = [
   './grouping.js',
   './prompt.js',
 ] as const
-const realCompactStubModules = new Map(
-  await Promise.all(
-    COMPACT_STUB_MODULES.map(async specifier =>
-      [
-        specifier,
-        await import(`${specifier}?real=${Date.now()}-${Math.random()}`),
-      ] as const,
-    ),
-  ),
-)
+let realCompactStubModules: Map<string, object> | undefined
+
+async function captureRealCompactStubModules(): Promise<Map<string, object>> {
+  if (!realCompactStubModules) {
+    realCompactStubModules = new Map(
+      await Promise.all(
+        COMPACT_STUB_MODULES.map(async specifier =>
+          [
+            specifier,
+            await import(`${specifier}?real=${Date.now()}-${Math.random()}`),
+          ] as const,
+        ),
+      ),
+    )
+  }
+  return realCompactStubModules
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -679,10 +686,16 @@ async function importCompact(options: CompactMockOptions = {}) {
 
 beforeEach(async () => {
   await acquireSharedMutationLock('services/compact/compact.test.ts')
-  mock.module('../../utils/model/providers.js', () => ({
-    ..._realProvidersModule,
-  }))
-  clearProviderEnv()
+  try {
+    await captureRealCompactStubModules()
+    mock.module('../../utils/model/providers.js', () => ({
+      ..._realProvidersModule,
+    }))
+    clearProviderEnv()
+  } catch (error) {
+    releaseSharedMutationLock()
+    throw error
+  }
 })
 
 afterEach(async () => {
@@ -698,6 +711,7 @@ afterEach(async () => {
 async function restoreCompactTestMocks() {
   mock.restore()
   clearProviderEnv()
+  const realCompactStubModules = await captureRealCompactStubModules()
   for (const specifier of COMPACT_STUB_MODULES) {
     const realModule = realCompactStubModules.get(specifier)
     if (!realModule) {
@@ -799,6 +813,7 @@ async function restoreCompactTestMocks() {
 afterAll(async () => {
   await acquireSharedMutationLock('services/compact/compact.test.ts teardown')
   try {
+    await captureRealCompactStubModules()
     await restoreCompactTestMocks()
   } finally {
     releaseSharedMutationLock()

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -23,17 +23,11 @@ import * as realConfig from '../../utils/config.js'
 // NOT clear it, so the cached bare-path import of providers.js inside betas.ts
 // (which compact.ts transitively imports) resolves to that stub unless we
 // override it. We import the real providers module through a cache-busting URL
-// and re-register it under the bare specifier at module level.
+// and register it under the bare specifier while this suite holds the shared
+// mutation lock.
 const _realProvidersModule = await import(
   `../../utils/model/providers.js?real=${Date.now()}-${Math.random()}`
 )
-mock.module('../../utils/model/providers.js', () => ({
-  getAPIProvider: _realProvidersModule.getAPIProvider,
-  usesAnthropicAccountFlow: _realProvidersModule.usesAnthropicAccountFlow,
-  isGithubNativeAnthropicMode: _realProvidersModule.isGithubNativeAnthropicMode,
-  getAPIProviderForStatsig: _realProvidersModule.getAPIProviderForStatsig,
-  isFirstPartyAnthropicBaseUrl: _realProvidersModule.isFirstPartyAnthropicBaseUrl,
-}))
 
 // Pre-import the real diskOutput module so we can restore it in afterAll
 // (compact's mock of getTaskOutputPath leaks and breaks BashTool tests).
@@ -118,6 +112,7 @@ const COMPACT_STUB_MODULES = [
   '../../utils/messages.js',
   '../../utils/messages/systemFactories.js',
   '../../utils/model/model.js',
+  '../../utils/model/providers.js',
   '../../utils/model/modelSupportOverrides.js',
   '../../utils/path.js',
   '../../utils/plans.js',
@@ -135,6 +130,17 @@ const COMPACT_STUB_MODULES = [
   './grouping.js',
   './prompt.js',
 ] as const
+
+const realCompactStubModules = new Map(
+  await Promise.all(
+    COMPACT_STUB_MODULES.map(async specifier =>
+      [
+        specifier,
+        await import(`${specifier}?real=${Date.now()}-${Math.random()}`),
+      ] as const,
+    ),
+  ),
+)
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -674,20 +680,15 @@ async function importCompact(options: CompactMockOptions = {}) {
 
 beforeEach(async () => {
   await acquireSharedMutationLock('services/compact/compact.test.ts')
+  mock.module('../../utils/model/providers.js', () => ({
+    ..._realProvidersModule,
+  }))
   clearProviderEnv()
 })
 
-afterEach(() => {
+afterEach(async () => {
   try {
-    mock.restore()
-    clearProviderEnv()
-    // mock.module() persists process-wide in bun:test. Restore the message
-    // helpers after each compact test so downstream test files do not import
-    // the compact-only createUserMessage stub.
-    mock.module('../../utils/messages.js', () => ({ ..._realMessagesModule }))
-    mock.module('../../utils/messages/systemFactories.js', () => ({
-      ..._realSystemFactoriesModule,
-    }))
+    await restoreCompactTestMocks()
   } finally {
     releaseSharedMutationLock()
   }
@@ -695,13 +696,14 @@ afterEach(() => {
 
 // Safety net: scrub provider env vars and restore mocks after all tests in
 // this file finish, so nothing leaks into subsequent test files.
-afterAll(async () => {
+async function restoreCompactTestMocks() {
   mock.restore()
   clearProviderEnv()
   for (const specifier of COMPACT_STUB_MODULES) {
-    const realModule = await import(
-      `${specifier}?real=${Date.now()}-${Math.random()}`
-    )
+    const realModule = realCompactStubModules.get(specifier)
+    if (!realModule) {
+      throw new Error(`Missing real compact stub module: ${specifier}`)
+    }
     mock.module(specifier, () => ({ ...realModule }))
   }
   // The compact test registers many mock.module() stubs that persist
@@ -793,6 +795,15 @@ afterAll(async () => {
     const { unlink } = await import('fs/promises')
     await unlink('/tmp/task').catch(() => {})
   } catch {}
+}
+
+afterAll(async () => {
+  await acquireSharedMutationLock('services/compact/compact.test.ts teardown')
+  try {
+    await restoreCompactTestMocks()
+  } finally {
+    releaseSharedMutationLock()
+  }
 })
 
 describe('compactConversation provider gate', () => {

--- a/src/services/compact/compact.test.ts
+++ b/src/services/compact/compact.test.ts
@@ -9,6 +9,7 @@ import {
   test,
 } from 'bun:test'
 import { randomUUID } from 'crypto'
+import { unlink } from 'fs/promises'
 import { tmpdir } from 'os'
 import { join } from 'path'
 
@@ -31,11 +32,6 @@ const _realProvidersModule = await import(
   `../../utils/model/providers.js?real=${Date.now()}-${Math.random()}`
 )
 
-// Pre-import the real diskOutput module so we can restore it in afterAll
-// (compact's mock of getTaskOutputPath leaks and breaks BashTool tests).
-const _realDiskOutputModule = await import(
-  `../../utils/task/diskOutput.js?real=${Date.now()}-${Math.random()}`
-)
 // Pre-import real modules that compact stubs but downstream tests need
 // (goal continuation controller, runAgent provider routing).
 const _realMessagesModule = await import(
@@ -732,27 +728,8 @@ async function restoreCompactTestMocks() {
     }
     mock.module(specifier, () => ({ ...realModule }))
   }
-  // The compact test registers many mock.module() stubs that persist
-  // process-wide. Restore the real implementations so downstream test files
-  // (goal controller, runAgent routing, BashTool) get correct behaviour.
-  mock.module('../../utils/task/diskOutput.js', () => ({
-    getTaskOutputDir: _realDiskOutputModule.getTaskOutputDir,
-    getTaskOutputPath: _realDiskOutputModule.getTaskOutputPath,
-    initTaskOutput: _realDiskOutputModule.initTaskOutput,
-    initTaskOutputAsSymlink: _realDiskOutputModule.initTaskOutputAsSymlink,
-    appendTaskOutput: _realDiskOutputModule.appendTaskOutput,
-    flushTaskOutput: _realDiskOutputModule.flushTaskOutput,
-    evictTaskOutput: _realDiskOutputModule.evictTaskOutput,
-    getTaskOutputDelta: _realDiskOutputModule.getTaskOutputDelta,
-    getTaskOutput: _realDiskOutputModule.getTaskOutput,
-    getTaskOutputSize: _realDiskOutputModule.getTaskOutputSize,
-    cleanupTaskOutput: _realDiskOutputModule.cleanupTaskOutput,
-    _clearOutputsForTest: _realDiskOutputModule._clearOutputsForTest,
-    _resetTaskOutputDirForTest: _realDiskOutputModule._resetTaskOutputDirForTest,
-    DiskTaskOutput: _realDiskOutputModule.DiskTaskOutput,
-    MAX_TASK_OUTPUT_BYTES: _realDiskOutputModule.MAX_TASK_OUTPUT_BYTES,
-    MAX_TASK_OUTPUT_BYTES_DISPLAY: _realDiskOutputModule.MAX_TASK_OUTPUT_BYTES_DISPLAY,
-  }))
+  // The generic loop above restores the full diskOutput module contract for
+  // downstream tests (goal controller, runAgent routing, BashTool).
   mock.module('../../utils/messages.js', () => ({ ..._realMessagesModule }))
   mock.module('../../utils/messages/systemFactories.js', () => ({
     ..._realSystemFactoriesModule,
@@ -818,9 +795,12 @@ async function restoreCompactTestMocks() {
   }))
   // Clean up only the unique test-owned path returned by the mock above.
   try {
-    const { unlink } = await import('fs/promises')
-    await unlink(compactTestTaskOutputPath).catch(() => {})
-  } catch {}
+    await unlink(compactTestTaskOutputPath)
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      throw error
+    }
+  }
 }
 
 afterAll(async () => {

--- a/src/utils/diff.test.ts
+++ b/src/utils/diff.test.ts
@@ -21,14 +21,22 @@ let countLinesChanged: Awaited<typeof import('./diff.js')>['countLinesChanged']
 let getTotalLinesAdded: Awaited<
   typeof import('../bootstrap/state.js')
 >['getTotalLinesAdded']
+let hasSharedMutationLock = false
 
 beforeAll(async () => {
   await acquireSharedMutationLock('utils/diff.test.ts')
-  mock.module('src/services/analytics/index.js', () => ({
-    logEvent: () => {},
-  }))
-  ;({ countLinesChanged } = await import('./diff.js'))
-  ;({ getTotalLinesAdded } = await import('../bootstrap/state.js'))
+  hasSharedMutationLock = true
+  try {
+    mock.module('src/services/analytics/index.js', () => ({
+      logEvent: () => {},
+    }))
+    ;({ countLinesChanged } = await import('./diff.js'))
+    ;({ getTotalLinesAdded } = await import('../bootstrap/state.js'))
+  } catch (error) {
+    releaseSharedMutationLock()
+    hasSharedMutationLock = false
+    throw error
+  }
 })
 
 // countLinesChanged is void; it feeds the running total via addToTotalLinesChanged.
@@ -40,12 +48,16 @@ function addedLinesFor(newFileContent: string): number {
 }
 
 afterAll(() => {
+  if (!hasSharedMutationLock) {
+    return
+  }
   try {
     mock.module('src/services/analytics/index.js', () => ({
       ...realAnalyticsModule,
     }))
   } finally {
     releaseSharedMutationLock()
+    hasSharedMutationLock = false
   }
 })
 

--- a/src/utils/diff.test.ts
+++ b/src/utils/diff.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
 
+const realAnalyticsModule = await import(
+  `../services/analytics/index.js?real=${Date.now()}-${Math.random()}`
+)
+
 // Analytics is a leaf side effect of countLinesChanged; stub it so the test
 // only exercises the counting. The stub is registered in beforeAll (NOT at
 // module load) and torn down in afterAll so the shared bun:test process loads
@@ -13,12 +17,6 @@ import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sh
 // depending on run order — the classic flaky "smoke" defect. Registering the
 // stub only for the lifetime of this suite (beforeAll → afterAll) keeps the
 // subject's import of the stubbed module isolated to this file.
-// Bun's bun:test types declare mock.module() as returning void | Promise<void>
-// and do not model the returned MockModule, so we capture the handle with an
-// explicit cast. The returned object exposes unmock(), which is the documented
-// teardown for a module mock (there is no mock.restoreModule()).
-type MockModuleHandle = { unmock: () => void | Promise<void> }
-let analyticsModuleMock: MockModuleHandle | undefined
 let countLinesChanged: Awaited<typeof import('./diff.js')>['countLinesChanged']
 let getTotalLinesAdded: Awaited<
   typeof import('../bootstrap/state.js')
@@ -26,9 +24,9 @@ let getTotalLinesAdded: Awaited<
 
 beforeAll(async () => {
   await acquireSharedMutationLock('utils/diff.test.ts')
-  analyticsModuleMock = mock.module('src/services/analytics/index.js', () => ({
+  mock.module('src/services/analytics/index.js', () => ({
     logEvent: () => {},
-  })) as unknown as MockModuleHandle
+  }))
   ;({ countLinesChanged } = await import('./diff.js'))
   ;({ getTotalLinesAdded } = await import('../bootstrap/state.js'))
 })
@@ -43,7 +41,9 @@ function addedLinesFor(newFileContent: string): number {
 
 afterAll(() => {
   try {
-    analyticsModuleMock?.unmock()
+    mock.module('src/services/analytics/index.js', () => ({
+      ...realAnalyticsModule,
+    }))
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/utils/diff.test.ts
+++ b/src/utils/diff.test.ts
@@ -33,6 +33,9 @@ beforeAll(async () => {
     ;({ countLinesChanged } = await import('./diff.js'))
     ;({ getTotalLinesAdded } = await import('../bootstrap/state.js'))
   } catch (error) {
+    mock.module('src/services/analytics/index.js', () => ({
+      ...realAnalyticsModule,
+    }))
     releaseSharedMutationLock()
     hasSharedMutationLock = false
     throw error

--- a/src/utils/diff.test.ts
+++ b/src/utils/diff.test.ts
@@ -1,13 +1,37 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, mock, test } from 'bun:test'
+import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
 
 // Analytics is a leaf side effect of countLinesChanged; stub it so the test
-// only exercises the counting.
-mock.module('src/services/analytics/index.js', () => ({
-  logEvent: () => {},
-}))
+// only exercises the counting. The stub is registered in beforeAll (NOT at
+// module load) and torn down in afterAll so the shared bun:test process loads
+// the REAL analytics module for every other test file at startup.
+//
+// bun evaluates all test files' module-level imports up front and caches the
+// resolved modules. A module-level mock.module() here would leak the
+// incomplete analytics stub into the ~245 importers of
+// src/services/analytics/index.js and break unrelated files in the smoke suite
+// depending on run order — the classic flaky "smoke" defect. Registering the
+// stub only for the lifetime of this suite (beforeAll → afterAll) keeps the
+// subject's import of the stubbed module isolated to this file.
+// Bun's bun:test types declare mock.module() as returning void | Promise<void>
+// and do not model the returned MockModule, so we capture the handle with an
+// explicit cast. The returned object exposes unmock(), which is the documented
+// teardown for a module mock (there is no mock.restoreModule()).
+type MockModuleHandle = { unmock: () => void | Promise<void> }
+let analyticsModuleMock: MockModuleHandle | undefined
+let countLinesChanged: Awaited<typeof import('./diff.js')>['countLinesChanged']
+let getTotalLinesAdded: Awaited<
+  typeof import('../bootstrap/state.js')
+>['getTotalLinesAdded']
 
-import { getTotalLinesAdded } from '../bootstrap/state.js'
-import { countLinesChanged } from './diff.js'
+beforeAll(async () => {
+  await acquireSharedMutationLock('utils/diff.test.ts')
+  analyticsModuleMock = mock.module('src/services/analytics/index.js', () => ({
+    logEvent: () => {},
+  })) as unknown as MockModuleHandle
+  ;({ countLinesChanged } = await import('./diff.js'))
+  ;({ getTotalLinesAdded } = await import('../bootstrap/state.js'))
+})
 
 // countLinesChanged is void; it feeds the running total via addToTotalLinesChanged.
 // Measure the delta it contributes for a given call.
@@ -16,6 +40,14 @@ function addedLinesFor(newFileContent: string): number {
   countLinesChanged([], newFileContent)
   return getTotalLinesAdded() - before
 }
+
+afterAll(() => {
+  try {
+    analyticsModuleMock?.unmock()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
 
 describe('countLinesChanged — new file additions', () => {
   test('a newline-terminated file counts one addition per content line, like git', () => {


### PR DESCRIPTION
## Summary

- Resolves the current `main` conflict and seals process-global `bun:test` module-mock leakage in `awaySummary`, `diff`, `compact`, and `autoCompact` test suites.
- Scopes module stubs to their suites/tests, restores real modules after cleanup or failed setup, and serializes mutations with `sharedMutationLock` without releasing a lock that the hook did not acquire.
- Captures cleanup modules via cache-busted imports and verifies the restored module contracts used by downstream smoke tests.

## Validation

- `bun install --frozen-lockfile`
- `bun test --feature=UNATTENDED_RETRY src/services/awaySummary.test.ts src/services/compact/autoCompact.test.ts src/services/compact/compact.test.ts src/utils/diff.test.ts` — 39 passed
- `bun run typecheck` — passed
- `bun test --feature=UNATTENDED_RETRY --max-concurrency=1` — 7,138 passed, 2 skipped, 54 failures. The remaining failure families reproduce on current `main` and are unrelated command, model-discovery, PowerShell/Bash-output, and xAI callback tests.

Final reviewed head: `1a83037e916a8e5595580a0fd1787f20ebba90af`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by scoping module mocks to individual test suites to prevent mock leakage across Bun test files.
  * Added coordinated mutation locking so mock setup/teardown and environment restoration run safely under concurrent execution.
  * Updated compact, auto-compact, away-summary, and diff test suites to cache-bust and restore real dependencies deterministically after each test/suite, including tighter cleanup of test output paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->