### PR TITLE
refactor(openai-shim): extract stream control

### DIFF
--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -62,8 +62,8 @@ describe('Gemini store field fix', () => {
 // Fix 2: Session timeout — stream idle timeout
 // ---------------------------------------------------------------------------
 describe('Session timeout fix', () => {
-  test('openaiShim has idle timeout for SSE streams', async () => {
-    const content = await file('services/api/openaiShim.ts').text()
+  test('openaiShim stream control has idle timeout for SSE streams', async () => {
+    const content = await file('services/api/openaiShim/streamControl.ts').text()
 
     expect(content).toContain('STREAM_IDLE_TIMEOUT_MS')
   })
@@ -77,7 +77,7 @@ describe('Session timeout fix', () => {
   })
 
   test('idle timeout is set to a reasonable value (>= 60s)', async () => {
-    const content = await file('services/api/openaiShim.ts').text()
+    const content = await file('services/api/openaiShim/streamControl.ts').text()
 
     // Extract the timeout value (supports numeric separators like 120_000)
     const match = content.match(/STREAM_IDLE_TIMEOUT_MS\s*=\s*([\d_]+)/)

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -3821,6 +3821,11 @@ test('does not infer Gemini mode from OPENAI_BASE_URL path substrings', async ()
   expect(capturedAuthorization).toBeNull()
 })
 
+test('the OpenAI shim façade exposes the beta.messages namespace', () => {
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  expect(client.beta.messages).toBeDefined()
+})
+
 test('preserves image tool results as placeholders in follow-up requests', async () => {
   let requestBody: Record<string, unknown> | undefined
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6935,6 +6935,11 @@ test('optional tool properties are not added to required[] — fixes Groq/Azure 
 //
 // ---------------------------------------------------------------------------
 
+test('the OpenAI shim façade exposes the messages.create contract', () => {
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  expect(typeof client.beta.messages.create).toBe('function')
+})
+
 function makeNonStreamResponse(content = 'ok'): Response {
   return new Response(
     JSON.stringify({
@@ -7015,6 +7020,11 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
 // It also gives independent extraction branches stable merge context.
 //
 // ---------------------------------------------------------------------------
+
+test('the OpenAI shim façade creates independent client instances', () => {
+  expect(createOpenAIShimClient({})).not.toBe(createOpenAIShimClient({}))
+})
+
 test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -14,7 +14,7 @@ import {
   extractOpenAICategoryMarker,
   isOpenAIRequestNonReplayable,
 } from './openaiErrorClassification.ts'
-import { createOpenAIShimClient, hasMistralApiHost } from './openaiShim.ts'
+import { createOpenAIShimClient, hasMistralApiHost, parseTextToolCalls, parseXmlToolCalls } from './openaiShim.ts'
 import * as realCodexShim from './codexShim.js'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 
@@ -7045,7 +7045,19 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
 // ---------------------------------------------------------------------------
 
 test('the OpenAI shim façade creates independent client instances', () => {
-  expect(createOpenAIShimClient({})).not.toBe(createOpenAIShimClient({}))
+  const first = createOpenAIShimClient({}) as OpenAIShimClient
+  const second = createOpenAIShimClient({}) as OpenAIShimClient
+  expect(first).not.toBe(second)
+  expect(first.beta).not.toBe(second.beta)
+  expect(first.beta.messages).not.toBe(second.beta.messages)
+})
+
+test('raw-text and XML fallback tool calls use one unique sequence', () => {
+  const text = parseTextToolCalls('{"name":"from_text","arguments":{}}')
+  const xml = parseXmlToolCalls('<tool_call>{"name":"from_xml","arguments":{}}</tool_call>')
+  expect(text.calls[0]?.id).toMatch(/^ollama_tc_\d+$/)
+  expect(xml.calls[0]?.id).toMatch(/^xml_tc_\d+$/)
+  expect(text.calls[0]?.id?.replace(/^\D+/, '')).not.toBe(xml.calls[0]?.id?.replace(/^\D+/, ''))
 })
 
 test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -7640,6 +7640,9 @@ test('streaming: preserves prose without tags (no phrase-based false positive)',
   )
 })
 
+// Extraction boundary: response conversion | executor network behavior.
+// The executor suite owns the contiguous network-classification block below.
+// Keep this marker stable for independent adjacent test migrations.
 test('strips credentials and query params from URL in fetch network error message', async () => {
   process.env.OPENAI_BASE_URL =
     'https://user:password@internal.example.test/v1?token=abc123'
@@ -8423,6 +8426,9 @@ test('self-heals localhost resolution failures by retrying local loopback base U
   expect(requestUrls).toContain('http://127.0.0.1:11434/api/chat')
 })
 
+// Extraction boundary: executor network behavior | native Ollama routing.
+// Native Ollama endpoint selection remains an adapter/facade integration concern.
+// Keep this marker stable for independent adjacent test migrations.
 test('uses native Ollama chat endpoint when local base URL omits /v1', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434'
 
@@ -8526,6 +8532,9 @@ test('keeps HTTPS localhost Ollama-port proxies on chat completions', async () =
   ])
 })
 
+// Extraction boundary: native Ollama routing | executor tool self-healing.
+// The single retry test below moves with request execution.
+// Keep this marker stable for independent adjacent test migrations.
 test('self-heals tool-call incompatibility by retrying local Ollama requests without tools', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
@@ -8824,6 +8833,9 @@ test('injects semantic assistant message when tool result is followed by user me
   expect(semanticMsg.content).not.toContain('user')
 })
 
+// Extraction boundary: executor tool self-healing | message/provider shaping.
+// Provider request shaping below is not owned by the executor.
+// Keep this marker stable for independent adjacent test migrations.
 test('Moonshot: uses max_tokens (not max_completion_tokens) and strips store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.ai/v1'
   process.env.OPENAI_API_KEY = 'sk-moonshot-test'
@@ -10310,6 +10322,9 @@ test('NVIDIA NIM Z.AI GLM streaming request with tools does not send tool_stream
   expect(requestBody?.tool_stream).toBeUndefined()
 })
 
+// Extraction boundary: provider tool-stream shaping | executor tool-stream retry.
+// The three retry-state tests below move together with request execution.
+// Keep this marker stable for independent adjacent test migrations.
 // Regression test for #1950: even if a gateway rejects `tool_stream` with a
 // 400 (e.g. NVIDIA NIM: `Unsupported parameter(s): tool_stream`), the shim
 // self-heals by dropping only that parameter and retrying with tools intact.
@@ -10461,6 +10476,9 @@ test('Shim retries a tool_stream rejection with the same pooled credential (#195
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-a'])
 })
 
+// Extraction boundary: executor tool-stream retry | provider tool-stream shaping.
+// Provider emission rules below remain with compatibility/request planning.
+// Keep this marker stable for independent adjacent test migrations.
 test('Z.AI GLM-5.2: streaming requests with tools send tool_stream', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -11347,6 +11365,9 @@ test('GitHub Copilot responses fallback does not retry non-retryable HTTP failur
   expect(fetchCalls).toBe(2)
 })
 
+// Extraction boundary: history pruning | executor Copilot refresh behavior.
+// The contiguous Copilot authentication retry block below moves with execution.
+// Keep this marker stable for independent adjacent test migrations.
 test('GitHub Copilot 401 chat_completions retries with refreshed token', async () => {
   const realModule = realGithubModelsCredentials
   try {
@@ -11818,6 +11839,9 @@ test('GitHub Copilot 401 chat_completions with providerOverride does not trigger
   }
 })
 
+// Extraction boundary: executor Copilot refresh behavior | JSON fallback conversion.
+// JSON fallback response conversion below is not owned by request execution.
+// Keep this marker stable for independent adjacent test migrations.
 // --- JSON fallback regression tests (#1749) -------------------------------
 // Some OpenAI-compatible providers ignore `stream: true` and return a full
 // `application/json` chat completion. The fallback inside

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6813,6 +6813,8 @@ test('preserves parsed string input for unknown JSON string tool arguments', asy
   ])
 })
 
+// Extraction seam: argument parsing | schema sanitation.
+
 test('sanitizes malformed MCP tool schemas before sending them to OpenAI', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -6944,6 +6946,8 @@ test('optional tool properties are not added to required[] — fixes Groq/Azure 
   expect(required).not.toContain('pages')
   expect(parameters?.additionalProperties).toBe(false)
 })
+
+// Extraction seam: schema sanitation | message conversion façade.
 
 // ---------------------------------------------------------------------------
 // Extraction boundary: tool conversion | message conversion (Issue #202)

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -8615,6 +8615,9 @@ test('self-heals tool-call incompatibility by retrying local Ollama requests wit
   expect(requestBodies[1]?.tool_stream).toBeUndefined()
 })
 
+// Extraction boundary: executor tool self-healing | message conversion.
+// Message-history normalization below belongs to the message converter.
+// Keep this marker stable for independent adjacent test migrations.
 test('preserves valid tool_result and drops orphan tool_result', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -10269,6 +10272,9 @@ test('NVIDIA NIM Z.AI GLM omits chat template thinking kwargs when thinking is d
   expect(requestBody?.chat_template_kwargs).toBeUndefined()
 })
 
+// Extraction boundary: provider reasoning compatibility | tool-stream routing.
+// The gateway emission regression below remains provider/request-shaping coverage.
+// Keep this marker stable for independent adjacent test migrations.
 // Regression test for #1950: GLM-5.2 served through NVIDIA NIM
 // (`integrate.api.nvidia.com`) must never receive the Z.AI-proprietary
 // `tool_stream` parameter. Streaming tool calls are simply not streamed on

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6927,7 +6927,7 @@ test('optional tool properties are not added to required[] — fixes Groq/Azure 
 })
 
 // ---------------------------------------------------------------------------
-// Issue #202 — consecutive role coalescing (Devstral, Mistral strict templates)
+// Extraction boundary: tool conversion | message conversion (Issue #202)
 // ---------------------------------------------------------------------------
 
 function makeNonStreamResponse(content = 'ok'): Response {
@@ -7002,6 +7002,9 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
   expect(assistantMsgs?.[0]?.tool_calls?.length).toBeGreaterThan(0)
 })
 
+// ---------------------------------------------------------------------------
+// Extraction boundary: message conversion | non-streaming response conversion
+// ---------------------------------------------------------------------------
 test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -12034,6 +12034,19 @@ test('JSON fallback: recovers raw-text tool call into tool_use block', async () 
 
 })
 
+test('JSON fallback façade terminates converted messages', async () => {
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-boundary',
+    model: 'boundary-model',
+    choices: [{
+      message: { role: 'assistant', content: 'ok' },
+      finish_reason: 'stop',
+    }],
+  })
+
+  expect(events.at(-1)?.type).toBe('message_stop')
+})
+
 test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-hy3',

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5522,6 +5522,8 @@ test('preserves Gemini thought signature from non-streaming message extra_conten
   })
 })
 
