### PR TITLE
.

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ by default. It does not read `~/.claude`, project `.claude/` directories, or
 `CLAUDE_CONFIG_DIR`; new users can start with an empty OpenClaude config and do
 not need Claude Code installed.
 
+This boundary includes IDE integration: OpenClaude discovers and cleans up only
+`.openclaude/ide` lockfiles (including supported WSL Windows-profile paths),
+never Claude Code's `.claude/ide` lockfiles. It does not use Claude Code
+credentials as an implicit IDE connection channel. Use OpenClaude's supported
+IDE setup instead of pointing it at a Claude Code configuration directory.
+
 If you previously used OpenClaude with `.claude` paths, migrate intentionally:
 copy only the settings, commands, agents, skills, scheduled tasks, or other files
 you personally created for OpenClaude into the matching `.openclaude` location.

--- a/src/utils/ide.ts
+++ b/src/utils/ide.ts
@@ -300,7 +300,7 @@ export function getTerminalIdeType(): IdeType | null {
 }
 
 /**
- * Gets sorted IDE lockfiles from ~/.claude/ide directory
+ * Gets sorted IDE lockfiles from OpenClaude's configured IDE directory
  * @returns Array of full lockfile paths sorted by modification time (newest first)
  */
 export async function getSortedIdeLockfiles(): Promise<string[]> {


### PR DESCRIPTION
.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that OpenClaude only discovers and cleans up its own IDE lockfiles, including supported WSL Windows-profile paths.
  * Documented that Claude Code IDE lockfiles and credentials are not used for OpenClaude IDE integration.
  * Updated guidance to use OpenClaude’s supported IDE setup.
  * Clarified that IDE lockfile sorting uses the configured OpenClaude IDE directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->