### PR TITLE
fix(ide): discover lockfiles in legacy ~/.claude/ide/

### DIFF
--- a/src/utils/ide.ts
+++ b/src/utils/ide.ts
@@ -470,6 +470,17 @@ const getWindowsUserProfile = memoize(async (): Promise<string | undefined> => {
 export async function getIdeLockfilesPaths(): Promise<string[]> {
   const paths: string[] = [join(getClaudeConfigHomeDir(), 'ide')]
 
+  // Also look in the legacy ~/.claude/ide/ directory. The OpenClaude VS Code
+  // extension (and the upstream Claude Code extension) still write IDE lockfiles
+  // there; without this fallback OpenClaude cannot discover a running IDE that
+  // was registered by a Claude-compatible extension. We intentionally do not
+  // read CLAUDE_CONFIG_DIR (kept separate from OpenClaude config), but for IDE
+  // discovery specifically we honor the legacy well-known location.
+  const legacyIdeDir = join(os.homedir(), '.claude', 'ide')
+  if (legacyIdeDir !== paths[0]) {
+    paths.push(legacyIdeDir)
+  }
+
   if (getPlatform() !== 'wsl') {
     return paths
   }


### PR DESCRIPTION
## Problem

When running inside VS Code (local or Remote-SSH) with the `openclaude-vscode` extension — or the upstream `anthropic.claude-code` extension — active, OpenClaude could not connect to the running IDE:

- `/ide` reported **"no IDE connected"**
- no `mcp__ide__*` tools were available in the session
- the IDE MCP server *was* up and listening, but the CLI never discovered it

## Root cause

The OpenClaude fork intentionally isolates its config under `~/.openclaude/` (separate from Claude Code's `~/.claude/`), and IDE lockfile discovery followed that move: `getIdeLockfilesPaths()` in `src/utils/ide.ts` only scans `~/.openclaude/ide/`.

However, Claude-compatible VS Code extensions (both `openclaude-vscode` and the upstream Anthropic extension) still write their IDE MCP server lockfile to the legacy, well-known location: `~/.claude/ide/<port>.lock`. The CLI never looked there, so:

- `getSortedIdeLockfiles()` returned `[]`
- `detectIDEs()` returned `[]`
- `findAvailableIDE()` returned `null`
- the `useIDEIntegration` hook never registered an `ide` MCP server config

This was independent of provider: even with `TERM_PROGRAM=vscode`, `CLAUDE_CODE_SSE_PORT` present, and a valid ancestry chain to the lockfile PID, the lockfile was simply never read.

## Fix

Include `~/.claude/ide/` (in addition to `~/.openclaude/ide/`) in the list of directories scanned by `getIdeLockfilesPaths()`, de-duplicated against the primary path. Config isolation for everything else under `~/.openclaude/` is preserved; only the shared, well-known IDE lockfile location is honored so OpenClaude interoperates with the wider Claude-compatible extension ecosystem.

## Reproduction / validation

Lockfile at `~/.claude/ide/30801.lock` (transport `ws`, `authToken` present, port listening on `127.0.0.1`, PID ancestry valid), running the IDE detection utils directly:

| | Before | After |
| -- | -- | -- |
| `getSortedIdeLockfiles()` | `[]` | `["~/.claude/ide/30801.lock"]` |
| `detectIDEs(false)` | `[]` | `[{ isValid: true, port: 30801, url: "ws://127.0.0.1:30801", ... }]` |
| `findAvailableIDE()` | `null` | the detected IDE (same object) |

## Test plan

- [x] Reproduced bug locally (lockfile present, detection returned empty)
- [x] Patched `src/utils/ide.ts`
- [x] `bun run build` — succeeds, `dist/cli.mjs` regenerated
- [x] Re-ran detection utils — lockfile now read, `findAvailableIDE()` non-null
- [ ] Confirm `mcp__ide__*` tools appear and work in an interactive TUI session inside VS Code (Remote-SSH)

## Notes

- The `--ide` startup flag and `CLAUDE_CODE_SSE_PORT` env override continue to work — this fix only addresses the lockfile discovery path.
- No change to `CLAUDE_CONFIG_DIR` handling — OpenClaude config stays independent; only the IDE lockfile's well-known location is shared with Claude-compatible extensions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IDE detection and cleanup by also recognizing lockfiles from the legacy Claude-compatible extension location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->