### PR TITLE
Add repo names to resume task labels

### DIFF
--- a/src/components/ResumeTask.test.ts
+++ b/src/components/ResumeTask.test.ts
@@ -1,6 +1,9 @@
 import { expect, test } from 'bun:test'
 
-import { buildResumeTaskOptionLabel } from './resumeTaskLabel.js'
+import {
+  buildResumeTaskOptionLabel,
+  getResumeTaskOptionLabelColumns,
+} from './resumeTaskLabel.js'
 
 const repo = {
   name: 'openclaude',
@@ -21,4 +24,19 @@ test('buildResumeTaskOptionLabel truncates the repository suffix for narrow term
   expect(
     buildResumeTaskOptionLabel('Updated', 'Investigate OAuth callback', repo, 7, 41),
   ).toBe('Updated  Investigate OAuth callback  Git…')
+})
+
+test('getResumeTaskOptionLabelColumns reserves select chrome width', () => {
+  const labelColumns = getResumeTaskOptionLabelColumns(41, 10)
+
+  expect(labelColumns).toBe(33)
+  expect(
+    buildResumeTaskOptionLabel(
+      'Updated',
+      'Investigate OAuth callback',
+      repo,
+      7,
+      labelColumns,
+    ),
+  ).toBe('Updated  Investigate OAuth callback')
 })

--- a/src/components/ResumeTask.test.ts
+++ b/src/components/ResumeTask.test.ts
@@ -1,8 +1,10 @@
 import { expect, test } from 'bun:test'
 
 import {
+  buildResumeTaskOptionsFromMetadata,
   buildResumeTaskOptionLabel,
   getResumeTaskOptionLabelColumns,
+  type ResumeTaskSessionMetadata,
 } from './resumeTaskLabel.js'
 
 const repo = {
@@ -39,4 +41,37 @@ test('getResumeTaskOptionLabelColumns reserves select chrome width', () => {
       labelColumns,
     ),
   ).toBe('Updated  Investigate OAuth callback')
+})
+
+test('buildResumeTaskOptionsFromMetadata passes repo and reserved width through mapping', () => {
+  const sessionMetadata: ResumeTaskSessionMetadata[] = [
+    {
+      id: 'session-1',
+      title: 'Fix bug',
+      description: '',
+      status: 'idle',
+      repo,
+      turns: [],
+      created_at: '2026-07-23T00:00:00.000Z',
+      updated_at: '2026-07-23T00:00:00.000Z',
+      timeString: 'Updated',
+    },
+  ]
+
+  const options = buildResumeTaskOptionsFromMetadata(sessionMetadata, 41)
+
+  expect(options).toEqual([
+    {
+      value: 'session-1',
+      label: buildResumeTaskOptionLabel(
+        'Updated',
+        'Fix bug',
+        repo,
+        7,
+        getResumeTaskOptionLabelColumns(41, 1),
+      ),
+    },
+  ])
+  expect(options[0]?.label).toContain('Git')
+  expect(options[0]?.label).not.toContain('Gitlawb/openclaude')
 })

--- a/src/components/ResumeTask.test.ts
+++ b/src/components/ResumeTask.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from 'bun:test'
+
+import { buildResumeTaskOptionLabel } from './resumeTaskLabel.js'
+
+const repo = {
+  name: 'openclaude',
+  owner: {
+    login: 'Gitlawb',
+  },
+  default_branch: 'main',
+} as const
+
+test('buildResumeTaskOptionLabel keeps time alignment and appends repo when available', () => {
+  expect(buildResumeTaskOptionLabel('Updated', 'Investigate OAuth callback', repo, 7)).toBe(
+    'Updated  Investigate OAuth callback  Gitlawb/openclaude',
+  )
+  expect(buildResumeTaskOptionLabel('2h ago', 'Untitled', null, 7)).toBe('2h ago   Untitled')
+})

--- a/src/components/ResumeTask.test.ts
+++ b/src/components/ResumeTask.test.ts
@@ -16,3 +16,9 @@ test('buildResumeTaskOptionLabel keeps time alignment and appends repo when avai
   )
   expect(buildResumeTaskOptionLabel('2h ago', 'Untitled', null, 7)).toBe('2h ago   Untitled')
 })
+
+test('buildResumeTaskOptionLabel truncates the repository suffix for narrow terminals', () => {
+  expect(
+    buildResumeTaskOptionLabel('Updated', 'Investigate OAuth callback', repo, 7, 41),
+  ).toBe('Updated  Investigate OAuth callback  Git…')
+})

