### PR TITLE
fix(session-title): ignore API error responses

### DIFF
--- a/src/utils/sessionTitle.test.ts
+++ b/src/utils/sessionTitle.test.ts
@@ -213,6 +213,30 @@ describe('generateSessionTitle', () => {
     })
   })
 
+  test('falls back when the title query returns an API error message', async () => {
+    queryHaikuImpl = async () => ({
+      isApiErrorMessage: true,
+      message: {
+        content: [{ type: 'text', text: 'API Error: 400 provider error' }],
+      },
+    })
+
+    const { generateSessionTitle } = await importSubject()
+    const title = await generateSessionTitle(
+      'Name a session with a failed title request',
+      new AbortController().signal,
+    )
+
+    expect(title).toBe('OpenClaude')
+    expect(debugMessages.at(-1)?.message).toContain(
+      'parse_failure=query_error',
+    )
+    expect(analyticsEvents).toContainEqual({
+      name: 'tengu_session_title_generated',
+      metadata: { success: false },
+    })
+  })
+
   test('propagates caller aborts to the internal title signal', async () => {
     queryHaikuImpl = async ({ signal }) => rejectWhenAborted(signal)
 

--- a/src/utils/sessionTitle.ts
+++ b/src/utils/sessionTitle.ts
@@ -423,6 +423,10 @@ export async function generateSessionTitle(
       },
     })
 
+    if (result.isApiErrorMessage) {
+      throw new Error('Session title query returned an API error')
+    }
+
     const text = extractTextContent(result.message.content)
     const parsed = parseSessionTitleResponse(text)
 


### PR DESCRIPTION
## Summary

- Treat session-title responses marked with `isApiErrorMessage` as failed metadata requests before parsing their text.
- Reuse the existing title-generation failure path so callers retain the normal `OpenClaude` or prompt-derived fallback.
- Add a regression test that reproduces the provider error being accepted as a terminal title.

The title request runs independently from the main task. Provider failures can therefore be returned as assistant error messages while the main task continues, and those messages must not become user-visible session titles.

Fixes #1991

## Impact

- user-facing impact: terminal tab/window titles no longer display background provider API errors while the main task is running normally.
- developer/maintainer impact: API error responses are rejected at the shared `generateSessionTitle` boundary, covering REPL, remote, bridge, and SDK callers without provider-specific parsing.

## Testing

- [x] `bun run smoke`
- [x] `bun run typecheck`
- [x] `bun run security:pr-scan`
- [x] `bun test src/utils/sessionTitle.test.ts` (19 pass, 0 fail)
- [x] `git diff --check origin/main...HEAD`
- [ ] `bun run check` (not run; focused test, typecheck, smoke, and PR scan were used for this two-file change)

## Notes

- Reviewed `CONTRIBUTING.md` and `AGENTS.md`.
- provider/model path tested: regression test uses the provider-independent `isApiErrorMessage` contract; the original issue was observed with an Anthropic-native custom endpoint and `claude-opus-4-8[1m]`. No live provider request was sent after the fix.
- screenshots attached (if UI changed): not attached. This changes only the terminal tab/window title source; the exact before-state title is recorded in #1991, and the original surrounding terminal state contains private provider details.
- self-review: two independent Codex review passes reported no findings.
- follow-up work or known limitations: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session title generation when the title service returns an API error.
  * Sessions now safely use the default title, “OpenClaude,” instead of producing an invalid title.
  * Added diagnostic tracking and analytics for failed title generation. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->