### PR TITLE
fix(permissions): anchor the session plan-file match on its exact shape

### DIFF
--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -277,9 +277,21 @@ export function isPlanFilePath(
   if (!normalizedPath.endsWith('.md')) {
     return false
   }
+  if (normalizedPath === expectedPrefix + '.md') {
+    return true
+  }
+  const agentPrefix = expectedPrefix + '-agent-'
+  if (!normalizedPath.startsWith(agentPrefix)) {
+    return false
+  }
+  // SECURITY: The remainder must be exactly one nonempty agent id followed by
+  // `.md`. Accepting the bare prefix would also allow a lookalike sibling
+  // *directory* ({slug}-agent-evil/anything.md), granting unprompted read and
+  // write to arbitrary files beneath it, as well as the malformed
+  // {slug}-agent-.md that getPlanFilePath never emits.
+  const agentId = normalizedPath.slice(agentPrefix.length, -'.md'.length)
   return (
-    normalizedPath === expectedPrefix + '.md' ||
-    normalizedPath.startsWith(expectedPrefix + '-agent-')
+    agentId.length > 0 && !agentId.includes('/') && !agentId.includes('\\')
   )
 }
 

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -258,17 +258,34 @@ function isClaudeConfigFilePath(filePath: string): boolean {
   )
 }
 