--- a/src/components/ResumeTask.tsx
+++ b/src/components/ResumeTask.tsx
@@ -12,117 +12,136 @@ import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { Select } from './CustomSelect/index.js';
 import { Byline } from './design-system/Byline.js';
 import { KeyboardShortcutHint } from './design-system/KeyboardShortcutHint.js';
-import {
-  buildResumeTaskOptionLabel,
-  getResumeTaskOptionLabelColumns,
-} from './resumeTaskLabel.js';
-import { Spinner } from './Spinner.js';
-import { TeleportError } from './TeleportError.js';
+import React, { useCallback, useState } from 'react'
+import { useTerminalSize } from 'src/hooks/useTerminalSize.js'
+import { type CodeSession, fetchCodeSessionsFromSessionsAPI } from 'src/utils/teleport/api.js'
+// eslint-disable-next-line custom-rules/prefer-use-keybindings -- raw j/k/arrow list navigation
+import { Box, Text, useInput } from '../ink.js'
+import { useKeybinding } from '../keybindings/useKeybinding.js'
+import { useShortcutDisplay } from '../keybindings/useShortcutDisplay.js'
+import { logForDebugging } from '../utils/debug.js'
+import { detectCurrentRepository } from '../utils/detectRepository.js'
+import { formatRelativeTime } from '../utils/format.js'
+import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js'
+import { Select } from './CustomSelect/index.js'
+import { Byline } from './design-system/Byline.js'
+import { KeyboardShortcutHint } from './design-system/KeyboardShortcutHint.js'
+import { buildResumeTaskOptionsFromMetadata } from './resumeTaskLabel.js';
+import { Spinner } from './Spinner.js'
+import { TeleportError } from './TeleportError.js'
+
 type Props = {
-  onSelect: (session: CodeSession) => void;
-  onCancel: () => void;
-  isEmbedded?: boolean;
-};
-type LoadErrorType = 'network' | 'auth' | 'api' | 'other';
-const UPDATED_STRING = 'Updated';
-const SPACE_BETWEEN_TABLE_COLUMNS = '  ';
+  onSelect: (session: CodeSession) => void
+  onCancel: () => void
+  isEmbedded?: boolean
+}
+
+type LoadErrorType = 'network' | 'auth' | 'api' | 'other'
+
+const UPDATED_STRING = 'Updated'
+const SPACE_BETWEEN_TABLE_COLUMNS = '  '
 
 export function ResumeTask({
   onSelect,
   onCancel,
-  isEmbedded = false
+  isEmbedded = false,
 }: Props): React.ReactNode {
-  const {
-    columns,
-    rows
-  } = useTerminalSize();
-  const [sessions, setSessions] = useState<CodeSession[]>([]);
-  const [currentRepo, setCurrentRepo] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [loadErrorType, setLoadErrorType] = useState<LoadErrorType | null>(null);
-  const [retrying, setRetrying] = useState(false);
-  const [hasCompletedTeleportErrorFlow, setHasCompletedTeleportErrorFlow] = useState(false);
+  const { columns, rows } = useTerminalSize()
+  const [sessions, setSessions] = useState<CodeSession[]>([])
+  const [currentRepo, setCurrentRepo] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [loadErrorType, setLoadErrorType] = useState<LoadErrorType | null>(null)
+  const [retrying, setRetrying] = useState(false)
+  const [hasCompletedTeleportErrorFlow, setHasCompletedTeleportErrorFlow] = useState(false)
 
   // Track focused index for scroll position display in title
-  const [focusedIndex, setFocusedIndex] = useState(1);
-  const escKey = useShortcutDisplay('confirm:no', 'Confirmation', 'Esc');
+  const [focusedIndex, setFocusedIndex] = useState(1)
+  const escKey = useShortcutDisplay('confirm:no', 'Confirmation', 'Esc')
+
   const loadSessions = useCallback(async () => {
     try {
-      setLoading(true);
-      setLoadErrorType(null);
+      setLoading(true)
+      setLoadErrorType(null)
 
       // Detect current repository
-      const detectedRepo = await detectCurrentRepository();
-      setCurrentRepo(detectedRepo);
-      logForDebugging(`Current repository: ${detectedRepo || 'not detected'}`);
-      const codeSessions = await fetchCodeSessionsFromSessionsAPI();
+      const detectedRepo = await detectCurrentRepository()
+      setCurrentRepo(detectedRepo)
+      logForDebugging(`Current repository: ${detectedRepo || 'not detected'}`)
+      const codeSessions = await fetchCodeSessionsFromSessionsAPI()
 
       // Filter sessions by current repository if detected
-      let filteredSessions = codeSessions;
+      let filteredSessions = codeSessions
       if (detectedRepo) {
         filteredSessions = codeSessions.filter(session => {
-          if (!session.repo) return false;
-          const sessionRepo = `${session.repo.owner.login}/${session.repo.name}`;
-          return sessionRepo === detectedRepo;
-        });
-        logForDebugging(`Filtered ${filteredSessions.length} sessions for repo ${detectedRepo} from ${codeSessions.length} total`);
+          if (!session.repo) return false
+          const sessionRepo = `${session.repo.owner.login}/${session.repo.name}`
+          return sessionRepo === detectedRepo
+        })
+        logForDebugging(
+          `Filtered ${filteredSessions.length} sessions for repo ${detectedRepo} from ${codeSessions.length} total`,
+        )
       }
 
       // Sort by updated_at (newest first)
       const sortedSessions = [...filteredSessions].sort((a, b) => {
-        const dateA = new Date(a.updated_at);
-        const dateB = new Date(b.updated_at);
-        return dateB.getTime() - dateA.getTime();
-      });
-      setSessions(sortedSessions);
+        const dateA = new Date(a.updated_at)
+        const dateB = new Date(b.updated_at)
+        return dateB.getTime() - dateA.getTime()
+      })
+      setSessions(sortedSessions)
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : String(err);
-      logForDebugging(`Error loading code sessions: ${errorMessage}`);
-      setLoadErrorType(determineErrorType(errorMessage));
+      const errorMessage = err instanceof Error ? err.message : String(err)
+      logForDebugging(`Error loading code sessions: ${errorMessage}`)
+      setLoadErrorType(determineErrorType(errorMessage))
     } finally {
-      setLoading(false);
-      setRetrying(false);
+      setLoading(false)
+      setRetrying(false)
     }