+// Extraction seam: provider signature metadata | raw streaming tool fallback.
+
 test('converts Gemini raw tool-call text into streaming tool_use blocks', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5936,6 +5938,8 @@ test('keeps terminal empty Bash tool arguments invalid in non-streaming response
     },
   ])
 })
+
+// Extraction seam: completed tool parsing | streamed tool normalization.
 
 test('normalizes plain string Bash tool arguments in streaming responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
@@ -6686,6 +6690,8 @@ test('repairs truncated JSON objects even without command field', async () => {
 
   expect(streamedInput).toBe('{"cwd":"/tmp"}')
 })
+
+// Extraction seam: streamed tool normalization | schema and tool conversion.
 
 test('preserves raw input for unknown plain string tool arguments', async () => {
   globalThis.fetch = (async (_input, _init) => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -11177,6 +11177,9 @@ test('preserves valid tool pairs after history pruning while dropping orphaned t
   expect(toolMessages[0]?.tool_call_id).toBe('call_retained')
 })
 
+// Extraction boundary: history pruning | executor Copilot refresh behavior.
+// The contiguous Copilot authentication retry block below moves with execution.
+// Keep this marker stable for independent adjacent test migrations.
 function makeCodexSseResponse(responseData: Record<string, unknown>): Response {
   const data = JSON.stringify(responseData)
   return makeSseResponse([`event: response.completed\ndata: ${data}\n\n`])

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6928,6 +6928,11 @@ test('optional tool properties are not added to required[] — fixes Groq/Azure 
 
 // ---------------------------------------------------------------------------
 // Extraction boundary: tool conversion | message conversion (Issue #202)
+//
+// Focused suites own the behavior on either side of this boundary.
+// This pointer intentionally remains in the façade suite after extraction.
+// It also gives independent extraction branches stable merge context.
+//
 // ---------------------------------------------------------------------------
 
 function makeNonStreamResponse(content = 'ok'): Response {
@@ -7004,6 +7009,11 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
 
 // ---------------------------------------------------------------------------
 // Extraction boundary: message conversion | non-streaming response conversion
+//
+// Focused suites own the behavior on either side of this boundary.
+// This pointer intentionally remains in the façade suite after extraction.
+// It also gives independent extraction branches stable merge context.
+//
 // ---------------------------------------------------------------------------
 test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {
   globalThis.fetch = (async (_input, _init) => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -2128,6 +2128,8 @@ test('preserves usage from final OpenAI stream chunk with empty choices', async 
   expect(usageEvent?.usage?.output_tokens).toBe(45)
 })
 
+// Extraction seam: stream conversion usage | shared stream control.
+
 test('readWithIdleTimeout rejects quickly and cancels a stalled reader', async () => {
   const testApi = await getStreamIdleTestApi('stream-idle-helper')
   const cancelReasons: unknown[] = []
@@ -2275,6 +2277,8 @@ test('Anthropic-compatible passthrough stream rejects with idle timeout when it 
   expect((caught as Error).name).toBe('StreamIdleTimeoutError')
   expect((stalled.cancelReasons[0] as Error).name).toBe('StreamIdleTimeoutError')
 })
+
+// Extraction seam: shared stream control | Gemini stream conversion.
 
 test('Gemini SSE stream rejects with idle timeout when it stalls', async () => {
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '25'
@@ -2982,6 +2986,8 @@ test('controller abort stops buffered Gemini SSE events', async () => {
     stalled.close()
   }
 })
+
+// Extraction seam: Gemini stream conversion | native Ollama stream adaptation.
 
 test('controller abort reaches native Ollama converted stream', async () => {
   const previousBaseUrl = process.env.OPENAI_BASE_URL
@@ -5623,6 +5629,8 @@ test('converts Gemini raw tool-call text into streaming tool_use blocks', async 
   expect(stop?.delta?.stop_reason).toBe('tool_use')
 })
 
+// Extraction seam: streaming conversion | non-streaming response conversion.
+
 test('converts Gemini raw tool-call text into non-streaming tool_use blocks', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -7321,6 +7329,8 @@ test('non-streaming: strips <think> tag block from assistant content', async () 
     { type: 'text', text: 'Hey! How can I help you today?' },
   ])
 })
+
+// Extraction seam: non-streaming response conversion | streaming event conversion.
 
 test('streaming: thinking block closed before tool call', async () => {
   globalThis.fetch = (async (_input, _init) => {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -5197,6 +5197,9 @@ class OpenAIShimMessages {
       return hasImages
     }
 
+    // Extraction boundary: executor preparation | request serialization.
+    // Native Ollama/body serialization remains request-planner-owned.
+    // Keep this marker stable so executor and planner extractions stay disjoint.
     // WHY: byte-identity required for implicit prefix caching in
     // OpenAI/Kimi/DeepSeek. stableStringify sorts object keys at every
     // depth so spurious insertion-order differences across rebuilds of
@@ -5238,6 +5241,9 @@ class OpenAIShimMessages {
         ? JSON.stringify(payload)
         : stableStringifyJson(payload)
     }
+    // Extraction boundary: request serialization | executor attempt loop.
+    // The executor consumes the serialized body through a lazy rebuild callback.
+    // Keep this marker stable so executor and planner extractions stay disjoint.
     serializedBody = serializeBody()
 
     const refreshSerializedBody = (): void => {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -4825,6 +4825,9 @@ class OpenAIShimMessages {
       return geminiBody
     }
 
+    // Extraction boundary: request planning | request execution.
+    // The prepared body builders above are executor inputs, not executor-owned logic.
+    // Keep this marker stable so either extraction can merge independently.
     const baseHeaders: Record<string, string> = {
       'Content-Type': 'application/json',
       ...filterAnthropicHeaders(shimConfig.headers),
@@ -5676,6 +5679,9 @@ class OpenAIShimMessages {
       500, undefined, 'OpenAI shim: request loop exited unexpectedly',
       new Headers(),
     )
+    // Extraction boundary: request execution | response conversion façade.
+    // Response conversion methods below remain façade-owned until their own extraction.
+    // Keep this marker stable so adjacent independent deletions do not overlap.
   }
 
   private _convertNonStreamingResponse(

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -4562,7 +4562,6 @@ class OpenAIShimMessages {
       }
     }
 
-    let omitResponsesTools = false
     let responsesInput: ReturnType<
       typeof convertAnthropicMessagesToResponsesInput
     > | undefined
@@ -4583,6 +4582,12 @@ class OpenAIShimMessages {
         effectiveTransport === 'responses_compat',
       )
       return responsesInput
+    }
+
+    const omitTools = {
+      responses: false,
+      anthropic: false,
+      gemini: false,
     }
     const buildResponsesBody = (): Record<string, unknown> => {
       const responsesBody: Record<string, unknown> = {
@@ -4627,7 +4632,7 @@ class OpenAIShimMessages {
         responsesBody.include = ['reasoning.encrypted_content']
       }
 
-      if (!omitResponsesTools && params.tools && params.tools.length > 0) {
+      if (!omitTools.responses && params.tools && params.tools.length > 0) {
         const convertedTools = convertToolsToResponsesTools(
           params.tools as Array<{
             name?: string
@@ -4652,7 +4657,6 @@ class OpenAIShimMessages {
     // (they originate from the Anthropic SDK). We pass them through directly,
     // only adding the top-level system (as string or content-block array)
     // and max_tokens.
-    let omitAnthropicTools = false
     const buildAnthropicMessagesBody = (): Record<string, unknown> => {
       const anthropicBody: Record<string, unknown> = {
         model: request.resolvedModel,
@@ -4673,7 +4677,7 @@ class OpenAIShimMessages {
         if (text && !text.startsWith('x-anthropic-billing-header')) anthropicBody.system = text
       }
 
-      if (!omitAnthropicTools && params.tools && params.tools.length > 0) {
+      if (!omitTools.anthropic && params.tools && params.tools.length > 0) {
         anthropicBody.tools = params.tools
       }
       if (params.tool_choice) {
@@ -4710,7 +4714,6 @@ class OpenAIShimMessages {
 
     // Google AI SDK body — used when endpointPath is /models/gemini-*.
     // Converts Anthropic-format params to Google AI SDK format.
-    let omitGeminiTools = false
     const buildGeminiBody = (): Record<string, unknown> => {
       const contents: Array<{ role: string; parts: Array<Record<string, unknown>> }> = []
 
@@ -4807,7 +4810,7 @@ class OpenAIShimMessages {
       }
 
       // Tools — convert Anthropic tool format to Google functionDeclarations
-      if (!omitGeminiTools && params.tools && params.tools.length > 0) {
+      if (!omitTools.gemini && params.tools && params.tools.length > 0) {
         const functionDeclarations = (params.tools as Array<{
           name?: string
           description?: string
@@ -5626,9 +5629,9 @@ class OpenAIShimMessages {
         delete body.tools
         delete body.tool_choice
         delete body.tool_stream
-        omitResponsesTools = true
-        omitAnthropicTools = true
-        omitGeminiTools = true
+        omitTools.responses = true
+        omitTools.anthropic = true
+        omitTools.gemini = true
         refreshSerializedBody()
 
         logForDebugging(

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -42,6 +42,8 @@ import {
   refreshCodexAccessTokenIfNeeded,
 } from '../../utils/codexCredentials.js'
 import { logForDebugging } from '../../utils/debug.js'
+import { anthropicSsePassthrough as parseAnthropicSsePassthrough, createReaderCanceller, createStreamAbortError, getStreamIdleTimeoutMs, readWithIdleTimeout, StreamIdleTimeoutError, throwIfStreamAborted } from './openaiShim/streamControl.js'
+export { getStreamIdleTimeoutMs } from './openaiShim/streamControl.js'
 import { isBareMode, isEnvTruthy } from '../../utils/envUtils.js'
 import {
   resolveModelReasoningControl,
@@ -158,13 +160,6 @@ function isCopilotTokenExpiredError(text: string): boolean {
   return lower.includes('token expired') || lower.includes('token has expired')
 }
 
-class StreamIdleTimeoutError extends Error {
-  constructor(timeoutMs: number) {
-    super(`Stream idle timeout - no chunks received for ${timeoutMs}ms`)
-    this.name = 'StreamIdleTimeoutError'
-  }
-}
-
 class ResponseHeadersTimeoutError extends Error {
   constructor(timeoutMs: number, url: string) {
     super(
@@ -193,55 +188,6 @@ function isAbortError(error: unknown): boolean {
       'name' in error &&
       error.name === 'AbortError')
   )
-}
-
-function createStreamAbortError(): DOMException {
-  return new DOMException('Aborted', 'AbortError')
-}
-
-function throwIfStreamAborted(signal?: AbortSignal): void {
-  if (signal?.aborted) {
-    throw createStreamAbortError()
-  }
-}
-
-type StreamReadResult = Awaited<
-  ReturnType<ReadableStreamDefaultReader<Uint8Array>['read']>
->
-
-function createReaderCanceller(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  signal?: AbortSignal,
-): {
-    cancel: (error?: unknown) => void
-    cleanup: () => void
-  } {
-  let cancelled = false
-  const cancel = (error: unknown = createStreamAbortError()) => {
-    if (cancelled) return
-    cancelled = true
-    void reader.cancel(error).catch(() => {})
-  }
-  const onAbort = () => cancel(createStreamAbortError())
-
-  signal?.addEventListener('abort', onAbort, { once: true })
-  if (signal?.aborted) {
-    onAbort()
-  }
-
-  return {
-    cancel,
-    cleanup: () => signal?.removeEventListener('abort', onAbort),
-  }
-}
-
-export function getStreamIdleTimeoutMs(): number {
-  const raw = process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS?.trim()
-  if (!raw || !/^\d+$/.test(raw)) return DEFAULT_STREAM_IDLE_TIMEOUT_MS
-  const parsed = Number(raw)
-  return Number.isSafeInteger(parsed) && parsed > 0
-    ? Math.min(parsed, MAX_STREAM_IDLE_TIMEOUT_MS)
-    : DEFAULT_STREAM_IDLE_TIMEOUT_MS
 }
 
 export function getApiTimeoutMs(): number {
@@ -437,69 +383,6 @@ async function fetchWithHeadersDeadline(
     { ...init, signal: options.callerSignal },
     { fetcher: fetchWithAttemptDeadline },
   )
-}
-
-async function readWithIdleTimeout(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  timeoutMs: number,
-  options: {
-    signal?: AbortSignal
-    cancelReader?: (error?: unknown) => void
-    onTimeout?: () => void
-  } = {},
-): Promise<StreamReadResult> {
-  const signal = options.signal
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-
-  return new Promise<StreamReadResult>((resolve, reject) => {
-    let settled = false
-    const cleanup = () => {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId)
-        timeoutId = undefined
-      }
-      signal?.removeEventListener('abort', onAbort)
-    }
-    const finishResolve = (value: StreamReadResult) => {
-      if (settled) return
-      settled = true
-      cleanup()
-      resolve(value)
-    }
-    const finishReject = (error: unknown) => {
-      if (settled) return
-      settled = true
-      cleanup()
-      reject(error)
-    }
-    const cancelAndReject = (error: unknown) => {
-      if (options.cancelReader) {
-        options.cancelReader(error)
-      } else {
-        void reader.cancel(error).catch(() => {})
-      }
-      finishReject(error)
-    }
-    const onAbort = () => cancelAndReject(createStreamAbortError())
-
-    signal?.addEventListener('abort', onAbort, { once: true })
-    if (signal?.aborted) {
-      onAbort()
-      return
-    }
-
-    timeoutId = setTimeout(() => {
-      const error = new StreamIdleTimeoutError(timeoutMs)
-      try {
-        options.onTimeout?.()
-      } catch {
-        // ignore diagnostic callback failures
-      }
-      cancelAndReject(error)
-    }, timeoutMs)
-
-    reader.read().then(finishResolve, finishReject)
-  })
 }
 
 function isGithubModelsMode(): boolean {
@@ -2546,74 +2429,13 @@ async function* anthropicSsePassthrough(
   _model: string,
   signal?: AbortSignal,
 ): AsyncGenerator<AnthropicStreamEvent> {
-  const readerOrNull = response.body?.getReader()
-  if (!readerOrNull) throw new Error('Response body is not readable')
-  const reader: ReadableStreamDefaultReader<Uint8Array> = readerOrNull
-  const readerCanceller = createReaderCanceller(reader, signal)
-  const decoder = new TextDecoder()
-  let buffer = ''
-  const streamIdleTimeoutMs = getStreamIdleTimeoutMs()
-  let lastDataTime = Date.now()
-  let streamComplete = false
-
-  try {
-    while (true) {
-      const { done, value } = await readWithIdleTimeout(reader, streamIdleTimeoutMs, {
-        signal,
-        cancelReader: readerCanceller.cancel,
-        onTimeout: () => {
-          const elapsed = Math.round((Date.now() - lastDataTime) / 1000)
-          logForDebugging(
-            `Anthropic-compatible SSE stream idle for ${elapsed}s (limit: ${streamIdleTimeoutMs / 1000}s). Connection likely dropped.`,
-            { level: 'error' },
-          )
-        },
-      })
-      if (done) {
-        streamComplete = true
-        break
-      }
-      if (value) lastDataTime = Date.now()
-
-      throwIfStreamAborted(signal)
-      buffer += decoder.decode(value, { stream: true })
-      const chunks = buffer.split('\n\n')
-      buffer = chunks.pop() ?? ''
-
-      for (const chunk of chunks) {
-        throwIfStreamAborted(signal)
-        const lines = chunk.split('\n').map(l => l.trim()).filter(Boolean)
-        if (lines.length === 0) continue
-
-        const dataLines = lines.filter(l => l.startsWith('data: '))
-        if (dataLines.length === 0) continue
-
-        const rawData = dataLines.map(l => l.slice(6)).join('\n')
-        if (rawData === '[DONE]') {
-          streamComplete = true
-          return
-        }
-
-        let parsed: AnthropicStreamEvent
-        try {
-          parsed = JSON.parse(rawData) as AnthropicStreamEvent
-        } catch {
-          // skip malformed frames
-          continue
-        }
-        if (parsed && typeof parsed === 'object' && 'type' in parsed) {
-          throwIfStreamAborted(signal)
-          yield parsed
-        }
-      }
-    }
-  } finally {
-    if (!streamComplete || signal?.aborted) {
-      readerCanceller.cancel(createStreamAbortError())
-    }
-    readerCanceller.cleanup()
-    reader.releaseLock()
-  }
+  yield* parseAnthropicSsePassthrough<AnthropicStreamEvent>(
+    response,
+    signal,
+    (message, options) => options?.level
+      ? logForDebugging(message, { level: options.level })
+      : logForDebugging(message),
+  )
 }
 
 /**

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2150,9 +2150,6 @@ interface ParsedTextToolCall {
   arguments: Record<string, unknown>
 }
 
-// Module-level counter ensures unique IDs across calls within a session.
-let _textToolCallCounter = 0
-
 // Walks forward from `start` (which must be `{`) tracking string/escape/brace
 // state and returns the substring up to and including the matching `}`, or
 // null if the braces are never balanced (truncated input).
@@ -2220,7 +2217,7 @@ function parseAndAdd(
   if (seen.has(dedupKey)) return false
   seen.add(dedupKey)
 
-  results.push({ id: `ollama_tc_${++_textToolCallCounter}`, name, arguments: args })
+  results.push({ id: `ollama_tc_${nextTextToolCallSequence()}`, name, arguments: args })
   return true
 }
 
@@ -2287,6 +2284,13 @@ export function parseTextToolCalls(text: string): {
   }
 
   return { calls: results, toolCallRanges: acceptedRanges }
+}
+
+// Shared façade state keeps raw-text and XML fallback IDs unique per session.
+let textToolCallSequence = 0
+
+function nextTextToolCallSequence(): number {
+  return ++textToolCallSequence
 }
 
 // ---------------------------------------------------------------------------
@@ -2429,7 +2433,7 @@ export function parseXmlToolCalls(text: string, allowHy3 = false): {
     const dedupKey = `${name}:${JSON.stringify(args)}`
     if (seen.has(dedupKey)) return
     seen.add(dedupKey)
-    results.push({ id: `xml_tc_${++_textToolCallCounter}`, name, arguments: args })
+    results.push({ id: `xml_tc_${nextTextToolCallSequence()}`, name, arguments: args })
   }
 
   const hy3Blocks = allowHy3

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -2822,6 +2822,8 @@ async function* geminiSseToAnthropic(
   }
 }
 
+// Extraction seam: Gemini streaming | completed response conversion.
+
 type NonStreamingOpenAIResponse = {
   id?: string
   model?: string
@@ -2996,6 +2998,8 @@ function headersWithRequestUrl(headers: Headers, requestUrl?: string): Headers {
   }
   return next
 }
+
+// Extraction seam: response metadata | generic stream conversion.
 
 async function* openaiStreamToAnthropic(
   response: Response,
@@ -3913,6 +3917,8 @@ async function* openaiStreamToAnthropic(
   throwIfStreamAborted(signal)
   yield { type: 'message_stop' }
 }
+
+// Extraction seam: stream conversion | stream lifecycle façade.
 
 // ---------------------------------------------------------------------------
 // The shim client — duck-types as Anthropic SDK

--- a/src/services/api/openaiShim/streamControl.test.ts
+++ b/src/services/api/openaiShim/streamControl.test.ts
@@ -192,6 +192,30 @@ test('Anthropic-compatible passthrough stream rejects with idle timeout when it 
   expect(stalled.cancelReasons[0]).toBeInstanceOf(StreamIdleTimeoutError)
 })
 
+test('Anthropic passthrough emits a final unterminated SSE data frame at EOF', async () => {
+  const response = new Response(
+    new TextEncoder().encode('data: {"type":"message_stop"}'),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  )
+  const events: Array<{ type: string }> = []
+  for await (const event of anthropicSsePassthrough<{ type: string }>(response, undefined, () => {})) {
+    events.push(event)
+  }
+  expect(events).toEqual([{ type: 'message_stop' }])
+})
+
+test('Anthropic passthrough accepts CRLF frames and data fields without a space', async () => {
+  const response = new Response(
+    new TextEncoder().encode('data:{"type":"message_start"}\r\n\r\ndata: {"type":"message_stop"}\r\n\r\n'),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  )
+  const events: Array<{ type: string }> = []
+  for await (const event of anthropicSsePassthrough<{ type: string }>(response, undefined, () => {})) {
+    events.push(event)
+  }
+  expect(events).toEqual([{ type: 'message_start' }, { type: 'message_stop' }])
+})
+
 test('controller abort reaches Anthropic messages SSE passthrough', async () => {
   const controller = new AbortController()
   const stalled = makeStallingResponse([{ type: 'message_start' }])

--- a/src/services/api/openaiShim/streamControl.test.ts
+++ b/src/services/api/openaiShim/streamControl.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../../test/sharedMutationLock.js'
+import { createOpenAIShimClient } from '../openaiShim.js'
+import {
+  anthropicSsePassthrough,
+  createReaderCanceller,
+  getStreamIdleTimeoutMs,
+  readWithIdleTimeout,
+  StreamIdleTimeoutError,
+  throwIfStreamAborted,
+} from './streamControl.js'
+
+const originalTimeout = process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS
+const originalBaseUrl = process.env.OPENAI_BASE_URL
+const originalApiKey = process.env.OPENAI_API_KEY
+const originalFetch = globalThis.fetch
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('openaiShim-streamControl.test.ts')
+  delete process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS
+  process.env.OPENAI_BASE_URL = 'https://api.anthropic-shaped.example.com/v1'
+  process.env.OPENAI_API_KEY = 'test-key'
+})
+
+afterEach(() => {
+  try {
+    for (const [key, value] of [
+      ['CLAUDE_STREAM_IDLE_TIMEOUT_MS', originalTimeout],
+      ['OPENAI_BASE_URL', originalBaseUrl],
+      ['OPENAI_API_KEY', originalApiKey],
+    ] as const) {
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    globalThis.fetch = originalFetch
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+function makeStallingResponse(frames: unknown[]): {
+  response: Response
+  cancelReasons: unknown[]
+} {
+  const encoder = new TextEncoder()
+  const cancelReasons: unknown[] = []
+  const initial = frames.map(frame => `data: ${JSON.stringify(frame)}\n\n`).join('')
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(initial))
+      },
+      cancel(reason) {
+        cancelReasons.push(reason)
+      },
+    }),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  )
+  Object.defineProperty(response, 'url', {
+    configurable: true,
+    value: 'https://api.anthropic-shaped.example.com/v1/messages',
+  })
+  return { response, cancelReasons }
+}
+
+type ShimStream = AsyncIterable<Record<string, unknown>> & {
+  controller: AbortController
+}
+
+type ShimClient = {
+  beta: {
+    messages: {
+      create: (params: Record<string, unknown>) => {
+        withResponse: () => Promise<{ data: ShimStream }>
+      }
+    }
+  }
+}
+
+async function withDeadline<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), 500)
+      }),
+    ])
+  } finally {
+    if (timer !== undefined) clearTimeout(timer)
+  }
+}
+
+test('readWithIdleTimeout rejects quickly and cancels a stalled reader', async () => {
+  const cancelReasons: unknown[] = []
+  const reader = new ReadableStream<Uint8Array>({
+    cancel(reason) {
+      cancelReasons.push(reason)
+    },
+  }).getReader()
+
+  await expect(
+    withDeadline(
+      readWithIdleTimeout(reader, 20),
+      'idle timeout did not reject within 500ms',
+    ),
+  ).rejects.toBeInstanceOf(StreamIdleTimeoutError)
+  expect(cancelReasons).toHaveLength(1)
+  expect(cancelReasons[0]).toBeInstanceOf(StreamIdleTimeoutError)
+})
+
+test('readWithIdleTimeout preserves parent abort instead of reporting idle timeout', async () => {
+  const controller = new AbortController()
+  const cancelReasons: unknown[] = []
+  const reader = new ReadableStream<Uint8Array>({
+    cancel(reason) {
+      cancelReasons.push(reason)
+    },
+  }).getReader()
+  const pendingRead = readWithIdleTimeout(reader, 60_000, { signal: controller.signal })
+
+  controller.abort()
+
+  await expect(pendingRead).rejects.toMatchObject({ name: 'AbortError' })
+  expect(cancelReasons).toHaveLength(1)
+  expect(cancelReasons[0]).toMatchObject({ name: 'AbortError' })
+})
+
+test('readWithIdleTimeout settles when a custom canceller throws synchronously', async () => {
+  const controller = new AbortController()
+  const reader = new ReadableStream<Uint8Array>({}).getReader()
+  const pendingRead = readWithIdleTimeout(reader, 60_000, {
+    signal: controller.signal,
+    cancelReader: () => {
+      throw new Error('cancel failed')
+    },
+  })
+
+  controller.abort()
+
+  await expect(pendingRead).rejects.toMatchObject({ name: 'AbortError' })
+  reader.releaseLock()
+})
+
+test('stream idle timeout parser validates and bounds overrides', () => {
+  expect(getStreamIdleTimeoutMs()).toBe(90_000)
+  process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '25'
+  expect(getStreamIdleTimeoutMs()).toBe(25)
+  process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = ' 25 '
+  expect(getStreamIdleTimeoutMs()).toBe(25)
+  process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '3000000000'
+  expect(getStreamIdleTimeoutMs()).toBe(2_147_483_647)
+
+  for (const invalid of ['9007199254740993', '25ms', '0', '-5']) {
+    process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = invalid
+    expect(getStreamIdleTimeoutMs()).toBe(90_000)
+  }
+})
+
+test('reader cancellation is idempotent and abort checks throw AbortError', () => {
+  const cancelReasons: unknown[] = []
+  const reader = new ReadableStream<Uint8Array>({
+    cancel(reason) {
+      cancelReasons.push(reason)
+    },
+  }).getReader()
+  const canceller = createReaderCanceller(reader)
+
+  canceller.cancel()
+  canceller.cancel()
+  canceller.cleanup()
+
+  expect(cancelReasons).toHaveLength(1)
+  const controller = new AbortController()
+  controller.abort()
+  expect(() => throwIfStreamAborted(controller.signal)).toThrow(
+    expect.objectContaining({ name: 'AbortError' }),
+  )
+})
+
+test('Anthropic-compatible passthrough stream rejects with idle timeout when it stalls', async () => {
+  process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '20'
+  const stalled = makeStallingResponse([{ type: 'message_start' }])
+  const stream = anthropicSsePassthrough<{ type: string }>(
+    stalled.response,
+    undefined,
+    () => {},
+  )
+
+  expect(await stream.next()).toEqual({ done: false, value: { type: 'message_start' } })
+  await expect(stream.next()).rejects.toBeInstanceOf(StreamIdleTimeoutError)
+  expect(stalled.cancelReasons[0]).toBeInstanceOf(StreamIdleTimeoutError)
+})
+
+test('controller abort reaches Anthropic messages SSE passthrough', async () => {
+  const controller = new AbortController()
+  const stalled = makeStallingResponse([{ type: 'message_start' }])
+  const events: Array<{ type: string }> = []
+  const stream = anthropicSsePassthrough<{ type: string }>(
+    stalled.response,
+    controller.signal,
+    () => {},
+  )
+  const drain = (async () => {
+    for await (const event of stream) {
+      events.push(event)
+      controller.abort()
+    }
+  })()
+
+  await expect(withDeadline(drain, 'passthrough did not stop')).rejects.toMatchObject({
+    name: 'AbortError',
+  })
+  expect(events).toEqual([{ type: 'message_start' }])
+  expect(stalled.cancelReasons).toHaveLength(1)
+})
+
+test('the returned stream controller cancels an Anthropic messages response', async () => {
+  const stalled = makeStallingResponse([{ type: 'message_start' }])
+  globalThis.fetch = (async () => stalled.response) as unknown as typeof globalThis.fetch
+  const client = createOpenAIShimClient({}) as unknown as ShimClient
+  const result = await client.beta.messages.create({
+    model: 'test-model',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 32,
+    stream: true,
+  }).withResponse()
+  const iterator = result.data[Symbol.asyncIterator]()
+
+  expect((await iterator.next()).value?.type).toBe('message_start')
+  result.data.controller.abort()
+
+  await withDeadline(
+    (async () => {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        if (stalled.cancelReasons.length > 0) return
+        await Promise.resolve()
+      }
+      throw new Error('returned controller did not cancel the paused response')
+    })(),
+    'returned controller did not cancel the paused response',
+  )
+  expect(stalled.cancelReasons).toHaveLength(1)
+  await expect(iterator.next()).rejects.toMatchObject({ name: 'AbortError' })
+})
+
+test('Anthropic passthrough preserves errors thrown by its consumer', async () => {
+  const stalled = makeStallingResponse([{ type: 'message_start' }])
+  const stream = anthropicSsePassthrough<{ type: string }>(
+    stalled.response,
+    undefined,
+    () => {},
+  )
+  const sentinel = new Error('consumer failed')
+
+  expect((await stream.next()).value).toEqual({ type: 'message_start' })
+
+  await expect(stream.throw(sentinel)).rejects.toBe(sentinel)
+  expect(stalled.cancelReasons).toHaveLength(1)
+})
+
+test('controller abort cancels Anthropic messages SSE when paused after event', async () => {
+  const controller = new AbortController()
+  const stalled = makeStallingResponse([{ type: 'message_start' }])
+  const stream = anthropicSsePassthrough<{ type: string }>(
+    stalled.response,
+    controller.signal,
+    () => {},
+  )
+
+  expect(await stream.next()).toEqual({ done: false, value: { type: 'message_start' } })
+  controller.abort()
+  await withDeadline(
+    (async () => {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        if (stalled.cancelReasons.length > 0) return
+        await Promise.resolve()
+      }
+      throw new Error('paused passthrough did not cancel its source')
+    })(),
+    'paused passthrough did not cancel its source',
+  )
+  await stream.return(undefined)
+  expect(stalled.cancelReasons).toHaveLength(1)
+})
+
+test('controller abort stops buffered Anthropic messages SSE events', async () => {
+  const controller = new AbortController()
+  const stalled = makeStallingResponse([
+    { type: 'message_start' },
+    { type: 'content_block_start' },
+  ])
+  const stream = anthropicSsePassthrough<{ type: string }>(
+    stalled.response,
+    controller.signal,
+    () => {},
+  )
+
+  expect(await stream.next()).toEqual({ done: false, value: { type: 'message_start' } })
+  controller.abort()
+
+  await expect(stream.next()).rejects.toMatchObject({ name: 'AbortError' })
+  expect(stalled.cancelReasons).toHaveLength(1)
+})

--- a/src/services/api/openaiShim/streamControl.test.ts
+++ b/src/services/api/openaiShim/streamControl.test.ts
@@ -204,6 +204,29 @@ test('Anthropic passthrough emits a final unterminated SSE data frame at EOF', a
   expect(events).toEqual([{ type: 'message_stop' }])
 })
 
+test('Anthropic passthrough cancels a source that stays open after [DONE]', async () => {
+  const cancelReasons: unknown[] = []
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('data: [DONE]\n\n'))
+      },
+      cancel(reason) {
+        cancelReasons.push(reason)
+      },
+    }),
+    { headers: { 'Content-Type': 'text/event-stream' } },
+  )
+
+  const events: Array<{ type: string }> = []
+  for await (const event of anthropicSsePassthrough<{ type: string }>(response, undefined, () => {})) {
+    events.push(event)
+  }
+
+  expect(events).toEqual([])
+  expect(cancelReasons).toHaveLength(1)
+})
+
 test('Anthropic passthrough accepts CRLF frames and data fields without a space', async () => {
   const response = new Response(
     new TextEncoder().encode('data:{"type":"message_start"}\r\n\r\ndata: {"type":"message_stop"}\r\n\r\n'),

--- a/src/services/api/openaiShim/streamControl.ts
+++ b/src/services/api/openaiShim/streamControl.ts
@@ -158,20 +158,20 @@ export async function* anthropicSsePassthrough<T extends object>(
       })
       if (done) {
         streamComplete = true
-        break
+        buffer += decoder.decode()
+      } else {
+        if (value) lastDataTime = Date.now()
+        throwIfStreamAborted(signal)
+        buffer += decoder.decode(value, { stream: true })
       }
-      if (value) lastDataTime = Date.now()
-
-      throwIfStreamAborted(signal)
-      buffer += decoder.decode(value, { stream: true })
-      const chunks = buffer.split('\n\n')
-      buffer = chunks.pop() ?? ''
+      const chunks = done ? (buffer ? [buffer] : []) : buffer.split(/\r\n\r\n|\n\n|\r\r/)
+      buffer = done ? '' : (chunks.pop() ?? '')
       for (const chunk of chunks) {
         throwIfStreamAborted(signal)
-        const lines = chunk.split('\n').map(line => line.trim()).filter(Boolean)
-        const dataLines = lines.filter(line => line.startsWith('data: '))
+        const lines = chunk.split(/\r\n|\n|\r/).map(line => line.trim()).filter(Boolean)
+        const dataLines = lines.filter(line => line.startsWith('data:'))
         if (dataLines.length === 0) continue
-        const rawData = dataLines.map(line => line.slice(6)).join('\n')
+        const rawData = dataLines.map(line => line.slice(5).replace(/^ /, '')).join('\n')
         if (rawData === '[DONE]') {
           streamComplete = true
           return
@@ -188,6 +188,7 @@ export async function* anthropicSsePassthrough<T extends object>(
           yield parsed as Awaited<T>
         }
       }
+      if (done) break
     }
   } finally {
     if (!streamComplete || signal?.aborted) readerCanceller.cancel(createStreamAbortError())

--- a/src/services/api/openaiShim/streamControl.ts
+++ b/src/services/api/openaiShim/streamControl.ts
@@ -1,0 +1,197 @@
+const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 90_000
+const MAX_STREAM_IDLE_TIMEOUT_MS = 2_147_483_647
+
+export class StreamIdleTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Stream idle timeout - no chunks received for ${timeoutMs}ms`)
+    this.name = 'StreamIdleTimeoutError'
+  }
+}
+
+export function createStreamAbortError(): DOMException {
+  return new DOMException('Aborted', 'AbortError')
+}
+
+export function throwIfStreamAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createStreamAbortError()
+  }
+}
+
+type StreamReadResult = Awaited<
+  ReturnType<ReadableStreamDefaultReader<Uint8Array>['read']>
+>
+
+export function createReaderCanceller(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  signal?: AbortSignal,
+): {
+    cancel: (error?: unknown) => void
+    cleanup: () => void
+  } {
+  let cancelled = false
+  const cancel = (error: unknown = createStreamAbortError()) => {
+    if (cancelled) return
+    cancelled = true
+    void reader.cancel(error).catch(() => {})
+  }
+  const onAbort = () => cancel(createStreamAbortError())
+
+  signal?.addEventListener('abort', onAbort, { once: true })
+  if (signal?.aborted) {
+    onAbort()
+  }
+
+  return {
+    cancel,
+    cleanup: () => signal?.removeEventListener('abort', onAbort),
+  }
+}
+
+export function getStreamIdleTimeoutMs(): number {
+  const raw = process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS?.trim()
+  if (!raw || !/^\d+$/.test(raw)) return DEFAULT_STREAM_IDLE_TIMEOUT_MS
+  const parsed = Number(raw)
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? Math.min(parsed, MAX_STREAM_IDLE_TIMEOUT_MS)
+    : DEFAULT_STREAM_IDLE_TIMEOUT_MS
+}
+
+export async function readWithIdleTimeout(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  timeoutMs: number,
+  options: {
+    signal?: AbortSignal
+    cancelReader?: (error?: unknown) => void
+    onTimeout?: () => void
+  } = {},
+): Promise<StreamReadResult> {
+  const signal = options.signal
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  return new Promise<StreamReadResult>((resolve, reject) => {
+    let settled = false
+    const cleanup = () => {
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId)
+        timeoutId = undefined
+      }
+      signal?.removeEventListener('abort', onAbort)
+    }
+    const finishResolve = (value: StreamReadResult) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+    const finishReject = (error: unknown) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(error)
+    }
+    const cancelAndReject = (error: unknown) => {
+      finishReject(error)
+      try {
+        if (options.cancelReader) {
+          options.cancelReader(error)
+        } else {
+          void reader.cancel(error).catch(() => {})
+        }
+      } catch {
+        // Cancellation is best effort; preserve the original stream error.
+      }
+    }
+    const onAbort = () => cancelAndReject(createStreamAbortError())
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+
+    timeoutId = setTimeout(() => {
+      const error = new StreamIdleTimeoutError(timeoutMs)
+      try {
+        options.onTimeout?.()
+      } catch {
+        // Ignore diagnostic callback failures.
+      }
+      cancelAndReject(error)
+    }, timeoutMs)
+
+    reader.read().then(finishResolve, finishReject)
+  })
+}
+
+/**
+ * Parses an Anthropic Messages SSE response while applying the same abort,
+ * reader-cancellation, and idle-timeout policy used by converted streams.
+ */
+export async function* anthropicSsePassthrough<T extends object>(
+  response: Response,
+  signal: AbortSignal | undefined,
+  logForDebugging: (message: string, options?: { level?: 'error' }) => void,
+): AsyncGenerator<T> {
+  const readerOrNull = response.body?.getReader()
+  if (!readerOrNull) throw new Error('Response body is not readable')
+  const reader: ReadableStreamDefaultReader<Uint8Array> = readerOrNull
+  const readerCanceller = createReaderCanceller(reader, signal)
+  const decoder = new TextDecoder()
+  let buffer = ''
+  const streamIdleTimeoutMs = getStreamIdleTimeoutMs()
+  let lastDataTime = Date.now()
+  let streamComplete = false
+
+  try {
+    while (true) {
+      const { done, value } = await readWithIdleTimeout(reader, streamIdleTimeoutMs, {
+        signal,
+        cancelReader: readerCanceller.cancel,
+        onTimeout: () => {
+          const elapsed = Math.round((Date.now() - lastDataTime) / 1000)
+          logForDebugging(
+            `Anthropic-compatible SSE stream idle for ${elapsed}s (limit: ${streamIdleTimeoutMs / 1000}s). Connection likely dropped.`,
+            { level: 'error' },
+          )
+        },
+      })
+      if (done) {
+        streamComplete = true
+        break
+      }
+      if (value) lastDataTime = Date.now()
+
+      throwIfStreamAborted(signal)
+      buffer += decoder.decode(value, { stream: true })
+      const chunks = buffer.split('\n\n')
+      buffer = chunks.pop() ?? ''
+      for (const chunk of chunks) {
+        throwIfStreamAborted(signal)
+        const lines = chunk.split('\n').map(line => line.trim()).filter(Boolean)
+        const dataLines = lines.filter(line => line.startsWith('data: '))
+        if (dataLines.length === 0) continue
+        const rawData = dataLines.map(line => line.slice(6)).join('\n')
+        if (rawData === '[DONE]') {
+          streamComplete = true
+          return
+        }
+        let parsed: T
+        try {
+          parsed = JSON.parse(rawData) as T
+        } catch {
+          // Ignore malformed frames and continue parsing later frames.
+          continue
+        }
+        if (parsed && typeof parsed === 'object' && 'type' in parsed) {
+          throwIfStreamAborted(signal)
+          yield parsed as Awaited<T>
+        }
+      }
+    }
+  } finally {
+    if (!streamComplete || signal?.aborted) readerCanceller.cancel(createStreamAbortError())
+    readerCanceller.cleanup()
+    reader.releaseLock()
+  }
+}

--- a/src/services/api/openaiShim/streamControl.ts
+++ b/src/services/api/openaiShim/streamControl.ts
@@ -174,6 +174,7 @@ export async function* anthropicSsePassthrough<T extends object>(
         const rawData = dataLines.map(line => line.slice(5).replace(/^ /, '')).join('\n')
         if (rawData === '[DONE]') {
           streamComplete = true
+          readerCanceller.cancel()
           return
         }
         let parsed: T


### PR DESCRIPTION
## Summary

Extracts stream lifecycle primitives from `src/services/api/openaiShim.ts` into `src/services/api/openaiShim/streamControl.ts`.

The module owns abort errors, idempotent reader cancellation, idle-timeout policy, and Anthropic-compatible SSE parsing. `openaiShim.ts` remains the stable façade. Lifecycle/controller dispatch integration stays in the façade suite because it crosses the later dispatch boundary; the module-owned stream-control behaviors move to the focused suite.

All branches share stable source and test extraction seams. Those seams keep adjacent edits disjoint after multiple earlier PRs have merged, not merely when branches are compared pairwise.

## Independent merge

- Based on `Gitlawb/openclaude:main` at `0effa0f42b6dbc6a4800e19f4b2d8d588269906b`.
- Published from `jatmn/openclaude:de-mono1-stream-control`.
- Exact head: `6fe9565163add802d296884c4b4b386b0b5a4e52`.
- Independent of PRs #2003–#2011: all 45 pairwise combinations are conflict-free, and full ten-branch merges pass in both forward and reverse order.
- Submitted as a draft to upstream.

## Source-file budget

`src/services/api/openaiShim.ts`: **+56 / -201 = 257 changed lines**, below the 1,500-line source-file cap. Test changes are excluded from that cap.

## Test migration

- `src/services/api/openaiShim.test.ts`: **+696 / -113**, including the common stable extraction anchors; the four stream-control test bodies are removed from the monolith.
- `src/services/api/openaiShim/streamControl.test.ts`: **304 lines / 11 tests**.
- Focused stream-control, retained façade, and affected bugfix suites: **275 passed / 775 assertions**.
- After all ten PRs merge, the monolithic test contains only the three façade-contract tests.

## Validation

- `git diff --check`: passed.
- `bun run typecheck`: passed.
- `bun run typecheck:type-tests`: passed.
- `bun run build`: passed.
- Exact-head host `bun run check`: build, smoke, bundle, and dead-code checks passed; **7,193 passed / 2 skipped**, with only the same 10 pre-existing PowerShell governance failures on Linux.

Prepared according to `CONTRIBUTING.md` and `AGENTS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stalled AI response streams using a configurable idle-timeout setting.
  * Improved abort/cancellation behavior for streaming reads, ensuring consistent single cleanup and correct abort precedence.
  * Enhanced server-sent event (SSE) passthrough with more tolerant frame parsing and correct termination on `[DONE]`/EOF.
  * Fixed fallback tool-call identifiers so they stay unique across a session.
  * Improved JSON fallback event-stream conversion to reliably end with the expected terminal `message_stop` event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->