### PR TITLE
fix(compaction): honor disabled auto-compact under memory pressure

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -1950,7 +1950,7 @@ async function* queryLoop(
         )
         const nextTracking: AutoCompactTrackingState = {
           ...(tracking ?? { compacted: false, turnId: '', turnCounter: 0 }),
-          forceReason: 'memory-pressure',
+          forceReason: 'context-overflow',
         }
         const next: State = {
           messages: messagesForQuery,

--- a/src/query/providerMaxTokensCapRetry.test.ts
+++ b/src/query/providerMaxTokensCapRetry.test.ts
@@ -355,7 +355,7 @@ test('compacts and retries once for context overflow errors', async () => {
   const messages = await collect(params)
 
   expect(callCount).toBe(2)
-  expect(seenForceReasons).toEqual([undefined, 'memory-pressure'])
+  expect(seenForceReasons).toEqual([undefined, 'context-overflow'])
   const retryMessages = seenRequestMessages[1] ?? []
   expect(
     retryMessages.some(

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -707,6 +707,34 @@ describe('autoCompactIfNeeded circuit breaker', () => {
     expect(result.wasCompacted).toBe(false)
   })
 
+  test('provider context-overflow recovery bypasses disabled auto-compact', async () => {
+    process.env.DISABLE_COMPACT = '1'
+    process.env.DISABLE_AUTO_COMPACT = '1'
+    const compactConversation = mock(async () => compactResult())
+    const trySessionMemoryCompaction = mock(async () => null)
+    const { autoCompactIfNeeded } = await importAutoCompact({
+      compactConversation,
+      trySessionMemoryCompaction,
+    })
+
+    const messages = underThresholdMessages()
+    const result = await autoCompactIfNeeded(
+      messages,
+      toolUseContext(),
+      cacheSafeParams(messages),
+      'repl_main_thread',
+      {
+        compacted: false,
+        turnCounter: 0,
+        turnId: 'turn',
+        forceReason: 'context-overflow',
+      },
+    )
+
+    expect(compactConversation).toHaveBeenCalledTimes(1)
+    expect(result.wasCompacted).toBe(true)
+  })
+
   test('expired cooldown allows a half-open compaction attempt', async () => {
     const compactConversation = mock(async () => compactResult())
     const trySessionMemoryCompaction = mock(async () => null)

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -34,6 +34,7 @@ const USER_ABORT_MESSAGE = 'API Error: Request was aborted.'
 let hasSharedMutationLock = false
 
 type ImportAutoCompactOptions = {
+  autoCompactEnabled?: boolean
   compactConversation?: ReturnType<typeof mock>
   trySessionMemoryCompaction?: ReturnType<typeof mock>
 }
@@ -46,7 +47,9 @@ async function importAutoCompact(options: ImportAutoCompactOptions = {}) {
   mock.module('../../utils/tokens.js', () => ({ ...realTokens }))
   mock.module('../../utils/config.js', () => ({
     ...realConfig,
-    getGlobalConfig: () => ({ autoCompactEnabled: true }),
+    getGlobalConfig: () => ({
+      autoCompactEnabled: options.autoCompactEnabled ?? true,
+    }),
   }))
   if (options.compactConversation) {
     mock.module('./compact.js', () => ({
@@ -680,11 +683,10 @@ describe('autoCompactIfNeeded circuit breaker', () => {
   })
 
   test('memory-pressure signals honor disabled auto-compact', async () => {
-    process.env.DISABLE_COMPACT = '1'
-    process.env.DISABLE_AUTO_COMPACT = '1'
     const compactConversation = mock(async () => compactResult())
     const trySessionMemoryCompaction = mock(async () => null)
     const { autoCompactIfNeeded } = await importAutoCompact({
+      autoCompactEnabled: false,
       compactConversation,
       trySessionMemoryCompaction,
     })

--- a/src/services/compact/autoCompact.test.ts
+++ b/src/services/compact/autoCompact.test.ts
@@ -679,6 +679,34 @@ describe('autoCompactIfNeeded circuit breaker', () => {
     expect(result.consecutiveFailures).toBe(0)
   })
 
+  test('memory-pressure signals honor disabled auto-compact', async () => {
+    process.env.DISABLE_COMPACT = '1'
+    process.env.DISABLE_AUTO_COMPACT = '1'
+    const compactConversation = mock(async () => compactResult())
+    const trySessionMemoryCompaction = mock(async () => null)
+    const { autoCompactIfNeeded } = await importAutoCompact({
+      compactConversation,
+      trySessionMemoryCompaction,
+    })
+
+    const messages = underThresholdMessages()
+    const result = await autoCompactIfNeeded(
+      messages,
+      toolUseContext(),
+      cacheSafeParams(messages),
+      'repl_main_thread',
+      {
+        compacted: false,
+        turnCounter: 0,
+        turnId: 'turn',
+        forceReason: 'memory-pressure',
+      },
+    )
+
+    expect(compactConversation).not.toHaveBeenCalled()
+    expect(result.wasCompacted).toBe(false)
+  })
+
   test('expired cooldown allows a half-open compaction attempt', async () => {
     const compactConversation = mock(async () => compactResult())
     const trySessionMemoryCompaction = mock(async () => null)

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -316,7 +316,15 @@ export async function shouldAutoCompact(
     }
   }
 
-  if (!forceReason && !isAutoCompactEnabled()) {
+  // Memory pressure is a process-resource signal, not evidence that this
+  // conversation has exhausted its context. Keep cache pruning available, but
+  // honor the user's disabled auto-compact choice rather than unexpectedly
+  // summarizing a short conversation (#1985). Message-count safety limits
+  // remain an explicit forced-compaction path.
+  if (
+    !isAutoCompactEnabled() &&
+    (!forceReason || forceReason === 'memory-pressure')
+  ) {
     return false
   }
 

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -75,7 +75,7 @@ export type AutoCompactTrackingState = {
   // When set, bypasses shouldAutoCompact() token threshold and user-disable checks.
   // Used by memory pressure and message count guards to force compaction
   // even when token usage is below the normal autocompact threshold.
-  forceReason?: 'memory-pressure' | 'message-count'
+  forceReason?: 'memory-pressure' | 'message-count' | 'context-overflow'
 }
 
 // Threshold buffer: auto-compact fires when token usage reaches this far below
@@ -316,11 +316,11 @@ export async function shouldAutoCompact(
     }
   }
 
-  // Memory pressure is a process-resource signal, not evidence that this
-  // conversation has exhausted its context. Keep cache pruning available, but
-  // honor the user's disabled auto-compact choice rather than unexpectedly
-  // summarizing a short conversation (#1985). Message-count safety limits
-  // remain an explicit forced-compaction path.
+  // Process memory pressure is not evidence that this conversation exhausted
+  // its context. Keep cache pruning available, but honor the user's disabled
+  // auto-compact choice rather than unexpectedly summarizing a short
+  // conversation (#1985). Explicit message-count and provider-overflow
+  // recovery remain forced compaction paths.
   if (
     !isAutoCompactEnabled() &&
     (!forceReason || forceReason === 'memory-pressure')

--- a/src/services/compact/autoCompact.ts
+++ b/src/services/compact/autoCompact.ts
@@ -72,9 +72,9 @@ export type AutoCompactTrackingState = {
   // threaded through query() callers rather than serialized into transcripts.
   nextRetryAtMs?: number
   lastFailureAtMs?: number
-  // When set, bypasses shouldAutoCompact() token threshold and user-disable checks.
-  // Used by memory pressure and message count guards to force compaction
-  // even when token usage is below the normal autocompact threshold.
+  // When set, bypasses the normal token threshold. Message-count and
+  // provider-overflow recovery also bypass user-disable; process-memory
+  // pressure respects that setting.
   forceReason?: 'memory-pressure' | 'message-count' | 'context-overflow'
 }
 
@@ -296,8 +296,9 @@ export async function shouldAutoCompact(
   // pre-snip context, so tokenCountWithEstimation can't see the savings.
   // Subtract the rough-delta that snip already computed.
   snipTokensFreed = 0,
-  // When set, skip user-disable and token-threshold checks but still run
-  // recursion/context-collapse guards. Used by runtime safety signals.
+  // When set, skip the token threshold but still run recursion and
+  // context-collapse guards. Only message-count and provider-overflow also
+  // bypass a user-disabled auto-compact setting.
   forceReason?: AutoCompactTrackingState['forceReason'],
 ): Promise<boolean> {
   // Recursion guards. session_memory and compact are forked agents that
@@ -416,8 +417,8 @@ export async function autoCompactIfNeeded(
   // Force compaction if a pressure/count signal set forceReason.
   // Intentionally consume the caller-owned flag in place so the same tracking
   // object cannot force multiple compaction cycles in one query loop pass.
-  // Forced safety compaction bypasses user-disable gates while preserving
-  // recursion/context-collapse guards.
+  // Message-count and provider-overflow bypass user-disable gates; memory
+  // pressure does not. All forced paths preserve recursion/collapse guards.
   const forcedBy = tracking?.forceReason
   if (tracking?.forceReason) {
     tracking.forceReason = undefined


### PR DESCRIPTION
Fixes #1985

## Root cause

The supplied report confirms a 1,048,576-token NVIDIA NIM context window but is diagnostic state rather than a compaction log. A separate runtime path could force compaction for elevated process RSS and bypass an explicitly disabled auto-compact setting, allowing an unexpected short-conversation compact.

## Change

Memory-pressure compaction now honors the configured auto-compact disable. Message-count safety compaction and one-shot provider context-overflow recovery remain intentionally forced; provider overflow uses its own reason rather than sharing the memory-pressure label.

## Validation

- bun test src/services/compact/autoCompact.test.ts src/query/providerMaxTokensCapRetry.test.ts src/query/autoCompactCooldown.test.ts --max-concurrency=1
- bun run typecheck
- bun run build
- bun run smoke
- bun run security:pr-scan -- --base upstream/main
- git diff --check

bun run check built successfully and completed 7,184 passing tests, but its parallel full-suite invocation hit 10 unrelated PowerShell policy failures; that test file passes serially (15/15).\n