-  }, []);
+  }, [])
+
   const handleRetry = () => {
-    setRetrying(true);
-    void loadSessions();
-  };
+    setRetrying(true)
+    void loadSessions()
+  }
 
   // Handle escape via keybinding
   useKeybinding('confirm:no', onCancel, {
-    context: 'Confirmation'
-  });
+    context: 'Confirmation',
+  })
+
   useInput((input, key) => {
     // We need to handle ctrl+c in case we don't render a <Select>
     if (key.ctrl && input === 'c') {
-      onCancel();
-      return;
+      onCancel()
+      return
     }
 
     // Handle retry in error state with 'ctrl+r'
     if (key.ctrl && input === 'r' && loadErrorType) {
-      handleRetry();
-      return;
+      handleRetry()
+      return
     }
 
     // Handle enter key for error states to allow continuation with regular teleport
     if (loadErrorType !== null && key.return) {
-      onCancel(); // This will continue with regular teleport flow
-      return;
+      onCancel() // This will continue with regular teleport flow
+      return
     }
-  });
+  })
+
   const handleErrorComplete = useCallback(() => {
-    setHasCompletedTeleportErrorFlow(true);
-    void loadSessions();
-  }, [setHasCompletedTeleportErrorFlow, loadSessions]);
+    setHasCompletedTeleportErrorFlow(true)
+    void loadSessions()
+  }, [setHasCompletedTeleportErrorFlow, loadSessions])
 
   // Show error dialog if needed
   if (!hasCompletedTeleportErrorFlow) {
-    return <TeleportError onComplete={handleErrorComplete} />;
+    return <TeleportError onComplete={handleErrorComplete} />
   }