-// Check if file is the plan file for the current session
-function isSessionPlanFile(absolutePath: string): boolean {
-  // Check if path is a plan file for this session (main or agent-specific)
-  // Main plan file: {plansDir}/{planSlug}.md
-  // Agent plan file: {plansDir}/{planSlug}-agent-{agentId}.md
-  const expectedPrefix = join(getPlansDirectory(), getPlanSlug())
+// Pure predicate for the two legitimate plan-file shapes getPlanFilePath emits:
+//   Main plan file:  {plansDir}/{planSlug}.md
+//   Agent plan file: {plansDir}/{planSlug}-agent-{agentId}.md
+// Anchored on those exact delimiters. A bare startsWith on {plansDir}/{slug}
+// also matches any sibling whose name merely begins with the slug
+// ({slug}nova.md, {slug}-other.md, {slug}dir/x.md), which would silently
+// auto-allow reads and un-prompted writes to files that are not this session's
+// plan. Exported for testing.
+export function isPlanFilePath(
+  plansDir: string,
+  planSlug: string,
+  absolutePath: string,
+): boolean {
+  const expectedPrefix = join(plansDir, planSlug)
   // SECURITY: Normalize to prevent path traversal bypasses via .. segments
   const normalizedPath = normalize(absolutePath)
+  if (!normalizedPath.endsWith('.md')) {
+    return false
+  }
   return (
-    normalizedPath.startsWith(expectedPrefix) && normalizedPath.endsWith('.md')
+    normalizedPath === expectedPrefix + '.md' ||
+    normalizedPath.startsWith(expectedPrefix + '-agent-')
   )
+}
+
+// Check if file is the plan file for the current session
+function isSessionPlanFile(absolutePath: string): boolean {
+  return isPlanFilePath(getPlansDirectory(), getPlanSlug(), absolutePath)
 }
 
 /**

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -289,6 +289,10 @@ export function isPlanFilePath(
   // *directory* ({slug}-agent-evil/anything.md), granting unprompted read and
   // write to arbitrary files beneath it, as well as the malformed
   // {slug}-agent-.md that getPlanFilePath never emits.
+  //
+  // This stays compatible with every path getPlanFilePath produces because it
+  // percent-escapes separators in the agent id (encodeAgentIdForPlanFile), so
+  // a teammate on a team named `a/b` still gets a single-component filename.
   const agentId = normalizedPath.slice(agentPrefix.length, -'.md'.length)
   return (
     agentId.length > 0 && !agentId.includes('/') && !agentId.includes('\\')

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -41,6 +41,7 @@ import {
   AGENT_PLANS_SUBDIR,
   getPlanSlug,
   getPlansDirectory,
+  isCanonicalPlanFileEncoding,
 } from '../plans.js'
 import { getPlatform } from '../platform.js'
 import { getProjectDir } from '../sessionStorage.js'
@@ -290,19 +291,17 @@ export function isPlanFilePath(
   if (!normalizedPath.startsWith(agentPrefix)) {
     return false
   }
-  // SECURITY: The remainder must be exactly one nonempty agent id followed by
-  // `.md`. Accepting the bare prefix would also allow a lookalike sibling
-  // *directory* ({subdir}/{slug}-agent-evil/anything.md), granting unprompted
-  // read and write to arbitrary files beneath it, as well as the malformed
-  // {slug}-agent-.md that getPlanFilePath never emits.
-  //
-  // This stays compatible with every path getPlanFilePath produces because it
-  // percent-escapes separators in the agent id (encodeAgentIdForPlanFile), so
-  // a teammate on a team named `a/b` still gets a single-component filename.
-  const agentId = normalizedPath.slice(agentPrefix.length, -'.md'.length)
-  return (
-    agentId.length > 0 && !agentId.includes('/') && !agentId.includes('\\')
-  )
+  // SECURITY: The remainder must be exactly the canonical encoded agent id that
+  // getPlanFilePath emits, followed by `.md`. Anchoring on the canonical
+  // encoding (isCanonicalPlanFileEncoding) rejects every path the encoder never
+  // produces: the bare prefix and the malformed {slug}-agent-.md; a lookalike
+  // sibling *directory* ({subdir}/{slug}-agent-evil/anything.md, whose raw `/`
+  // is not canonical); and raw-`%` lookalikes such as {slug}-agent-writer@100%.md
+  // (canonical form ...writer@100%25.md) or ...writer@a%2Fb.md (canonical form
+  // ...writer@a%252Fb.md). Any of those would otherwise be auto-allowed for
+  // unprompted read/write even though they are not this session's plan file.
+  const encodedAgentId = normalizedPath.slice(agentPrefix.length, -'.md'.length)
+  return isCanonicalPlanFileEncoding(encodedAgentId)
 }
 
 // Check if file is the plan file for the current session

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -37,7 +37,11 @@ import {
   getDirectoryForPath,
   sanitizePath,
 } from '../path.js'
-import { getPlanSlug, getPlansDirectory } from '../plans.js'
+import {
+  AGENT_PLANS_SUBDIR,
+  getPlanSlug,
+  getPlansDirectory,
+} from '../plans.js'
 import { getPlatform } from '../platform.js'
 import { getProjectDir } from '../sessionStorage.js'
 import { SETTING_SOURCES } from '../settings/constants.js'
@@ -260,7 +264,7 @@ function isClaudeConfigFilePath(filePath: string): boolean {
 
 // Pure predicate for the two legitimate plan-file shapes getPlanFilePath emits:
 //   Main plan file:  {plansDir}/{planSlug}.md
-//   Agent plan file: {plansDir}/{planSlug}-agent-{agentId}.md
+//   Agent plan file: {plansDir}/{AGENT_PLANS_SUBDIR}/{planSlug}-agent-{agentId}.md
 // Anchored on those exact delimiters. A bare startsWith on {plansDir}/{slug}
 // also matches any sibling whose name merely begins with the slug
 // ({slug}nova.md, {slug}-other.md, {slug}dir/x.md), which would silently
@@ -280,14 +284,16 @@ export function isPlanFilePath(
   if (normalizedPath === expectedPrefix + '.md') {
     return true
   }
-  const agentPrefix = expectedPrefix + '-agent-'
+  // Agent plans live in the dedicated subdirectory that keeps their escaped
+  // filenames from colliding with legacy plans written directly under plansDir.
+  const agentPrefix = join(plansDir, AGENT_PLANS_SUBDIR, `${planSlug}-agent-`)
   if (!normalizedPath.startsWith(agentPrefix)) {
     return false
   }
   // SECURITY: The remainder must be exactly one nonempty agent id followed by
   // `.md`. Accepting the bare prefix would also allow a lookalike sibling
-  // *directory* ({slug}-agent-evil/anything.md), granting unprompted read and
-  // write to arbitrary files beneath it, as well as the malformed
+  // *directory* ({subdir}/{slug}-agent-evil/anything.md), granting unprompted
+  // read and write to arbitrary files beneath it, as well as the malformed
   // {slug}-agent-.md that getPlanFilePath never emits.
   //
   // This stays compatible with every path getPlanFilePath produces because it

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto'
 import ignore from 'ignore'
 import memoize from 'lodash-es/memoize.js'
 import { homedir, tmpdir } from 'os'
-import { join, normalize, posix, sep } from 'path'
+import { dirname, join, normalize, posix, sep } from 'path'
 import { hasAutoMemPathOverride, isAutoMemPath } from 'src/memdir/paths.js'
 import { isAgentMemoryPath } from 'src/tools/AgentTool/agentMemory.js'
 import {
@@ -304,9 +304,48 @@ export function isPlanFilePath(
   return isCanonicalPlanFileEncoding(encodedAgentId)
 }
 
+/**
+ * SECURITY: the plan-file carve-out grants unprompted read/write on a lexical
+ * name match, so a symlinked path component (e.g. a symlinked `agents`
+ * subdirectory, or a symlinked plans directory) could redirect the real target
+ * outside the plans directory. Resolve the deepest existing ancestor of the
+ * candidate (the file itself may not exist yet on a first write) and require it
+ * to stay within the *resolved* plans directory before honoring the carve-out.
+ */
+function isResolvedWithinPlansDir(
+  absolutePath: string,
+  plansDir: string,
+): boolean {
+  const fs = getFsImplementation()
+  let realPlansDir: string
+  try {
+    realPlansDir = fs.realpathSync(plansDir)
+  } catch {
+    // Cannot resolve the plans directory itself -> cannot prove containment.
+    return false
+  }
+  let probe = absolutePath
+  for (;;) {
+    try {
+      const real = fs.realpathSync(probe)
+      return real === realPlansDir || real.startsWith(realPlansDir + sep)
+    } catch (error) {
+      if (!isENOENT(error)) return false
+      const parent = dirname(probe)
+      // Reached the filesystem root without resolving anything inside plansDir.
+      if (parent === probe) return false
+      probe = parent
+    }
+  }
+}
+
 // Check if file is the plan file for the current session
 function isSessionPlanFile(absolutePath: string): boolean {
-  return isPlanFilePath(getPlansDirectory(), getPlanSlug(), absolutePath)
+  const plansDir = getPlansDirectory()
+  if (!isPlanFilePath(plansDir, getPlanSlug(), absolutePath)) {
+    return false
+  }
+  return isResolvedWithinPlansDir(absolutePath, plansDir)
 }
 
 /**

--- a/src/utils/permissions/filesystem.ts
+++ b/src/utils/permissions/filesystem.ts
@@ -42,6 +42,7 @@ import {
   getPlanSlug,
   getPlansDirectory,
   isCanonicalPlanFileEncoding,
+  isResolvedPathWithinPlansDir,
 } from '../plans.js'
 import { getPlatform } from '../platform.js'
 import { getProjectDir } from '../sessionStorage.js'
@@ -304,48 +305,19 @@ export function isPlanFilePath(
   return isCanonicalPlanFileEncoding(encodedAgentId)
 }
 
-/**
- * SECURITY: the plan-file carve-out grants unprompted read/write on a lexical
- * name match, so a symlinked path component (e.g. a symlinked `agents`
- * subdirectory, or a symlinked plans directory) could redirect the real target
- * outside the plans directory. Resolve the deepest existing ancestor of the
- * candidate (the file itself may not exist yet on a first write) and require it
- * to stay within the *resolved* plans directory before honoring the carve-out.
- */
-function isResolvedWithinPlansDir(
-  absolutePath: string,
-  plansDir: string,
-): boolean {
-  const fs = getFsImplementation()
-  let realPlansDir: string
-  try {
-    realPlansDir = fs.realpathSync(plansDir)
-  } catch {
-    // Cannot resolve the plans directory itself -> cannot prove containment.
-    return false
-  }
-  let probe = absolutePath
-  for (;;) {
-    try {
-      const real = fs.realpathSync(probe)
-      return real === realPlansDir || real.startsWith(realPlansDir + sep)
-    } catch (error) {
-      if (!isENOENT(error)) return false
-      const parent = dirname(probe)
-      // Reached the filesystem root without resolving anything inside plansDir.
-      if (parent === probe) return false
-      probe = parent
-    }
-  }
-}
-
 // Check if file is the plan file for the current session
 function isSessionPlanFile(absolutePath: string): boolean {
   const plansDir = getPlansDirectory()
   if (!isPlanFilePath(plansDir, getPlanSlug(), absolutePath)) {
     return false
   }
-  return isResolvedWithinPlansDir(absolutePath, plansDir)
+  // SECURITY: the plan-file carve-out grants unprompted read/write on a lexical
+  // name match, so a symlinked path component (e.g. a symlinked `agents`
+  // subdirectory, or a symlinked plans directory) could redirect the real
+  // target outside the plans directory. Resolve the deepest existing ancestor
+  // of the candidate and require it to stay within the *resolved* plans
+  // directory before honoring the carve-out. Shares the recovery-path helper.
+  return isResolvedPathWithinPlansDir(absolutePath, plansDir)
 }
 
 /**

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -38,6 +38,28 @@ test('rejects a sibling directory whose name begins with the slug', () => {
   ).toBe(false)
 })
 
+test('rejects a lookalike agent directory', () => {
+  // {slug}-agent-evil/ is a sibling directory, not an agent plan file. Matching
+  // it would auto-allow unprompted reads and writes to everything beneath it.
+  expect(
+    isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}-agent-evil`, 'x.md')),
+  ).toBe(false)
+  expect(
+    isPlanFilePath(
+      PLANS,
+      SLUG,
+      join(PLANS, `${SLUG}-agent-a`, 'b', 'deep.md'),
+    ),
+  ).toBe(false)
+})
+
+test('rejects an agent plan file with an empty agent id', () => {
+  // getPlanFilePath never emits this shape.
+  expect(isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}-agent-.md`))).toBe(
+    false,
+  )
+})
+
 test('rejects a different session slug', () => {
   expect(isPlanFilePath(PLANS, SLUG, join(PLANS, 'calm-quiet-fox.md'))).toBe(
     false,

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from 'bun:test'
+import { join } from 'path'
+
+import { isPlanFilePath } from './filesystem.js'
+
+// isPlanFilePath gates two permission carve-outs in checkEditableInternalPath /
+// checkReadableInternalPath: a plan file for the current session is auto-allowed
+// for read AND for write with no prompt. The match must be exactly this
+// session's plan, not any sibling that shares the slug as a name prefix.
+const PLANS = join('/home/user', '.openclaude', 'plans')
+const SLUG = 'brave-swift-otter'
+
+test('accepts the main plan file', () => {
+  expect(isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}.md`))).toBe(true)
+})
+
+test('accepts an agent plan file', () => {
+  expect(
+    isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}-agent-abc123.md`)),
+  ).toBe(true)
+})
+
+test('rejects a sibling whose name merely begins with the slug', () => {
+  // Before the fix these all passed a bare startsWith({plansDir}/{slug}) check
+  // and were silently auto-allowed for read and un-prompted write.
+  for (const name of [
+    `${SLUG}nova.md`,
+    `${SLUG}-other.md`,
+    `${SLUG}2.md`,
+  ]) {
+    expect(isPlanFilePath(PLANS, SLUG, join(PLANS, name))).toBe(false)
+  }
+})
+
+test('rejects a sibling directory whose name begins with the slug', () => {
+  expect(
+    isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}dir`, 'anything.md')),
+  ).toBe(false)
+})
+
+test('rejects a different session slug', () => {
+  expect(isPlanFilePath(PLANS, SLUG, join(PLANS, 'calm-quiet-fox.md'))).toBe(
+    false,
+  )
+})
+
+test('rejects non-.md paths', () => {
+  expect(isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}.txt`))).toBe(false)
+  expect(isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}`))).toBe(false)
+})
+
+test('normalizes traversal segments before matching', () => {
+  // A path that resolves outside the plans dir must not match.
+  expect(
+    isPlanFilePath(PLANS, SLUG, join(PLANS, '..', 'evil', `${SLUG}.md`)),
+  ).toBe(false)
+})

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -13,6 +13,7 @@ import { join } from 'path'
 import { isPlanFilePath } from './filesystem.js'
 import {
   encodeAgentIdForPlanFile,
+  isPathWithinPlansDir,
   readAndMigrateLegacyPlan,
 } from '../plans.js'
 
@@ -160,6 +161,30 @@ describe('legacy plan file recovery', () => {
     expect(
       readAndMigrateLegacyPlan(join(dir, `${SLUG}-agent-nothing.md`), escaped),
     ).toBeNull()
+  })
+
+  test('confines the legacy lookup to the plans directory', () => {
+    // The legacy path is built from the RAW agent id, so a traversal-shaped
+    // team/agent name can collapse to a path outside plansDir. Recovery must
+    // refuse it before reading + renaming, or it would move an arbitrary file.
+    const plansDir = join(dir, 'plans')
+    for (const agentId of [
+      '../../../etc/passwd',
+      'x/../../../../etc/passwd',
+      '../../../../root/.ssh/authorized_keys',
+      'a/../../..//tmp/evil',
+    ]) {
+      const legacy = join(plansDir, `${SLUG}-agent-${agentId}.md`)
+      // Each collapses to a path outside plansDir; recovery must refuse it.
+      expect(isPathWithinPlansDir(legacy, plansDir)).toBe(false)
+    }
+
+    // Every id a producer actually emits keeps the legacy path inside plansDir:
+    // the `/` lands a level deeper, not outside.
+    for (const agentId of ['abc123', 'writer@myteam', 'writer@a/b']) {
+      const legacy = join(plansDir, `${SLUG}-agent-${agentId}.md`)
+      expect(isPathWithinPlansDir(legacy, plansDir)).toBe(true)
+    }
   })
 
   test('does nothing when the id needed no escaping', () => {

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -1,8 +1,20 @@
-import { expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs'
+import { tmpdir } from 'os'
 import { join } from 'path'
 
 import { isPlanFilePath } from './filesystem.js'
-import { encodeAgentIdForPlanFile } from '../plans.js'
+import {
+  encodeAgentIdForPlanFile,
+  readAndMigrateLegacyPlan,
+} from '../plans.js'
 
 // isPlanFilePath gates two permission carve-outs in checkEditableInternalPath /
 // checkReadableInternalPath: a plan file for the current session is auto-allowed
@@ -106,4 +118,56 @@ test('normalizes traversal segments before matching', () => {
   expect(
     isPlanFilePath(PLANS, SLUG, join(PLANS, '..', 'evil', `${SLUG}.md`)),
   ).toBe(false)
+})
+
+describe('legacy plan file recovery', () => {
+  // Escaping changed the pathname for teammates whose id already contained a
+  // separator, and every reader now builds the escaped name. Without recovery
+  // an existing plan reads as missing on upgrade and a second file is created
+  // beside it, silently orphaning the teammate's work.
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'planmigrate-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  test('reads a plan written under the unescaped name and moves it', () => {
+    const legacyDir = join(dir, `${SLUG}-agent-writer@a`)
+    mkdirSync(legacyDir, { recursive: true })
+    const legacy = join(legacyDir, 'b.md')
+    const escaped = join(
+      dir,
+      `${SLUG}-agent-${encodeAgentIdForPlanFile('writer@a/b')}.md`,
+    )
+    writeFileSync(legacy, 'the plan')
+
+    expect(readAndMigrateLegacyPlan(legacy, escaped)).toBe('the plan')
+    // Moved, not copied: the escaped name is the one the permission carve-out
+    // recognizes, so leaving it behind would keep prompting on every write.
+    expect(existsSync(escaped)).toBe(true)
+    expect(existsSync(legacy)).toBe(false)
+    expect(readFileSync(escaped, 'utf-8')).toBe('the plan')
+    // And the migrated path is one the predicate accepts.
+    expect(isPlanFilePath(dir, SLUG, escaped)).toBe(true)
+  })
+
+  test('returns null when there is no legacy file', () => {
+    const escaped = join(dir, `${SLUG}-agent-writer%2Fb.md`)
+    expect(
+      readAndMigrateLegacyPlan(join(dir, `${SLUG}-agent-nothing.md`), escaped),
+    ).toBeNull()
+  })
+
+  test('does nothing when the id needed no escaping', () => {
+    // The overwhelmingly common case: both names are identical, so there is no
+    // legacy file to look for and no move to make.
+    const path = join(dir, `${SLUG}-agent-abc123.md`)
+    writeFileSync(path, 'plan')
+    expect(readAndMigrateLegacyPlan(path, path)).toBeNull()
+    expect(existsSync(path)).toBe(true)
+  })
 })

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test'
 import { join } from 'path'
 
 import { isPlanFilePath } from './filesystem.js'
+import { encodeAgentIdForPlanFile } from '../plans.js'
 
 // isPlanFilePath gates two permission carve-outs in checkEditableInternalPath /
 // checkReadableInternalPath: a plan file for the current session is auto-allowed
@@ -69,6 +70,35 @@ test('rejects a different session slug', () => {
 test('rejects non-.md paths', () => {
   expect(isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}.txt`))).toBe(false)
   expect(isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}`))).toBe(false)
+})
+
+// Producer-to-predicate: TeamCreateTool accepts any nonblank team name and
+// teammate spawning only strips `@` from the teammate name, so the agent id can
+// legitimately carry a path separator. Every id a producer can emit has to
+// survive the round trip, or that teammate loses access to its own plan file.
+test('accepts every plan path the producer can emit for a real agent id', () => {
+  for (const agentId of [
+    'abc123',
+    'writer@myteam',
+    'writer@a/b',
+    'writer@a\\b',
+    'writer@a/b/c',
+    'writer@100%',
+  ]) {
+    const emitted = join(
+      PLANS,
+      `${SLUG}-agent-${encodeAgentIdForPlanFile(agentId)}.md`,
+    )
+    expect(isPlanFilePath(PLANS, SLUG, emitted)).toBe(true)
+  }
+})
+
+test('distinct agent ids never collide on one plan file', () => {
+  // The escaping has to stay reversible: two teammates must not share a plan.
+  const encoded = ['a/b', 'a%2Fb', 'a\\b', 'a%5Cb', 'a%25b'].map(
+    encodeAgentIdForPlanFile,
+  )
+  expect(new Set(encoded).size).toBe(encoded.length)
 })
 
 test('normalizes traversal segments before matching', () => {

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -476,7 +476,7 @@ describe('legacy plan file recovery', () => {
     expect(readFileSync(escaped, 'utf-8')).toBe('move me')
   })
 
-  test('isResolvedPathWithinPlansDir rejects a symlinked intermediate directory', () => {
+  test.skipIf(process.platform === 'win32')('isResolvedPathWithinPlansDir rejects a symlinked intermediate directory', () => {
     const plansDir = join(dir, 'plans')
     mkdirSync(plansDir, { recursive: true })
     const outside = join(dir, 'outside')
@@ -497,7 +497,7 @@ describe('legacy plan file recovery', () => {
     ).toBe(false)
   })
 
-  test('readLegacyUnescapedPlan refuses recovery through a symlinked parent dir', () => {
+  test.skipIf(process.platform === 'win32')('readLegacyUnescapedPlan refuses recovery through a symlinked parent dir', () => {
     const plansDir = join(dir, 'plans')
     mkdirSync(join(plansDir, AGENT_PLANS_SUBDIR), { recursive: true })
     const outside = join(dir, 'outside')

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -12,13 +12,21 @@ import { join } from 'path'
 
 import type { AgentId } from 'src/types/ids.js'
 
+import { getSessionId } from '../../bootstrap/state.js'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../../test/sharedMutationLock.js'
 import { isPlanFilePath } from './filesystem.js'
 import {
   AGENT_PLANS_SUBDIR,
   encodeAgentIdForPlanFile,
+  getPlan,
+  getPlansDirectory,
   isPathWithinPlansDir,
   readAndMigrateLegacyPlan,
   readLegacyUnescapedPlan,
+  setPlanSlug,
 } from '../plans.js'
 
 // isPlanFilePath gates two permission carve-outs in checkEditableInternalPath /
@@ -279,5 +287,47 @@ describe('legacy plan file recovery', () => {
     )
     expect(existsSync(escaped)).toBe(true)
     expect(existsSync(legacy)).toBe(false)
+  })
+
+  // Wire-through coverage: the whole user-visible fix is getPlan() falling back
+  // to recovery on ENOENT. Drive the real getPlan() (not the helper) so a
+  // regression in that branch can't hide behind green helper tests.
+  test('getPlan recovers a legacy plan on ENOENT and migrates it into the subdir', async () => {
+    await acquireSharedMutationLock('utils/permissions/planFilePath.test.ts')
+    const savedCfg = process.env.OPENCLAUDE_CONFIG_DIR
+    const configDir = mkdtempSync(join(tmpdir(), 'plancfg-'))
+    process.env.OPENCLAUDE_CONFIG_DIR = configDir
+    // getPlansDirectory is memoized; clear it so it recomputes under the temp
+    // config dir, and again on teardown so later tests are unaffected.
+    ;(getPlansDirectory as unknown as { cache: Map<string, string> }).cache.clear()
+    try {
+      const plansDir = getPlansDirectory()
+      setPlanSlug(getSessionId(), SLUG)
+      // A pre-escape legacy plan for an id that needs escaping, at the flat root.
+      const legacy = join(plansDir, `${SLUG}-agent-writer@team.md`)
+      writeFileSync(legacy, 'legacy body')
+
+      // getPlan builds the escaped subdir path, misses (ENOENT), and recovers.
+      expect(getPlan('writer@team' as AgentId)).toBe('legacy body')
+
+      const escaped = join(
+        plansDir,
+        AGENT_PLANS_SUBDIR,
+        `${SLUG}-agent-writer@team.md`,
+      )
+      expect(existsSync(escaped)).toBe(true)
+      expect(existsSync(legacy)).toBe(false)
+    } finally {
+      if (savedCfg === undefined) {
+        delete process.env.OPENCLAUDE_CONFIG_DIR
+      } else {
+        process.env.OPENCLAUDE_CONFIG_DIR = savedCfg
+      }
+      ;(
+        getPlansDirectory as unknown as { cache: Map<string, string> }
+      ).cache.clear()
+      rmSync(configDir, { recursive: true, force: true })
+      releaseSharedMutationLock()
+    }
   })
 })

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -10,11 +10,15 @@ import {
 import { tmpdir } from 'os'
 import { join } from 'path'
 
+import type { AgentId } from 'src/types/ids.js'
+
 import { isPlanFilePath } from './filesystem.js'
 import {
+  AGENT_PLANS_SUBDIR,
   encodeAgentIdForPlanFile,
   isPathWithinPlansDir,
   readAndMigrateLegacyPlan,
+  readLegacyUnescapedPlan,
 } from '../plans.js'
 
 // isPlanFilePath gates two permission carve-outs in checkEditableInternalPath /
@@ -28,10 +32,23 @@ test('accepts the main plan file', () => {
   expect(isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}.md`))).toBe(true)
 })
 
-test('accepts an agent plan file', () => {
+test('accepts an agent plan file in the agents subdirectory', () => {
+  expect(
+    isPlanFilePath(
+      PLANS,
+      SLUG,
+      join(PLANS, AGENT_PLANS_SUBDIR, `${SLUG}-agent-abc123.md`),
+    ),
+  ).toBe(true)
+})
+
+test('rejects a legacy flat agent plan path (agent plans now live in the subdir)', () => {
+  // getPlanFilePath no longer emits agent plans directly under plansDir, so the
+  // carve-out must not auto-allow that shape -- a legacy file is only ever
+  // touched by recovery, which migrates it into the subdir.
   expect(
     isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}-agent-abc123.md`)),
-  ).toBe(true)
+  ).toBe(false)
 })
 
 test('rejects a sibling whose name merely begins with the slug', () => {
@@ -53,25 +70,26 @@ test('rejects a sibling directory whose name begins with the slug', () => {
 })
 
 test('rejects a lookalike agent directory', () => {
-  // {slug}-agent-evil/ is a sibling directory, not an agent plan file. Matching
-  // it would auto-allow unprompted reads and writes to everything beneath it.
+  // {subdir}/{slug}-agent-evil/ is a sibling directory, not an agent plan file.
+  // Matching it would auto-allow unprompted reads and writes beneath it.
+  const sub = join(PLANS, AGENT_PLANS_SUBDIR)
   expect(
-    isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}-agent-evil`, 'x.md')),
+    isPlanFilePath(PLANS, SLUG, join(sub, `${SLUG}-agent-evil`, 'x.md')),
   ).toBe(false)
   expect(
-    isPlanFilePath(
-      PLANS,
-      SLUG,
-      join(PLANS, `${SLUG}-agent-a`, 'b', 'deep.md'),
-    ),
+    isPlanFilePath(PLANS, SLUG, join(sub, `${SLUG}-agent-a`, 'b', 'deep.md')),
   ).toBe(false)
 })
 
 test('rejects an agent plan file with an empty agent id', () => {
   // getPlanFilePath never emits this shape.
-  expect(isPlanFilePath(PLANS, SLUG, join(PLANS, `${SLUG}-agent-.md`))).toBe(
-    false,
-  )
+  expect(
+    isPlanFilePath(
+      PLANS,
+      SLUG,
+      join(PLANS, AGENT_PLANS_SUBDIR, `${SLUG}-agent-.md`),
+    ),
+  ).toBe(false)
 })
 
 test('rejects a different session slug', () => {
@@ -100,6 +118,7 @@ test('accepts every plan path the producer can emit for a real agent id', () => 
   ]) {
     const emitted = join(
       PLANS,
+      AGENT_PLANS_SUBDIR,
       `${SLUG}-agent-${encodeAgentIdForPlanFile(agentId)}.md`,
     )
     expect(isPlanFilePath(PLANS, SLUG, emitted)).toBe(true)
@@ -142,8 +161,10 @@ describe('legacy plan file recovery', () => {
     const legacy = join(legacyDir, 'b.md')
     const escaped = join(
       dir,
+      AGENT_PLANS_SUBDIR,
       `${SLUG}-agent-${encodeAgentIdForPlanFile('writer@a/b')}.md`,
     )
+    mkdirSync(join(dir, AGENT_PLANS_SUBDIR), { recursive: true })
     writeFileSync(legacy, 'the plan')
 
     expect(readAndMigrateLegacyPlan(legacy, escaped)).toBe('the plan')
@@ -154,6 +175,20 @@ describe('legacy plan file recovery', () => {
     expect(readFileSync(escaped, 'utf-8')).toBe('the plan')
     // And the migrated path is one the predicate accepts.
     expect(isPlanFilePath(dir, SLUG, escaped)).toBe(true)
+  })
+
+  test('does not overwrite a plan already at the escaped path (no-clobber)', () => {
+    const legacy = join(dir, `${SLUG}-agent-writer@team.md`)
+    const escaped = join(dir, AGENT_PLANS_SUBDIR, `${SLUG}-agent-fresh.md`)
+    mkdirSync(join(dir, AGENT_PLANS_SUBDIR), { recursive: true })
+    writeFileSync(legacy, 'legacy plan')
+    writeFileSync(escaped, 'live plan')
+
+    // The legacy contents come back, but the live plan at the escaped path is
+    // left intact rather than clobbered by the rename.
+    expect(readAndMigrateLegacyPlan(legacy, escaped)).toBe('legacy plan')
+    expect(readFileSync(escaped, 'utf-8')).toBe('live plan')
+    expect(existsSync(legacy)).toBe(true)
   })
 
   test('returns null when there is no legacy file', () => {
@@ -194,5 +229,55 @@ describe('legacy plan file recovery', () => {
     writeFileSync(path, 'plan')
     expect(readAndMigrateLegacyPlan(path, path)).toBeNull()
     expect(existsSync(path)).toBe(true)
+  })
+
+  // Exercise the guard through readLegacyUnescapedPlan itself (not just
+  // isPathWithinPlansDir in isolation), so a future regression that drops the
+  // check inside the recovery flow is caught.
+  test('readLegacyUnescapedPlan refuses traversal-shaped ids and touches nothing', () => {
+    const plansDir = join(dir, 'plans')
+    mkdirSync(plansDir, { recursive: true })
+    // A file the traversal ids would resolve onto if the guard were missing.
+    const victim = join(plansDir, `${SLUG}.md`)
+    writeFileSync(victim, 'main plan')
+    const escaped = join(
+      plansDir,
+      AGENT_PLANS_SUBDIR,
+      `${SLUG}-agent-x.md`,
+    )
+
+    for (const agentId of [
+      `writer@a/../${SLUG}`,
+      `writer@a/../${SLUG}-agent-victim`,
+      '../../../etc/passwd',
+      'a/../../..//tmp/evil',
+    ]) {
+      expect(
+        readLegacyUnescapedPlan(agentId as AgentId, escaped, plansDir, SLUG),
+      ).toBeNull()
+    }
+
+    // Nothing was read into a migration or renamed: the victim survives and no
+    // escaped file was created.
+    expect(readFileSync(victim, 'utf-8')).toBe('main plan')
+    expect(existsSync(escaped)).toBe(false)
+  })
+
+  test('readLegacyUnescapedPlan recovers a legitimate legacy plan into the subdir', () => {
+    const plansDir = join(dir, 'plans')
+    mkdirSync(join(plansDir, AGENT_PLANS_SUBDIR), { recursive: true })
+    const legacy = join(plansDir, `${SLUG}-agent-writer@team.md`)
+    writeFileSync(legacy, 'legacy body')
+    const escaped = join(
+      plansDir,
+      AGENT_PLANS_SUBDIR,
+      `${SLUG}-agent-writer@team.md`,
+    )
+
+    expect(readLegacyUnescapedPlan('writer@team' as AgentId, escaped, plansDir, SLUG)).toBe(
+      'legacy body',
+    )
+    expect(existsSync(escaped)).toBe(true)
+    expect(existsSync(legacy)).toBe(false)
   })
 })

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'fs'
 import { tmpdir } from 'os'
@@ -20,6 +21,7 @@ import {
 import { isPlanFilePath } from './filesystem.js'
 import {
   AGENT_PLANS_SUBDIR,
+  clearPlanSlug,
   encodeAgentIdForPlanFile,
   getPlan,
   getPlansDirectory,
@@ -131,6 +133,49 @@ test('accepts every plan path the producer can emit for a real agent id', () => 
     )
     expect(isPlanFilePath(PLANS, SLUG, emitted)).toBe(true)
   }
+})
+
+// The agent branch must accept ONLY the canonical encoded filename
+// getPlanFilePath emits, not raw-`%` / raw-separator lookalikes that share the
+// prefix. `writer@100%` is stored at `…writer@100%25.md`, so the unencoded
+// `…writer@100%.md` sibling is a different file the producer never writes;
+// auto-allowing it would grant unprompted read/write outside this session's plan.
+test('rejects unencoded-percent lookalikes the producer never emits', () => {
+  const sub = join(PLANS, AGENT_PLANS_SUBDIR)
+  for (const rawComponent of [
+    'writer@100%', // canonical form is writer@100%25
+    'writer@a%2Fb'.replace('%2F', '%'), // writer@a%b -> canonical writer@a%25b
+    'a%', // bare trailing percent
+    'a%zz', // percent not starting a known escape
+    'a%2', // truncated escape
+  ]) {
+    expect(
+      isPlanFilePath(PLANS, SLUG, join(sub, `${SLUG}-agent-${rawComponent}.md`)),
+    ).toBe(false)
+  }
+})
+
+test('accepts the canonical encoded form of a percent/separator id, and only that form', () => {
+  const sub = join(PLANS, AGENT_PLANS_SUBDIR)
+  // Each pair: [agent id, the single filename component getPlanFilePath emits].
+  const pairs: [string, string][] = [
+    ['writer@100%', 'writer@100%25'],
+    ['writer@a/b', 'writer@a%2Fb'],
+    ['writer@a\\b', 'writer@a%5Cb'],
+    ['writer@a%2Fb', 'writer@a%252Fb'],
+  ]
+  for (const [agentId, canonical] of pairs) {
+    expect(encodeAgentIdForPlanFile(agentId)).toBe(canonical)
+    // The canonical file is accepted...
+    expect(
+      isPlanFilePath(PLANS, SLUG, join(sub, `${SLUG}-agent-${canonical}.md`)),
+    ).toBe(true)
+  }
+  // ...while writer@a%2Fb (canonical writer@a%252Fb) and writer@a/b (canonical
+  // writer@a%2Fb) map to DISTINCT files -- no aliasing between the two ids.
+  expect(encodeAgentIdForPlanFile('writer@a%2Fb')).not.toBe(
+    encodeAgentIdForPlanFile('writer@a/b'),
+  )
 })
 
 test('distinct agent ids never collide on one plan file', () => {
@@ -291,29 +336,41 @@ describe('legacy plan file recovery', () => {
 
   // Wire-through coverage: the whole user-visible fix is getPlan() falling back
   // to recovery on ENOENT. Drive the real getPlan() (not the helper) so a
-  // regression in that branch can't hide behind green helper tests.
-  test('getPlan recovers a legacy plan on ENOENT and migrates it into the subdir', async () => {
+  // regression in that branch can't hide behind green helper tests. The id is
+  // chosen so encodeAgentIdForPlanFile changes the pathname (writer@a/b ->
+  // writer@a%2Fb): a byte-identical id would not exercise the escaped-vs-legacy
+  // path at all.
+  test('getPlan recovers a legacy separator-id plan on ENOENT and migrates it into the subdir', async () => {
+    // Acquire the lock first, then guard EVERY mutation (env, memo cache, slug,
+    // temp dir) inside try/finally so a throw during setup still restores state.
     await acquireSharedMutationLock('utils/permissions/planFilePath.test.ts')
     const savedCfg = process.env.OPENCLAUDE_CONFIG_DIR
-    const configDir = mkdtempSync(join(tmpdir(), 'plancfg-'))
-    process.env.OPENCLAUDE_CONFIG_DIR = configDir
-    // getPlansDirectory is memoized; clear it so it recomputes under the temp
-    // config dir, and again on teardown so later tests are unaffected.
-    ;(getPlansDirectory as unknown as { cache: Map<string, string> }).cache.clear()
+    let configDir: string | undefined
+    const clearPlansCache = () =>
+      (
+        getPlansDirectory as unknown as { cache: Map<string, string> }
+      ).cache.clear()
     try {
+      configDir = mkdtempSync(join(tmpdir(), 'plancfg-'))
+      process.env.OPENCLAUDE_CONFIG_DIR = configDir
+      // getPlansDirectory is memoized; clear it so it recomputes under the temp
+      // config dir.
+      clearPlansCache()
       const plansDir = getPlansDirectory()
       setPlanSlug(getSessionId(), SLUG)
+      const AGENT_ID = 'writer@a/b'
       // A pre-escape legacy plan for an id that needs escaping, at the flat root.
-      const legacy = join(plansDir, `${SLUG}-agent-writer@team.md`)
+      const legacy = join(plansDir, `${SLUG}-agent-${AGENT_ID}.md`)
+      mkdirSync(join(plansDir, `${SLUG}-agent-writer@a`), { recursive: true })
       writeFileSync(legacy, 'legacy body')
 
       // getPlan builds the escaped subdir path, misses (ENOENT), and recovers.
-      expect(getPlan('writer@team' as AgentId)).toBe('legacy body')
+      expect(getPlan(AGENT_ID as AgentId)).toBe('legacy body')
 
       const escaped = join(
         plansDir,
         AGENT_PLANS_SUBDIR,
-        `${SLUG}-agent-writer@team.md`,
+        `${SLUG}-agent-${encodeAgentIdForPlanFile(AGENT_ID)}.md`,
       )
       expect(existsSync(escaped)).toBe(true)
       expect(existsSync(legacy)).toBe(false)
@@ -323,11 +380,79 @@ describe('legacy plan file recovery', () => {
       } else {
         process.env.OPENCLAUDE_CONFIG_DIR = savedCfg
       }
-      ;(
-        getPlansDirectory as unknown as { cache: Map<string, string> }
-      ).cache.clear()
-      rmSync(configDir, { recursive: true, force: true })
+      clearPlansCache()
+      clearPlanSlug(getSessionId())
+      if (configDir) rmSync(configDir, { recursive: true, force: true })
       releaseSharedMutationLock()
     }
+  })
+
+  // An empty/whitespace escaped stub (e.g. materialized by a direct FileWrite
+  // before migration) must not permanently shadow a legacy plan that still has
+  // content: getPlan falls through to recovery, and no-clobber keeps the stub.
+  // Drive the real getPlan() so the empty-read fallthrough branch is covered.
+  test('getPlan prefers a legacy plan over an empty escaped stub', async () => {
+    await acquireSharedMutationLock('utils/permissions/planFilePath.test.ts')
+    const savedCfg = process.env.OPENCLAUDE_CONFIG_DIR
+    let configDir: string | undefined
+    const clearPlansCache = () =>
+      (
+        getPlansDirectory as unknown as { cache: Map<string, string> }
+      ).cache.clear()
+    try {
+      configDir = mkdtempSync(join(tmpdir(), 'planstub-'))
+      process.env.OPENCLAUDE_CONFIG_DIR = configDir
+      clearPlansCache()
+      const plansDir = getPlansDirectory()
+      setPlanSlug(getSessionId(), SLUG)
+      mkdirSync(join(plansDir, AGENT_PLANS_SUBDIR), { recursive: true })
+      const legacy = join(plansDir, `${SLUG}-agent-writer@team.md`)
+      const escaped = join(
+        plansDir,
+        AGENT_PLANS_SUBDIR,
+        `${SLUG}-agent-writer@team.md`,
+      )
+      writeFileSync(legacy, 'real plan body')
+      writeFileSync(escaped, '   \n') // whitespace-only stub jumped ahead of migration
+
+      // Reads the empty stub, falls through to recovery, and returns the legacy
+      // body -- while no-clobber leaves the stub itself intact.
+      expect(getPlan('writer@team' as AgentId)).toBe('real plan body')
+      expect(readFileSync(escaped, 'utf-8')).toBe('   \n')
+      expect(existsSync(legacy)).toBe(true)
+    } finally {
+      if (savedCfg === undefined) {
+        delete process.env.OPENCLAUDE_CONFIG_DIR
+      } else {
+        process.env.OPENCLAUDE_CONFIG_DIR = savedCfg
+      }
+      clearPlansCache()
+      clearPlanSlug(getSessionId())
+      if (configDir) rmSync(configDir, { recursive: true, force: true })
+      releaseSharedMutationLock()
+    }
+  })
+
+  // Recovery reads and renames the legacy path, so it must reject a symlink
+  // planted at that slot rather than following it to an arbitrary target.
+  test('readLegacyUnescapedPlan refuses a symlinked legacy slot', () => {
+    const plansDir = join(dir, 'plans')
+    mkdirSync(join(plansDir, AGENT_PLANS_SUBDIR), { recursive: true })
+    const secret = join(dir, 'secret.md')
+    writeFileSync(secret, 'SECRET')
+    const legacy = join(plansDir, `${SLUG}-agent-writer@team.md`)
+    symlinkSync(secret, legacy)
+    const escaped = join(
+      plansDir,
+      AGENT_PLANS_SUBDIR,
+      `${SLUG}-agent-writer@team.md`,
+    )
+
+    expect(
+      readLegacyUnescapedPlan('writer@team' as AgentId, escaped, plansDir, SLUG),
+    ).toBeNull()
+    // The symlink target was neither read into a migration nor renamed away.
+    expect(existsSync(secret)).toBe(true)
+    expect(existsSync(escaped)).toBe(false)
   })
 })

--- a/src/utils/permissions/planFilePath.test.ts
+++ b/src/utils/permissions/planFilePath.test.ts
@@ -26,6 +26,7 @@ import {
   getPlan,
   getPlansDirectory,
   isPathWithinPlansDir,
+  isResolvedPathWithinPlansDir,
   readAndMigrateLegacyPlan,
   readLegacyUnescapedPlan,
   setPlanSlug,
@@ -431,6 +432,91 @@ describe('legacy plan file recovery', () => {
       if (configDir) rmSync(configDir, { recursive: true, force: true })
       releaseSharedMutationLock()
     }
+  })
+
+  // On POSIX, `\` is a legal filename character, so a team id like `a\..\b` was
+  // persisted as one flat filename. The traversal guard must not treat those
+  // literal backslashes as separators (that would wrongly reject recovery and
+  // make the existing plan look absent). Windows, where `\` IS a separator,
+  // keeps rejecting it -- so this case is POSIX-only.
+  test.skipIf(process.platform === 'win32')(
+    'recovers a POSIX legacy id containing literal backslash-dotdot-backslash',
+    () => {
+      const plansDir = join(dir, 'plans')
+      mkdirSync(join(plansDir, AGENT_PLANS_SUBDIR), { recursive: true })
+      const rawId = 'a\\..\\b' // literal backslashes, a single flat filename on POSIX
+      const legacy = join(plansDir, `${SLUG}-agent-${rawId}.md`)
+      writeFileSync(legacy, 'posix body')
+      const escaped = join(
+        plansDir,
+        AGENT_PLANS_SUBDIR,
+        `${SLUG}-agent-${encodeAgentIdForPlanFile(rawId)}.md`,
+      )
+
+      expect(
+        readLegacyUnescapedPlan(rawId as AgentId, escaped, plansDir, SLUG),
+      ).toBe('posix body')
+      expect(existsSync(escaped)).toBe(true)
+      expect(existsSync(legacy)).toBe(false)
+    },
+  )
+
+  test('migration is a genuine move: escaped is a new link, legacy is removed', () => {
+    const plansDir = join(dir, 'plans')
+    mkdirSync(join(plansDir, AGENT_PLANS_SUBDIR), { recursive: true })
+    const legacy = join(plansDir, `${SLUG}-agent-writer@team.md`)
+    writeFileSync(legacy, 'move me')
+    const escaped = join(
+      plansDir,
+      AGENT_PLANS_SUBDIR,
+      `${SLUG}-agent-writer@team.md`,
+    )
+    expect(readAndMigrateLegacyPlan(legacy, escaped)).toBe('move me')
+    expect(existsSync(legacy)).toBe(false)
+    expect(readFileSync(escaped, 'utf-8')).toBe('move me')
+  })
+
+  test('isResolvedPathWithinPlansDir rejects a symlinked intermediate directory', () => {
+    const plansDir = join(dir, 'plans')
+    mkdirSync(plansDir, { recursive: true })
+    const outside = join(dir, 'outside')
+    mkdirSync(outside, { recursive: true })
+
+    // A real subdir path resolves inside plansDir.
+    const realSub = join(plansDir, 'sub')
+    mkdirSync(realSub)
+    expect(
+      isResolvedPathWithinPlansDir(join(realSub, 'x.md'), plansDir),
+    ).toBe(true)
+
+    // A symlinked subdir pointing outside plansDir does not.
+    const linkSub = join(plansDir, 'evil')
+    symlinkSync(outside, linkSub)
+    expect(
+      isResolvedPathWithinPlansDir(join(linkSub, 'x.md'), plansDir),
+    ).toBe(false)
+  })
+
+  test('readLegacyUnescapedPlan refuses recovery through a symlinked parent dir', () => {
+    const plansDir = join(dir, 'plans')
+    mkdirSync(join(plansDir, AGENT_PLANS_SUBDIR), { recursive: true })
+    const outside = join(dir, 'outside')
+    mkdirSync(outside, { recursive: true })
+    // Plant the real file outside, then symlink the intermediate legacy dir to it.
+    writeFileSync(join(outside, 'b.md'), 'SECRET')
+    // Legacy id `writer@a/b` -> legacyPath = {plansDir}/{slug}-agent-writer@a/b.md
+    symlinkSync(outside, join(plansDir, `${SLUG}-agent-writer@a`))
+    const escaped = join(
+      plansDir,
+      AGENT_PLANS_SUBDIR,
+      `${SLUG}-agent-${encodeAgentIdForPlanFile('writer@a/b')}.md`,
+    )
+
+    expect(
+      readLegacyUnescapedPlan('writer@a/b' as AgentId, escaped, plansDir, SLUG),
+    ).toBeNull()
+    expect(existsSync(escaped)).toBe(false)
+    expect(readFileSync(join(outside, 'b.md'), 'utf-8')).toBe('SECRET')
   })
 
   // Recovery reads and renames the legacy path, so it must reject a symlink

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -200,6 +200,19 @@ export function getPlan(agentId?: AgentId): string | null {
  *
  * Exported for testing.
  */
+/**
+ * Whether a legacy plan path (built from an unescaped, attacker-influenced
+ * agent id) still resolves inside the plans directory after `..` collapse.
+ *
+ * Exported for testing.
+ */
+export function isPathWithinPlansDir(
+  candidatePath: string,
+  plansDir: string,
+): boolean {
+  return candidatePath === plansDir || candidatePath.startsWith(plansDir + sep)
+}
+
 export function readAndMigrateLegacyPlan(
   legacyPath: string,
   escapedPath: string,
@@ -232,10 +245,16 @@ function readLegacyUnescapedPlan(
   escapedPath: string,
 ): string | null {
   if (!agentId) return null
+  const plansDir = getPlansDirectory()
   const legacyPath = join(
-    getPlansDirectory(),
+    plansDir,
     `${getPlanSlug(getSessionId())}-agent-${agentId}.md`,
   )
+  // SECURITY: agentId is intentionally left unescaped here so the pre-escape
+  // filename can be recovered, so it can still carry `/`, `\`, or `..`. Once
+  // join() collapses those the path can land outside plansDir, and the migrate
+  // step reads then renames it -- moving an arbitrary file.
+  if (!isPathWithinPlansDir(legacyPath, plansDir)) return null
   return readAndMigrateLegacyPlan(legacyPath, escapedPath)
 }
 

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -128,6 +128,26 @@ export const getPlansDirectory = memoize(function getPlansDirectory(): string {
 })
 
 /**
+ * Escape the path separators an agent ID may legitimately contain so it always
+ * lands in a single filename component.
+ *
+ * A teammate's ID is `{name}@{teamName}`, and neither producer strips
+ * separators from the team name, so a team called `a/b` would otherwise emit
+ * `{slug}-agent-writer@a/b.md` -- a path in a *subdirectory* of the plans dir,
+ * not a plan file. Percent-escaping is reversible and leaves every ordinary ID
+ * (which contains none of these characters) byte-identical, so existing plan
+ * files keep their paths.
+ *
+ * Exported for testing.
+ */
+export function encodeAgentIdForPlanFile(agentId: string): string {
+  return agentId
+    .replaceAll('%', '%25')
+    .replaceAll('/', '%2F')
+    .replaceAll('\\', '%5C')
+}
+
+/**
  * Get the file path for a session's plan
  * @param agentId Optional agent ID for subagents. If not provided, returns main session plan.
  * For main conversation (no agentId), returns {planSlug}.md
@@ -142,7 +162,10 @@ export function getPlanFilePath(agentId?: AgentId): string {
   }
 
   // Subagents: include agent ID
-  return join(getPlansDirectory(), `${planSlug}-agent-${agentId}.md`)
+  return join(
+    getPlansDirectory(),
+    `${planSlug}-agent-${encodeAgentIdForPlanFile(agentId)}.md`,
+  )
 }
 
 /**

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -177,10 +177,66 @@ export function getPlan(agentId?: AgentId): string | null {
   try {
     return getFsImplementation().readFileSync(filePath, { encoding: 'utf-8' })
   } catch (error) {
-    if (isENOENT(error)) return null
-    logError(error)
+    if (!isENOENT(error)) {
+      logError(error)
+      return null
+    }
+    return readLegacyUnescapedPlan(agentId, filePath)
+  }
+}
+
+/**
+ * Recover a plan written before agent IDs were escaped into the filename.
+ *
+ * Team names have always accepted arbitrary nonblank text, so plans for ids
+ * like `writer@a/b` or `writer@100%` are already on disk under the raw name.
+ * Every reader now builds the escaped name, so without this the teammate's plan
+ * reads as missing on upgrade and a second file is created beside it.
+ *
+ * Moving it is what makes the recovery stick: the escaped name is the one the
+ * permission carve-out recognizes, so a plan left at the old path would keep
+ * falling through to ordinary permission handling on every later write.
+ * A failed move is not fatal -- the content was already read.
+ *
+ * Exported for testing.
+ */
+export function readAndMigrateLegacyPlan(
+  legacyPath: string,
+  escapedPath: string,
+): string | null {
+  if (legacyPath === escapedPath) return null
+
+  let contents: string
+  try {
+    contents = getFsImplementation().readFileSync(legacyPath, {
+      encoding: 'utf-8',
+    })
+  } catch (error) {
+    if (!isENOENT(error)) logError(error)
     return null
   }
+
+  try {
+    getFsImplementation().renameSync(legacyPath, escapedPath)
+  } catch (error) {
+    logForDebugging(
+      `Could not move legacy plan file ${legacyPath} to ${escapedPath}: ${error instanceof Error ? error.message : error}`,
+      { level: 'warn' },
+    )
+  }
+  return contents
+}
+
+function readLegacyUnescapedPlan(
+  agentId: AgentId | undefined,
+  escapedPath: string,
+): string | null {
+  if (!agentId) return null
+  const legacyPath = join(
+    getPlansDirectory(),
+    `${getPlanSlug(getSessionId())}-agent-${agentId}.md`,
+  )
+  return readAndMigrateLegacyPlan(legacyPath, escapedPath)
 }
 
 /**

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from 'crypto'
+import type { Stats } from 'fs'
 import { copyFile, writeFile } from 'fs/promises'
 import memoize from 'lodash-es/memoize.js'
 import { homedir } from 'os'
-import { join, resolve, sep } from 'path'
+import { dirname, join, resolve, sep } from 'path'
 import type { AgentId, SessionId } from 'src/types/ids.js'
 import type { LogOption } from 'src/types/logs.js'
 import type {
@@ -269,47 +270,175 @@ export function isPathWithinPlansDir(
   return candidatePath === plansDir || candidatePath.startsWith(plansDir + sep)
 }
 
+/**
+ * Like {@link isPathWithinPlansDir} but resolves symlinks. The lexical check
+ * above cannot see a symlinked intermediate directory (e.g. a slash-bearing
+ * legacy id `writer@a/b` whose `{slug}-agent-writer@a` parent is a symlink to
+ * outside the plans dir); recovery would then read/migrate through it. Resolve
+ * the deepest existing ancestor of the legacy path and require it to stay inside
+ * the resolved plans directory.
+ *
+ * Exported for testing.
+ */
+export function isResolvedPathWithinPlansDir(
+  candidatePath: string,
+  plansDir: string,
+): boolean {
+  const fs = getFsImplementation()
+  let realPlansDir: string
+  try {
+    realPlansDir = fs.realpathSync(plansDir)
+  } catch {
+    return false
+  }
+  let probe = candidatePath
+  for (;;) {
+    try {
+      const real = fs.realpathSync(probe)
+      return real === realPlansDir || real.startsWith(realPlansDir + sep)
+    } catch (error) {
+      if (!isENOENT(error)) return false
+      const parent = dirname(probe)
+      if (parent === probe) return false
+      probe = parent
+    }
+  }
+}
+
+function errorCode(error: unknown): string | undefined {
+  return typeof error === 'object' && error !== null && 'code' in error
+    ? String((error as { code?: unknown }).code)
+    : undefined
+}
+
+/**
+ * Read a path that must be a regular file, proving the object did not change
+ * across the read. A pathname pre-check (`lstat`) followed by a separate
+ * `readFileSync` is a TOCTOU: an attacker who can write the plans directory can
+ * swap the checked regular file for a symlink in the gap, so recovery would
+ * read the link target. Without a no-follow file handle in the fs abstraction we
+ * instead bracket the read with `lstat` and require the same inode/device and a
+ * regular file both before and after -- so a swap in the window is detected and
+ * the read is discarded rather than trusted.
+ */
+function readRegularFileStable(path: string): string | null {
+  const fs = getFsImplementation()
+  let before: Stats
+  try {
+    before = fs.lstatSync(path)
+  } catch (error) {
+    if (!isENOENT(error)) logError(error)
+    return null
+  }
+  if (!before.isFile()) return null
+
+  let contents: string
+  try {
+    contents = fs.readFileSync(path, { encoding: 'utf-8' })
+  } catch (error) {
+    if (!isENOENT(error)) logError(error)
+    return null
+  }
+
+  let after: Stats
+  try {
+    after = fs.lstatSync(path)
+  } catch (error) {
+    if (!isENOENT(error)) logError(error)
+    return null
+  }
+  if (
+    !after.isFile() ||
+    after.ino !== before.ino ||
+    after.dev !== before.dev
+  ) {
+    return null
+  }
+  return contents
+}
+
 export function readAndMigrateLegacyPlan(
   legacyPath: string,
   escapedPath: string,
 ): string | null {
   if (legacyPath === escapedPath) return null
 
-  // SECURITY: recovery reads and then renames this path, so it must be a real
+  const fs = getFsImplementation()
+
+  // SECURITY: recovery reads and then migrates this path, so it must be a real
   // regular file. A symlink planted at the legacy slot would otherwise let
-  // recovery return the contents of (and rename) an arbitrary target outside the
-  // plans directory. lstat does not follow the link, so a symlink fails isFile().
+  // recovery return the contents of an arbitrary target outside the plans
+  // directory. Capture the file identity up front; the migration below pins that
+  // inode via an atomic hard link so a later swap cannot redirect the read.
+  let legacyStat: Stats
   try {
-    if (!getFsImplementation().lstatSync(legacyPath).isFile()) return null
+    legacyStat = fs.lstatSync(legacyPath)
+  } catch (error) {
+    if (!isENOENT(error)) logError(error)
+    return null
+  }
+  if (!legacyStat.isFile()) return null
+
+  // Genuine no-clobber move: `linkSync` fails with EEXIST if the escaped path
+  // already exists, so it never replaces a live plan the way a check-then-act
+  // `existsSync` + `renameSync` would under a concurrent writer. On success the
+  // escaped name is a hard link to the exact inode we just lstat'd, immune to a
+  // symlink swap of the legacy pathname.
+  try {
+    fs.linkSync(legacyPath, escapedPath)
+  } catch (error) {
+    const code = errorCode(error)
+    if (code === 'ENOENT') return null
+    if (code === 'EEXIST') {
+      // A live plan is already at the escaped path: do not migrate. Return the
+      // legacy contents (read with swap detection) without touching either file.
+      return readRegularFileStable(legacyPath)
+    }
+    // Hard links may be unsupported (e.g. cross-device, some Windows FS). Fall
+    // back to reading the legacy file in place without migrating.
+    logForDebugging(
+      `Could not link legacy plan file ${legacyPath} to ${escapedPath}: ${error instanceof Error ? error.message : error}`,
+      { level: 'warn' },
+    )
+    return readRegularFileStable(legacyPath)
+  }
+
+  // Confirm the linked inode is the regular file we captured -- a swap between
+  // the lstat and the link would otherwise pin an attacker's object.
+  try {
+    const linked = fs.lstatSync(escapedPath)
+    if (
+      !linked.isFile() ||
+      linked.ino !== legacyStat.ino ||
+      linked.dev !== legacyStat.dev
+    ) {
+      try {
+        fs.unlinkSync(escapedPath)
+      } catch {
+        // best effort
+      }
+      return null
+    }
   } catch (error) {
     if (!isENOENT(error)) logError(error)
     return null
   }
 
+  // Read from the pinned escaped hard link, then drop the legacy name to
+  // complete the move. Reading the link (not legacyPath) means a swap of the
+  // legacy pathname after this point cannot affect the returned contents.
   let contents: string
   try {
-    contents = getFsImplementation().readFileSync(legacyPath, {
-      encoding: 'utf-8',
-    })
+    contents = fs.readFileSync(escapedPath, { encoding: 'utf-8' })
   } catch (error) {
     if (!isENOENT(error)) logError(error)
     return null
   }
-
-  // No-clobber: never rename a legacy file over a plan that already exists at
-  // the escaped path. getPlan only reaches recovery after the escaped read
-  // missed, but a concurrent writer can create it in between; overwriting it
-  // would lose a live plan. The legacy contents were already read, so return
-  // them without migrating.
-  if (getFsImplementation().existsSync(escapedPath)) {
-    return contents
-  }
-
   try {
-    getFsImplementation().renameSync(legacyPath, escapedPath)
+    fs.unlinkSync(legacyPath)
   } catch (error) {
     logForDebugging(
-      `Could not move legacy plan file ${legacyPath} to ${escapedPath}: ${error instanceof Error ? error.message : error}`,
+      `Could not remove legacy plan file ${legacyPath} after migration: ${error instanceof Error ? error.message : error}`,
       { level: 'warn' },
     )
   }
@@ -335,7 +464,13 @@ export function readLegacyUnescapedPlan(
   // (`a/../{slug}` -> the main plan; `a/../{slug}-agent-victim` -> a sibling),
   // which the migrate step would then read and rename -- moving another agent's
   // file. Reject any traversal segment before building the path.
-  if (agentId.split(/[/\\]/).includes('..')) return null
+  //
+  // Split on the host platform's real separators: on POSIX only `/` is a
+  // separator, and `\` is a legal filename character, so a legitimate legacy id
+  // such as `a\..\b` was persisted as one flat filename and must still recover.
+  // On Windows both `/` and `\` are separators (keep that safeguard).
+  const traversalSeparators = sep === '\\' ? /[/\\]/ : /\//
+  if (agentId.split(traversalSeparators).includes('..')) return null
 
   const legacyPath = join(plansDir, `${slug}-agent-${agentId}.md`)
   // Defense in depth: the legacy file must still sit inside the plans dir and
@@ -344,6 +479,10 @@ export function readLegacyUnescapedPlan(
   const agentPrefix = join(plansDir, `${slug}-agent-`)
   if (!isPathWithinPlansDir(legacyPath, plansDir)) return null
   if (!legacyPath.startsWith(agentPrefix)) return null
+  // SECURITY: a slash-bearing legacy id lands the file under an intermediate
+  // directory; if that directory is a symlink the lexical checks above still
+  // pass. Require the resolved path to stay inside the plans dir before reading.
+  if (!isResolvedPathWithinPlansDir(legacyPath, plansDir)) return null
   return readAndMigrateLegacyPlan(legacyPath, escapedPath)
 }
 

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -25,6 +25,20 @@ import { generateWordSlug } from './words.js'
 
 const MAX_SLUG_RETRIES = 10
 
+/**
+ * Encoded agent plans live in this dedicated subdirectory of the plans dir so
+ * their filenames can never collide with a legacy (pre-escape) plan written
+ * directly under it. Two distinct teammates `writer@a/b` and `writer@a%2Fb`
+ * otherwise both map onto `{slug}-agent-writer@a%2Fb.md` -- one as the new
+ * escaped name, the other as its raw legacy name -- and read or clobber each
+ * other's plan. A real path separator is the one thing a raw single-component
+ * legacy name can never contain, so a subdirectory is what makes the escaped
+ * and legacy namespaces provably disjoint.
+ *
+ * Exported so the permission carve-out recognizes the same location.
+ */
+export const AGENT_PLANS_SUBDIR = 'agents'
+
 export function getDefaultPlansDirectory({
   configDirEnv = resolveConfigDirEnv({
     openClaudeConfigDir: process.env.OPENCLAUDE_CONFIG_DIR,
@@ -151,7 +165,8 @@ export function encodeAgentIdForPlanFile(agentId: string): string {
  * Get the file path for a session's plan
  * @param agentId Optional agent ID for subagents. If not provided, returns main session plan.
  * For main conversation (no agentId), returns {planSlug}.md
- * For subagents (agentId provided), returns {planSlug}-agent-{agentId}.md
+ * For subagents (agentId provided), returns
+ * {AGENT_PLANS_SUBDIR}/{planSlug}-agent-{encodedAgentId}.md
  */
 export function getPlanFilePath(agentId?: AgentId): string {
   const planSlug = getPlanSlug(getSessionId())
@@ -161,9 +176,16 @@ export function getPlanFilePath(agentId?: AgentId): string {
     return join(getPlansDirectory(), `${planSlug}.md`)
   }
 
-  // Subagents: include agent ID
+  // Subagents: include agent ID, in the dedicated subdirectory that keeps the
+  // escaped filename namespace disjoint from legacy plans (see AGENT_PLANS_SUBDIR).
+  const agentPlansDir = join(getPlansDirectory(), AGENT_PLANS_SUBDIR)
+  try {
+    getFsImplementation().mkdirSync(agentPlansDir)
+  } catch (error) {
+    logError(error)
+  }
   return join(
-    getPlansDirectory(),
+    agentPlansDir,
     `${planSlug}-agent-${encodeAgentIdForPlanFile(agentId)}.md`,
   )
 }
@@ -185,21 +207,6 @@ export function getPlan(agentId?: AgentId): string | null {
   }
 }
 
-/**
- * Recover a plan written before agent IDs were escaped into the filename.
- *
- * Team names have always accepted arbitrary nonblank text, so plans for ids
- * like `writer@a/b` or `writer@100%` are already on disk under the raw name.
- * Every reader now builds the escaped name, so without this the teammate's plan
- * reads as missing on upgrade and a second file is created beside it.
- *
- * Moving it is what makes the recovery stick: the escaped name is the one the
- * permission carve-out recognizes, so a plan left at the old path would keep
- * falling through to ordinary permission handling on every later write.
- * A failed move is not fatal -- the content was already read.
- *
- * Exported for testing.
- */
 /**
  * Whether a legacy plan path (built from an unescaped, attacker-influenced
  * agent id) still resolves inside the plans directory after `..` collapse.
@@ -229,6 +236,15 @@ export function readAndMigrateLegacyPlan(
     return null
   }
 
+  // No-clobber: never rename a legacy file over a plan that already exists at
+  // the escaped path. getPlan only reaches recovery after the escaped read
+  // missed, but a concurrent writer can create it in between; overwriting it
+  // would lose a live plan. The legacy contents were already read, so return
+  // them without migrating.
+  if (getFsImplementation().existsSync(escapedPath)) {
+    return contents
+  }
+
   try {
     getFsImplementation().renameSync(legacyPath, escapedPath)
   } catch (error) {
@@ -240,21 +256,34 @@ export function readAndMigrateLegacyPlan(
   return contents
 }
 
-function readLegacyUnescapedPlan(
+/**
+ * Recover a plan written before agent IDs were escaped into the filename,
+ * confining the read/rename to a legitimate per-agent slot inside the plans dir.
+ *
+ * Exported for testing.
+ */
+export function readLegacyUnescapedPlan(
   agentId: AgentId | undefined,
   escapedPath: string,
+  plansDir: string = getPlansDirectory(),
+  slug: string = getPlanSlug(getSessionId()),
 ): string | null {
   if (!agentId) return null
-  const plansDir = getPlansDirectory()
-  const legacyPath = join(
-    plansDir,
-    `${getPlanSlug(getSessionId())}-agent-${agentId}.md`,
-  )
   // SECURITY: agentId is intentionally left unescaped here so the pre-escape
-  // filename can be recovered, so it can still carry `/`, `\`, or `..`. Once
-  // join() collapses those the path can land outside plansDir, and the migrate
-  // step reads then renames it -- moving an arbitrary file.
+  // filename can be recovered, so it can still carry `/`, `\`, or `..`. A `..`
+  // segment lets join() climb back into the plans dir onto a *different* plan
+  // (`a/../{slug}` -> the main plan; `a/../{slug}-agent-victim` -> a sibling),
+  // which the migrate step would then read and rename -- moving another agent's
+  // file. Reject any traversal segment before building the path.
+  if (agentId.split(/[/\\]/).includes('..')) return null
+
+  const legacyPath = join(plansDir, `${slug}-agent-${agentId}.md`)
+  // Defense in depth: the legacy file must still sit inside the plans dir and
+  // under this session's `{slug}-agent-` prefix after separator collapse, so a
+  // stray path can never resolve onto the main plan or another agent's file.
+  const agentPrefix = join(plansDir, `${slug}-agent-`)
   if (!isPathWithinPlansDir(legacyPath, plansDir)) return null
+  if (!legacyPath.startsWith(agentPrefix)) return null
   return readAndMigrateLegacyPlan(legacyPath, escapedPath)
 }
 

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -162,6 +162,41 @@ export function encodeAgentIdForPlanFile(agentId: string): string {
 }
 
 /**
+ * Inverse of {@link encodeAgentIdForPlanFile}. The escapes must be undone in the
+ * reverse order they were applied -- `%25` last -- so a literal `%2F` in the id
+ * (encoded as `%252F`) is not mis-decoded to `/`.
+ *
+ * Exported for testing.
+ */
+export function decodeAgentIdForPlanFile(encoded: string): string {
+  return encoded
+    .replaceAll('%5C', '\\')
+    .replaceAll('%2F', '/')
+    .replaceAll('%25', '%')
+}
+
+/**
+ * Whether a `{slug}-agent-` filename component is exactly what
+ * {@link encodeAgentIdForPlanFile} would emit -- i.e. a canonical plan path.
+ *
+ * The encoder only ever produces the escapes `%25`, `%2F`, `%5C` and no raw
+ * separators, so a component is canonical iff re-encoding its decode reproduces
+ * it byte-for-byte. This rejects lookalikes that `getPlanFilePath` never emits:
+ * a raw separator (`writer@a%2Fb` decodes to `writer@a/b`, whose canonical form
+ * is `writer@a%252Fb`), or a raw/partial `%` such as `writer@100%` (canonical
+ * form `writer@100%25`). Both would otherwise pass a naive separator-only check
+ * and grant unprompted read/write to a sibling `.md` outside this session's plan.
+ *
+ * Exported for testing.
+ */
+export function isCanonicalPlanFileEncoding(component: string): boolean {
+  return (
+    component.length > 0 &&
+    encodeAgentIdForPlanFile(decodeAgentIdForPlanFile(component)) === component
+  )
+}
+
+/**
  * Get the file path for a session's plan
  * @param agentId Optional agent ID for subagents. If not provided, returns main session plan.
  * For main conversation (no agentId), returns {planSlug}.md
@@ -196,8 +231,11 @@ export function getPlanFilePath(agentId?: AgentId): string {
  */
 export function getPlan(agentId?: AgentId): string | null {
   const filePath = getPlanFilePath(agentId)
+  let contents: string
   try {
-    return getFsImplementation().readFileSync(filePath, { encoding: 'utf-8' })
+    contents = getFsImplementation().readFileSync(filePath, {
+      encoding: 'utf-8',
+    })
   } catch (error) {
     if (!isENOENT(error)) {
       logError(error)
@@ -205,6 +243,17 @@ export function getPlan(agentId?: AgentId): string | null {
     }
     return readLegacyUnescapedPlan(agentId, filePath)
   }
+  // An empty/whitespace escaped file is not a real plan. isPlanFilePath allows a
+  // direct FileWrite/FileEdit to the canonical escaped path before migration has
+  // run, and such a stub would otherwise permanently shadow a legacy plan that
+  // still holds the real content. Fall through to legacy recovery in that case;
+  // recovery's no-clobber guard returns the legacy contents without renaming
+  // over the stub, so a genuine concurrent escaped write is never lost.
+  if (contents.trim() === '') {
+    const legacy = readLegacyUnescapedPlan(agentId, filePath)
+    if (legacy !== null) return legacy
+  }
+  return contents
 }
 
 /**
@@ -225,6 +274,17 @@ export function readAndMigrateLegacyPlan(
   escapedPath: string,
 ): string | null {
   if (legacyPath === escapedPath) return null
+
+  // SECURITY: recovery reads and then renames this path, so it must be a real
+  // regular file. A symlink planted at the legacy slot would otherwise let
+  // recovery return the contents of (and rename) an arbitrary target outside the
+  // plans directory. lstat does not follow the link, so a symlink fails isFile().
+  try {
+    if (!getFsImplementation().lstatSync(legacyPath).isFile()) return null
+  } catch (error) {
+    if (!isENOENT(error)) logError(error)
+    return null
+  }
 
   let contents: string
   try {


### PR DESCRIPTION
### Problem

`isSessionPlanFile` auto-allows the current session's plan file for **both** read (`checkReadableInternalPath`) and **un-prompted write** (`checkEditableInternalPath` → `behavior: 'allow'`). It matched with a bare prefix check:

```js
const expectedPrefix = join(getPlansDirectory(), getPlanSlug())
return normalizedPath.startsWith(expectedPrefix) && normalizedPath.endsWith('.md')
```

With no delimiter anchor, `startsWith({plansDir}/{slug})` also matches any sibling whose name merely begins with the slug. With slug `brave-swift-otter`:

- `{plansDir}/brave-swift-otternova.md` → auto-allowed (read + write)
- `{plansDir}/brave-swift-otter-other.md` → auto-allowed
- `{plansDir}/brave-swift-otterdir/anything.md` → write auto-allowed into a newly-created sibling subtree

None of those are this session's plan file, yet they're silently readable and writable with no permission prompt. The only two legitimate shapes `getPlanFilePath` emits are `{slug}.md` and `{slug}-agent-{agentId}.md`.

Scope is confined to the plans directory (`normalize()` resolves `..` before the check, so no traversal escape), and it's model-initiated rather than remotely triggerable — a permission-tightness defect, not a credential/data-leak-grade bug.

### Fix

Anchor on the two exact shapes: `=== {slug}.md` or `startsWith({slug}-agent-)`. Extracted the decision into a pure `isPlanFilePath(plansDir, slug, path)` helper so it's unit-testable without session state; `normalize()` still runs first.

Same missing-separator class as the path-containment fix in #1974.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Percent-encode agent identifiers for sub-agent plan filenames and store them in a dedicated subdirectory.
  - Use the updated filename scheme when generating sub-agent plan paths.
- **Bug Fixes**
  - Tightened plan-file detection to reject invalid filenames, traversal attempts, lookalikes, and symlink-based escapes.
  - Recover and migrate legacy unescaped plans safely without overwriting existing data.
  - Fall back when an escaped plan file is empty while preserving valid errors.
- **Tests**
  - Added coverage for path matching, encoding, migration, traversal protection, symlink safety, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->