+
   if (loading) {
-    return <Box flexDirection="column" padding={1}>
+    return (
+      <Box flexDirection="column" padding={1}>
         <Box flexDirection="row">
           <Spinner />
           <Text bold>Loading OpenClaude sessions…</Text>
@@ -130,10 +149,13 @@ export function ResumeTask({
         <Text dimColor>
           {retrying ? 'Retrying…' : 'Fetching your OpenClaude sessions…'}
         </Text>
-      </Box>;
+      </Box>
+    )
   }
+
   if (loadErrorType) {
-    return <Box flexDirection="column" padding={1}>
+    return (
+      <Box flexDirection="column" padding={1}>
         <Text bold color="error">
           Error loading OpenClaude sessions
         </Text>
@@ -144,10 +166,13 @@ export function ResumeTask({
           Press <Text bold>Ctrl+R</Text> to retry · Press{' '}
           <Text bold>{escKey}</Text> to cancel
         </Text>
-      </Box>;
+      </Box>
+    )
   }
+
   if (sessions.length === 0) {
-    return <Box flexDirection="column" padding={1}>
+    return (
+      <Box flexDirection="column" padding={1}>
         <Text bold>
           No OpenClaude sessions found
           {currentRepo && <Text> for {currentRepo}</Text>}
@@ -157,44 +182,43 @@ export function ResumeTask({
             Press <Text bold>{escKey}</Text> to cancel
           </Text>
         </Box>
-      </Box>;
+      </Box>
+    )
   }
+
   const sessionMetadata = sessions.map(session_0 => ({
     ...session_0,
-    timeString: formatRelativeTime(new Date(session_0.updated_at))
-  }));
-  const optionLabelColumns = getResumeTaskOptionLabelColumns(
-    columns,
-    sessions.length,
-  );
-  const maxTimeStringLength = Math.max(UPDATED_STRING.length, ...sessionMetadata.map(meta => meta.timeString.length));
-  const options = sessionMetadata.map(({
-    timeString,
-    title,
-    repo,
-    id
-  }) => {
-    return {
-      label: buildResumeTaskOptionLabel(timeString, title, repo, maxTimeStringLength, optionLabelColumns),
-      value: id
-    };
-  });
+    timeString: formatRelativeTime(new Date(session_0.updated_at)),
+  }))
+  const options = buildResumeTaskOptionsFromMetadata(sessionMetadata, columns)
+  const maxTimeStringLength = Math.max(
+    UPDATED_STRING.length,
+    ...sessionMetadata.map(meta => meta.timeString.length),
+  )
 
   // Adjust layout for embedded vs full-screen rendering
   // Overhead: padding (2) + title (1) + marginY (2) + header (1) + footer (1) = 7
-  const layoutOverhead = 7;
-  const maxVisibleOptions = Math.max(1, isEmbedded ? Math.min(sessions.length, 5, rows - 6 - layoutOverhead) : Math.min(sessions.length, rows - 1 - layoutOverhead));
-  const maxHeight = maxVisibleOptions + layoutOverhead;
+  const layoutOverhead = 7
+  const maxVisibleOptions = Math.max(
+    1,
+    isEmbedded
+      ? Math.min(sessions.length, 5, rows - 6 - layoutOverhead)
+      : Math.min(sessions.length, rows - 1 - layoutOverhead),
+  )
+  const maxHeight = maxVisibleOptions + layoutOverhead
 
   // Show scroll position in title when list needs scrolling
-  const showScrollPosition = sessions.length > maxVisibleOptions;
-  return <Box flexDirection="column" padding={1} height={maxHeight}>
+  const showScrollPosition = sessions.length > maxVisibleOptions
+  return (
+    <Box flexDirection="column" padding={1} height={maxHeight}>
       <Text bold>
         Select a session to resume
-        {showScrollPosition && <Text dimColor>
+        {showScrollPosition && (
+          <Text dimColor>
             {' '}
             ({focusedIndex} of {sessions.length})
-          </Text>}
+          </Text>
+        )}
         {currentRepo && <Text dimColor> ({currentRepo})</Text>}:
       </Text>
       <Box flexDirection="column" marginTop={1} flexGrow={1}>
@@ -205,45 +229,74 @@ export function ResumeTask({
             {'Session / Repository'}
           </Text>
         </Box>
-        <Select visibleOptionCount={maxVisibleOptions} options={options} onChange={value => {
-        const session_1 = sessions.find(s => s.id === value);
-        if (session_1) {
-          onSelect(session_1);
-        }
-      }} onFocus={value_0 => {
-        const index = options.findIndex(o => o.value === value_0);
-        if (index >= 0) {
-          setFocusedIndex(index + 1);
-        }
-      }} />
+        <Select
+          visibleOptionCount={maxVisibleOptions}
+          options={options}
+          onChange={value => {
+            const session_1 = sessions.find(s => s.id === value)
+            if (session_1) {
+              onSelect(session_1)
+            }
+          }}
+          onFocus={value_0 => {
+            const index = options.findIndex(o => o.value === value_0)
+            if (index >= 0) {
+              setFocusedIndex(index + 1)
+            }
+          }}
+        />
       </Box>
       <Box flexDirection="row">
         <Text dimColor>
           <Byline>
             <KeyboardShortcutHint shortcut="↑/↓" action="select" />
             <KeyboardShortcutHint shortcut="Enter" action="confirm" />
-            <ConfigurableShortcutHint action="confirm:no" context="Confirmation" fallback="Esc" description="cancel" />
+            <ConfigurableShortcutHint
+              action="confirm:no"
+              context="Confirmation"
+              fallback="Esc"
+              description="cancel"
+            />
           </Byline>
         </Text>
       </Box>
-    </Box>;
+    </Box>
+  )
 }
 
 /**
  * Determines the type of error based on the error message
  */
 function determineErrorType(errorMessage: string): LoadErrorType {
-  const message = errorMessage.toLowerCase();
-  if (message.includes('fetch') || message.includes('network') || message.includes('timeout')) {
-    return 'network';
+  const message = errorMessage.toLowerCase()
+  if (
+    message.includes('fetch') ||
+    message.includes('network') ||
+    message.includes('timeout')
+  ) {
+    return 'network'
   }
-  if (message.includes('auth') || message.includes('token') || message.includes('permission') || message.includes('oauth') || message.includes('not authenticated') || message.includes('/login') || message.includes('console account') || message.includes('403')) {
-    return 'auth';
+  if (
+    message.includes('auth') ||
+    message.includes('token') ||
+    message.includes('permission') ||
+    message.includes('oauth') ||
+    message.includes('not authenticated') ||
+    message.includes('/login') ||
+    message.includes('console account') ||
+    message.includes('403')
+  ) {
+    return 'auth'
   }
-  if (message.includes('api') || message.includes('rate limit') || message.includes('500') || message.includes('529')) {
-    return 'api';
+  if (
+    message.includes('api') ||
+    message.includes('rate limit') ||
+    message.includes('500') ||
+    message.includes('529')
+  ) {
+    return 'api'
   }
-  return 'other';
+  return 'other'
 }
 
 /**
@@ -252,24 +305,32 @@ function determineErrorType(errorMessage: string): LoadErrorType {
 function renderErrorSpecificGuidance(errorType: LoadErrorType): React.ReactNode {
   switch (errorType) {
     case 'network':
-      return <Box marginY={1} flexDirection="column">
+      return (
+        <Box marginY={1} flexDirection="column">
           <Text dimColor>Check your internet connection</Text>
-        </Box>;
+        </Box>
+      )
     case 'auth':
-      return <Box marginY={1} flexDirection="column">
+      return (
+        <Box marginY={1} flexDirection="column">
           <Text dimColor>Teleport requires a Claude account</Text>
           <Text dimColor>
             Run <Text bold>/login</Text> and select &quot;Claude account with
             subscription&quot;
           </Text>
-        </Box>;
+        </Box>
+      )
     case 'api':
-      return <Box marginY={1} flexDirection="column">
+      return (
+        <Box marginY={1} flexDirection="column">
           <Text dimColor>Sorry, Claude encountered an error</Text>
-        </Box>;
+        </Box>
+      )
     case 'other':
-      return <Box marginY={1} flexDirection="row">
+      return (
+        <Box marginY={1} flexDirection="row">
           <Text dimColor>Sorry, OpenClaude encountered an error</Text>
-        </Box>;
+        </Box>
+      )
   }
 }

--- a/src/components/ResumeTask.tsx
+++ b/src/components/ResumeTask.tsx
@@ -12,6 +12,7 @@ import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { Select } from './CustomSelect/index.js';
 import { Byline } from './design-system/Byline.js';
 import { KeyboardShortcutHint } from './design-system/KeyboardShortcutHint.js';
+import { buildResumeTaskOptionLabel } from './resumeTaskLabel.js';
 import { Spinner } from './Spinner.js';
 import { TeleportError } from './TeleportError.js';
 type Props = {
@@ -22,6 +23,7 @@ type Props = {
 type LoadErrorType = 'network' | 'auth' | 'api' | 'other';
 const UPDATED_STRING = 'Updated';
 const SPACE_BETWEEN_TABLE_COLUMNS = '  ';
+
 export function ResumeTask({
   onSelect,
   onCancel,
@@ -161,13 +163,11 @@ export function ResumeTask({
   const options = sessionMetadata.map(({
     timeString,
     title,
+    repo,
     id
   }) => {
-    const paddedTime = timeString.padEnd(maxTimeStringLength, ' ');
-
-    // TODO: include branch name when API returns it
     return {
-      label: `${paddedTime}  ${title}`,
+      label: buildResumeTaskOptionLabel(timeString, title, repo, maxTimeStringLength),
       value: id
     };
   });

--- a/src/components/ResumeTask.tsx
+++ b/src/components/ResumeTask.tsx
@@ -30,6 +30,7 @@ export function ResumeTask({
   isEmbedded = false
 }: Props): React.ReactNode {
   const {
+    columns,
     rows
   } = useTerminalSize();
   const [sessions, setSessions] = useState<CodeSession[]>([]);
@@ -167,7 +168,7 @@ export function ResumeTask({
     id
   }) => {
     return {
-      label: buildResumeTaskOptionLabel(timeString, title, repo, maxTimeStringLength),
+      label: buildResumeTaskOptionLabel(timeString, title, repo, maxTimeStringLength, columns),
       value: id
     };
   });
@@ -194,7 +195,7 @@ export function ResumeTask({
           <Text bold>
             {UPDATED_STRING.padEnd(maxTimeStringLength, ' ')}
             {SPACE_BETWEEN_TABLE_COLUMNS}
-            {'Session Title'}
+            {'Session / Repository'}
           </Text>
         </Box>
         <Select visibleOptionCount={maxVisibleOptions} options={options} onChange={value => {

--- a/src/components/ResumeTask.tsx
+++ b/src/components/ResumeTask.tsx
@@ -12,7 +12,10 @@ import { ConfigurableShortcutHint } from './ConfigurableShortcutHint.js';
 import { Select } from './CustomSelect/index.js';
 import { Byline } from './design-system/Byline.js';
 import { KeyboardShortcutHint } from './design-system/KeyboardShortcutHint.js';
-import { buildResumeTaskOptionLabel } from './resumeTaskLabel.js';
+import {
+  buildResumeTaskOptionLabel,
+  getResumeTaskOptionLabelColumns,
+} from './resumeTaskLabel.js';
 import { Spinner } from './Spinner.js';
 import { TeleportError } from './TeleportError.js';
 type Props = {
@@ -160,6 +163,10 @@ export function ResumeTask({
     ...session_0,
     timeString: formatRelativeTime(new Date(session_0.updated_at))
   }));
+  const optionLabelColumns = getResumeTaskOptionLabelColumns(
+    columns,
+    sessions.length,
+  );
   const maxTimeStringLength = Math.max(UPDATED_STRING.length, ...sessionMetadata.map(meta => meta.timeString.length));
   const options = sessionMetadata.map(({
     timeString,
@@ -168,7 +175,7 @@ export function ResumeTask({
     id
   }) => {
     return {
-      label: buildResumeTaskOptionLabel(timeString, title, repo, maxTimeStringLength, columns),
+      label: buildResumeTaskOptionLabel(timeString, title, repo, maxTimeStringLength, optionLabelColumns),
       value: id
     };
   });

--- a/src/components/resumeTaskLabel.ts
+++ b/src/components/resumeTaskLabel.ts
@@ -1,5 +1,9 @@
 import type { CodeSession } from 'src/utils/teleport/api.js'
 
+export type ResumeTaskSessionMetadata = CodeSession & {
+  timeString: string
+}
+
 export function buildResumeTaskOptionLabel(
   timeString: string,
   title: string,
@@ -45,4 +49,29 @@ export function getResumeTaskOptionLabelColumns(
   const rowChromeWidth = 2 + indexColumnWidth + 2
 
   return Math.max(0, terminalColumns - rowChromeWidth)
+}
+
+export function buildResumeTaskOptionsFromMetadata(
+  sessionMetadata: ResumeTaskSessionMetadata[],
+  terminalColumns: number,
+): Array<{ label: string; value: string }> {
+  const optionLabelColumns = getResumeTaskOptionLabelColumns(
+    terminalColumns,
+    sessionMetadata.length,
+  )
+  const maxTimeStringLength = Math.max(
+    'Updated'.length,
+    ...sessionMetadata.map(meta => meta.timeString.length),
+  )
+
+  return sessionMetadata.map(({ timeString, title, repo, id }) => ({
+    label: buildResumeTaskOptionLabel(
+      timeString,
+      title,
+      repo,
+      maxTimeStringLength,
+      optionLabelColumns,
+    ),
+    value: id,
+  }))
 }

--- a/src/components/resumeTaskLabel.ts
+++ b/src/components/resumeTaskLabel.ts
@@ -1,0 +1,18 @@
+export type ResumeTaskRepo = {
+  name: string
+  owner: {
+    login: string
+  }
+} | null
+
+export function buildResumeTaskOptionLabel(
+  timeString: string,
+  title: string,
+  repo: ResumeTaskRepo,
+  maxTimeStringLength: number,
+): string {
+  const paddedTime = timeString.padEnd(maxTimeStringLength, ' ')
+  const repoLabel = repo ? `  ${repo.owner.login}/${repo.name}` : ''
+
+  return `${paddedTime}  ${title}${repoLabel}`
+}

--- a/src/components/resumeTaskLabel.ts
+++ b/src/components/resumeTaskLabel.ts
@@ -1,14 +1,9 @@
-export type ResumeTaskRepo = {
-  name: string
-  owner: {
-    login: string
-  }
-} | null
+import type { CodeSession } from 'src/utils/teleport/api.js'
 
 export function buildResumeTaskOptionLabel(
   timeString: string,
   title: string,
-  repo: ResumeTaskRepo,
+  repo: CodeSession['repo'],
   maxTimeStringLength: number,
   terminalColumns?: number,
 ): string {
@@ -40,4 +35,14 @@ export function buildResumeTaskOptionLabel(
   }
 
   return `${baseLabel}${repoCharacters.slice(0, availableRepoLabelWidth - 1).join('')}…`
+}
+
+export function getResumeTaskOptionLabelColumns(
+  terminalColumns: number,
+  optionCount: number,
+): number {
+  const indexColumnWidth = String(optionCount).length + 2
+  const rowChromeWidth = 2 + indexColumnWidth + 2
+
+  return Math.max(0, terminalColumns - rowChromeWidth)
 }

--- a/src/components/resumeTaskLabel.ts
+++ b/src/components/resumeTaskLabel.ts
@@ -10,9 +10,34 @@ export function buildResumeTaskOptionLabel(
   title: string,
   repo: ResumeTaskRepo,
   maxTimeStringLength: number,
+  terminalColumns?: number,
 ): string {
   const paddedTime = timeString.padEnd(maxTimeStringLength, ' ')
-  const repoLabel = repo ? `  ${repo.owner.login}/${repo.name}` : ''
+  const baseLabel = `${paddedTime}  ${title}`
 
-  return `${paddedTime}  ${title}${repoLabel}`
+  if (!repo) {
+    return baseLabel
+  }
+
+  const repoLabel = `  ${repo.owner.login}/${repo.name}`
+  if (terminalColumns === undefined) {
+    return `${baseLabel}${repoLabel}`
+  }
+
+  const baseLabelWidth = Array.from(baseLabel).length
+  const availableRepoLabelWidth = terminalColumns - baseLabelWidth
+  if (availableRepoLabelWidth <= 0) {
+    return baseLabel
+  }
+
+  const repoCharacters = Array.from(repoLabel)
+  if (repoCharacters.length <= availableRepoLabelWidth) {
+    return `${baseLabel}${repoLabel}`
+  }
+
+  if (availableRepoLabelWidth <= 1) {
+    return baseLabel
+  }
+
+  return `${baseLabel}${repoCharacters.slice(0, availableRepoLabelWidth - 1).join('')}…`
 }


### PR DESCRIPTION
This updates the session resume picker so each option shows the repository owner/name when that metadata is available, while keeping the existing time alignment and current filtering/sorting behavior.

A small pure helper was added so the label formatting can be tested without importing the TSX component.

Tested with:
- `/home/codespace/.bun/bin/bun test --feature=UNATTENDED_RETRY src/components/ResumeTask.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume task dropdown option labels to keep time and session titles aligned, and to append repository details (`owner/name`) when available.
  * Updated the select table header to **“Session / Repository”** to match the enriched option labels.
  * Improved narrow-layout behavior by truncating the repository portion with an ellipsis (`…`) when space is limited.

* **Tests**
  * Added Bun tests covering label formatting for null/non-null repositories, narrow-width truncation, and width-based column calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->