### PR TITLE
refactor(openai-shim): extract message content conversion

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -1,5 +1,6 @@
 import { APIError } from '@anthropic-ai/sdk'
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { getEventListeners } from 'node:events'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
 import { asMockFetch } from '../../test/typedMocks.js'
 import { _clearRegistryForTesting, ensureIntegrationsLoaded, registerGateway } from '../../integrations/index.ts'
@@ -9,7 +10,11 @@ import {
   getAssistantMessageFromError,
   OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
 } from './errors.ts'
-import { createOpenAIShimClient, hasMistralApiHost } from './openaiShim.ts'
+import {
+  extractOpenAICategoryMarker,
+  isOpenAIRequestNonReplayable,
+} from './openaiErrorClassification.ts'
+import { createOpenAIShimClient, hasMistralApiHost, parseTextToolCalls, parseXmlToolCalls } from './openaiShim.ts'
 import * as realCodexShim from './codexShim.js'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 
@@ -50,12 +55,15 @@ const originalEnv = {
   OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
   DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY,
   MIMO_API_KEY: process.env.MIMO_API_KEY,
+  LONGCAT_API_KEY: process.env.LONGCAT_API_KEY,
+  CLINE_API_KEY: process.env.CLINE_API_KEY,
   OPENGATEWAY_API_KEY: process.env.OPENGATEWAY_API_KEY,
   OPENGATEWAY_BASE_URL: process.env.OPENGATEWAY_BASE_URL,
   OPENCODE_API_KEY: process.env.OPENCODE_API_KEY,
   CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED: process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED,
   CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID: process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID,
   CLAUDE_STREAM_IDLE_TIMEOUT_MS: process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS,
+  API_TIMEOUT_MS: process.env.API_TIMEOUT_MS,
 }
 
 const originalFetch = globalThis.fetch
@@ -364,6 +372,7 @@ function importFreshOpenAIShim(
 
 type StreamIdleTestApi = {
   StreamIdleTimeoutError: new (timeoutMs: number) => Error
+  getApiTimeoutMs: () => number
   getStreamIdleTimeoutMs: () => number
   readWithIdleTimeout: (
     reader: ReadableStreamDefaultReader<Uint8Array>,
@@ -376,6 +385,7 @@ async function getStreamIdleTestApi(cacheKey: string): Promise<StreamIdleTestApi
   const mod = await importFreshOpenAIShim(cacheKey)
   const testApi = mod.__test as unknown as Partial<StreamIdleTestApi>
   expect(typeof testApi.StreamIdleTimeoutError).toBe('function')
+  expect(typeof testApi.getApiTimeoutMs).toBe('function')
   expect(typeof testApi.getStreamIdleTimeoutMs).toBe('function')
   expect(typeof testApi.readWithIdleTimeout).toBe('function')
   return testApi as StreamIdleTestApi
@@ -402,6 +412,48 @@ function makeChatCompletionResponse(model: string): Response {
       },
     },
   )
+}
+
+function makeGithubChatFallbackResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      error: { message: '/chat/completions is not accessible for this model' },
+    }),
+    { status: 400, headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function makeResponsesApiResponse(model: string): Response {
+  return new Response(
+    JSON.stringify({
+      id: 'resp-fallback-test',
+      model,
+      output: [
+        {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'ok' }],
+        },
+      ],
+      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+    }),
+    { headers: { 'Content-Type': 'application/json' } },
+  )
+}
+
+function pendingFetchUntilAbort(
+  init: RequestInit | undefined,
+): Promise<Response> {
+  return new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal
+    if (!signal) return
+
+    const rejectFromAbort = () => {
+      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+    }
+    signal.addEventListener('abort', rejectFromAbort, { once: true })
+    if (signal.aborted) rejectFromAbort()
+  })
 }
 
 async function captureChatCompletionRequest(
@@ -466,12 +518,15 @@ beforeEach(async () => {
   delete process.env.OPENROUTER_API_KEY
   delete process.env.DEEPSEEK_API_KEY
   delete process.env.MIMO_API_KEY
+  delete process.env.LONGCAT_API_KEY
+  delete process.env.CLINE_API_KEY
   delete process.env.OPENGATEWAY_API_KEY
   delete process.env.OPENGATEWAY_BASE_URL
   delete process.env.OPENCODE_API_KEY
   delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
   delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
   delete process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS
+  delete process.env.API_TIMEOUT_MS
 })
 
 afterEach(() => {
@@ -510,12 +565,15 @@ afterEach(() => {
     restoreEnv('OPENROUTER_API_KEY', originalEnv.OPENROUTER_API_KEY)
     restoreEnv('DEEPSEEK_API_KEY', originalEnv.DEEPSEEK_API_KEY)
     restoreEnv('MIMO_API_KEY', originalEnv.MIMO_API_KEY)
+    restoreEnv('LONGCAT_API_KEY', originalEnv.LONGCAT_API_KEY)
+    restoreEnv('CLINE_API_KEY', originalEnv.CLINE_API_KEY)
     restoreEnv('OPENGATEWAY_API_KEY', originalEnv.OPENGATEWAY_API_KEY)
     restoreEnv('OPENGATEWAY_BASE_URL', originalEnv.OPENGATEWAY_BASE_URL)
     restoreEnv('OPENCODE_API_KEY', originalEnv.OPENCODE_API_KEY)
     restoreEnv('CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED', originalEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED)
     restoreEnv('CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID', originalEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID)
     restoreEnv('CLAUDE_STREAM_IDLE_TIMEOUT_MS', originalEnv.CLAUDE_STREAM_IDLE_TIMEOUT_MS)
+    restoreEnv('API_TIMEOUT_MS', originalEnv.API_TIMEOUT_MS)
     globalThis.fetch = originalFetch
     _clearRegistryForTesting()
     ensureIntegrationsLoaded()
@@ -524,68 +582,12 @@ afterEach(() => {
   }
 })
 
-test('strips canonical Anthropic headers from direct shim defaultHeaders', async () => {
-  let capturedHeaders: Headers | undefined
+// openaiShim test extraction seam 001 start: strips canonical Anthropic headers from direct shim defaultHeaders
 
-  globalThis.fetch = (async (_input, init) => {
-    capturedHeaders = new Headers(init?.headers)
+// openaiShim test extraction seam 001 end
 
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'gpt-4o',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: 'ok',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 8,
-          completion_tokens: 3,
-          total_tokens: 11,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
 
-  const client = createOpenAIShimClient({
-    defaultHeaders: {
-      'anthropic-version': '2023-06-01',
-      'anthropic-beta': 'prompt-caching-2024-07-31',
-      'x-anthropic-additional-protection': 'true',
-      'x-claude-remote-session-id': 'remote-123',
-      'x-app': 'cli',
-      'x-client-app': 'sdk',
-      'x-safe-header': 'keep-me',
-    },
-  }) as OpenAIShimClient
-
-  await client.beta.messages.create({
-    model: 'gpt-4o',
-    system: 'test system',
-    messages: [{ role: 'user', content: 'hello' }],
-    max_tokens: 64,
-    stream: false,
-  })
-
-  expect(capturedHeaders?.get('anthropic-version')).toBeNull()
-  expect(capturedHeaders?.get('anthropic-beta')).toBeNull()
-  expect(capturedHeaders?.get('x-anthropic-additional-protection')).toBeNull()
-  expect(capturedHeaders?.get('x-claude-remote-session-id')).toBeNull()
-  expect(capturedHeaders?.get('x-app')).toBeNull()
-  expect(capturedHeaders?.get('x-client-app')).toBeNull()
-  expect(capturedHeaders?.get('x-safe-header')).toBe('keep-me')
-})
-
+// openaiShim test extraction seam 002 start: uses OpenAI-compatible responses endpoint when OPENAI_API_FORMAT=responses
 test('uses OpenAI-compatible responses endpoint when OPENAI_API_FORMAT=responses', async () => {
   process.env.OPENAI_API_FORMAT = 'responses'
   let capturedUrl = ''
@@ -643,7 +645,10 @@ test('uses OpenAI-compatible responses endpoint when OPENAI_API_FORMAT=responses
     },
   ])
 })
+// openaiShim test extraction seam 002 end
 
+
+// openaiShim test extraction seam 003 start: nests reasoning effort for OpenAI-compatible responses endpoint
 test('nests reasoning effort for OpenAI-compatible responses endpoint', async () => {
   process.env.OPENAI_API_FORMAT = 'responses'
   let capturedBody: Record<string, unknown> | undefined
@@ -685,6 +690,7 @@ test('nests reasoning effort for OpenAI-compatible responses endpoint', async ()
   expect(capturedBody).not.toHaveProperty('reasoning_effort')
   expect(capturedBody).not.toHaveProperty('reasoning_summary')
 })
+// openaiShim test extraction seam 003 end
 
 test('auto-routes gpt-5.6 to /responses on api.openai.com with tools and nested reasoning', async () => {
   // No OPENAI_API_FORMAT set: the model+base predicate must pick responses.
@@ -1252,6 +1258,7 @@ test('auto-routed gpt-5.6 on an Azure base nests reasoning.effort and the encryp
   expect(capturedBody?.include).toEqual(['reasoning.encrypted_content'])
 })
 
+// openaiShim test extraction seam 004 start: uses OpenAI-compatible responses endpoint with text chunk types when OPENAI_API_FORMAT=responses_compat
 test('uses OpenAI-compatible responses endpoint with text chunk types when OPENAI_API_FORMAT=responses_compat', async () => {
   process.env.OPENAI_API_FORMAT = 'responses_compat'
   let capturedUrl = ''
@@ -1309,7 +1316,10 @@ test('uses OpenAI-compatible responses endpoint with text chunk types when OPENA
     },
   ])
 })
+// openaiShim test extraction seam 004 end
 
+
+// openaiShim test extraction seam 005 start: uses correct empty input fallback schema for standard responses and responses_compat
 test('uses correct empty input fallback schema for standard responses and responses_compat', async () => {
   let capturedBody: Record<string, unknown> | undefined
 
@@ -1354,7 +1364,10 @@ test('uses correct empty input fallback schema for standard responses and respon
     },
   ])
 })
+// openaiShim test extraction seam 005 end
 
+
+// openaiShim test extraction seam 006 start: strips store from strict OpenAI-compatible responses providers
 test('strips store from strict OpenAI-compatible responses providers', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.ai/v1'
   process.env.OPENAI_API_FORMAT = 'responses'
@@ -1397,7 +1410,10 @@ test('strips store from strict OpenAI-compatible responses providers', async () 
   expect(capturedUrl).toBe('https://api.moonshot.ai/v1/responses')
   expect(capturedBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 006 end
 
+
+// openaiShim test extraction seam 007 start: strips store when providerOverride routes chat_completions to the Gemini host
 test('strips store when providerOverride routes chat_completions to the Gemini host', async () => {
   let capturedBody: Record<string, unknown> | undefined
 
@@ -1430,7 +1446,10 @@ test('strips store when providerOverride routes chat_completions to the Gemini h
 
   expect(capturedBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 007 end
 
+
+// openaiShim test extraction seam 008 start: strips store when providerOverride routes responses API to the Gemini host
 test('strips store when providerOverride routes responses API to the Gemini host', async () => {
   process.env.OPENAI_API_FORMAT = 'responses'
   let capturedBody: Record<string, unknown> | undefined
@@ -1470,7 +1489,10 @@ test('strips store when providerOverride routes responses API to the Gemini host
 
   expect(capturedBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 008 end
 
+
+// openaiShim test extraction seam 009 start: uses custom OpenAI-compatible auth header value when configured
 test('uses custom OpenAI-compatible auth header value when configured', async () => {
   process.env.OPENAI_API_KEY = 'generic-key'
   process.env.OPENAI_AUTH_HEADER = 'api-key'
@@ -1505,7 +1527,10 @@ test('uses custom OpenAI-compatible auth header value when configured', async ()
   expect(capturedHeaders?.get('api-key')).toBe('hicap-header-value')
   expect(capturedHeaders?.get('authorization')).toBeNull()
 })
+// openaiShim test extraction seam 009 end
 
+
+// openaiShim test extraction seam 010 start: uses Hicap api-key auth header for the Hicap route
 test('uses Hicap api-key auth header for the Hicap route', async () => {
   process.env.OPENAI_API_KEY = 'hicap-live-key'
   process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
@@ -1539,7 +1564,10 @@ test('uses Hicap api-key auth header for the Hicap route', async () => {
   expect(capturedHeaders?.get('api-key')).toBe('hicap-live-key')
   expect(capturedHeaders?.get('authorization')).toBeNull()
 })
+// openaiShim test extraction seam 010 end
 
+
+// openaiShim test extraction seam 011 start: defaults Authorization custom auth header to bearer scheme
 test('defaults Authorization custom auth header to bearer scheme', async () => {
   process.env.OPENAI_API_KEY = 'authorization-key'
   process.env.OPENAI_AUTH_HEADER = 'Authorization'
@@ -1572,7 +1600,10 @@ test('defaults Authorization custom auth header to bearer scheme', async () => {
 
   expect(capturedHeaders?.get('authorization')).toBe('Bearer authorization-key')
 })
+// openaiShim test extraction seam 011 end
 
+
+// openaiShim test extraction seam 012 start: honors bearer scheme for custom OpenAI-compatible auth headers
 test('honors bearer scheme for custom OpenAI-compatible auth headers', async () => {
   process.env.OPENAI_API_KEY = 'custom-key'
   process.env.OPENAI_AUTH_HEADER = 'X-Custom-Authorization'
@@ -1607,7 +1638,10 @@ test('honors bearer scheme for custom OpenAI-compatible auth headers', async () 
   expect(capturedHeaders?.get('x-custom-authorization')).toBe('Bearer custom-key')
   expect(capturedHeaders?.get('authorization')).toBeNull()
 })
+// openaiShim test extraction seam 012 end
 
+
+// openaiShim test extraction seam 013 start: ignores custom auth header value when no custom header is configured
 test('ignores custom auth header value when no custom header is configured', async () => {
   delete process.env.OPENAI_API_KEY
   process.env.OPENAI_AUTH_HEADER_VALUE = 'gateway-header-value'
@@ -1640,64 +1674,15 @@ test('ignores custom auth header value when no custom header is configured', asy
 
   expect(capturedHeaders?.get('authorization')).toBeNull()
 })
+// openaiShim test extraction seam 013 end
 
-test('strips canonical Anthropic headers from per-request shim headers too', async () => {
-  let capturedHeaders: Headers | undefined
 
-  globalThis.fetch = (async (_input, init) => {
-    capturedHeaders = new Headers(init?.headers)
+// openaiShim test extraction seam 014 start: strips canonical Anthropic headers from per-request shim headers too
 
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'gpt-4o',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: 'ok',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 8,
-          completion_tokens: 3,
-          total_tokens: 11,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
+// openaiShim test extraction seam 014 end
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
 
-  await client.beta.messages.create(
-    {
-      model: 'gpt-4o',
-      system: 'test system',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 64,
-      stream: false,
-    },
-    {
-      headers: {
-        'anthropic-version': '2023-06-01',
-        'anthropic-beta': 'prompt-caching-2024-07-31',
-        'x-safe-header': 'keep-me',
-      },
-    },
-  )
-
-  expect(capturedHeaders?.get('anthropic-version')).toBeNull()
-  expect(capturedHeaders?.get('anthropic-beta')).toBeNull()
-  expect(capturedHeaders?.get('x-safe-header')).toBe('keep-me')
-})
-
+// openaiShim test extraction seam 015 start: applies descriptor static headers before client and request headers
 test('applies descriptor static headers before client and request headers', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -1781,7 +1766,10 @@ test('applies descriptor static headers before client and request headers', asyn
   expect(capturedHeaders?.get('x-static-header')).toBe('from-descriptor')
   expect(capturedHeaders?.get('x-override-header')).toBe('from-request')
 })
+// openaiShim test extraction seam 015 end
 
+
+// openaiShim test extraction seam 016 start: opengateway sends Accept-Encoding: identity header on chat requests
 test('opengateway sends Accept-Encoding: identity header on chat requests', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -1864,7 +1852,10 @@ test('opengateway sends Accept-Encoding: identity header on chat requests', asyn
 
   expect(capturedHeaders?.get('Accept-Encoding')).toBe('identity')
 })
+// openaiShim test extraction seam 016 end
 
+
+// openaiShim test extraction seam 017 start: strips Anthropic-specific headers on GitHub Codex transport requests
 test('strips Anthropic-specific headers on GitHub Codex transport requests', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -1913,7 +1904,10 @@ test('strips Anthropic-specific headers on GitHub Codex transport requests', asy
   expect(capturedHeaders?.get('authorization')).toBe('Bearer github-test-key')
   expect(capturedHeaders?.get('editor-plugin-version')).toBe('copilot-chat/0.26.7')
 })
+// openaiShim test extraction seam 017 end
 
+
+// openaiShim test extraction seam 018 start: uses direct GitHub Copilot Enterprise key for shim authentication
 test('uses direct GitHub Copilot Enterprise key for shim authentication', async () => {
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
   process.env.GITHUB_COPILOT_KEY = 'enterprise-direct-key'
@@ -1928,7 +1922,10 @@ test('uses direct GitHub Copilot Enterprise key for shim authentication', async 
   expect(authorization).toBe('Bearer enterprise-direct-key')
   expect(url).toBe('https://github.mycompany.com/api/copilot/chat/completions')
 })
+// openaiShim test extraction seam 018 end
 
+
+// openaiShim test extraction seam 019 start: direct GitHub Copilot key wins over stale OpenAI key
 test('direct GitHub Copilot key wins over stale OpenAI key', async () => {
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
   process.env.GITHUB_COPILOT_KEY = 'enterprise-direct-key'
@@ -1942,7 +1939,10 @@ test('direct GitHub Copilot key wins over stale OpenAI key', async () => {
 
   expect(authorization).toBe('Bearer enterprise-direct-key')
 })
+// openaiShim test extraction seam 019 end
 
+
+// openaiShim test extraction seam 020 start: strips Anthropic-specific headers on GitHub Codex transport with providerOverride API key
 test('strips Anthropic-specific headers on GitHub Codex transport with providerOverride API key', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -1993,7 +1993,10 @@ test('strips Anthropic-specific headers on GitHub Codex transport with providerO
   expect(capturedHeaders?.get('authorization')).toBe('Bearer provider-override-key')
   expect(capturedHeaders?.get('editor-plugin-version')).toBe('copilot-chat/0.26.7')
 })
+// openaiShim test extraction seam 020 end
 
+
+// openaiShim test extraction seam 021 start: preserves usage from final OpenAI stream chunk with empty choices
 test('preserves usage from final OpenAI stream chunk with empty choices', async () => {
   globalThis.fetch = (async (_input, init) => {
     const url = typeof _input === 'string' ? _input : _input.url
@@ -2069,9 +2072,12 @@ test('preserves usage from final OpenAI stream chunk with empty choices', async 
   expect(usageEvent?.usage?.input_tokens).toBe(123)
   expect(usageEvent?.usage?.output_tokens).toBe(45)
 })
+// openaiShim test extraction seam 021 end
+
 
 // Extraction seam: stream conversion usage | shared stream control.
 
+// openaiShim test extraction seam 022 start: readWithIdleTimeout rejects quickly and cancels a stalled reader
 test('readWithIdleTimeout rejects quickly and cancels a stalled reader', async () => {
   const testApi = await getStreamIdleTestApi('stream-idle-helper')
   const cancelReasons: unknown[] = []
@@ -2095,7 +2101,10 @@ test('readWithIdleTimeout rejects quickly and cancels a stalled reader', async (
   expect(cancelReasons).toHaveLength(1)
   expect(cancelReasons[0]).toBeInstanceOf(testApi.StreamIdleTimeoutError)
 })
+// openaiShim test extraction seam 022 end
 
+
+// openaiShim test extraction seam 023 start: readWithIdleTimeout preserves parent abort instead of reporting idle timeout
 test('readWithIdleTimeout preserves parent abort instead of reporting idle timeout', async () => {
   const testApi = await getStreamIdleTestApi('stream-idle-user-abort')
   const parent = new AbortController()
@@ -2124,7 +2133,10 @@ test('readWithIdleTimeout preserves parent abort instead of reporting idle timeo
   expect(cancelReasons[0]).toBeInstanceOf(DOMException)
   expect((cancelReasons[0] as DOMException).name).toBe('AbortError')
 })
+// openaiShim test extraction seam 023 end
 
+
+// openaiShim test extraction seam 024 start: stream idle timeout env parser parses and bounds overrides
 test('stream idle timeout env parser parses and bounds overrides', async () => {
   const testApi = await getStreamIdleTestApi('stream-idle-env-parser')
 
@@ -2152,7 +2164,30 @@ test('stream idle timeout env parser parses and bounds overrides', async () => {
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '-5'
   expect(testApi.getStreamIdleTimeoutMs()).toBe(90_000)
 })
+// openaiShim test extraction seam 024 end
 
+test('API timeout env parser accepts safe positive integers and falls back otherwise', async () => {
+  const testApi = await getStreamIdleTestApi('api-timeout-env-parser')
+
+  delete process.env.API_TIMEOUT_MS
+  expect(testApi.getApiTimeoutMs()).toBe(600_000)
+
+  process.env.API_TIMEOUT_MS = '50'
+  expect(testApi.getApiTimeoutMs()).toBe(50)
+
+  process.env.API_TIMEOUT_MS = ' 50 '
+  expect(testApi.getApiTimeoutMs()).toBe(50)
+
+  process.env.API_TIMEOUT_MS = '3000000000'
+  expect(testApi.getApiTimeoutMs()).toBe(2_147_483_647)
+
+  for (const invalid of ['abc', '-5', '', '0', '1.5', '9007199254740993']) {
+    process.env.API_TIMEOUT_MS = invalid
+    expect(testApi.getApiTimeoutMs()).toBe(600_000)
+  }
+})
+
+// openaiShim test extraction seam 025 start: Anthropic-compatible passthrough stream rejects with idle timeout when it stalls
 test('Anthropic-compatible passthrough stream rejects with idle timeout when it stalls', async () => {
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '25'
   const stalled = makeStallingResponse(
@@ -2198,9 +2233,12 @@ test('Anthropic-compatible passthrough stream rejects with idle timeout when it 
   expect((caught as Error).name).toBe('StreamIdleTimeoutError')
   expect((stalled.cancelReasons[0] as Error).name).toBe('StreamIdleTimeoutError')
 })
+// openaiShim test extraction seam 025 end
+
 
 // Extraction seam: shared stream control | Gemini stream conversion.
 
+// openaiShim test extraction seam 026 start: Gemini SSE stream rejects with idle timeout when it stalls
 test('Gemini SSE stream rejects with idle timeout when it stalls', async () => {
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '25'
   const stalled = makeStallingResponse(
@@ -2243,7 +2281,10 @@ test('Gemini SSE stream rejects with idle timeout when it stalls', async () => {
   expect((caught as Error).name).toBe('StreamIdleTimeoutError')
   expect((stalled.cancelReasons[0] as Error).name).toBe('StreamIdleTimeoutError')
 })
+// openaiShim test extraction seam 026 end
 
+
+// openaiShim test extraction seam 027 start: OpenAI-compatible stream rejects with idle timeout when it stalls after a chunk
 test('OpenAI-compatible stream rejects with idle timeout when it stalls after a chunk', async () => {
   await getStreamIdleTestApi('stream-idle-openai-stall')
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '25'
@@ -2288,7 +2329,10 @@ test('OpenAI-compatible stream rejects with idle timeout when it stalls after a 
   })
   expect(textDeltas).toEqual(['partial'])
 })
+// openaiShim test extraction seam 027 end
 
+
+// openaiShim test extraction seam 028 start: OpenAI-compatible stream keeps slow active chunks alive under the idle timeout
 test('OpenAI-compatible stream keeps slow active chunks alive under the idle timeout', async () => {
   await getStreamIdleTestApi('stream-idle-openai-active')
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '500'
@@ -2390,7 +2434,10 @@ test('OpenAI-compatible stream keeps slow active chunks alive under the idle tim
   expect(Date.now() - startedAt).toBeGreaterThan(500)
   expect(textDeltas.join('')).toBe('hello')
 })
+// openaiShim test extraction seam 028 end
 
+
+// openaiShim test extraction seam 029 start: controller abort reaches generic OpenAI SSE converter
 test('controller abort reaches generic OpenAI SSE converter', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2423,7 +2470,10 @@ test('controller abort reaches generic OpenAI SSE converter', async () => {
     stalled.close()
   }
 })
+// openaiShim test extraction seam 029 end
 
+
+// openaiShim test extraction seam 030 start: controller abort cancels generic OpenAI SSE before iteration starts
 test('controller abort cancels generic OpenAI SSE before iteration starts', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2460,7 +2510,10 @@ test('controller abort cancels generic OpenAI SSE before iteration starts', asyn
     stalled.close()
   }
 })
+// openaiShim test extraction seam 030 end
 
+
+// openaiShim test extraction seam 031 start: controller abort cancels generic OpenAI SSE when paused after message_start
 test('controller abort cancels generic OpenAI SSE when paused after message_start', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2489,7 +2542,10 @@ test('controller abort cancels generic OpenAI SSE when paused after message_star
     stalled.close()
   }
 })
+// openaiShim test extraction seam 031 end
 
+
+// openaiShim test extraction seam 032 start: controller abort stops buffered generic OpenAI SSE events
 test('controller abort stops buffered generic OpenAI SSE events', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'first' }) +
@@ -2520,7 +2576,10 @@ test('controller abort stops buffered generic OpenAI SSE events', async () => {
     stalled.close()
   }
 })
+// openaiShim test extraction seam 032 end
 
+
+// openaiShim test extraction seam 033 start: controller abort reaches Anthropic messages SSE passthrough
 test('controller abort reaches Anthropic messages SSE passthrough', async () => {
   const stalled = makeStallingResponse(
     `data: ${JSON.stringify({
@@ -2566,7 +2625,10 @@ test('controller abort reaches Anthropic messages SSE passthrough', async () => 
     stalled.close()
   }
 })
+// openaiShim test extraction seam 033 end
 
+
+// openaiShim test extraction seam 034 start: controller abort cancels Anthropic messages SSE when paused after event
 test('controller abort cancels Anthropic messages SSE when paused after event', async () => {
   const stalled = makeStallingResponse(
     `data: ${JSON.stringify({
@@ -2608,7 +2670,10 @@ test('controller abort cancels Anthropic messages SSE when paused after event', 
     stalled.close()
   }
 })
+// openaiShim test extraction seam 034 end
 
+
+// openaiShim test extraction seam 035 start: controller abort stops buffered Anthropic messages SSE events
 test('controller abort stops buffered Anthropic messages SSE events', async () => {
   const stalled = makeStallingResponse(
     [
@@ -2680,7 +2745,10 @@ test('controller abort stops buffered Anthropic messages SSE events', async () =
     stalled.close()
   }
 })
+// openaiShim test extraction seam 035 end
 
+
+// openaiShim test extraction seam 036 start: parent signal abort still reaches OpenAI SSE converter
 test('parent signal abort still reaches OpenAI SSE converter', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2717,7 +2785,10 @@ test('parent signal abort still reaches OpenAI SSE converter', async () => {
     stalled.close()
   }
 })
+// openaiShim test extraction seam 036 end
 
+
+// openaiShim test extraction seam 037 start: parent signal abort cancels OpenAI SSE before iteration starts
 test('parent signal abort cancels OpenAI SSE before iteration starts', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2758,7 +2829,10 @@ test('parent signal abort cancels OpenAI SSE before iteration starts', async () 
     stalled.close()
   }
 })
+// openaiShim test extraction seam 037 end
 
+
+// openaiShim test extraction seam 038 start: controller abort reaches Codex responses stream converter
 test('controller abort reaches Codex responses stream converter', async () => {
   const stalled = makeStallingResponse(
     `event: response.output_text.delta\ndata: ${JSON.stringify({ delta: 'partial' })}\n\n`,
@@ -2792,7 +2866,10 @@ test('controller abort reaches Codex responses stream converter', async () => {
     stalled.close()
   }
 })
+// openaiShim test extraction seam 038 end
 
+
+// openaiShim test extraction seam 039 start: controller abort cancels Codex responses stream when paused after message_start
 test('controller abort cancels Codex responses stream when paused after message_start', async () => {
   const stalled = makeStallingResponse(
     `event: response.output_text.delta\ndata: ${JSON.stringify({ delta: 'partial' })}\n\n`,
@@ -2822,7 +2899,10 @@ test('controller abort cancels Codex responses stream when paused after message_
     stalled.close()
   }
 })
+// openaiShim test extraction seam 039 end
 
+
+// openaiShim test extraction seam 040 start: controller abort reaches Gemini SSE converter
 test('controller abort reaches Gemini SSE converter', async () => {
   const stalled = makeStallingResponse(
     `data: ${JSON.stringify({
@@ -2865,7 +2945,10 @@ test('controller abort reaches Gemini SSE converter', async () => {
     stalled.close()
   }
 })
+// openaiShim test extraction seam 040 end
 
+
+// openaiShim test extraction seam 041 start: controller abort stops buffered Gemini SSE events
 test('controller abort stops buffered Gemini SSE events', async () => {
   const makeGeminiFrame = (text: string) =>
     `data: ${JSON.stringify({
@@ -2907,9 +2990,12 @@ test('controller abort stops buffered Gemini SSE events', async () => {
     stalled.close()
   }
 })
+// openaiShim test extraction seam 041 end
+
 
 // Extraction seam: Gemini stream conversion | native Ollama stream adaptation.
 
+// openaiShim test extraction seam 042 start: controller abort reaches native Ollama converted stream
 test('controller abort reaches native Ollama converted stream', async () => {
   const previousBaseUrl = process.env.OPENAI_BASE_URL
   let stalled: StallingResponse | undefined
@@ -2954,7 +3040,10 @@ test('controller abort reaches native Ollama converted stream', async () => {
     restoreEnv('OPENAI_BASE_URL', previousBaseUrl)
   }
 })
+// openaiShim test extraction seam 042 end
 
+
+// openaiShim test extraction seam 043 start: normal OpenAI SSE stream still completes after controller wiring
 test('normal OpenAI SSE stream still completes after controller wiring', async () => {
   globalThis.fetch = (async () =>
     makeSseResponse(makeStreamChunks([
@@ -3005,7 +3094,10 @@ test('normal OpenAI SSE stream still completes after controller wiring', async (
   expect(textDeltas.join('')).toBe('complete')
   expect((result.data as unknown as ShimStream).controller.signal.aborted).toBe(false)
 })
+// openaiShim test extraction seam 043 end
 
+
+// openaiShim test extraction seam 044 start: uses max_tokens instead of max_completion_tokens for local providers
 test('uses max_tokens instead of max_completion_tokens for local providers', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
@@ -3044,6 +3136,7 @@ test('uses max_tokens instead of max_completion_tokens for local providers', asy
     stream: false,
   })
 })
+// openaiShim test extraction seam 044 end
 
 test('does not send stream_options to local OpenAI-compatible servers', async () => {
   process.env.OPENAI_BASE_URL = 'http://127.0.0.1:8000/v1'
@@ -3066,6 +3159,7 @@ test('does not send stream_options to local OpenAI-compatible servers', async ()
   })
 })
 
+// openaiShim test extraction seam 045 start: keeps max_completion_tokens for non-local non-github providers
 test('keeps max_completion_tokens for non-local non-github providers', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
 
@@ -3110,7 +3204,10 @@ test('keeps max_completion_tokens for non-local non-github providers', async () 
     stream: false,
   })
 })
+// openaiShim test extraction seam 045 end
 
+
+// openaiShim test extraction seam 046 start: uses route-specific credential env vars for descriptor-backed openai-compatible routes
 test('uses route-specific credential env vars for descriptor-backed openai-compatible routes', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -3160,178 +3257,20 @@ test('uses route-specific credential env vars for descriptor-backed openai-compa
 
   expect(capturedHeaders?.get('authorization')).toBe('Bearer or-route-key')
 })
+// openaiShim test extraction seam 046 end
 
-test('preserves Gemini tool call extra_content in follow-up requests', async () => {
-  let requestBody: Record<string, unknown> | undefined
 
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
+// openaiShim test extraction seam 047 start: preserves Gemini tool call extra_content in follow-up requests
 
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'google/gemini-3.1-pro-preview',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: 'done',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 12,
-          completion_tokens: 4,
-          total_tokens: 16,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
+// openaiShim test extraction seam 047 end
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
 
-  await client.beta.messages.create({
-    model: 'google/gemini-3.1-pro-preview',
-    system: 'test system',
-    messages: [
-      { role: 'user', content: 'Use Bash' },
-      {
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool_use',
-            id: 'call_1',
-            name: 'Bash',
-            input: { command: 'pwd' },
-            extra_content: {
-              google: {
-                thought_signature: 'sig-123',
-              },
-            },
-          },
-        ],
-      },
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'tool_result',
-            tool_use_id: 'call_1',
-            content: 'D:\\repo',
-          },
-        ],
-      },
-    ],
-    max_tokens: 64,
-    stream: false,
-  })
+// openaiShim test extraction seam 048 start: replays Gemini tool signatures for OpenGateway Gemini models
 
-  const assistantWithToolCall = (requestBody?.messages as Array<Record<string, unknown>>).find(
-    message => Array.isArray(message.tool_calls),
-  ) as { tool_calls?: Array<Record<string, unknown>> } | undefined
+// openaiShim test extraction seam 048 end
 
-  expect(assistantWithToolCall?.tool_calls?.[0]).toMatchObject({
-    id: 'call_1',
-    type: 'function',
-    function: {
-      name: 'Bash',
-      arguments: JSON.stringify({ command: 'pwd' }),
-    },
-    extra_content: {
-      google: {
-        thought_signature: 'sig-123',
-      },
-    },
-  })
-})
 
-test('replays Gemini tool signatures for OpenGateway Gemini models', async () => {
-  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
-  let requestBody: Record<string, unknown> | undefined
-
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
-
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'google/gemini-3.1-flash-lite',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: 'done',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 12,
-          completion_tokens: 4,
-          total_tokens: 16,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  await client.beta.messages.create({
-    model: 'google/gemini-3.1-flash-lite',
-    messages: [
-      { role: 'user', content: 'Use Write' },
-      {
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool_use',
-            id: 'call_1',
-            name: 'Write',
-            input: { file_path: 'todo.md', content: 'todo' },
-            signature: 'sig-opengateway',
-          },
-        ],
-      },
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'tool_result',
-            tool_use_id: 'call_1',
-            content: 'created',
-          },
-        ],
-      },
-    ],
-    max_tokens: 64,
-    stream: false,
-  })
-
-  const assistantWithToolCall = (requestBody?.messages as Array<Record<string, unknown>>).find(
-    message => Array.isArray(message.tool_calls),
-  ) as { tool_calls?: Array<Record<string, unknown>> } | undefined
-
-  expect(assistantWithToolCall?.tool_calls?.[0]).toMatchObject({
-    id: 'call_1',
-    extra_content: {
-      google: {
-        thought_signature: 'sig-opengateway',
-      },
-    },
-  })
-})
-
+// openaiShim test extraction seam 049 start: OpenGateway MiMo replays real reasoning_content without adding empty fallback
 test('OpenGateway MiMo replays real reasoning_content without adding empty fallback', async () => {
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
   process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
@@ -3412,7 +3351,10 @@ test('OpenGateway MiMo replays real reasoning_content without adding empty fallb
   )
   expect(requestBody).not.toHaveProperty('store')
 })
+// openaiShim test extraction seam 049 end
 
+
+// openaiShim test extraction seam 050 start: Xiaomi MiMo replays real reasoning_content without adding empty fallback
 test('Xiaomi MiMo replays real reasoning_content without adding empty fallback', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.xiaomimimo.com/v1'
   process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
@@ -3495,7 +3437,10 @@ test('Xiaomi MiMo replays real reasoning_content without adding empty fallback',
   )
   expect(requestBody).not.toHaveProperty('store')
 })
+// openaiShim test extraction seam 050 end
 
+
+// openaiShim test extraction seam 051 start: OpenGateway MiMo does not synthesize empty reasoning_content when missing
 test('OpenGateway MiMo does not synthesize empty reasoning_content when missing', async () => {
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
   process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
@@ -3570,7 +3515,10 @@ test('OpenGateway MiMo does not synthesize empty reasoning_content when missing'
   expect(assistantWithToolCall).not.toHaveProperty('reasoning_content')
   expect(requestBody).not.toHaveProperty('store')
 })
+// openaiShim test extraction seam 051 end
 
+
+// openaiShim test extraction seam 052 start: strips unsupported stream_options for Xiaomi MiMo streams
 test('strips unsupported stream_options for Xiaomi MiMo streams', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.xiaomimimo.com/v1'
   process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
@@ -3627,131 +3575,28 @@ test('strips unsupported stream_options for Xiaomi MiMo streams', async () => {
   expect(requestBody).not.toHaveProperty('stream_options')
   expect(requestBody).not.toHaveProperty('store')
 })
+// openaiShim test extraction seam 052 end
 
-test('preserves Grep tool pattern field in OpenAI-compatible schemas', async () => {
-  let requestBody: Record<string, unknown> | undefined
 
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
+// openaiShim test extraction seam 053 start: preserves Grep tool pattern field in OpenAI-compatible schemas
 
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-grep-schema',
-        model: 'qwen/qwen3.6-plus',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: 'done',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 12,
-          completion_tokens: 4,
-          total_tokens: 16,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
+// openaiShim test extraction seam 053 end
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
 
-  await client.beta.messages.create({
-    model: 'qwen/qwen3.6-plus',
-    system: 'test system',
-    messages: [{ role: 'user', content: 'Use Grep' }],
-    tools: [
-      {
-        name: 'Grep',
-        description: 'Search file contents',
-        input_schema: {
-          type: 'object',
-          properties: {
-            pattern: { type: 'string', description: 'Search pattern' },
-            path: { type: 'string' },
-          },
-          required: ['pattern'],
-          additionalProperties: false,
-        },
-      },
-    ],
-    max_tokens: 64,
-    stream: false,
-  })
+// openaiShim test extraction seam 054 start: does not infer Gemini mode from OPENAI_BASE_URL path substrings
 
-  const tools = requestBody?.tools as Array<Record<string, unknown>> | undefined
-  const grepTool = tools?.find(tool => (tool.function as Record<string, unknown>)?.name === 'Grep') as
-    | { function?: { parameters?: { properties?: Record<string, unknown>; required?: string[] } } }
-    | undefined
+// openaiShim test extraction seam 054 end
 
-  expect(Object.keys(grepTool?.function?.parameters?.properties ?? {})).toContain('pattern')
-  expect(grepTool?.function?.parameters?.required).toContain('pattern')
-})
 
-test('does not infer Gemini mode from OPENAI_BASE_URL path substrings', async () => {
-  let capturedAuthorization: string | null = null
-
-  process.env.OPENAI_BASE_URL =
-    'https://evil.example/generativelanguage.googleapis.com/v1beta/openai'
-  delete process.env.OPENAI_API_KEY
-  process.env.GEMINI_API_KEY = 'gemini-secret'
-
-  globalThis.fetch = (async (_input, init) => {
-    const headers = init?.headers as Record<string, string> | undefined
-    capturedAuthorization =
-      headers?.Authorization ?? headers?.authorization ?? null
-
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'fake-model',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: 'ok',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 12,
-          completion_tokens: 4,
-          total_tokens: 16,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  await client.beta.messages.create({
-    model: 'fake-model',
-    messages: [{ role: 'user', content: 'hello' }],
-    max_tokens: 64,
-    stream: false,
-  })
-
-  expect(capturedAuthorization).toBeNull()
-})
-
+// openaiShim test extraction seam 055 start: the OpenAI shim façade exposes the beta.messages namespace
 test('the OpenAI shim façade exposes the beta.messages namespace', () => {
   const client = createOpenAIShimClient({}) as OpenAIShimClient
   expect(client.beta.messages).toBeDefined()
 })
+// openaiShim test extraction seam 055 end
 
+
+// openaiShim test extraction seam 056 start: preserves image tool results as placeholders in follow-up requests
 test('preserves image tool results as placeholders in follow-up requests', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -3854,7 +3699,10 @@ test('preserves image tool results as placeholders in follow-up requests', async
     },
   ])
 })
+// openaiShim test extraction seam 056 end
 
+
+// openaiShim test extraction seam 057 start: adds text part for image-only user messages
 test('adds text part for image-only user messages', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -3930,7 +3778,10 @@ test('adds text part for image-only user messages', async () => {
     },
   ])
 })
+// openaiShim test extraction seam 057 end
 
+
+// openaiShim test extraction seam 058 start: preserves mixed text and image tool results as multipart content
 test('preserves mixed text and image tool results as multipart content', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -4025,7 +3876,10 @@ test('preserves mixed text and image tool results as multipart content', async (
     image_url: { url: 'data:image/png;base64,ZmFrZQ==' },
   })
 })
+// openaiShim test extraction seam 058 end
 
+
+// openaiShim test extraction seam 059 start: uses GEMINI_ACCESS_TOKEN for Gemini OpenAI-compatible requests
 test('uses GEMINI_ACCESS_TOKEN for Gemini OpenAI-compatible requests', async () => {
   let capturedAuthorization: string | null = null
   let capturedProject: string | null = null
@@ -4097,7 +3951,10 @@ test('uses GEMINI_ACCESS_TOKEN for Gemini OpenAI-compatible requests', async () 
   expect<string | null>(capturedAuthorization).toBe('Bearer gemini-access-token')
   expect<string | null>(capturedProject).toBe('gemini-project')
 })
+// openaiShim test extraction seam 059 end
 
+
+// openaiShim test extraction seam 060 start: uses NVIDIA_API_KEY for NVIDIA NIM requests without OPENAI_API_KEY
 test('uses NVIDIA_API_KEY for NVIDIA NIM requests without OPENAI_API_KEY', async () => {
   let capturedAuthorization: string | null = null
 
@@ -4151,7 +4008,10 @@ test('uses NVIDIA_API_KEY for NVIDIA NIM requests without OPENAI_API_KEY', async
 
   expect<string | null>(capturedAuthorization).toBe('Bearer nvidia-live-key')
 })
+// openaiShim test extraction seam 060 end
 
+
+// openaiShim test extraction seam 061 start: does not use stale NVIDIA_API_KEY for non-NVIDIA OpenAI-compatible routes
 test('does not use stale NVIDIA_API_KEY for non-NVIDIA OpenAI-compatible routes', async () => {
   let capturedAuthorization: string | null = null
 
@@ -4201,7 +4061,10 @@ test('does not use stale NVIDIA_API_KEY for non-NVIDIA OpenAI-compatible routes'
 
   expect(capturedAuthorization).toBeNull()
 })
+// openaiShim test extraction seam 061 end
 
+
+// openaiShim test extraction seam 062 start: does not use MINIMAX_API_KEY for non-MiniMax OpenAI-compatible routes
 test('does not use MINIMAX_API_KEY for non-MiniMax OpenAI-compatible routes', async () => {
   let capturedAuthorization: string | null = null
 
@@ -4250,7 +4113,10 @@ test('does not use MINIMAX_API_KEY for non-MiniMax OpenAI-compatible routes', as
 
   expect(capturedAuthorization).toBeNull()
 })
+// openaiShim test extraction seam 062 end
 
+
+// openaiShim test extraction seam 063 start: xiaomi mimo route uses api-key auth header and max_completion_tokens
 test('xiaomi mimo route uses api-key auth header and max_completion_tokens', async () => {
   let capturedHeaders: Record<string, string> | undefined
   let capturedBody: Record<string, unknown> | undefined
@@ -4301,6 +4167,9 @@ test('xiaomi mimo route uses api-key auth header and max_completion_tokens', asy
   expect(capturedBody).toMatchObject({ max_completion_tokens: 32 })
   expect(capturedBody).not.toHaveProperty('max_tokens')
 })
+// openaiShim test extraction seam 063 end
+
+// openaiShim test extraction seam 064 start: xiaomi mimo token plan uses raw api-key and OpenAI-compatible reasoning_effort
 test('xiaomi mimo token plan uses raw api-key and OpenAI-compatible reasoning_effort', async () => {
   let capturedHeaders: Record<string, string> | undefined
   let capturedBody: Record<string, unknown> | undefined
@@ -4339,6 +4208,8 @@ test('xiaomi mimo token plan uses raw api-key and OpenAI-compatible reasoning_ef
   expect(capturedBody).not.toHaveProperty('store')
   expect(capturedBody).not.toHaveProperty('stream_options')
 })
+// openaiShim test extraction seam 064 end
+
 
 test.each([
   'minimax-m3',
@@ -4421,6 +4292,7 @@ test.each([
   expect(capturedBody).not.toHaveProperty('store')
 })
 
+// openaiShim test extraction seam 065 start: opencode go messages endpoint rotates raw x-api-key credentials after rate-limit failure
 test('opencode go messages endpoint rotates raw x-api-key credentials after rate-limit failure', async () => {
   const capturedUrls: string[] = []
   const capturedKeys: Array<string | null> = []
@@ -4481,7 +4353,10 @@ test('opencode go messages endpoint rotates raw x-api-key credentials after rate
   ])
   expect(capturedKeys).toEqual(['fake-opencode-a', 'fake-opencode-b'])
 })
+// openaiShim test extraction seam 065 end
 
+
+// openaiShim test extraction seam 066 start: gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY as bearer auth despite stale generic base URL
 test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY as bearer auth despite stale generic base URL', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_MODEL = 'gpt-5.5'
@@ -4496,7 +4371,10 @@ test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY as bearer auth
   expect(captured.url).toBe('https://opengateway.gitlawb.com/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
+// openaiShim test extraction seam 066 end
 
+
+// openaiShim test extraction seam 067 start: gitlawb opengateway provider flag accepts OPENAI_API_KEY compatibility fallback
 test('gitlawb opengateway provider flag accepts OPENAI_API_KEY compatibility fallback', async () => {
   delete process.env.OPENAI_BASE_URL
   delete process.env.OPENGATEWAY_API_KEY
@@ -4509,7 +4387,10 @@ test('gitlawb opengateway provider flag accepts OPENAI_API_KEY compatibility fal
 
   expect(captured.authorization).toBe('Bearer fake-openai-fallback')
 })
+// openaiShim test extraction seam 067 end
 
+
+// openaiShim test extraction seam 068 start: gitlawb opengateway provider flag sends OPENAI_API_KEY fallback despite stale generic base URL
 test('gitlawb opengateway provider flag sends OPENAI_API_KEY fallback despite stale generic base URL', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'fake-openai-fallback'
@@ -4523,7 +4404,10 @@ test('gitlawb opengateway provider flag sends OPENAI_API_KEY fallback despite st
   expect(captured.url).toBe('https://opengateway.gitlawb.com/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-openai-fallback')
 })
+// openaiShim test extraction seam 068 end
 
+
+// openaiShim test extraction seam 069 start: gitlawb opengateway provider flag trims OPENGATEWAY_API_KEY before bearer auth
 test('gitlawb opengateway provider flag trims OPENGATEWAY_API_KEY before bearer auth', async () => {
   process.env.OPENGATEWAY_API_KEY = ' fake-ogw-key '
   delete process.env.OPENAI_API_KEY
@@ -4535,7 +4419,10 @@ test('gitlawb opengateway provider flag trims OPENGATEWAY_API_KEY before bearer 
 
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
+// openaiShim test extraction seam 069 end
 
+
+// openaiShim test extraction seam 070 start: gitlawb opengateway provider flag ignores blank OPENGATEWAY_API_KEY and uses OPENAI_API_KEY fallback
 test('gitlawb opengateway provider flag ignores blank OPENGATEWAY_API_KEY and uses OPENAI_API_KEY fallback', async () => {
   process.env.OPENGATEWAY_API_KEY = '   '
   process.env.OPENAI_API_KEY = 'fake-openai-fallback'
@@ -4547,7 +4434,10 @@ test('gitlawb opengateway provider flag ignores blank OPENGATEWAY_API_KEY and us
 
   expect(captured.authorization).toBe('Bearer fake-openai-fallback')
 })
+// openaiShim test extraction seam 070 end
 
+
+// openaiShim test extraction seam 071 start: gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to OPENGATEWAY_BASE_URL override
 test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to OPENGATEWAY_BASE_URL override', async () => {
   process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
@@ -4561,7 +4451,10 @@ test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to OPENGATEWAY
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
+// openaiShim test extraction seam 071 end
 
+
+// openaiShim test extraction seam 072 start: gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to custom OPENAI_BASE_URL fallback
 test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to custom OPENAI_BASE_URL fallback', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
@@ -4576,7 +4469,10 @@ test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to custom OPEN
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
+// openaiShim test extraction seam 072 end
 
+
+// openaiShim test extraction seam 073 start: gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEY for custom base URL
 test('gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEY for custom base URL', async () => {
   process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
@@ -4590,7 +4486,10 @@ test('gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
+// openaiShim test extraction seam 073 end
 
+
+// openaiShim test extraction seam 074 start: gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEYS pool
 test('gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEYS pool', async () => {
   process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
@@ -4605,7 +4504,200 @@ test('gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
+// openaiShim test extraction seam 074 end
 
+test('longcat provider flag prefers LONGCAT_API_KEY over generic OPENAI_API_KEYS pool', async () => {
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  process.env.OPENAI_API_KEYS = 'fake-openai-pool-a,fake-openai-pool-b'
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_API_KEY
+
+  const result = applyProviderFlag('longcat', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
+  expect(captured.authorization).toBe('Bearer fake-longcat-key')
+})
+
+test('longcat provider flag strips unsupported tool definitions', async () => {
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+    return makeChatCompletionResponse('LongCat-2.0')
+  }) as unknown as FetchType
+
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_API_KEY
+
+  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'LongCat-2.0',
+    messages: [
+      { role: 'user', content: 'List files' },
+    ],
+    tools: [{
+      name: 'Bash',
+      description: 'Run a shell command',
+      input_schema: {
+        type: 'object',
+        properties: { command: { type: 'string' } },
+        required: ['command'],
+      },
+    }],
+    max_tokens: 32,
+    stream: false,
+  })
+
+  expect(requestBody?.tools).toBeUndefined()
+})
+
+test('longcat rejects image input before dispatch', async () => {
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_API_KEY
+
+  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await expect(client.beta.messages.create({
+    model: 'LongCat-2.0',
+    messages: [{
+      role: 'user',
+      content: [
+        { type: 'text', text: 'Describe this image.' },
+        { type: 'image', source: { type: 'url', url: 'https://example.com/image.png' } },
+      ],
+    }],
+    max_tokens: 32,
+    stream: false,
+  })).rejects.toThrow('does not support image inputs')
+})
+
+test('longcat rejects image tool results before dispatch', async () => {
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_API_KEY
+  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await expect(client.beta.messages.create({
+    model: 'LongCat-2.0',
+    messages: [
+      { role: 'user', content: 'Inspect the screenshot' },
+      { role: 'assistant', content: [{ type: 'tool_use', id: 'call_screenshot', name: 'Screenshot', input: {} }] },
+      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_screenshot', content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'aGVsbG8=' } }] }] },
+    ],
+    tools: [{ name: 'Screenshot', description: 'Capture a screenshot', input_schema: { type: 'object', properties: {} } }],
+    max_tokens: 32,
+    stream: false,
+  })).rejects.toThrow('does not support image inputs')
+})
+
+test('longcat accepts the documented bare OpenAI SDK base URL', async () => {
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai'
+  delete process.env.OPENAI_API_KEY
+
+  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
+  expect(captured.authorization).toBe('Bearer fake-longcat-key')
+})
+
+test('longcat accepts the documented bare OpenAI SDK base URL with a trailing slash', async () => {
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/'
+  delete process.env.OPENAI_API_KEY
+
+  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
+  expect(captured.authorization).toBe('Bearer fake-longcat-key')
+})
+
+test('longcat does not append chat completions to a configured endpoint URL', async () => {
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/v1/chat/completions'
+  delete process.env.OPENAI_API_KEY
+
+  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
+  expect(captured.authorization).toBe('Bearer fake-longcat-key')
+})
+
+test('longcat normalizes a configured endpoint URL with a trailing slash', async () => {
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/v1/chat/completions/'
+  delete process.env.OPENAI_API_KEY
+
+  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
+  const captured = await captureChatCompletionRequest()
+  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
+})
+
+test('longcat accepts the documented CodeBuddy endpoint URL', async () => {
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/chat/completions'
+  delete process.env.OPENAI_API_KEY
+
+  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
+  const captured = await captureChatCompletionRequest()
+  expect(captured.url).toBe('https://api.longcat.chat/openai/chat/completions')
+})
+
+test('longcat prefers its dedicated credential over a copied key from another provider', async () => {
+  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
+  process.env.MIMO_API_KEY = 'fake-mimo-key'
+  process.env.OPENAI_API_KEY = 'fake-mimo-key'
+  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/v1'
+
+  const captured = await captureChatCompletionRequest('LongCat-2.0')
+
+  expect(captured.authorization).toBe('Bearer fake-longcat-key')
+})
+
+test('longcat provider flag never falls back to an OPENAI_API_KEYS pool', async () => {
+  process.env.OPENAI_API_KEYS = 'other-provider-secret'
+  delete process.env.LONGCAT_API_KEY
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.OPENAI_API_KEY
+
+  const result = applyProviderFlag('longcat', [])
+  expect(result.error).toBeUndefined()
+
+  const captured = await captureChatCompletionRequest()
+
+  expect(captured.authorization).not.toBe('Bearer other-provider-secret')
+})
+
+test('dedicated-only ClinePass route never falls back to generic OpenAI credentials', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.cline.bot/api/v1'
+  process.env.OPENAI_MODEL = 'cline-pass/deepseek-v4-flash'
+  process.env.OPENAI_API_KEY = 'generic-openai-key'
+  process.env.OPENAI_API_KEYS = 'generic-openai-pool-a,generic-openai-pool-b'
+  delete process.env.CLINE_API_KEY
+
+  const captured = await captureChatCompletionRequest(
+    'cline-pass/deepseek-v4-flash',
+  )
+
+  expect(captured.authorization).toBeNull()
+})
+
+// openaiShim test extraction seam 075 start: gitlawb opengateway provider flag uses generic OPENAI_API_KEYS pool before generic OPENAI_API_KEY fallback
 test('gitlawb opengateway provider flag uses generic OPENAI_API_KEYS pool before generic OPENAI_API_KEY fallback', async () => {
   process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENAI_API_KEYS = 'fake-openai-pool-a,fake-openai-pool-b'
@@ -4620,7 +4712,10 @@ test('gitlawb opengateway provider flag uses generic OPENAI_API_KEYS pool before
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-openai-pool-a')
 })
+// openaiShim test extraction seam 075 end
 
+
+// openaiShim test extraction seam 076 start: gitlawb opengateway stored provider profile key becomes bearer auth
 test('gitlawb opengateway stored provider profile key becomes bearer auth', async () => {
   delete process.env.OPENAI_API_KEY
   delete process.env.OPENGATEWAY_API_KEY
@@ -4638,7 +4733,10 @@ test('gitlawb opengateway stored provider profile key becomes bearer auth', asyn
 
   expect(captured.authorization).toBe('Bearer fake-profile-key')
 })
+// openaiShim test extraction seam 076 end
 
+
+// openaiShim test extraction seam 077 start: openai route still sends OPENAI_API_KEY as bearer auth
 test('openai route still sends OPENAI_API_KEY as bearer auth', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
@@ -4650,7 +4748,10 @@ test('openai route still sends OPENAI_API_KEY as bearer auth', async () => {
 
   expect(captured.authorization).toBe('Bearer fake-openai-key')
 })
+// openaiShim test extraction seam 077 end
 
+
+// openaiShim test extraction seam 078 start: OPENAI_API_KEYS rejects placeholder values before sending requests
 test('OPENAI_API_KEYS rejects placeholder values before sending requests', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4678,6 +4779,9 @@ test('OPENAI_API_KEYS rejects placeholder values before sending requests', async
 
   expect(authorizations).toEqual([])
 })
+// openaiShim test extraction seam 078 end
+
+// openaiShim test extraction seam 079 start: OPENAI_API_KEYS rotates to the next key on rate-limit failure
 test('OPENAI_API_KEYS rotates to the next key on rate-limit failure', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4711,7 +4815,10 @@ test('OPENAI_API_KEYS rotates to the next key on rate-limit failure', async () =
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
+// openaiShim test extraction seam 079 end
 
+
+// openaiShim test extraction seam 080 start: OPENAI_API_KEYS does not reuse a cooled-down key after every key is rate-limited
 test('OPENAI_API_KEYS does not reuse a cooled-down key after every key is rate-limited', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4742,7 +4849,10 @@ test('OPENAI_API_KEYS does not reuse a cooled-down key after every key is rate-l
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
+// openaiShim test extraction seam 080 end
 
+
+// openaiShim test extraction seam 081 start: comma-separated OPENAI_API_KEY rotates to the next key on rate-limit failure
 test('comma-separated OPENAI_API_KEY rotates to the next key on rate-limit failure', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4776,7 +4886,10 @@ test('comma-separated OPENAI_API_KEY rotates to the next key on rate-limit failu
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
+// openaiShim test extraction seam 081 end
 
+
+// openaiShim test extraction seam 082 start: OPENAI_API_KEYS does not rotate through pool on provider 5xx outage
 test('OPENAI_API_KEYS does not rotate through pool on provider 5xx outage', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4808,6 +4921,9 @@ test('OPENAI_API_KEYS does not rotate through pool on provider 5xx outage', asyn
 
   expect(authorizations).toEqual(['Bearer key-a'])
 })
+// openaiShim test extraction seam 082 end
+
+// openaiShim test extraction seam 083 start: OPENAI_API_KEYS preserves cooldown state across client requests
 test('OPENAI_API_KEYS preserves cooldown state across client requests', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4846,7 +4962,10 @@ test('OPENAI_API_KEYS preserves cooldown state across client requests', async ()
     'Bearer key-b',
   ])
 })
+// openaiShim test extraction seam 083 end
 
+
+// openaiShim test extraction seam 084 start: OPENAI_API_KEYS rotates Azure api-key auth on auth failure
 test('OPENAI_API_KEYS rotates Azure api-key auth on auth failure', async () => {
   const apiKeys: Array<string | null> = []
 
@@ -4879,7 +4998,10 @@ test('OPENAI_API_KEYS rotates Azure api-key auth on auth failure', async () => {
 
   expect(apiKeys).toEqual(['azure-key-a', 'azure-key-b'])
 })
+// openaiShim test extraction seam 084 end
 
+
+// openaiShim test extraction seam 085 start: OPENAI_API_KEYS does not reuse auth-disabled credentials across client requests
 test('OPENAI_API_KEYS does not reuse auth-disabled credentials across client requests', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4920,7 +5042,10 @@ test('OPENAI_API_KEYS does not reuse auth-disabled credentials across client req
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
+// openaiShim test extraction seam 085 end
 
+
+// openaiShim test extraction seam 086 start: OPENAI_API_KEYS permanently evicts 403 auth failures
 test('OPENAI_API_KEYS permanently evicts 403 auth failures', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4961,6 +5086,9 @@ test('OPENAI_API_KEYS permanently evicts 403 auth failures', async () => {
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
+// openaiShim test extraction seam 086 end
+
+// openaiShim test extraction seam 087 start: does not use BNKR_API_KEY for non-Bankr OpenAI-compatible routes
 test('does not use BNKR_API_KEY for non-Bankr OpenAI-compatible routes', async () => {
   let capturedAuthorization: string | null = null
 
@@ -5009,250 +5137,27 @@ test('does not use BNKR_API_KEY for non-Bankr OpenAI-compatible routes', async (
 
   expect(capturedAuthorization).toBeNull()
 })
+// openaiShim test extraction seam 087 end
 
-test('preserves Gemini tool call extra_content from streaming chunks', async () => {
-  globalThis.fetch = (async (_input, _init) => {
-    const chunks = makeStreamChunks([
-      {
-        id: 'chatcmpl-1',
-        object: 'chat.completion.chunk',
-        model: 'google/gemini-3.1-pro-preview',
-        choices: [
-          {
-            index: 0,
-            delta: {
-              role: 'assistant',
-              tool_calls: [
-                {
-                  index: 0,
-                  id: 'function-call-1',
-                  type: 'function',
-                  extra_content: {
-                    google: {
-                      thought_signature: 'sig-stream',
-                    },
-                  },
-                  function: {
-                    name: 'Bash',
-                    arguments: '{"command":"pwd"}',
-                  },
-                },
-              ],
-            },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-1',
-        object: 'chat.completion.chunk',
-        model: 'google/gemini-3.1-pro-preview',
-        choices: [
-          {
-            index: 0,
-            delta: {},
-            finish_reason: 'tool_calls',
-          },
-        ],
-      },
-    ])
 
-    return makeSseResponse(chunks)
-  }) as unknown as FetchType
+// openaiShim test extraction seam 088 start: preserves Gemini tool call extra_content from streaming chunks
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
+// openaiShim test extraction seam 088 end
 
-  const result = await client.beta.messages
-    .create({
-      model: 'google/gemini-3.1-pro-preview',
-      system: 'test system',
-      messages: [{ role: 'user', content: 'Use Bash' }],
-      max_tokens: 64,
-      stream: true,
-    })
-    .withResponse()
 
-  const events: Array<Record<string, unknown>> = []
-  for await (const event of result.data) {
-    events.push(event)
-  }
+// openaiShim test extraction seam 089 start: preserves Gemini thought signature from streaming delta extra_content
 
-  const toolStart = events.find(
-    event =>
-      event.type === 'content_block_start' &&
-      typeof event.content_block === 'object' &&
-      event.content_block !== null &&
-      (event.content_block as Record<string, unknown>).type === 'tool_use',
-  ) as { content_block?: Record<string, unknown> } | undefined
+// openaiShim test extraction seam 089 end
 
-  expect(toolStart?.content_block).toMatchObject({
-    type: 'tool_use',
-    id: 'function-call-1',
-    name: 'Bash',
-    extra_content: {
-      google: {
-        thought_signature: 'sig-stream',
-      },
-    },
-  })
-})
 
-test('preserves Gemini thought signature from streaming delta extra_content', async () => {
-  globalThis.fetch = (async (_input, _init) => {
-    const chunks = makeStreamChunks([
-      {
-        id: 'chatcmpl-1',
-        object: 'chat.completion.chunk',
-        model: 'google/gemini-3.1-flash-lite',
-        choices: [
-          {
-            index: 0,
-            delta: {
-              role: 'assistant',
-              extra_content: {
-                google: {
-                  thought_signature: 'sig-delta',
-                },
-              },
-              tool_calls: [
-                {
-                  index: 0,
-                  id: 'function-call-1',
-                  type: 'function',
-                  function: {
-                    name: 'Write',
-                    arguments: '{"file_path":"todo.md","content":"todo"}',
-                  },
-                },
-              ],
-            },
-            finish_reason: null,
-          },
-        ],
-      },
-      {
-        id: 'chatcmpl-1',
-        object: 'chat.completion.chunk',
-        model: 'google/gemini-3.1-flash-lite',
-        choices: [
-          {
-            index: 0,
-            delta: {},
-            finish_reason: 'tool_calls',
-          },
-        ],
-      },
-    ])
+// openaiShim test extraction seam 090 start: preserves Gemini thought signature from non-streaming message extra_content
 
-    return makeSseResponse(chunks)
-  }) as unknown as FetchType
+// openaiShim test extraction seam 090 end
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  const result = await client.beta.messages
-    .create({
-      model: 'google/gemini-3.1-flash-lite',
-      messages: [{ role: 'user', content: 'Use Write' }],
-      max_tokens: 64,
-      stream: true,
-    })
-    .withResponse()
-
-  const events: Array<Record<string, unknown>> = []
-  for await (const event of result.data) {
-    events.push(event)
-  }
-
-  const toolStart = events.find(
-    event =>
-      event.type === 'content_block_start' &&
-      typeof event.content_block === 'object' &&
-      event.content_block !== null &&
-      (event.content_block as Record<string, unknown>).type === 'tool_use',
-  ) as { content_block?: Record<string, unknown> } | undefined
-
-  expect(toolStart?.content_block).toMatchObject({
-    type: 'tool_use',
-    id: 'function-call-1',
-    name: 'Write',
-    extra_content: {
-      google: {
-        thought_signature: 'sig-delta',
-      },
-    },
-    signature: 'sig-delta',
-  })
-})
-
-test('preserves Gemini thought signature from non-streaming message extra_content', async () => {
-  globalThis.fetch = (async (_input, _init) => {
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'google/gemini-3.1-flash-lite',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              extra_content: {
-                google: {
-                  thought_signature: 'sig-message',
-                },
-              },
-              tool_calls: [
-                {
-                  id: 'function-call-1',
-                  type: 'function',
-                  function: {
-                    name: 'Write',
-                    arguments: '{"file_path":"todo.md","content":"todo"}',
-                  },
-                },
-              ],
-            },
-            finish_reason: 'tool_calls',
-          },
-        ],
-        usage: {
-          prompt_tokens: 12,
-          completion_tokens: 4,
-          total_tokens: 16,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  const message = await client.beta.messages.create({
-    model: 'google/gemini-3.1-flash-lite',
-    messages: [{ role: 'user', content: 'Use Write' }],
-    max_tokens: 64,
-    stream: false,
-  }) as {
-    content?: Array<Record<string, unknown>>
-  }
-
-  expect(message.content?.[0]).toMatchObject({
-    type: 'tool_use',
-    id: 'function-call-1',
-    name: 'Write',
-    extra_content: {
-      google: {
-        thought_signature: 'sig-message',
-      },
-    },
-    signature: 'sig-message',
-  })
-})
 
 // Extraction seam: provider signature metadata | raw streaming tool fallback.
 
+// openaiShim test extraction seam 091 start: converts Gemini raw tool-call text into streaming tool_use blocks
 test('converts Gemini raw tool-call text into streaming tool_use blocks', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5359,9 +5264,12 @@ test('converts Gemini raw tool-call text into streaming tool_use blocks', async 
     | undefined
   expect(stop?.delta?.stop_reason).toBe('tool_use')
 })
+// openaiShim test extraction seam 091 end
+
 
 // Extraction seam: streaming conversion | non-streaming response conversion.
 
+// openaiShim test extraction seam 092 start: converts Gemini raw tool-call text into non-streaming tool_use blocks
 test('converts Gemini raw tool-call text into non-streaming tool_use blocks', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -5418,7 +5326,10 @@ test('converts Gemini raw tool-call text into non-streaming tool_use blocks', as
     },
   ])
 })
+// openaiShim test extraction seam 092 end
 
+
+// openaiShim test extraction seam 093 start: normalizes plain string Bash tool arguments from OpenAI-compatible responses
 test('normalizes plain string Bash tool arguments from OpenAI-compatible responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -5480,7 +5391,10 @@ test('normalizes plain string Bash tool arguments from OpenAI-compatible respons
     },
   ])
 })
+// openaiShim test extraction seam 093 end
 
+
+// openaiShim test extraction seam 094 start: normalizes Bash tool arguments that are valid JSON strings
 test('normalizes Bash tool arguments that are valid JSON strings', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -5540,6 +5454,8 @@ test('normalizes Bash tool arguments that are valid JSON strings', async () => {
     },
   ])
 })
+// openaiShim test extraction seam 094 end
+
 
 test.each([
   ['false', false],
@@ -5608,6 +5524,7 @@ test.each([
   },
 )
 
+// openaiShim test extraction seam 095 start: keeps terminal empty Bash tool arguments invalid in non-streaming responses
 test('keeps terminal empty Bash tool arguments invalid in non-streaming responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -5667,9 +5584,12 @@ test('keeps terminal empty Bash tool arguments invalid in non-streaming response
     },
   ])
 })
+// openaiShim test extraction seam 095 end
+
 
 // Extraction seam: completed tool parsing | streamed tool normalization.
 
+// openaiShim test extraction seam 096 start: normalizes plain string Bash tool arguments in streaming responses
 test('normalizes plain string Bash tool arguments in streaming responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5745,7 +5665,10 @@ test('normalizes plain string Bash tool arguments in streaming responses', async
 
   expect(normalizedInput).toBe('{"command":"pwd"}')
 })
+// openaiShim test extraction seam 096 end
 
+
+// openaiShim test extraction seam 097 start: normalizes plain string Bash tool arguments when streaming starts with an empty chunk
 test('normalizes plain string Bash tool arguments when streaming starts with an empty chunk', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5843,7 +5766,10 @@ test('normalizes plain string Bash tool arguments when streaming starts with an 
 
   expect(normalizedInput).toBe('{"command":"pwd"}')
 })
+// openaiShim test extraction seam 097 end
 
+
+// openaiShim test extraction seam 098 start: normalizes plain string Bash tool arguments when streaming starts with whitespace
 test('normalizes plain string Bash tool arguments when streaming starts with whitespace', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5941,7 +5867,10 @@ test('normalizes plain string Bash tool arguments when streaming starts with whi
 
   expect(normalizedInput).toBe('{"command":" pwd"}')
 })
+// openaiShim test extraction seam 098 end
 
+
+// openaiShim test extraction seam 099 start: keeps terminal whitespace-only Bash arguments invalid in streaming responses
 test('keeps terminal whitespace-only Bash arguments invalid in streaming responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6017,7 +5946,10 @@ test('keeps terminal whitespace-only Bash arguments invalid in streaming respons
 
   expect(normalizedInput).toBe('{}')
 })
+// openaiShim test extraction seam 099 end
 
+
+// openaiShim test extraction seam 100 start: normalizes streaming Bash arguments that begin with bracket syntax
 test('normalizes streaming Bash arguments that begin with bracket syntax', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6093,7 +6025,10 @@ test('normalizes streaming Bash arguments that begin with bracket syntax', async
 
   expect(normalizedInput).toBe('{"command":"[ -f package.json ] && pwd"}')
 })
+// openaiShim test extraction seam 100 end
 
+
+// openaiShim test extraction seam 101 start: normalizes streaming Bash arguments when the first chunk is only an opening brace
 test('normalizes streaming Bash arguments when the first chunk is only an opening brace', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6191,7 +6126,10 @@ test('normalizes streaming Bash arguments when the first chunk is only an openin
 
   expect(normalizedInput).toBe('{"command":"{ pwd; }"}')
 })
+// openaiShim test extraction seam 101 end
 
+
+// openaiShim test extraction seam 102 start: repairs truncated structured Bash JSON in streaming responses
 test('repairs truncated structured Bash JSON in streaming responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6267,7 +6205,10 @@ test('repairs truncated structured Bash JSON in streaming responses', async () =
 
   expect(normalizedInput).toBe('{"command":"pwd"}')
 })
+// openaiShim test extraction seam 102 end
 
+
+// openaiShim test extraction seam 103 start: does not normalize incomplete streamed Bash commands when finish_reason is length
 test('does not normalize incomplete streamed Bash commands when finish_reason is length', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6343,7 +6284,10 @@ test('does not normalize incomplete streamed Bash commands when finish_reason is
 
   expect(streamedInput).toBe('rg --fi')
 })
+// openaiShim test extraction seam 103 end
 
+
+// openaiShim test extraction seam 104 start: repairs truncated JSON objects even without command field
 test('repairs truncated JSON objects even without command field', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6419,9 +6363,12 @@ test('repairs truncated JSON objects even without command field', async () => {
 
   expect(streamedInput).toBe('{"cwd":"/tmp"}')
 })
+// openaiShim test extraction seam 104 end
+
 
 // Extraction seam: streamed tool normalization | schema and tool conversion.
 
+// openaiShim test extraction seam 105 start: preserves raw input for unknown plain string tool arguments
 test('preserves raw input for unknown plain string tool arguments', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6481,7 +6428,10 @@ test('preserves raw input for unknown plain string tool arguments', async () => 
     },
   ])
 })
+// openaiShim test extraction seam 105 end
 
+
+// openaiShim test extraction seam 106 start: preserves parsed string input for unknown JSON string tool arguments
 test('preserves parsed string input for unknown JSON string tool arguments', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6541,9 +6491,12 @@ test('preserves parsed string input for unknown JSON string tool arguments', asy
     },
   ])
 })
+// openaiShim test extraction seam 106 end
+
 
 // Extraction seam: argument parsing | schema sanitation.
 
+// openaiShim test extraction seam 107 start: sanitizes malformed MCP tool schemas before sending them to OpenAI
 test('sanitizes malformed MCP tool schemas before sending them to OpenAI', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -6618,7 +6571,10 @@ test('sanitizes malformed MCP tool schemas before sending them to OpenAI', async
   expect(properties?.priority?.enum).toEqual([0, 1, 2, 3])
   expect(properties?.priority).not.toHaveProperty('default')
 })
+// openaiShim test extraction seam 107 end
 
+
+// openaiShim test extraction seam 108 start: optional tool properties are not added to required[] — fixes Groq/Azure 400 tool_use_failed
 test('optional tool properties are not added to required[] — fixes Groq/Azure 400 tool_use_failed', async () => {
   // Regression test for: all optional properties being sent as required in strict mode,
   // causing providers like Groq to reject valid tool calls where the model omits optional args.
@@ -6675,6 +6631,8 @@ test('optional tool properties are not added to required[] — fixes Groq/Azure 
   expect(required).not.toContain('pages')
   expect(parameters?.additionalProperties).toBe(false)
 })
+// openaiShim test extraction seam 108 end
+
 
 // Extraction seam: schema sanitation | message conversion façade.
 
@@ -6687,10 +6645,13 @@ test('optional tool properties are not added to required[] — fixes Groq/Azure 
 //
 // ---------------------------------------------------------------------------
 
+// openaiShim test extraction seam 109 start: the OpenAI shim façade exposes the messages.create contract
 test('the OpenAI shim façade exposes the messages.create contract', () => {
   const client = createOpenAIShimClient({}) as OpenAIShimClient
   expect(typeof client.beta.messages.create).toBe('function')
 })
+// openaiShim test extraction seam 109 end
+
 
 function makeNonStreamResponse(content = 'ok'): Response {
   return new Response(
@@ -6704,6 +6665,7 @@ function makeNonStreamResponse(content = 'ok'): Response {
   )
 }
 
+// openaiShim test extraction seam 110 start: coalesces consecutive user messages to avoid alternation errors (issue #202)
 test('coalesces consecutive user messages to avoid alternation errors (issue #202)', async () => {
   let sentMessages: Array<{ role: string; content: unknown }> | undefined
 
@@ -6732,7 +6694,10 @@ test('coalesces consecutive user messages to avoid alternation errors (issue #20
   expect(userContent).toContain('first message')
   expect(userContent).toContain('second message')
 })
+// openaiShim test extraction seam 110 end
 
+
+// openaiShim test extraction seam 111 start: coalesces consecutive assistant messages preserving tool_calls (issue #202)
 test('coalesces consecutive assistant messages preserving tool_calls (issue #202)', async () => {
   let sentMessages: Array<{ role: string; content: unknown; tool_calls?: unknown[] }> | undefined
 
@@ -6763,6 +6728,8 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
   expect(assistantMsgs?.length).toBe(1)
   expect(assistantMsgs?.[0]?.tool_calls?.length).toBeGreaterThan(0)
 })
+// openaiShim test extraction seam 111 end
+
 
 // ---------------------------------------------------------------------------
 // Extraction boundary: message conversion | non-streaming response conversion
@@ -6773,10 +6740,26 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
 //
 // ---------------------------------------------------------------------------
 
+// openaiShim test extraction seam 112 start: the OpenAI shim façade creates independent client instances
 test('the OpenAI shim façade creates independent client instances', () => {
-  expect(createOpenAIShimClient({})).not.toBe(createOpenAIShimClient({}))
+  const first = createOpenAIShimClient({}) as OpenAIShimClient
+  const second = createOpenAIShimClient({}) as OpenAIShimClient
+  expect(first).not.toBe(second)
+  expect(first.beta).not.toBe(second.beta)
+  expect(first.beta.messages).not.toBe(second.beta.messages)
+})
+// openaiShim test extraction seam 112 end
+
+test('raw-text and XML fallback tool calls use one unique sequence', () => {
+  const text = parseTextToolCalls('{"name":"from_text","arguments":{}}')
+  const xml = parseXmlToolCalls('<tool_call>{"name":"from_xml","arguments":{}}</tool_call>')
+  expect(text.calls[0]?.id).toMatch(/^ollama_tc_\d+$/)
+  expect(xml.calls[0]?.id).toMatch(/^xml_tc_\d+$/)
+  expect(text.calls[0]?.id?.replace(/^\D+/, '')).not.toBe(xml.calls[0]?.id?.replace(/^\D+/, ''))
 })
 
+// ---------------------------------------------------------------------------
+// openaiShim test extraction seam 113 start: non-streaming: reasoning_content emitted as thinking block only when content is null
 test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6821,7 +6804,10 @@ test('non-streaming: reasoning_content emitted as thinking block only when conte
     { type: 'thinking', thinking: 'Let me think about this step by step.' },
   ])
 })
+// openaiShim test extraction seam 113 end
 
+
+// openaiShim test extraction seam 114 start: non-streaming: empty string content does not fall through to reasoning_content as text
 test('non-streaming: empty string content does not fall through to reasoning_content as text', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6866,7 +6852,10 @@ test('non-streaming: empty string content does not fall through to reasoning_con
     { type: 'thinking', thinking: 'Chain of thought here.' },
   ])
 })
+// openaiShim test extraction seam 114 end
 
+
+// openaiShim test extraction seam 115 start: non-streaming: real content takes precedence over reasoning_content
 test('non-streaming: real content takes precedence over reasoning_content', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6912,7 +6901,10 @@ test('non-streaming: real content takes precedence over reasoning_content', asyn
     { type: 'text', text: 'The answer is 42.' },
   ])
 })
+// openaiShim test extraction seam 115 end
 
+
+// openaiShim test extraction seam 116 start: non-streaming: preserves response body when usage parsing fails
 test('non-streaming: preserves response body when usage parsing fails', async () => {
   const json = JSON as unknown as { parse: typeof JSON.parse }
   const originalJSONParse = json.parse
@@ -6980,7 +6972,10 @@ test('non-streaming: preserves response body when usage parsing fails', async ()
     json.parse = originalJSONParse
   }
 })
+// openaiShim test extraction seam 116 end
 
+
+// openaiShim test extraction seam 117 start: non-streaming: preserves response.url routing metadata after body read
 test('non-streaming: preserves response.url routing metadata after body read', async () => {
   // _doRequest reads the body for usage extraction and recreates the
   // Response with new Response(bodyText, ...). That drops response.url to
@@ -7028,7 +7023,10 @@ test('non-streaming: preserves response.url routing metadata after body read', a
   // and content would not match.
   expect(result.content).toEqual([{ type: 'text', text: 'passthrough ok' }])
 })
+// openaiShim test extraction seam 117 end
 
+
+// openaiShim test extraction seam 118 start: non-streaming: strips <think> tag block from assistant content
 test('non-streaming: strips <think> tag block from assistant content', async () => {
   globalThis.fetch = asMockFetch(mock(async () => {
     return new Response(
@@ -7068,9 +7066,12 @@ test('non-streaming: strips <think> tag block from assistant content', async () 
     { type: 'text', text: 'Hey! How can I help you today?' },
   ])
 })
+// openaiShim test extraction seam 118 end
+
 
 // Extraction seam: non-streaming response conversion | streaming event conversion.
 
+// openaiShim test extraction seam 119 start: streaming: thinking block closed before tool call
 test('streaming: thinking block closed before tool call', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -7162,7 +7163,10 @@ test('streaming: thinking block closed before tool call', async () => {
   }
   expect(thinkingStart?.content_block?.type).toBe('thinking')
 })
+// openaiShim test extraction seam 119 end
 
+
+// openaiShim test extraction seam 120 start: streaming: strips <think> tag block from assistant content deltas
 test('streaming: strips <think> tag block from assistant content deltas', async () => {
   globalThis.fetch = asMockFetch(mock(async () => {
     const chunks = makeStreamChunks([
@@ -7220,7 +7224,10 @@ test('streaming: strips <think> tag block from assistant content deltas', async 
 
   expect(textDeltas.join('')).toBe('Hey! How can I help you today?')
 })
+// openaiShim test extraction seam 120 end
 
+
+// openaiShim test extraction seam 121 start: streaming: strips <think> tag split across multiple content chunks
 test('streaming: strips <think> tag split across multiple content chunks', async () => {
   globalThis.fetch = asMockFetch(mock(async () => {
     const chunks = makeStreamChunks([
@@ -7306,7 +7313,10 @@ test('streaming: strips <think> tag split across multiple content chunks', async
 
   expect(textDeltas.join('')).toBe('Hey! How can I help you today?')
 })
+// openaiShim test extraction seam 121 end
 
+
+// openaiShim test extraction seam 122 start: streaming: preserves prose without tags (no phrase-based false positive)
 test('streaming: preserves prose without tags (no phrase-based false positive)', async () => {
   // Regression: older phrase-based sanitizer would strip "I should..." prose.
   // The tag-based approach leaves legitimate assistant output alone.
@@ -7368,10 +7378,13 @@ test('streaming: preserves prose without tags (no phrase-based false positive)',
     'I should note that the user role requires a briefly concise friendly response format.',
   )
 })
+// openaiShim test extraction seam 122 end
+
 
 // Extraction boundary: response conversion | executor network behavior.
 // The executor suite owns the contiguous network-classification block below.
 // Keep this marker stable for independent adjacent test migrations.
+// openaiShim test extraction seam 123 start: strips credentials and query params from URL in fetch network error message
 test('strips credentials and query params from URL in fetch network error message', async () => {
   process.env.OPENAI_BASE_URL =
     'https://user:password@internal.example.test/v1?token=abc123'
@@ -7404,7 +7417,75 @@ test('strips credentials and query params from URL in fetch network error messag
   expect(message).not.toContain('user:')
   expect(message).not.toContain('token=abc123')
 })
+// openaiShim test extraction seam 123 end
 
+test('redacts configured secret substrings from fetch network error messages', async () => {
+  const secret = 'route/key+AbC123'
+  process.env.OPENAI_API_KEY = secret
+
+  globalThis.fetch = asMockFetch(mock(async () => {
+    throw new TypeError(`fetch failed while routing ${secret}`)
+  }))
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await expect(
+    client.beta.messages.create({
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    }),
+  ).rejects.not.toThrow(secret)
+})
+
+test('redacts encoded configured secrets from non-URL transport error messages', async () => {
+  const secret = 'route/key+AbC123'
+  const encodedSecret = encodeURIComponent(secret)
+  const doubleEncodedSecret = encodeURIComponent(encodedSecret)
+  const fullyEncodedSecret = Array.from(new TextEncoder().encode(secret))
+    .map(byte => `%${byte.toString(16).padStart(2, '0')}`)
+    .join('')
+  const malformedAdjacentSecret = `%E0%A4${encodedSecret}`
+  const encodedCategoryMarker = '%5Bopenai_category%3Dauth_invalid%5D'
+  const encodedControlSequence = '%1B%5B31m'
+  process.env.OPENAI_API_KEY = secret
+
+  globalThis.fetch = asMockFetch(mock(async () => {
+    throw new TypeError(
+      `proxy failed ${encodedCategoryMarker} ${encodedControlSequence} for path /v1/${encodedSecret}?nested=${doubleEncodedSecret}&fully=${fullyEncodedSecret}&malformed=${malformedAdjacentSecret}`,
+    )
+  }))
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  let caught: unknown
+  try {
+    await client.beta.messages.create({
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    })
+  } catch (error) {
+    caught = error
+  }
+
+  expect(caught).toBeDefined()
+  const message = (caught as Error).message
+  expect(message).toContain('proxy failed')
+  expect(message).toContain(encodedCategoryMarker)
+  expect(message).toContain(encodedControlSequence)
+  expect(message).not.toContain('\u001B')
+  expect(extractOpenAICategoryMarker(message)).toBe('network_error')
+  expect(message).not.toContain(secret)
+  expect(message).not.toContain(encodedSecret)
+  expect(message).not.toContain(doubleEncodedSecret)
+  expect(message).not.toContain(fullyEncodedSecret)
+  expect(message).not.toContain(malformedAdjacentSecret)
+})
+
+// openaiShim test extraction seam 124 start: classifies localhost transport failures with actionable category marker
 test('classifies localhost transport failures with actionable category marker', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
@@ -7436,7 +7517,10 @@ test('classifies localhost transport failures with actionable category marker', 
     }),
   ).rejects.toThrow('local server is running')
 })
+// openaiShim test extraction seam 124 end
 
+
+// openaiShim test extraction seam 125 start: transport failures are not labeled with HTTP status 503
 test('transport failures are not labeled with HTTP status 503', async () => {
   // Issue #971: ENETDOWN (and other transport errors) are emitted before any
   // HTTP response is received. Reporting them as "503" makes users believe the
@@ -7474,8 +7558,10 @@ test('transport failures are not labeled with HTTP status 503', async () => {
   expect(err.message).toContain('code=ENETDOWN')
   expect(err.message).toContain('openai_category=network_error')
 })
+// openaiShim test extraction seam 125 end
 
-test('propagates AbortError without wrapping it as transport failure', async () => {
+test('propagates caller AbortError without wrapping it as transport failure', async () => {
+// openaiShim test extraction seam 126 start: propagates AbortError without wrapping it as transport failure
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
   const abortError = new DOMException('The operation was aborted.', 'AbortError')
@@ -7484,7 +7570,8 @@ test('propagates AbortError without wrapping it as transport failure', async () 
   }))
 
   const controller = new AbortController()
-  controller.abort()
+  const callerReason = new DOMException('Cancelled by caller', 'AbortError')
+  controller.abort(callerReason)
 
   const client = createOpenAIShimClient({}) as OpenAIShimClient
 
@@ -7498,9 +7585,519 @@ test('propagates AbortError without wrapping it as transport failure', async () 
       },
       { signal: controller.signal },
     ),
-  ).rejects.toBe(abortError)
+  ).rejects.toBe(callerReason)
 })
 
+test('classifies a pre-header API timeout without replaying the request', async () => {
+  process.env.API_TIMEOUT_MS = '20'
+  const pathSecret = 'route/key+AbC123'
+  const encodedPathSecret = encodeURIComponent(pathSecret)
+  const doubleEncodedPathSecret = encodeURIComponent(encodedPathSecret)
+  const escapeLookingSecret = 'abc%2FdefLONG'
+  const encodedEscapeLookingSecret = encodeURIComponent(escapeLookingSecret)
+  const decodedEscapeLookingSecret = decodeURIComponent(escapeLookingSecret)
+  const malformedUtf8Secret = 'éSECRET_VALUE_123'
+  const encodedMalformedUtf8Secret = encodeURIComponent(malformedUtf8Secret)
+  process.env.OPENAI_API_KEY = pathSecret
+  process.env.OPENROUTER_API_KEY = escapeLookingSecret
+  process.env.DEEPSEEK_API_KEY = malformedUtf8Secret
+  process.env.OPENAI_BASE_URL =
+    `https://user:password@slow.example.test/v1/invalid%ZZ/${doubleEncodedPathSecret}/${encodedEscapeLookingSecret}/%E0%A4${encodedMalformedUtf8Secret}` +
+    `?prompt=${encodedPathSecret}&nested=${doubleEncodedPathSecret}` +
+    `&escape=${encodedEscapeLookingSecret}&malformed=%E0%A4${encodedMalformedUtf8Secret}` +
+    '&token=secret'
+  let fetchCalls = 0
+  let completedGenerations = 0
+  const receivedBodies: string[] = []
+  globalThis.fetch = (async (_input, init) => {
+    fetchCalls++
+    receivedBodies.push(String(init?.body))
+    return new Promise<Response>((resolve, reject) => {
+      setTimeout(() => {
+        completedGenerations++
+        resolve(makeChatCompletionResponse('gpt-4o-mini'))
+      }, 50)
+      const signal = init?.signal
+      if (!signal) return
+      const rejectFromAbort = () => {
+        reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+      }
+      signal.addEventListener('abort', rejectFromAbort, { once: true })
+      if (signal.aborted) rejectFromAbort()
+    })
+  }) as unknown as FetchType
+
+  const safety = new AbortController()
+  const safetyTimer = setTimeout(() => safety.abort(), 500)
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  let caught: unknown
+  try {
+    await waitForPromise(
+      client.beta.messages.create(
+        {
+          model: 'gpt-4o-mini',
+          messages: [{ role: 'user', content: 'hello' }],
+          max_tokens: 64,
+          stream: false,
+        },
+        { signal: safety.signal },
+      ),
+      750,
+      'pre-header timeout did not settle',
+    )
+  } catch (error) {
+    caught = error
+  } finally {
+    clearTimeout(safetyTimer)
+  }
+  await new Promise(resolve => setTimeout(resolve, 60))
+
+  expect(caught).toBeDefined()
+  const error = caught as Error & { constructor: { name: string } }
+  expect(error.constructor.name).toBe('APIConnectionError')
+  expect(isOpenAIRequestNonReplayable(error)).toBe(true)
+  expect(error.message).toContain('no response headers within 20ms (API_TIMEOUT_MS)')
+  expect(error.message).toContain('slow.example.test')
+  expect(error.message).toContain('openai_category=request_timeout')
+  expect(error.message).not.toContain('password')
+  expect(error.message).not.toContain('token=secret')
+  expect(error.message).not.toContain(pathSecret)
+  expect(error.message).not.toContain(encodedPathSecret)
+  expect(error.message).not.toContain(doubleEncodedPathSecret)
+  expect(error.message).not.toContain(escapeLookingSecret)
+  expect(error.message).not.toContain(encodedEscapeLookingSecret)
+  expect(error.message).not.toContain(decodedEscapeLookingSecret)
+  expect(error.message).not.toContain(malformedUtf8Secret)
+  expect(error.message).not.toContain(encodedMalformedUtf8Secret)
+  expect(fetchCalls).toBe(1)
+  expect(receivedBodies).toHaveLength(1)
+  expect(completedGenerations).toBe(1)
+})
+
+test('does not proxy-retry when a deadline abort surfaces as fetch failed', async () => {
+  process.env.API_TIMEOUT_MS = '20'
+  let fetchCalls = 0
+  globalThis.fetch = (async (_input, init) => {
+    fetchCalls++
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      const rejectFromAbort = () => reject(new TypeError('fetch failed'))
+      signal?.addEventListener('abort', rejectFromAbort, { once: true })
+      if (signal?.aborted) rejectFromAbort()
+    })
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await expect(
+    client.beta.messages.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    }),
+  ).rejects.toThrow('no response headers within 20ms (API_TIMEOUT_MS)')
+
+  expect(fetchCalls).toBe(1)
+})
+
+test('deadline wins when an abort-ignoring fetch resolves 504 afterward', async () => {
+  process.env.API_TIMEOUT_MS = '20'
+  let fetchCalls = 0
+  globalThis.fetch = (async (_input, init) => {
+    fetchCalls++
+    return new Promise<Response>(resolve => {
+      const resolveAfterAbort = () => {
+        resolve(new Response('Gateway Timeout', { status: 504 }))
+      }
+      init?.signal?.addEventListener('abort', resolveAfterAbort, { once: true })
+      if (init?.signal?.aborted) resolveAfterAbort()
+    })
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await expect(
+    client.beta.messages.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    }),
+  ).rejects.toThrow('no response headers within 20ms (API_TIMEOUT_MS)')
+
+  expect(fetchCalls).toBe(1)
+})
+
+test('gives a proxy retry its own response-header deadline', async () => {
+  process.env.API_TIMEOUT_MS = '50'
+  let fetchCalls = 0
+  globalThis.fetch = (async () => {
+    fetchCalls++
+    if (fetchCalls === 1) {
+      await new Promise(resolve => setTimeout(resolve, 30))
+      return new Response('Gateway Timeout', { status: 504 })
+    }
+    await new Promise(resolve => setTimeout(resolve, 30))
+    return makeChatCompletionResponse('gpt-4o-mini')
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const response = await client.beta.messages.create({
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(response).toBeDefined()
+  expect(fetchCalls).toBe(2)
+})
+
+test('bounds nested URL decoding while retaining encoded secret redaction', async () => {
+  const secret = 'route/key+AbC123'
+  const secretVariants = [secret]
+  for (let layer = 0; layer < 4; layer++) {
+    secretVariants.push(
+      encodeURIComponent(secretVariants[secretVariants.length - 1]!),
+    )
+  }
+  const deeplyNestedValue = `%${'25'.repeat(200)}`
+  process.env.OPENAI_API_KEY = secret
+  process.env.OPENAI_BASE_URL =
+    `https://slow.example.test/v1/${deeplyNestedValue}/${secretVariants[4]}`
+  globalThis.fetch = asMockFetch(mock(async () => {
+    throw new TypeError('fetch failed')
+  }))
+
+  const originalDecodeURIComponent = globalThis.decodeURIComponent
+  let decodeCalls = 0
+  globalThis.decodeURIComponent = ((value: string) => {
+    decodeCalls++
+    return originalDecodeURIComponent(value)
+  }) as typeof decodeURIComponent
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  let caught: unknown
+  try {
+    await client.beta.messages.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    })
+  } catch (error) {
+    caught = error
+  } finally {
+    globalThis.decodeURIComponent = originalDecodeURIComponent
+  }
+
+  expect(caught).toBeDefined()
+  for (const secretVariant of secretVariants) {
+    expect((caught as Error).message).not.toContain(secretVariant)
+  }
+  expect(decodeCalls).toBeLessThanOrEqual(32)
+})
+
+test('decodes malformed URL escape runs in linear work', async () => {
+  const secret = 'route/key+AbC123'
+  const encodedSecret = encodeURIComponent(secret)
+  const malformedEscapeCount = 200
+  const malformedUtf8Run = '%80'.repeat(malformedEscapeCount)
+  process.env.OPENAI_API_KEY = secret
+  process.env.OPENAI_BASE_URL =
+    `https://slow.example.test/v1/${malformedUtf8Run}/${encodedSecret}`
+  globalThis.fetch = asMockFetch(mock(async () => {
+    throw new TypeError('fetch failed')
+  }))
+
+  const originalDecodeURIComponent = globalThis.decodeURIComponent
+  let malformedDecodeCalls = 0
+  globalThis.decodeURIComponent = ((value: string) => {
+    if (value.includes('%80')) malformedDecodeCalls++
+    return originalDecodeURIComponent(value)
+  }) as typeof decodeURIComponent
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  let caught: unknown
+  try {
+    await client.beta.messages.create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    })
+  } catch (error) {
+    caught = error
+  } finally {
+    globalThis.decodeURIComponent = originalDecodeURIComponent
+  }
+
+  expect(caught).toBeDefined()
+  expect((caught as Error).message).not.toContain(secret)
+  expect((caught as Error).message).not.toContain(encodedSecret)
+  expect(malformedDecodeCalls).toBeLessThanOrEqual(malformedEscapeCount * 10)
+})
+
+test('preserves caller cancellation while waiting for response headers without retrying', async () => {
+  process.env.API_TIMEOUT_MS = '200'
+  let fetchCalls = 0
+  globalThis.fetch = (async (_input, init) => {
+    fetchCalls++
+    return pendingFetchUntilAbort(init)
+  }) as unknown as FetchType
+
+  const caller = new AbortController()
+  const callerReason = new DOMException('Cancelled by user', 'AbortError')
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const originalAbortSignalAny = Object.getOwnPropertyDescriptor(
+    AbortSignal,
+    'any',
+  )
+  Object.defineProperty(AbortSignal, 'any', {
+    value: undefined,
+    configurable: true,
+  })
+  try {
+    const request = client.beta.messages.create(
+      {
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: 'hello' }],
+        max_tokens: 64,
+        stream: false,
+      },
+      { signal: caller.signal },
+    )
+
+    setTimeout(() => caller.abort(callerReason), 10)
+
+    await expect(
+      waitForPromise(request, 500, 'caller abort did not settle'),
+    ).rejects.toBe(callerReason)
+    expect(fetchCalls).toBe(1)
+  } finally {
+    if (originalAbortSignalAny) {
+      Object.defineProperty(AbortSignal, 'any', originalAbortSignalAny)
+    }
+  }
+})
+
+test('native signal composition preserves the caller abort reason when fetch rejects AbortError', async () => {
+  expect(typeof AbortSignal.any).toBe('function')
+  process.env.API_TIMEOUT_MS = '200'
+  let fetchCalls = 0
+  const fetchAbortError = new DOMException(
+    'The operation was aborted.',
+    'AbortError',
+  )
+  globalThis.fetch = (async (_input, init) => {
+    fetchCalls++
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return
+      const rejectFromAbort = () => reject(fetchAbortError)
+      signal.addEventListener('abort', rejectFromAbort, { once: true })
+      if (signal.aborted) rejectFromAbort()
+    })
+  }) as unknown as FetchType
+
+  const caller = new AbortController()
+  const callerReason = new DOMException('Cancelled by user', 'AbortError')
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const request = client.beta.messages.create(
+    {
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    },
+    { signal: caller.signal },
+  )
+
+  const abortTimer = setTimeout(() => caller.abort(callerReason), 10)
+
+  try {
+    await expect(
+      waitForPromise(request, 500, 'caller abort did not settle'),
+    ).rejects.toBe(callerReason)
+  } finally {
+    clearTimeout(abortTimer)
+  }
+  expect(fetchCalls).toBe(1)
+})
+
+test('caller abort winning the timeout catch race prevents a retry', async () => {
+  process.env.API_TIMEOUT_MS = '20'
+  let fetchCalls = 0
+  const caller = new AbortController()
+  const callerReason = new DOMException('Cancelled by user', 'AbortError')
+  globalThis.fetch = (async (_input, init) => {
+    fetchCalls++
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal
+      if (!signal) return
+      const rejectFromAbort = () => {
+        reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
+        if (fetchCalls === 1) {
+          queueMicrotask(() => caller.abort(callerReason))
+        }
+      }
+      signal.addEventListener('abort', rejectFromAbort, { once: true })
+      if (signal.aborted) rejectFromAbort()
+    })
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await expect(
+    waitForPromise(
+      client.beta.messages.create(
+        {
+          model: 'gpt-4o-mini',
+          messages: [{ role: 'user', content: 'hello' }],
+          max_tokens: 64,
+          stream: false,
+        },
+        { signal: caller.signal },
+      ),
+      500,
+      'caller abort race did not settle',
+    ),
+  ).rejects.toBe(callerReason)
+  expect(fetchCalls).toBe(1)
+})
+
+test('manual signal fallback preserves caller cancellation after headers arrive', async () => {
+  process.env.API_TIMEOUT_MS = '200'
+  const fetchSignals: AbortSignal[] = []
+  const stalled = makeStallingResponse(
+    makeOpenAIStreamFrame({ role: 'assistant', content: 'started' }),
+  )
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.signal) fetchSignals.push(init.signal)
+    return stalled.response
+  }) as unknown as FetchType
+
+  const caller = new AbortController()
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const originalAbortSignalAny = Object.getOwnPropertyDescriptor(
+    AbortSignal,
+    'any',
+  )
+  Object.defineProperty(AbortSignal, 'any', {
+    value: undefined,
+    configurable: true,
+  })
+  try {
+    const result = await client.beta.messages
+      .create(
+        {
+          model: 'gpt-4o-mini',
+          messages: [{ role: 'user', content: 'hello' }],
+          max_tokens: 64,
+          stream: true,
+        },
+        { signal: caller.signal },
+      )
+      .withResponse()
+
+    await expectAbortStopsStream({
+      abort: () => caller.abort(),
+      cancelReasons: stalled.cancelReasons,
+      expectedEventsBeforeAbort: 1,
+      label: 'manual combined signal after headers',
+      stream: result.data as ShimStream,
+    })
+
+    expect(fetchSignals).toHaveLength(1)
+    expect(fetchSignals[0].aborted).toBe(true)
+  } finally {
+    stalled.close()
+    if (originalAbortSignalAny) {
+      Object.defineProperty(AbortSignal, 'any', originalAbortSignalAny)
+    }
+  }
+})
+
+test('manual signal fallback removes caller forwarding after the body settles', async () => {
+  process.env.API_TIMEOUT_MS = '200'
+  globalThis.fetch = asMockFetch(mock(async () =>
+    makeChatCompletionResponse('gpt-4o-mini')))
+
+  const caller = new AbortController()
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const originalAbortSignalAny = Object.getOwnPropertyDescriptor(
+    AbortSignal,
+    'any',
+  )
+  Object.defineProperty(AbortSignal, 'any', {
+    value: undefined,
+    configurable: true,
+  })
+  try {
+    for (let request = 0; request < 2; request++) {
+      await client.beta.messages.create(
+        {
+          model: 'gpt-4o-mini',
+          messages: [{ role: 'user', content: 'hello' }],
+          max_tokens: 64,
+          stream: false,
+        },
+        { signal: caller.signal },
+      )
+      expect(getEventListeners(caller.signal, 'abort')).toHaveLength(0)
+    }
+  } finally {
+    if (originalAbortSignalAny) {
+      Object.defineProperty(AbortSignal, 'any', originalAbortSignalAny)
+    }
+  }
+})
+
+test('disarms the API timeout after headers arrive while the body keeps streaming', async () => {
+  process.env.API_TIMEOUT_MS = '20'
+  const fetchSignals: AbortSignal[] = []
+  const encoder = new TextEncoder()
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.signal) fetchSignals.push(init.signal)
+    return new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          setTimeout(() => {
+            controller.enqueue(encoder.encode(makeOpenAIStreamFrame(
+              { role: 'assistant', content: 'late body' },
+              'stop',
+            )))
+            controller.enqueue(encoder.encode('data: [DONE]\n\n'))
+            controller.close()
+          }, 50)
+        },
+      }),
+      { headers: { 'Content-Type': 'text/event-stream' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const result = await client.beta.messages
+    .create({
+      model: 'gpt-4o-mini',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: true,
+    })
+    .withResponse()
+
+  const events: Array<Record<string, unknown>> = []
+  for await (const event of result.data) events.push(event)
+
+  expect(events.length).toBeGreaterThan(0)
+  expect(fetchSignals).toHaveLength(1)
+  expect(fetchSignals[0].aborted).toBe(false)
+})
+// openaiShim test extraction seam 126 end
+
+
+// openaiShim test extraction seam 127 start: classifies chat-completions endpoint 404 failures with endpoint_not_found marker
 test('classifies chat-completions endpoint 404 failures with endpoint_not_found marker', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434'
 
@@ -7523,6 +8120,9 @@ test('classifies chat-completions endpoint 404 failures with endpoint_not_found 
     }),
   ).rejects.toThrow('openai_category=endpoint_not_found')
 })
+// openaiShim test extraction seam 127 end
+
+// openaiShim test extraction seam 128 start: self-heals localhost resolution failures by retrying local loopback base URL
 test('self-heals localhost resolution failures by retrying local loopback base URL', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
@@ -7580,10 +8180,13 @@ test('self-heals localhost resolution failures by retrying local loopback base U
   expect(requestUrls[0]).toBe('http://localhost:11434/api/chat')
   expect(requestUrls).toContain('http://127.0.0.1:11434/api/chat')
 })
+// openaiShim test extraction seam 128 end
+
 
 // Extraction boundary: executor network behavior | native Ollama routing.
 // Native Ollama endpoint selection remains an adapter/facade integration concern.
 // Keep this marker stable for independent adjacent test migrations.
+// openaiShim test extraction seam 129 start: uses native Ollama chat endpoint when local base URL omits /v1
 test('uses native Ollama chat endpoint when local base URL omits /v1', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434'
 
@@ -7626,7 +8229,10 @@ test('uses native Ollama chat endpoint when local base URL omits /v1', async () 
 
   expect(requestUrls).toEqual(['http://localhost:11434/api/chat'])
 })
+// openaiShim test extraction seam 129 end
 
+
+// openaiShim test extraction seam 130 start: keeps remote Ollama-named gateways on chat completions
 test('keeps remote Ollama-named gateways on chat completions', async () => {
   process.env.OPENAI_BASE_URL = 'https://ollama-gateway.example.com/v1'
 
@@ -7656,7 +8262,10 @@ test('keeps remote Ollama-named gateways on chat completions', async () => {
     'https://ollama-gateway.example.com/v1/chat/completions',
   ])
 })
+// openaiShim test extraction seam 130 end
 
+
+// openaiShim test extraction seam 131 start: keeps HTTPS localhost Ollama-port proxies on chat completions
 test('keeps HTTPS localhost Ollama-port proxies on chat completions', async () => {
   process.env.OPENAI_BASE_URL = 'https://localhost:11434/v1'
 
@@ -7686,10 +8295,13 @@ test('keeps HTTPS localhost Ollama-port proxies on chat completions', async () =
     'https://localhost:11434/v1/chat/completions',
   ])
 })
+// openaiShim test extraction seam 131 end
+
 
 // Extraction boundary: native Ollama routing | executor tool self-healing.
 // The single retry test below moves with request execution.
 // Keep this marker stable for independent adjacent test migrations.
+// openaiShim test extraction seam 132 start: self-heals tool-call incompatibility by retrying local Ollama requests without tools
 test('self-heals tool-call incompatibility by retrying local Ollama requests without tools', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
@@ -7769,10 +8381,13 @@ test('self-heals tool-call incompatibility by retrying local Ollama requests wit
   expect(requestBodies[1]?.tool_choice).toBeUndefined()
   expect(requestBodies[1]?.tool_stream).toBeUndefined()
 })
+// openaiShim test extraction seam 132 end
+
 
 // Extraction boundary: executor tool self-healing | message conversion.
 // Message-history normalization below belongs to the message converter.
 // Keep this marker stable for independent adjacent test migrations.
+// openaiShim test extraction seam 133 start: preserves valid tool_result and drops orphan tool_result
 test('preserves valid tool_result and drops orphan tool_result', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -7868,7 +8483,10 @@ test('preserves valid tool_result and drops orphan tool_result', async () => {
   const assistantMessages = messages.filter(m => m.role === 'assistant')
   expect(assistantMessages.some(m => m.content === '[Tool results received]')).toBe(true)
 })
+// openaiShim test extraction seam 133 end
 
+
+// openaiShim test extraction seam 134 start: drops empty assistant message when only thinking block was present and stripped
 test('drops empty assistant message when only thinking block was present and stripped', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -7905,7 +8523,10 @@ test('drops empty assistant message when only thinking block was present and str
   expect(String(messages[0].content)).toContain('Initial')
   expect(String(messages[0].content)).toContain('Interrupting query')
 })
+// openaiShim test extraction seam 134 end
 
+
+// openaiShim test extraction seam 135 start: drops empty assistant message when only redacted_thinking block was present and stripped
 test('drops empty assistant message when only redacted_thinking block was present and stripped', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -7942,7 +8563,10 @@ test('drops empty assistant message when only redacted_thinking block was presen
   expect(String(messages[0].content)).toContain('Initial')
   expect(String(messages[0].content)).toContain('Interrupting query')
 })
+// openaiShim test extraction seam 135 end
 
+
+// openaiShim test extraction seam 136 start: injects semantic assistant message when tool result is followed by user message
 test('injects semantic assistant message when tool result is followed by user message', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -7990,10 +8614,13 @@ test('injects semantic assistant message when tool result is followed by user me
   expect(semanticMsg.content).not.toContain('interrupted')
   expect(semanticMsg.content).not.toContain('user')
 })
+// openaiShim test extraction seam 136 end
+
 
 // Extraction boundary: executor tool self-healing | message/provider shaping.
 // Provider request shaping below is not owned by the executor.
 // Keep this marker stable for independent adjacent test migrations.
+// openaiShim test extraction seam 137 start: Moonshot: uses max_tokens (not max_completion_tokens) and strips store
 test('Moonshot: uses max_tokens (not max_completion_tokens) and strips store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.ai/v1'
   process.env.OPENAI_API_KEY = 'sk-moonshot-test'
@@ -8027,7 +8654,10 @@ test('Moonshot: uses max_tokens (not max_completion_tokens) and strips store', a
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 137 end
 
+
+// openaiShim test extraction seam 138 start: Cerebras: strips unsupported store on chat_completions (#1023)
 test('Cerebras: strips unsupported store on chat_completions (#1023)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.cerebras.ai/v1'
   process.env.OPENAI_API_KEY = 'csk-test'
@@ -8059,7 +8689,10 @@ test('Cerebras: strips unsupported store on chat_completions (#1023)', async () 
 
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 138 end
 
+
+// openaiShim test extraction seam 139 start: Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_completions (#672)
 test('Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_completions (#672)', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:8000/v1'
   process.env.OPENAI_API_KEY = 'sk-local'
@@ -8091,7 +8724,10 @@ test('Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_comple
 
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 139 end
 
+
+// openaiShim test extraction seam 140 start: Mistral: strips unsupported store on chat_completions (#739)
 test('Mistral: strips unsupported store on chat_completions (#739)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.mistral.ai/v1'
   process.env.OPENAI_API_KEY = 'mistral-test'
@@ -8123,7 +8759,10 @@ test('Mistral: strips unsupported store on chat_completions (#739)', async () =>
 
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 140 end
 
+
+// openaiShim test extraction seam 141 start: Mistral host fallback: strips store on an unresolved Mistral-host route (#739)
 test('Mistral host fallback: strips store on an unresolved Mistral-host route (#739)', async () => {
   // `api.mistral.ai/v1` resolves to the Mistral descriptor route, whose
   // removeBodyFields already strips `store` — so the test above passes even
@@ -8168,19 +8807,15 @@ test('Mistral host fallback: strips store on an unresolved Mistral-host route (#
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.max_tokens).toBe(64)
 })
+// openaiShim test extraction seam 141 end
 
-test('hasMistralApiHost matches the Mistral host and its subdomains only', () => {
-  expect(hasMistralApiHost('https://api.mistral.ai/v1')).toBe(true)
-  expect(hasMistralApiHost('https://proxy.mistral.ai/v1')).toBe(true)
-  expect(hasMistralApiHost('https://eu.mistral.ai/v1')).toBe(true)
-  // Non-Mistral hosts (and look-alikes) must keep `store`.
-  expect(hasMistralApiHost('https://api.openai.com/v1')).toBe(false)
-  expect(hasMistralApiHost('https://notmistral.ai/v1')).toBe(false)
-  expect(hasMistralApiHost('https://api.mistral.ai.evil.com/v1')).toBe(false)
-  expect(hasMistralApiHost(undefined)).toBe(false)
-  expect(hasMistralApiHost('not a url')).toBe(false)
-})
 
+// openaiShim test extraction seam 142 start: hasMistralApiHost matches the Mistral host and its subdomains only
+
+// openaiShim test extraction seam 142 end
+
+
+// openaiShim test extraction seam 143 start: Groq: keeps max_completion_tokens and strips unsupported store
 test('Groq: keeps max_completion_tokens and strips unsupported store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.groq.com/openai/v1'
   process.env.OPENAI_API_KEY = 'gsk-test'
@@ -8214,8 +8849,11 @@ test('Groq: keeps max_completion_tokens and strips unsupported store', async () 
   expect(requestBody?.max_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 143 end
 
 
+
+// openaiShim test extraction seam 144 start: Groq: strips reasoning_effort even when compat inference matches the model
 test('Groq: strips reasoning_effort even when compat inference matches the model', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.groq.com/openai/v1'
   process.env.OPENAI_API_KEY = 'gsk-test'
@@ -8250,6 +8888,9 @@ test('Groq: strips reasoning_effort even when compat inference matches the model
   expect(requestBody?.reasoning_effort).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 144 end
+
+// openaiShim test extraction seam 145 start: Moonshot: echoes reasoning_content on assistant tool-call messages
 test('Moonshot: echoes reasoning_content on assistant tool-call messages', async () => {
   // Regression for: "API Error: 400 {"error":{"message":"thinking is enabled
   // but reasoning_content is missing in assistant tool call message at index
@@ -8321,7 +8962,10 @@ test('Moonshot: echoes reasoning_content on assistant tool-call messages', async
     'Need to inspect logs via Bash; running a cat.',
   )
 })
+// openaiShim test extraction seam 145 end
 
+
+// openaiShim test extraction seam 146 start: DeepSeek echoes reasoning_content on assistant tool-call messages
 test('DeepSeek echoes reasoning_content on assistant tool-call messages', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -8379,7 +9023,10 @@ test('DeepSeek echoes reasoning_content on assistant tool-call messages', async 
   expect(assistantWithToolCall).toBeDefined()
   expect(assistantWithToolCall?.reasoning_content).toBe('thought')
 })
+// openaiShim test extraction seam 146 end
 
+
+// openaiShim test extraction seam 147 start: generic OpenAI-compatible providers do not echo reasoning_content on assistant tool-call messages
 test('generic OpenAI-compatible providers do not echo reasoning_content on assistant tool-call messages', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'sk-openai-test'
@@ -8437,7 +9084,10 @@ test('generic OpenAI-compatible providers do not echo reasoning_content on assis
   expect(assistantWithToolCall).toBeDefined()
   expect(assistantWithToolCall?.reasoning_content).toBeUndefined()
 })
+// openaiShim test extraction seam 147 end
 
+
+// openaiShim test extraction seam 148 start: gateway-routed DeepSeek models inherit descriptor-backed reasoning and token shaping
 test('gateway-routed DeepSeek models inherit descriptor-backed reasoning and token shaping', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
@@ -8504,7 +9154,10 @@ test('gateway-routed DeepSeek models inherit descriptor-backed reasoning and tok
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 148 end
 
+
+// openaiShim test extraction seam 149 start: Moonshot: cn host is also detected
 test('Moonshot: cn host is also detected', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.cn/v1'
   process.env.OPENAI_API_KEY = 'sk-moonshot-test'
@@ -8536,7 +9189,10 @@ test('Moonshot: cn host is also detected', async () => {
 
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 149 end
 
+
+// openaiShim test extraction seam 150 start: Kimi Code endpoint inherits Moonshot max_tokens/store compatibility
 test('Kimi Code endpoint inherits Moonshot max_tokens/store compatibility', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.kimi.com/coding/v1'
   process.env.OPENAI_API_KEY = 'sk-kimi-test'
@@ -8570,7 +9226,10 @@ test('Kimi Code endpoint inherits Moonshot max_tokens/store compatibility', asyn
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 150 end
 
+
+// openaiShim test extraction seam 151 start: Kimi Code endpoint echoes reasoning_content on assistant tool-call messages
 test('Kimi Code endpoint echoes reasoning_content on assistant tool-call messages', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.kimi.com/coding/v1'
   process.env.OPENAI_API_KEY = 'sk-kimi-test'
@@ -8637,7 +9296,10 @@ test('Kimi Code endpoint echoes reasoning_content on assistant tool-call message
     'Need to inspect logs via Bash; running a cat.',
   )
 })
+// openaiShim test extraction seam 151 end
 
+
+// openaiShim test extraction seam 152 start: DeepSeek sends thinking toggle and normalized reasoning effort
 test('DeepSeek sends thinking toggle and normalized reasoning effort', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -8676,82 +9338,20 @@ test('DeepSeek sends thinking toggle and normalized reasoning effort', async () 
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 152 end
 
-test('NVIDIA NIM DeepSeek sends chat template thinking kwargs', async () => {
-  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
-  process.env.NVIDIA_API_KEY = 'nvapi-test'
 
-  let requestBody: Record<string, unknown> | undefined
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'deepseek-ai/deepseek-v4-pro',
-        choices: [
-          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
-        ],
-        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
-      }),
-      { headers: { 'Content-Type': 'application/json' } },
-    )
-  }) as unknown as FetchType
+// openaiShim test extraction seam 153 start: NVIDIA NIM DeepSeek sends chat template thinking kwargs
 
-  const client = createOpenAIShimClient({
-    reasoningEffort: 'xhigh',
-  }) as OpenAIShimClient
-  await client.beta.messages.create({
-    model: 'deepseek-ai/deepseek-v4-pro',
-    system: 'test',
-    messages: [{ role: 'user', content: 'hi' }],
-    max_tokens: 64,
-    stream: false,
-    thinking: { type: 'enabled' },
-  })
+// openaiShim test extraction seam 153 end
 
-  expect(requestBody?.thinking).toEqual({ type: 'enabled' })
-  expect(requestBody?.reasoning_effort).toBe('max')
-  expect(requestBody?.chat_template_kwargs).toEqual({
-    thinking: true,
-    enable_thinking: true,
-  })
-})
 
-test('NVIDIA NIM DeepSeek omits chat template thinking kwargs when thinking is disabled', async () => {
-  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
-  process.env.NVIDIA_API_KEY = 'nvapi-test'
+// openaiShim test extraction seam 154 start: NVIDIA NIM DeepSeek omits chat template thinking kwargs when thinking is disabled
 
-  let requestBody: Record<string, unknown> | undefined
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'deepseek-ai/deepseek-v4-pro',
-        choices: [
-          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
-        ],
-      }),
-      { headers: { 'Content-Type': 'application/json' } },
-    )
-  }) as unknown as FetchType
+// openaiShim test extraction seam 154 end
 
-  const client = createOpenAIShimClient({
-    reasoningEffort: 'xhigh',
-  }) as OpenAIShimClient
-  await client.beta.messages.create({
-    model: 'deepseek-ai/deepseek-v4-pro?thinking=disabled',
-    system: 'test',
-    messages: [{ role: 'user', content: 'hi' }],
-    max_tokens: 64,
-    stream: false,
-  })
 
-  expect(requestBody?.thinking).toBeUndefined()
-  expect(requestBody?.reasoning_effort).toBeUndefined()
-  expect(requestBody?.chat_template_kwargs).toBeUndefined()
-})
-
+// openaiShim test extraction seam 155 start: DeepSeek omits thinking controls when the Anthropic-side request does not set them
 test('DeepSeek omits thinking controls when the Anthropic-side request does not set them', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -8784,7 +9384,10 @@ test('DeepSeek omits thinking controls when the Anthropic-side request does not 
   expect(requestBody?.thinking).toBeUndefined()
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
+// openaiShim test extraction seam 155 end
 
+
+// openaiShim test extraction seam 156 start: DeepSeek forwards an explicit thinking disable toggle for V4 models
 test('DeepSeek forwards an explicit thinking disable toggle for V4 models', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -8818,8 +9421,11 @@ test('DeepSeek forwards an explicit thinking disable toggle for V4 models', asyn
   expect(requestBody?.thinking).toEqual({ type: 'disabled' })
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
+// openaiShim test extraction seam 156 end
 
 
+
+// openaiShim test extraction seam 157 start: collapses multiple text blocks in tool_result to string for DeepSeek compatibility (issue #774)
 test('collapses multiple text blocks in tool_result to string for DeepSeek compatibility (issue #774)', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -8896,7 +9502,10 @@ test('collapses multiple text blocks in tool_result to string for DeepSeek compa
   expect(typeof toolMessages[0].content).toBe('string')
   expect(toolMessages[0].content).toBe('line one\n\nline two')
 })
+// openaiShim test extraction seam 157 end
 
+
+// openaiShim test extraction seam 158 start: collapses multiple text blocks into a single string for DeepSeek compatibility (issue #774)
 test('collapses multiple text blocks into a single string for DeepSeek compatibility (issue #774)', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -8954,7 +9563,10 @@ test('collapses multiple text blocks into a single string for DeepSeek compatibi
   expect(typeof messages[1].content).toBe('string')
   expect(messages[1].content).toBe('Hello!\n\nHow are you?')
 })
+// openaiShim test extraction seam 158 end
 
+
+// openaiShim test extraction seam 159 start: preserves mixed text and image tool results as multipart content
 test('preserves mixed text and image tool results as multipart content', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -9040,7 +9652,10 @@ test('preserves mixed text and image tool results as multipart content', async (
   expect(content[0].type).toBe('text')
   expect(content[1].type).toBe('image_url')
 })
+// openaiShim test extraction seam 159 end
 
+
+// openaiShim test extraction seam 160 start: Z.AI: uses max_tokens (not max_completion_tokens) and strips store
 test('Z.AI: uses max_tokens (not max_completion_tokens) and strips store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9074,7 +9689,10 @@ test('Z.AI: uses max_tokens (not max_completion_tokens) and strips store', async
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
+// openaiShim test extraction seam 160 end
 
+
+// openaiShim test extraction seam 161 start: Z.AI: thinking mode enabled when requested
 test('Z.AI: thinking mode enabled when requested', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9116,7 +9734,10 @@ test('Z.AI: thinking mode enabled when requested', async () => {
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.max_tokens).toBe(1024)
 })
+// openaiShim test extraction seam 161 end
 
+
+// openaiShim test extraction seam 162 start: Z.AI GLM-5.2: default request relies on provider thinking defaults
 test('Z.AI GLM-5.2: default request relies on provider thinking defaults', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9148,7 +9769,10 @@ test('Z.AI GLM-5.2: default request relies on provider thinking defaults', async
   expect(requestBody?.thinking).toBeUndefined()
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
+// openaiShim test extraction seam 162 end
 
+
+// openaiShim test extraction seam 163 start: Z.AI GLM-5.2: user-selected xhigh effort maps to provider max effort
 test('Z.AI GLM-5.2: user-selected xhigh effort maps to provider max effort', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9182,6 +9806,8 @@ test('Z.AI GLM-5.2: user-selected xhigh effort maps to provider max effort', asy
   expect(requestBody?.thinking).toEqual({ type: 'enabled' })
   expect(requestBody?.reasoning_effort).toBe('max')
 })
+// openaiShim test extraction seam 163 end
+
 
 test.each([
   ['glm-5.2?reasoning=low', 'high'],
@@ -9260,6 +9886,7 @@ test.each([
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
 
+// openaiShim test extraction seam 164 start: Z.AI GLM-5.2: model-query thinking disable omits reasoning effort
 test('Z.AI GLM-5.2: model-query thinking disable omits reasoning effort', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9291,7 +9918,10 @@ test('Z.AI GLM-5.2: model-query thinking disable omits reasoning effort', async 
   expect(requestBody?.thinking).toEqual({ type: 'disabled' })
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
+// openaiShim test extraction seam 164 end
 
+
+// openaiShim test extraction seam 165 start: Z.AI GLM-5.2: per-turn thinking overrides model-query default
 test('Z.AI GLM-5.2: per-turn thinking overrides model-query default', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9323,109 +9953,23 @@ test('Z.AI GLM-5.2: per-turn thinking overrides model-query default', async () =
   expect(requestBody?.thinking).toEqual({ type: 'enabled' })
   expect(requestBody?.reasoning_effort).toBe('high')
 })
+// openaiShim test extraction seam 165 end
 
-test('NVIDIA NIM Z.AI GLM sends chat template thinking kwargs', async () => {
-  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
-  process.env.NVIDIA_API_KEY = 'nvapi-test'
 
-  let requestBody: Record<string, unknown> | undefined
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'z-ai/glm-5.2',
-        choices: [
-          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
-        ],
-      }),
-      { headers: { 'Content-Type': 'application/json' } },
-    )
-  }) as unknown as FetchType
+// openaiShim test extraction seam 166 start: NVIDIA NIM Z.AI GLM sends chat template thinking kwargs
 
-  const client = createOpenAIShimClient({
-    reasoningEffort: 'xhigh',
-  }) as OpenAIShimClient
-  await client.beta.messages.create({
-    model: 'z-ai/glm-5.2',
-    messages: [{ role: 'user', content: 'hi' }],
-    max_tokens: 64,
-    stream: false,
-  })
+// openaiShim test extraction seam 166 end
 
-  expect(requestBody?.thinking).toEqual({ type: 'enabled' })
-  expect(requestBody?.reasoning_effort).toBe('max')
-  expect(requestBody?.chat_template_kwargs).toEqual({
-    thinking: true,
-    enable_thinking: true,
-  })
-})
 
-test('NVIDIA NIM Z.AI GLM omits chat template thinking kwargs without a reasoning request', async () => {
-  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
-  process.env.NVIDIA_API_KEY = 'nvapi-test'
+// openaiShim test extraction seam 167 start: NVIDIA NIM Z.AI GLM omits chat template thinking kwargs without a reasoning request
 
-  let requestBody: Record<string, unknown> | undefined
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'z-ai/glm-5.2',
-        choices: [
-          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
-        ],
-      }),
-      { headers: { 'Content-Type': 'application/json' } },
-    )
-  }) as unknown as FetchType
+// openaiShim test extraction seam 167 end
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  await client.beta.messages.create({
-    model: 'z-ai/glm-5.2',
-    messages: [{ role: 'user', content: 'hi' }],
-    max_tokens: 64,
-    stream: false,
-  })
 
-  expect(requestBody?.thinking).toBeUndefined()
-  expect(requestBody?.reasoning_effort).toBeUndefined()
-  expect(requestBody?.chat_template_kwargs).toBeUndefined()
-})
+// openaiShim test extraction seam 168 start: NVIDIA NIM Z.AI GLM omits chat template thinking kwargs when thinking is disabled
 
-test('NVIDIA NIM Z.AI GLM omits chat template thinking kwargs when thinking is disabled', async () => {
-  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
-  process.env.NVIDIA_API_KEY = 'nvapi-test'
+// openaiShim test extraction seam 168 end
 
-  let requestBody: Record<string, unknown> | undefined
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'z-ai/glm-5.2',
-        choices: [
-          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
-        ],
-      }),
-      { headers: { 'Content-Type': 'application/json' } },
-    )
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({
-    reasoningEffort: 'xhigh',
-  }) as OpenAIShimClient
-  await client.beta.messages.create({
-    model: 'z-ai/glm-5.2?thinking=disabled',
-    messages: [{ role: 'user', content: 'hi' }],
-    max_tokens: 64,
-    stream: false,
-  })
-
-  expect(requestBody?.thinking).toEqual({ type: 'disabled' })
-  expect(requestBody?.reasoning_effort).toBeUndefined()
-  expect(requestBody?.chat_template_kwargs).toBeUndefined()
-})
 
 // Extraction boundary: provider reasoning compatibility | tool-stream routing.
 // The gateway emission regression below remains provider/request-shaping coverage.
@@ -9435,6 +9979,7 @@ test('NVIDIA NIM Z.AI GLM omits chat template thinking kwargs when thinking is d
 // `tool_stream` parameter. Streaming tool calls are simply not streamed on
 // this gateway; sending the parameter aborts the request with
 // `400 Unsupported parameter(s): tool_stream`.
+// openaiShim test extraction seam 169 start: NVIDIA NIM Z.AI GLM streaming request with tools does not send tool_stream (regression #1950)
 test('NVIDIA NIM Z.AI GLM streaming request with tools does not send tool_stream (regression #1950)', async () => {
   process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
   process.env.NVIDIA_API_KEY = 'nvapi-test'
@@ -9482,6 +10027,8 @@ test('NVIDIA NIM Z.AI GLM streaming request with tools does not send tool_stream
   // aren't streamed on this gateway.
   expect(requestBody?.tool_stream).toBeUndefined()
 })
+// openaiShim test extraction seam 169 end
+
 
 // Extraction boundary: provider tool-stream shaping | executor tool-stream retry.
 // The three retry-state tests below move together with request execution.
@@ -9492,6 +10039,7 @@ test('NVIDIA NIM Z.AI GLM streaming request with tools does not send tool_stream
 // Here we exercise the generic self-heal using a Z.AI-contract gateway that
 // actually sends `tool_stream`, then rejects it — proving the retry drops the
 // parameter rather than surfacing a hard error.
+// openaiShim test extraction seam 170 start: Shim self-heals a JSON `tool_stream` rejection by retrying without it (#1950)
 test('Shim self-heals a JSON `tool_stream` rejection by retrying without it (#1950)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9550,7 +10098,10 @@ test('Shim self-heals a JSON `tool_stream` rejection by retrying without it (#19
   // Tools are preserved across the retry.
   expect(Array.isArray(requestBodies[1]?.tools)).toBe(true)
 })
+// openaiShim test extraction seam 170 end
 
+
+// openaiShim test extraction seam 171 start: Shim stops after one tool_stream self-heal retry when the retry also fails (#1950)
 test('Shim stops after one tool_stream self-heal retry when the retry also fails (#1950)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9587,7 +10138,10 @@ test('Shim stops after one tool_stream self-heal retry when the retry also fails
   expect(requestBodies[0]?.tool_stream).toBe(true)
   expect(requestBodies[1]?.tool_stream).toBeUndefined()
 })
+// openaiShim test extraction seam 171 end
 
+
+// openaiShim test extraction seam 172 start: Shim retries a tool_stream rejection with the same pooled credential (#1950)
 test('Shim retries a tool_stream rejection with the same pooled credential (#1950)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEYS = 'key-a,key-b'
@@ -9636,10 +10190,13 @@ test('Shim retries a tool_stream rejection with the same pooled credential (#195
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-a'])
 })
+// openaiShim test extraction seam 172 end
+
 
 // Extraction boundary: executor tool-stream retry | provider tool-stream shaping.
 // Provider emission rules below remain with compatibility/request planning.
 // Keep this marker stable for independent adjacent test migrations.
+// openaiShim test extraction seam 173 start: Z.AI GLM-5.2: streaming requests with tools send tool_stream
 test('Z.AI GLM-5.2: streaming requests with tools send tool_stream', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9684,7 +10241,10 @@ test('Z.AI GLM-5.2: streaming requests with tools send tool_stream', async () =>
 
   expect(requestBody?.tool_stream).toBe(true)
 })
+// openaiShim test extraction seam 173 end
 
+
+// openaiShim test extraction seam 174 start: Hicap GLM-5.2: uses Z.AI-compatible request shaping
 test('Hicap GLM-5.2: uses Z.AI-compatible request shaping', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
   process.env.HICAP_API_KEY = 'sk-hicap-test'
@@ -9735,6 +10295,9 @@ test('Hicap GLM-5.2: uses Z.AI-compatible request shaping', async () => {
   expect(requestBody?.reasoning_effort).toBe('max')
   expect(requestBody?.tool_stream).toBe(true)
 })
+// openaiShim test extraction seam 174 end
+
+// openaiShim test extraction seam 175 start: Z.AI GLM-5.2: remote tool incompatibility does not use local toolless retry
 test('Z.AI GLM-5.2: remote tool incompatibility does not use local toolless retry', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9772,6 +10335,8 @@ test('Z.AI GLM-5.2: remote tool incompatibility does not use local toolless retr
   expect(requestBodies).toHaveLength(1)
   expect(requestBodies[0]?.tool_stream).toBe(true)
 })
+// openaiShim test extraction seam 175 end
+
 
 test.each([
   ['non-streaming Z.AI request with tools', 'https://api.z.ai/api/coding/paas/v4', false, true, 'glm-5.2'],
@@ -9836,6 +10401,7 @@ test.each([
   expect(requestBody?.tool_stream).toBeUndefined()
 })
 
+// openaiShim test extraction seam 176 start: Z.AI GLM-5.2: preserved thinking round-trips with tool calls
 test('Z.AI GLM-5.2: preserved thinking round-trips with tool calls', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9902,7 +10468,10 @@ test('Z.AI GLM-5.2: preserved thinking round-trips with tool calls', async () =>
     },
   ])
 })
+// openaiShim test extraction seam 176 end
 
+
+// openaiShim test extraction seam 177 start: strips Anthropic attribution header block from chat-completions system prompt (#607)
 test('strips Anthropic attribution header block from chat-completions system prompt (#607)', async () => {
   let capturedBody: Record<string, unknown> | undefined
 
@@ -9952,7 +10521,10 @@ test('strips Anthropic attribution header block from chat-completions system pro
   expect(sysMsg?.content).toContain('You are Claude Code, helpful assistant.')
   expect(sysMsg?.content).toContain('Project context: bun + react.')
 })
+// openaiShim test extraction seam 177 end
 
+
+// openaiShim test extraction seam 178 start: strips Anthropic attribution header block from responses-API instructions (#607)
 test('strips Anthropic attribution header block from responses-API instructions (#607)', async () => {
   process.env.OPENAI_API_FORMAT = 'responses'
   let capturedBody: Record<string, unknown> | undefined
@@ -9998,7 +10570,10 @@ test('strips Anthropic attribution header block from responses-API instructions 
   expect(instructions).not.toContain('cc_version=')
   expect(instructions).toContain('You are Claude Code.')
 })
+// openaiShim test extraction seam 178 end
 
+
+// openaiShim test extraction seam 179 start: emits reasoning_effort on chat_completions when reasoningEffort is passed
 test('emits reasoning_effort on chat_completions when reasoningEffort is passed', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'test-key'
@@ -10039,7 +10614,10 @@ test('emits reasoning_effort on chat_completions when reasoningEffort is passed'
 
   expect(requestBody?.reasoning_effort).toBe('xhigh')
 })
+// openaiShim test extraction seam 179 end
 
+
+// openaiShim test extraction seam 180 start: omits reasoning_effort on chat_completions when no override and model has no alias default
 test('omits reasoning_effort on chat_completions when no override and model has no alias default', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'test-key'
@@ -10075,7 +10653,10 @@ test('omits reasoning_effort on chat_completions when no override and model has 
 
   expect(requestBody && 'reasoning_effort' in requestBody).toBe(false)
 })
+// openaiShim test extraction seam 180 end
 
+
+// openaiShim test extraction seam 181 start: emits reasoning_effort from codex alias default when no override is passed
 test('emits reasoning_effort from codex alias default when no override is passed', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'test-key'
@@ -10114,7 +10695,10 @@ test('emits reasoning_effort from codex alias default when no override is passed
 
   expect(requestBody?.reasoning_effort).toBe('high')
 })
+// openaiShim test extraction seam 181 end
 
+
+// openaiShim test extraction seam 182 start: DeepSeek: redacted_thinking block preserves continuity with reasoning_content: ""
 test('DeepSeek: redacted_thinking block preserves continuity with reasoning_content: ""', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -10175,7 +10759,10 @@ test('DeepSeek: redacted_thinking block preserves continuity with reasoning_cont
   // message carries a tool_call, so it falls back to reasoning_content: ""
   expect(assistantWithToolCall?.reasoning_content).toBe('')
 })
+// openaiShim test extraction seam 182 end
 
+
+// openaiShim test extraction seam 183 start: DeepSeek: redacted_thinking block with non-empty data propagates data into reasoning_content
 test('DeepSeek: redacted_thinking block with non-empty data propagates data into reasoning_content', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -10242,6 +10829,103 @@ test('DeepSeek: redacted_thinking block with non-empty data propagates data into
     'encrypted_chain_of_thought_payload_v1',
   )
 })
+// openaiShim test extraction seam 183 end
+
+
+// openaiShim test extraction seam 184 start: renders tool_reference blocks as text on the chat/completions path
+test('renders tool_reference blocks as text on the chat/completions path', async () => {
+  const { __test } = await import('./openaiShim.ts')
+
+  const messages = __test.convertMessages(
+    [
+      {
+        role: 'assistant',
+        content: [
+          { type: 'tool_use', id: 'call_ts1', name: 'ToolSearch', input: { query: 'memory' } },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_ts1',
+            content: [
+              { type: 'tool_reference', tool_name: 'mcp__example__memory_search' },
+              { type: 'tool_reference', tool_name: 'mcp__example__memory_store' },
+            ],
+          },
+        ],
+      },
+    ],
+    undefined,
+  )
+
+  const toolMsg = messages.find(m => m.role === 'tool')
+  expect(toolMsg).toBeDefined()
+  // The rendering contract is plain text: text-only parts collapse to a string.
+  expect(typeof toolMsg!.content).toBe('string')
+  const content = toolMsg!.content as string
+  expect(content).toContain('mcp__example__memory_search')
+  expect(content).toContain('mcp__example__memory_store')
+})
+// openaiShim test extraction seam 184 end
+
+
+// openaiShim test extraction seam 185 start: preserves valid tool pairs after history pruning while dropping orphaned tool calls
+test('preserves valid tool pairs after history pruning while dropping orphaned tool calls', async () => {
+  const { __test } = await import('./openaiShim.ts')
+
+  const messages = __test.convertMessages(
+    [
+      { role: 'user', content: 'compacted summary of previous work' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_pruned_without_result',
+            name: 'Read',
+            input: { file_path: 'old.ts' },
+          },
+        ],
+      },
+      { role: 'user', content: 'continue with retained context' },
+      {
+        role: 'assistant',
+        content: [
+          { type: 'text', text: 'Reading the current file.' },
+          {
+            type: 'tool_use',
+            id: 'call_retained',
+            name: 'Read',
+            input: { file_path: 'current.ts' },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_retained',
+            content: 'current contents',
+          },
+        ],
+      },
+    ],
+    undefined,
+  )
+
+  const toolCalls = messages.flatMap(message => message.tool_calls ?? [])
+  expect(toolCalls.map(toolCall => toolCall.id)).toEqual(['call_retained'])
+
+  const toolMessages = messages.filter(message => message.role === 'tool')
+  expect(toolMessages).toHaveLength(1)
+  expect(toolMessages[0]?.tool_call_id).toBe('call_retained')
+})
+// openaiShim test extraction seam 185 end
+
 
 // Extraction boundary: history pruning | executor Copilot refresh behavior.
 // The contiguous Copilot authentication retry block below moves with execution.
@@ -10251,6 +10935,196 @@ function makeCodexSseResponse(responseData: Record<string, unknown>): Response {
   return makeSseResponse([`event: response.completed\ndata: ${data}\n\n`])
 }
 
+test('GitHub Copilot codex responses transport does not replay after a pre-header timeout', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+  process.env.OPENAI_API_KEY = 'test-token'
+  process.env.API_TIMEOUT_MS = '20'
+  let fetchCalls = 0
+  const requestUrls: string[] = []
+
+  globalThis.fetch = (async (input, init) => {
+    fetchCalls++
+    requestUrls.push(String(input))
+    return pendingFetchUntilAbort(init)
+  }) as unknown as FetchType
+
+  const safety = new AbortController()
+  const safetyTimer = setTimeout(() => safety.abort(), 500)
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  let caught: unknown
+  try {
+    await waitForPromise(
+      client.beta.messages.create(
+        {
+          model: 'gpt-5',
+          messages: [{ role: 'user', content: 'hello' }],
+          max_tokens: 32,
+          stream: false,
+        },
+        { signal: safety.signal },
+      ),
+      750,
+      'GitHub codex responses timeout did not settle',
+    )
+  } catch (error) {
+    caught = error
+  } finally {
+    clearTimeout(safetyTimer)
+  }
+
+  expect(caught).toBeDefined()
+  const error = caught as Error & { constructor: { name: string } }
+  expect(error.constructor.name).toBe('APIConnectionError')
+  expect(isOpenAIRequestNonReplayable(error)).toBe(true)
+  expect(fetchCalls).toBe(1)
+  expect(requestUrls).toEqual([
+    'https://api.githubcopilot.com/responses',
+  ])
+})
+
+test('GitHub Copilot responses fallback does not replay after a pre-header timeout', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+  process.env.OPENAI_API_KEY = 'test-token'
+  process.env.API_TIMEOUT_MS = '20'
+  const requestUrls: string[] = []
+
+  globalThis.fetch = (async (input, init) => {
+    const url = String(input)
+    requestUrls.push(url)
+    if (url.endsWith('/chat/completions')) {
+      return makeGithubChatFallbackResponse()
+    }
+    return pendingFetchUntilAbort(init)
+  }) as unknown as FetchType
+
+  const safety = new AbortController()
+  const safetyTimer = setTimeout(() => safety.abort(), 500)
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  let caught: unknown
+  try {
+    await waitForPromise(
+      client.beta.messages.create(
+        {
+          model: 'gpt-4',
+          messages: [{ role: 'user', content: 'hello' }],
+          max_tokens: 32,
+          stream: false,
+        },
+        { signal: safety.signal },
+      ),
+      750,
+      'GitHub responses fallback timeout did not settle',
+    )
+  } catch (error) {
+    caught = error
+  } finally {
+    clearTimeout(safetyTimer)
+  }
+
+  expect(caught).toBeDefined()
+  const error = caught as Error & { constructor: { name: string } }
+  expect(error.constructor.name).toBe('APIConnectionError')
+  expect(isOpenAIRequestNonReplayable(error)).toBe(true)
+  expect(requestUrls).toEqual([
+    'https://api.githubcopilot.com/chat/completions',
+    'https://api.githubcopilot.com/responses',
+  ])
+})
+
+test('GitHub Copilot responses fallback preserves caller abort without retrying', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+  process.env.OPENAI_API_KEY = 'test-token'
+  process.env.API_TIMEOUT_MS = '200'
+  let fetchCalls = 0
+
+  globalThis.fetch = (async (input, init) => {
+    fetchCalls++
+    if (String(input).endsWith('/chat/completions')) {
+      return makeGithubChatFallbackResponse()
+    }
+    return pendingFetchUntilAbort(init)
+  }) as unknown as FetchType
+
+  const caller = new AbortController()
+  const callerReason = new DOMException('Cancelled by user', 'AbortError')
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const request = client.beta.messages.create(
+    {
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 32,
+      stream: false,
+    },
+    { signal: caller.signal },
+  )
+  setTimeout(() => caller.abort(callerReason), 10)
+
+  await expect(
+    waitForPromise(request, 500, 'GitHub responses fallback abort did not settle'),
+  ).rejects.toBe(callerReason)
+  expect(fetchCalls).toBe(2)
+})
+
+test('GitHub Copilot responses fallback preserves non-caller transport aborts', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+  process.env.OPENAI_API_KEY = 'test-token'
+  let fetchCalls = 0
+  const transportAbort = new DOMException('Proxy aborted request', 'AbortError')
+
+  globalThis.fetch = (async input => {
+    fetchCalls++
+    if (String(input).endsWith('/chat/completions')) {
+      return makeGithubChatFallbackResponse()
+    }
+    throw transportAbort
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await expect(
+    client.beta.messages.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 32,
+      stream: false,
+    }),
+  ).rejects.toBe(transportAbort)
+  expect(fetchCalls).toBe(2)
+})
+
+test('GitHub Copilot responses fallback does not retry non-retryable HTTP failures', async () => {
+  process.env.CLAUDE_CODE_USE_GITHUB = '1'
+  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
+  process.env.OPENAI_API_KEY = 'test-token'
+  let fetchCalls = 0
+
+  globalThis.fetch = (async input => {
+    fetchCalls++
+    if (String(input).endsWith('/chat/completions')) {
+      return makeGithubChatFallbackResponse()
+    }
+    return new Response(
+      JSON.stringify({ error: { message: 'invalid token' } }),
+      { status: 401, headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await expect(
+    client.beta.messages.create({
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 32,
+      stream: false,
+    }),
+  ).rejects.toMatchObject({ status: 401 })
+  expect(fetchCalls).toBe(2)
+})
+
+// openaiShim test extraction seam 186 start: GitHub Copilot 401 chat_completions retries with refreshed token
 test('GitHub Copilot 401 chat_completions retries with refreshed token', async () => {
   const realModule = realGithubModelsCredentials
   try {
@@ -10320,7 +11194,10 @@ test('GitHub Copilot 401 chat_completions retries with refreshed token', async (
     mock.module('../../utils/githubModelsCredentials.js', () => realModule)
   }
 })
+// openaiShim test extraction seam 186 end
 
+
+// openaiShim test extraction seam 187 start: GitHub Copilot 401 codex_responses retries with refreshed token
 test('GitHub Copilot 401 codex_responses retries with refreshed token', async () => {
   const realGithubModule = realGithubModelsCredentials
   const realCodexModule = realCodexShim
@@ -10397,7 +11274,10 @@ test('GitHub Copilot 401 codex_responses retries with refreshed token', async ()
     mock.module('./codexShim.js', () => realCodexModule)
   }
 })
+// openaiShim test extraction seam 187 end
 
+
+// openaiShim test extraction seam 188 start: GitHub Copilot 401 with credential pool uses refreshed token not pool key
 test('GitHub Copilot 401 with credential pool uses refreshed token not pool key', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -10459,7 +11339,10 @@ test('GitHub Copilot 401 with credential pool uses refreshed token not pool key'
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
+// openaiShim test extraction seam 188 end
 
+
+// openaiShim test extraction seam 189 start: GitHub Copilot 401 with "token has expired" triggers refresh
 test('GitHub Copilot 401 with "token has expired" triggers refresh', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -10515,7 +11398,10 @@ test('GitHub Copilot 401 with "token has expired" triggers refresh', async () =>
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
+// openaiShim test extraction seam 189 end
 
+
+// openaiShim test extraction seam 190 start: GitHub Copilot 401 without expired-token message does not trigger refresh
 test('GitHub Copilot 401 without expired-token message does not trigger refresh', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -10563,7 +11449,10 @@ test('GitHub Copilot 401 without expired-token message does not trigger refresh'
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
+// openaiShim test extraction seam 190 end
 
+
+// openaiShim test extraction seam 191 start: GitHub Copilot 401 refresh returning same token does not update auth
 test('GitHub Copilot 401 refresh returning same token does not update auth', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -10620,7 +11509,10 @@ test('GitHub Copilot 401 refresh returning same token does not update auth', asy
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
+// openaiShim test extraction seam 191 end
 
+
+// openaiShim test extraction seam 192 start: GitHub Copilot 401 codex_responses with providerOverride does not trigger refresh
 test('GitHub Copilot 401 codex_responses with providerOverride does not trigger refresh', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -10671,7 +11563,10 @@ test('GitHub Copilot 401 codex_responses with providerOverride does not trigger 
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
+// openaiShim test extraction seam 192 end
 
+
+// openaiShim test extraction seam 193 start: GitHub Copilot 401 chat_completions with providerOverride does not trigger refresh
 test('GitHub Copilot 401 chat_completions with providerOverride does not trigger refresh', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -10721,6 +11616,8 @@ test('GitHub Copilot 401 chat_completions with providerOverride does not trigger
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
+// openaiShim test extraction seam 193 end
+
 
 // Extraction boundary: executor Copilot refresh behavior | JSON fallback conversion.
 // JSON fallback response conversion below is not owned by request execution.
@@ -10765,6 +11662,7 @@ async function collectFallbackEvents(
   }
 }
 
+// openaiShim test extraction seam 194 start: JSON fallback: preserves tool_calls as a tool_use block
 test('JSON fallback: preserves tool_calls as a tool_use block', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-tool',
@@ -10816,7 +11714,10 @@ test('JSON fallback: preserves tool_calls as a tool_use block', async () => {
     | undefined
   expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
 })
+// openaiShim test extraction seam 194 end
 
+
+// openaiShim test extraction seam 195 start: JSON fallback: maps finish_reason=length to max_tokens
 test('JSON fallback: maps finish_reason=length to max_tokens', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-len',
@@ -10830,7 +11731,10 @@ test('JSON fallback: maps finish_reason=length to max_tokens', async () => {
     | undefined
   expect(stopEvent?.delta?.stop_reason).toBe('max_tokens')
 })
+// openaiShim test extraction seam 195 end
 
+
+// openaiShim test extraction seam 196 start: JSON fallback: preserves OpenCode Go quota error guidance
 test('JSON fallback: preserves OpenCode Go quota error guidance', async () => {
   process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
   const previousFetch = globalThis.fetch
@@ -10879,7 +11783,10 @@ test('JSON fallback: preserves OpenCode Go quota error guidance', async () => {
     globalThis.fetch = previousFetch
   }
 })
+// openaiShim test extraction seam 196 end
 
+
+// openaiShim test extraction seam 197 start: JSON fallback: strips <think> tags from emitted text
 test('JSON fallback: strips <think> tags from emitted text', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-think',
@@ -10901,7 +11808,10 @@ test('JSON fallback: strips <think> tags from emitted text', async () => {
   expect(textDelta?.delta?.text).toBe('visible answer')
   expect(textDelta?.delta?.text).not.toContain('private plan')
 })
+// openaiShim test extraction seam 197 end
 
+
+// openaiShim test extraction seam 198 start: JSON fallback: normalizes array content into a text string
 test('JSON fallback: normalizes array content into a text string', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-array',
@@ -10929,7 +11839,10 @@ test('JSON fallback: normalizes array content into a text string', async () => {
   expect(typeof textDelta?.delta?.text).toBe('string')
   expect(textDelta?.delta?.text).toBe('line one\nline two')
 })
+// openaiShim test extraction seam 198 end
 
+
+// openaiShim test extraction seam 199 start: JSON fallback: recovers raw-text tool call into tool_use block
 test('JSON fallback: recovers raw-text tool call into tool_use block', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-raw',
@@ -10965,7 +11878,10 @@ test('JSON fallback: recovers raw-text tool call into tool_use block', async () 
   expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
 
 })
+// openaiShim test extraction seam 199 end
 
+
+// openaiShim test extraction seam 200 start: JSON fallback façade terminates converted messages
 test('JSON fallback façade terminates converted messages', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-boundary',
@@ -10978,7 +11894,10 @@ test('JSON fallback façade terminates converted messages', async () => {
 
   expect(events.at(-1)?.type).toBe('message_stop')
 })
+// openaiShim test extraction seam 200 end
 
+
+// openaiShim test extraction seam 201 start: JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks
 test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-hy3',
@@ -11021,7 +11940,10 @@ test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks',
     | undefined
   expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
 })
+// openaiShim test extraction seam 201 end
 
+
+// openaiShim test extraction seam 202 start: JSON fallback: preserves HY3-looking text for non-Tencent model names
 test('JSON fallback: preserves HY3-looking text for non-Tencent model names', async () => {
   const text =
     '<tool_call:example>TaskCreate\nsubject: merely a documentation example\n</tool_call:example>'
@@ -11053,7 +11975,10 @@ test('JSON fallback: preserves HY3-looking text for non-Tencent model names', as
   expect(toolStart).toBeUndefined()
   expect(textDelta?.delta?.text).toBe(text)
 })
+// openaiShim test extraction seam 202 end
 
+
+// openaiShim test extraction seam 203 start: JSON fallback: empty tool_calls array does not block raw-text recovery
 test('JSON fallback: empty tool_calls array does not block raw-text recovery', async () => {
   // tool_calls: [] is truthy; it must be treated as "no structured tool calls"
   // so the raw "Tool calls requested" recovery still runs.
@@ -11085,7 +12010,10 @@ test('JSON fallback: empty tool_calls array does not block raw-text recovery', a
     name: 'Bash',
   })
 })
+// openaiShim test extraction seam 203 end
 
+
+// openaiShim test extraction seam 204 start: JSON fallback: empty tool_calls does not block raw-text recovery on array content
 test('JSON fallback: empty tool_calls does not block raw-text recovery on array content', async () => {
   // Companion to the string-content case above: the array-content branch must
   // also treat tool_calls: [] as "no structured tool calls" so raw recovery runs.
@@ -11119,3 +12047,4 @@ test('JSON fallback: empty tool_calls does not block raw-text recovery on array 
     name: 'Bash',
   })
 })
+// openaiShim test extraction seam 204 end

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -1,6 +1,5 @@
 import { APIError } from '@anthropic-ai/sdk'
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
-import { getEventListeners } from 'node:events'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
 import { asMockFetch } from '../../test/typedMocks.js'
 import { _clearRegistryForTesting, ensureIntegrationsLoaded, registerGateway } from '../../integrations/index.ts'
@@ -10,11 +9,7 @@ import {
   getAssistantMessageFromError,
   OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
 } from './errors.ts'
-import {
-  extractOpenAICategoryMarker,
-  isOpenAIRequestNonReplayable,
-} from './openaiErrorClassification.ts'
-import { createOpenAIShimClient, hasMistralApiHost, parseTextToolCalls, parseXmlToolCalls } from './openaiShim.ts'
+import { createOpenAIShimClient, hasMistralApiHost } from './openaiShim.ts'
 import * as realCodexShim from './codexShim.js'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 
@@ -55,15 +50,12 @@ const originalEnv = {
   OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
   DEEPSEEK_API_KEY: process.env.DEEPSEEK_API_KEY,
   MIMO_API_KEY: process.env.MIMO_API_KEY,
-  LONGCAT_API_KEY: process.env.LONGCAT_API_KEY,
-  CLINE_API_KEY: process.env.CLINE_API_KEY,
   OPENGATEWAY_API_KEY: process.env.OPENGATEWAY_API_KEY,
   OPENGATEWAY_BASE_URL: process.env.OPENGATEWAY_BASE_URL,
   OPENCODE_API_KEY: process.env.OPENCODE_API_KEY,
   CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED: process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED,
   CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID: process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID,
   CLAUDE_STREAM_IDLE_TIMEOUT_MS: process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS,
-  API_TIMEOUT_MS: process.env.API_TIMEOUT_MS,
 }
 
 const originalFetch = globalThis.fetch
@@ -372,7 +364,6 @@ function importFreshOpenAIShim(
 
 type StreamIdleTestApi = {
   StreamIdleTimeoutError: new (timeoutMs: number) => Error
-  getApiTimeoutMs: () => number
   getStreamIdleTimeoutMs: () => number
   readWithIdleTimeout: (
     reader: ReadableStreamDefaultReader<Uint8Array>,
@@ -385,7 +376,6 @@ async function getStreamIdleTestApi(cacheKey: string): Promise<StreamIdleTestApi
   const mod = await importFreshOpenAIShim(cacheKey)
   const testApi = mod.__test as unknown as Partial<StreamIdleTestApi>
   expect(typeof testApi.StreamIdleTimeoutError).toBe('function')
-  expect(typeof testApi.getApiTimeoutMs).toBe('function')
   expect(typeof testApi.getStreamIdleTimeoutMs).toBe('function')
   expect(typeof testApi.readWithIdleTimeout).toBe('function')
   return testApi as StreamIdleTestApi
@@ -412,48 +402,6 @@ function makeChatCompletionResponse(model: string): Response {
       },
     },
   )
-}
-
-function makeGithubChatFallbackResponse(): Response {
-  return new Response(
-    JSON.stringify({
-      error: { message: '/chat/completions is not accessible for this model' },
-    }),
-    { status: 400, headers: { 'Content-Type': 'application/json' } },
-  )
-}
-
-function makeResponsesApiResponse(model: string): Response {
-  return new Response(
-    JSON.stringify({
-      id: 'resp-fallback-test',
-      model,
-      output: [
-        {
-          type: 'message',
-          role: 'assistant',
-          content: [{ type: 'output_text', text: 'ok' }],
-        },
-      ],
-      usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
-    }),
-    { headers: { 'Content-Type': 'application/json' } },
-  )
-}
-
-function pendingFetchUntilAbort(
-  init: RequestInit | undefined,
-): Promise<Response> {
-  return new Promise<Response>((_resolve, reject) => {
-    const signal = init?.signal
-    if (!signal) return
-
-    const rejectFromAbort = () => {
-      reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
-    }
-    signal.addEventListener('abort', rejectFromAbort, { once: true })
-    if (signal.aborted) rejectFromAbort()
-  })
 }
 
 async function captureChatCompletionRequest(
@@ -518,15 +466,12 @@ beforeEach(async () => {
   delete process.env.OPENROUTER_API_KEY
   delete process.env.DEEPSEEK_API_KEY
   delete process.env.MIMO_API_KEY
-  delete process.env.LONGCAT_API_KEY
-  delete process.env.CLINE_API_KEY
   delete process.env.OPENGATEWAY_API_KEY
   delete process.env.OPENGATEWAY_BASE_URL
   delete process.env.OPENCODE_API_KEY
   delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
   delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
   delete process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS
-  delete process.env.API_TIMEOUT_MS
 })
 
 afterEach(() => {
@@ -565,15 +510,12 @@ afterEach(() => {
     restoreEnv('OPENROUTER_API_KEY', originalEnv.OPENROUTER_API_KEY)
     restoreEnv('DEEPSEEK_API_KEY', originalEnv.DEEPSEEK_API_KEY)
     restoreEnv('MIMO_API_KEY', originalEnv.MIMO_API_KEY)
-    restoreEnv('LONGCAT_API_KEY', originalEnv.LONGCAT_API_KEY)
-    restoreEnv('CLINE_API_KEY', originalEnv.CLINE_API_KEY)
     restoreEnv('OPENGATEWAY_API_KEY', originalEnv.OPENGATEWAY_API_KEY)
     restoreEnv('OPENGATEWAY_BASE_URL', originalEnv.OPENGATEWAY_BASE_URL)
     restoreEnv('OPENCODE_API_KEY', originalEnv.OPENCODE_API_KEY)
     restoreEnv('CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED', originalEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED)
     restoreEnv('CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID', originalEnv.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID)
     restoreEnv('CLAUDE_STREAM_IDLE_TIMEOUT_MS', originalEnv.CLAUDE_STREAM_IDLE_TIMEOUT_MS)
-    restoreEnv('API_TIMEOUT_MS', originalEnv.API_TIMEOUT_MS)
     globalThis.fetch = originalFetch
     _clearRegistryForTesting()
     ensureIntegrationsLoaded()
@@ -582,12 +524,68 @@ afterEach(() => {
   }
 })
 
-// openaiShim test extraction seam 001 start: strips canonical Anthropic headers from direct shim defaultHeaders
+test('strips canonical Anthropic headers from direct shim defaultHeaders', async () => {
+  let capturedHeaders: Headers | undefined
 
-// openaiShim test extraction seam 001 end
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = new Headers(init?.headers)
 
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'gpt-4o',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 8,
+          completion_tokens: 3,
+          total_tokens: 11,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
 
-// openaiShim test extraction seam 002 start: uses OpenAI-compatible responses endpoint when OPENAI_API_FORMAT=responses
+  const client = createOpenAIShimClient({
+    defaultHeaders: {
+      'anthropic-version': '2023-06-01',
+      'anthropic-beta': 'prompt-caching-2024-07-31',
+      'x-anthropic-additional-protection': 'true',
+      'x-claude-remote-session-id': 'remote-123',
+      'x-app': 'cli',
+      'x-client-app': 'sdk',
+      'x-safe-header': 'keep-me',
+    },
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'gpt-4o',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(capturedHeaders?.get('anthropic-version')).toBeNull()
+  expect(capturedHeaders?.get('anthropic-beta')).toBeNull()
+  expect(capturedHeaders?.get('x-anthropic-additional-protection')).toBeNull()
+  expect(capturedHeaders?.get('x-claude-remote-session-id')).toBeNull()
+  expect(capturedHeaders?.get('x-app')).toBeNull()
+  expect(capturedHeaders?.get('x-client-app')).toBeNull()
+  expect(capturedHeaders?.get('x-safe-header')).toBe('keep-me')
+})
+
 test('uses OpenAI-compatible responses endpoint when OPENAI_API_FORMAT=responses', async () => {
   process.env.OPENAI_API_FORMAT = 'responses'
   let capturedUrl = ''
@@ -645,10 +643,7 @@ test('uses OpenAI-compatible responses endpoint when OPENAI_API_FORMAT=responses
     },
   ])
 })
-// openaiShim test extraction seam 002 end
 
-
-// openaiShim test extraction seam 003 start: nests reasoning effort for OpenAI-compatible responses endpoint
 test('nests reasoning effort for OpenAI-compatible responses endpoint', async () => {
   process.env.OPENAI_API_FORMAT = 'responses'
   let capturedBody: Record<string, unknown> | undefined
@@ -690,7 +685,6 @@ test('nests reasoning effort for OpenAI-compatible responses endpoint', async ()
   expect(capturedBody).not.toHaveProperty('reasoning_effort')
   expect(capturedBody).not.toHaveProperty('reasoning_summary')
 })
-// openaiShim test extraction seam 003 end
 
 test('auto-routes gpt-5.6 to /responses on api.openai.com with tools and nested reasoning', async () => {
   // No OPENAI_API_FORMAT set: the model+base predicate must pick responses.
@@ -1258,7 +1252,6 @@ test('auto-routed gpt-5.6 on an Azure base nests reasoning.effort and the encryp
   expect(capturedBody?.include).toEqual(['reasoning.encrypted_content'])
 })
 
-// openaiShim test extraction seam 004 start: uses OpenAI-compatible responses endpoint with text chunk types when OPENAI_API_FORMAT=responses_compat
 test('uses OpenAI-compatible responses endpoint with text chunk types when OPENAI_API_FORMAT=responses_compat', async () => {
   process.env.OPENAI_API_FORMAT = 'responses_compat'
   let capturedUrl = ''
@@ -1316,10 +1309,7 @@ test('uses OpenAI-compatible responses endpoint with text chunk types when OPENA
     },
   ])
 })
-// openaiShim test extraction seam 004 end
 
-
-// openaiShim test extraction seam 005 start: uses correct empty input fallback schema for standard responses and responses_compat
 test('uses correct empty input fallback schema for standard responses and responses_compat', async () => {
   let capturedBody: Record<string, unknown> | undefined
 
@@ -1364,10 +1354,7 @@ test('uses correct empty input fallback schema for standard responses and respon
     },
   ])
 })
-// openaiShim test extraction seam 005 end
 
-
-// openaiShim test extraction seam 006 start: strips store from strict OpenAI-compatible responses providers
 test('strips store from strict OpenAI-compatible responses providers', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.ai/v1'
   process.env.OPENAI_API_FORMAT = 'responses'
@@ -1410,10 +1397,7 @@ test('strips store from strict OpenAI-compatible responses providers', async () 
   expect(capturedUrl).toBe('https://api.moonshot.ai/v1/responses')
   expect(capturedBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 006 end
 
-
-// openaiShim test extraction seam 007 start: strips store when providerOverride routes chat_completions to the Gemini host
 test('strips store when providerOverride routes chat_completions to the Gemini host', async () => {
   let capturedBody: Record<string, unknown> | undefined
 
@@ -1446,10 +1430,7 @@ test('strips store when providerOverride routes chat_completions to the Gemini h
 
   expect(capturedBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 007 end
 
-
-// openaiShim test extraction seam 008 start: strips store when providerOverride routes responses API to the Gemini host
 test('strips store when providerOverride routes responses API to the Gemini host', async () => {
   process.env.OPENAI_API_FORMAT = 'responses'
   let capturedBody: Record<string, unknown> | undefined
@@ -1489,10 +1470,7 @@ test('strips store when providerOverride routes responses API to the Gemini host
 
   expect(capturedBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 008 end
 
-
-// openaiShim test extraction seam 009 start: uses custom OpenAI-compatible auth header value when configured
 test('uses custom OpenAI-compatible auth header value when configured', async () => {
   process.env.OPENAI_API_KEY = 'generic-key'
   process.env.OPENAI_AUTH_HEADER = 'api-key'
@@ -1527,10 +1505,7 @@ test('uses custom OpenAI-compatible auth header value when configured', async ()
   expect(capturedHeaders?.get('api-key')).toBe('hicap-header-value')
   expect(capturedHeaders?.get('authorization')).toBeNull()
 })
-// openaiShim test extraction seam 009 end
 
-
-// openaiShim test extraction seam 010 start: uses Hicap api-key auth header for the Hicap route
 test('uses Hicap api-key auth header for the Hicap route', async () => {
   process.env.OPENAI_API_KEY = 'hicap-live-key'
   process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
@@ -1564,10 +1539,7 @@ test('uses Hicap api-key auth header for the Hicap route', async () => {
   expect(capturedHeaders?.get('api-key')).toBe('hicap-live-key')
   expect(capturedHeaders?.get('authorization')).toBeNull()
 })
-// openaiShim test extraction seam 010 end
 
-
-// openaiShim test extraction seam 011 start: defaults Authorization custom auth header to bearer scheme
 test('defaults Authorization custom auth header to bearer scheme', async () => {
   process.env.OPENAI_API_KEY = 'authorization-key'
   process.env.OPENAI_AUTH_HEADER = 'Authorization'
@@ -1600,10 +1572,7 @@ test('defaults Authorization custom auth header to bearer scheme', async () => {
 
   expect(capturedHeaders?.get('authorization')).toBe('Bearer authorization-key')
 })
-// openaiShim test extraction seam 011 end
 
-
-// openaiShim test extraction seam 012 start: honors bearer scheme for custom OpenAI-compatible auth headers
 test('honors bearer scheme for custom OpenAI-compatible auth headers', async () => {
   process.env.OPENAI_API_KEY = 'custom-key'
   process.env.OPENAI_AUTH_HEADER = 'X-Custom-Authorization'
@@ -1638,10 +1607,7 @@ test('honors bearer scheme for custom OpenAI-compatible auth headers', async () 
   expect(capturedHeaders?.get('x-custom-authorization')).toBe('Bearer custom-key')
   expect(capturedHeaders?.get('authorization')).toBeNull()
 })
-// openaiShim test extraction seam 012 end
 
-
-// openaiShim test extraction seam 013 start: ignores custom auth header value when no custom header is configured
 test('ignores custom auth header value when no custom header is configured', async () => {
   delete process.env.OPENAI_API_KEY
   process.env.OPENAI_AUTH_HEADER_VALUE = 'gateway-header-value'
@@ -1674,15 +1640,64 @@ test('ignores custom auth header value when no custom header is configured', asy
 
   expect(capturedHeaders?.get('authorization')).toBeNull()
 })
-// openaiShim test extraction seam 013 end
 
+test('strips canonical Anthropic headers from per-request shim headers too', async () => {
+  let capturedHeaders: Headers | undefined
 
-// openaiShim test extraction seam 014 start: strips canonical Anthropic headers from per-request shim headers too
+  globalThis.fetch = (async (_input, init) => {
+    capturedHeaders = new Headers(init?.headers)
 
-// openaiShim test extraction seam 014 end
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'gpt-4o',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 8,
+          completion_tokens: 3,
+          total_tokens: 11,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
 
-// openaiShim test extraction seam 015 start: applies descriptor static headers before client and request headers
+  await client.beta.messages.create(
+    {
+      model: 'gpt-4o',
+      system: 'test system',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      stream: false,
+    },
+    {
+      headers: {
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': 'prompt-caching-2024-07-31',
+        'x-safe-header': 'keep-me',
+      },
+    },
+  )
+
+  expect(capturedHeaders?.get('anthropic-version')).toBeNull()
+  expect(capturedHeaders?.get('anthropic-beta')).toBeNull()
+  expect(capturedHeaders?.get('x-safe-header')).toBe('keep-me')
+})
+
 test('applies descriptor static headers before client and request headers', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -1766,10 +1781,7 @@ test('applies descriptor static headers before client and request headers', asyn
   expect(capturedHeaders?.get('x-static-header')).toBe('from-descriptor')
   expect(capturedHeaders?.get('x-override-header')).toBe('from-request')
 })
-// openaiShim test extraction seam 015 end
 
-
-// openaiShim test extraction seam 016 start: opengateway sends Accept-Encoding: identity header on chat requests
 test('opengateway sends Accept-Encoding: identity header on chat requests', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -1852,10 +1864,7 @@ test('opengateway sends Accept-Encoding: identity header on chat requests', asyn
 
   expect(capturedHeaders?.get('Accept-Encoding')).toBe('identity')
 })
-// openaiShim test extraction seam 016 end
 
-
-// openaiShim test extraction seam 017 start: strips Anthropic-specific headers on GitHub Codex transport requests
 test('strips Anthropic-specific headers on GitHub Codex transport requests', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -1904,10 +1913,7 @@ test('strips Anthropic-specific headers on GitHub Codex transport requests', asy
   expect(capturedHeaders?.get('authorization')).toBe('Bearer github-test-key')
   expect(capturedHeaders?.get('editor-plugin-version')).toBe('copilot-chat/0.26.7')
 })
-// openaiShim test extraction seam 017 end
 
-
-// openaiShim test extraction seam 018 start: uses direct GitHub Copilot Enterprise key for shim authentication
 test('uses direct GitHub Copilot Enterprise key for shim authentication', async () => {
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
   process.env.GITHUB_COPILOT_KEY = 'enterprise-direct-key'
@@ -1922,10 +1928,7 @@ test('uses direct GitHub Copilot Enterprise key for shim authentication', async 
   expect(authorization).toBe('Bearer enterprise-direct-key')
   expect(url).toBe('https://github.mycompany.com/api/copilot/chat/completions')
 })
-// openaiShim test extraction seam 018 end
 
-
-// openaiShim test extraction seam 019 start: direct GitHub Copilot key wins over stale OpenAI key
 test('direct GitHub Copilot key wins over stale OpenAI key', async () => {
   process.env.CLAUDE_CODE_USE_GITHUB = '1'
   process.env.GITHUB_COPILOT_KEY = 'enterprise-direct-key'
@@ -1939,10 +1942,7 @@ test('direct GitHub Copilot key wins over stale OpenAI key', async () => {
 
   expect(authorization).toBe('Bearer enterprise-direct-key')
 })
-// openaiShim test extraction seam 019 end
 
-
-// openaiShim test extraction seam 020 start: strips Anthropic-specific headers on GitHub Codex transport with providerOverride API key
 test('strips Anthropic-specific headers on GitHub Codex transport with providerOverride API key', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -1993,10 +1993,7 @@ test('strips Anthropic-specific headers on GitHub Codex transport with providerO
   expect(capturedHeaders?.get('authorization')).toBe('Bearer provider-override-key')
   expect(capturedHeaders?.get('editor-plugin-version')).toBe('copilot-chat/0.26.7')
 })
-// openaiShim test extraction seam 020 end
 
-
-// openaiShim test extraction seam 021 start: preserves usage from final OpenAI stream chunk with empty choices
 test('preserves usage from final OpenAI stream chunk with empty choices', async () => {
   globalThis.fetch = (async (_input, init) => {
     const url = typeof _input === 'string' ? _input : _input.url
@@ -2072,12 +2069,9 @@ test('preserves usage from final OpenAI stream chunk with empty choices', async 
   expect(usageEvent?.usage?.input_tokens).toBe(123)
   expect(usageEvent?.usage?.output_tokens).toBe(45)
 })
-// openaiShim test extraction seam 021 end
-
 
 // Extraction seam: stream conversion usage | shared stream control.
 
-// openaiShim test extraction seam 022 start: readWithIdleTimeout rejects quickly and cancels a stalled reader
 test('readWithIdleTimeout rejects quickly and cancels a stalled reader', async () => {
   const testApi = await getStreamIdleTestApi('stream-idle-helper')
   const cancelReasons: unknown[] = []
@@ -2101,10 +2095,7 @@ test('readWithIdleTimeout rejects quickly and cancels a stalled reader', async (
   expect(cancelReasons).toHaveLength(1)
   expect(cancelReasons[0]).toBeInstanceOf(testApi.StreamIdleTimeoutError)
 })
-// openaiShim test extraction seam 022 end
 
-
-// openaiShim test extraction seam 023 start: readWithIdleTimeout preserves parent abort instead of reporting idle timeout
 test('readWithIdleTimeout preserves parent abort instead of reporting idle timeout', async () => {
   const testApi = await getStreamIdleTestApi('stream-idle-user-abort')
   const parent = new AbortController()
@@ -2133,10 +2124,7 @@ test('readWithIdleTimeout preserves parent abort instead of reporting idle timeo
   expect(cancelReasons[0]).toBeInstanceOf(DOMException)
   expect((cancelReasons[0] as DOMException).name).toBe('AbortError')
 })
-// openaiShim test extraction seam 023 end
 
-
-// openaiShim test extraction seam 024 start: stream idle timeout env parser parses and bounds overrides
 test('stream idle timeout env parser parses and bounds overrides', async () => {
   const testApi = await getStreamIdleTestApi('stream-idle-env-parser')
 
@@ -2164,30 +2152,7 @@ test('stream idle timeout env parser parses and bounds overrides', async () => {
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '-5'
   expect(testApi.getStreamIdleTimeoutMs()).toBe(90_000)
 })
-// openaiShim test extraction seam 024 end
 
-test('API timeout env parser accepts safe positive integers and falls back otherwise', async () => {
-  const testApi = await getStreamIdleTestApi('api-timeout-env-parser')
-
-  delete process.env.API_TIMEOUT_MS
-  expect(testApi.getApiTimeoutMs()).toBe(600_000)
-
-  process.env.API_TIMEOUT_MS = '50'
-  expect(testApi.getApiTimeoutMs()).toBe(50)
-
-  process.env.API_TIMEOUT_MS = ' 50 '
-  expect(testApi.getApiTimeoutMs()).toBe(50)
-
-  process.env.API_TIMEOUT_MS = '3000000000'
-  expect(testApi.getApiTimeoutMs()).toBe(2_147_483_647)
-
-  for (const invalid of ['abc', '-5', '', '0', '1.5', '9007199254740993']) {
-    process.env.API_TIMEOUT_MS = invalid
-    expect(testApi.getApiTimeoutMs()).toBe(600_000)
-  }
-})
-
-// openaiShim test extraction seam 025 start: Anthropic-compatible passthrough stream rejects with idle timeout when it stalls
 test('Anthropic-compatible passthrough stream rejects with idle timeout when it stalls', async () => {
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '25'
   const stalled = makeStallingResponse(
@@ -2233,12 +2198,9 @@ test('Anthropic-compatible passthrough stream rejects with idle timeout when it 
   expect((caught as Error).name).toBe('StreamIdleTimeoutError')
   expect((stalled.cancelReasons[0] as Error).name).toBe('StreamIdleTimeoutError')
 })
-// openaiShim test extraction seam 025 end
-
 
 // Extraction seam: shared stream control | Gemini stream conversion.
 
-// openaiShim test extraction seam 026 start: Gemini SSE stream rejects with idle timeout when it stalls
 test('Gemini SSE stream rejects with idle timeout when it stalls', async () => {
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '25'
   const stalled = makeStallingResponse(
@@ -2281,10 +2243,7 @@ test('Gemini SSE stream rejects with idle timeout when it stalls', async () => {
   expect((caught as Error).name).toBe('StreamIdleTimeoutError')
   expect((stalled.cancelReasons[0] as Error).name).toBe('StreamIdleTimeoutError')
 })
-// openaiShim test extraction seam 026 end
 
-
-// openaiShim test extraction seam 027 start: OpenAI-compatible stream rejects with idle timeout when it stalls after a chunk
 test('OpenAI-compatible stream rejects with idle timeout when it stalls after a chunk', async () => {
   await getStreamIdleTestApi('stream-idle-openai-stall')
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '25'
@@ -2329,10 +2288,7 @@ test('OpenAI-compatible stream rejects with idle timeout when it stalls after a 
   })
   expect(textDeltas).toEqual(['partial'])
 })
-// openaiShim test extraction seam 027 end
 
-
-// openaiShim test extraction seam 028 start: OpenAI-compatible stream keeps slow active chunks alive under the idle timeout
 test('OpenAI-compatible stream keeps slow active chunks alive under the idle timeout', async () => {
   await getStreamIdleTestApi('stream-idle-openai-active')
   process.env.CLAUDE_STREAM_IDLE_TIMEOUT_MS = '500'
@@ -2434,10 +2390,7 @@ test('OpenAI-compatible stream keeps slow active chunks alive under the idle tim
   expect(Date.now() - startedAt).toBeGreaterThan(500)
   expect(textDeltas.join('')).toBe('hello')
 })
-// openaiShim test extraction seam 028 end
 
-
-// openaiShim test extraction seam 029 start: controller abort reaches generic OpenAI SSE converter
 test('controller abort reaches generic OpenAI SSE converter', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2470,10 +2423,7 @@ test('controller abort reaches generic OpenAI SSE converter', async () => {
     stalled.close()
   }
 })
-// openaiShim test extraction seam 029 end
 
-
-// openaiShim test extraction seam 030 start: controller abort cancels generic OpenAI SSE before iteration starts
 test('controller abort cancels generic OpenAI SSE before iteration starts', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2510,10 +2460,7 @@ test('controller abort cancels generic OpenAI SSE before iteration starts', asyn
     stalled.close()
   }
 })
-// openaiShim test extraction seam 030 end
 
-
-// openaiShim test extraction seam 031 start: controller abort cancels generic OpenAI SSE when paused after message_start
 test('controller abort cancels generic OpenAI SSE when paused after message_start', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2542,10 +2489,7 @@ test('controller abort cancels generic OpenAI SSE when paused after message_star
     stalled.close()
   }
 })
-// openaiShim test extraction seam 031 end
 
-
-// openaiShim test extraction seam 032 start: controller abort stops buffered generic OpenAI SSE events
 test('controller abort stops buffered generic OpenAI SSE events', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'first' }) +
@@ -2576,10 +2520,7 @@ test('controller abort stops buffered generic OpenAI SSE events', async () => {
     stalled.close()
   }
 })
-// openaiShim test extraction seam 032 end
 
-
-// openaiShim test extraction seam 033 start: controller abort reaches Anthropic messages SSE passthrough
 test('controller abort reaches Anthropic messages SSE passthrough', async () => {
   const stalled = makeStallingResponse(
     `data: ${JSON.stringify({
@@ -2625,10 +2566,7 @@ test('controller abort reaches Anthropic messages SSE passthrough', async () => 
     stalled.close()
   }
 })
-// openaiShim test extraction seam 033 end
 
-
-// openaiShim test extraction seam 034 start: controller abort cancels Anthropic messages SSE when paused after event
 test('controller abort cancels Anthropic messages SSE when paused after event', async () => {
   const stalled = makeStallingResponse(
     `data: ${JSON.stringify({
@@ -2670,10 +2608,7 @@ test('controller abort cancels Anthropic messages SSE when paused after event', 
     stalled.close()
   }
 })
-// openaiShim test extraction seam 034 end
 
-
-// openaiShim test extraction seam 035 start: controller abort stops buffered Anthropic messages SSE events
 test('controller abort stops buffered Anthropic messages SSE events', async () => {
   const stalled = makeStallingResponse(
     [
@@ -2745,10 +2680,7 @@ test('controller abort stops buffered Anthropic messages SSE events', async () =
     stalled.close()
   }
 })
-// openaiShim test extraction seam 035 end
 
-
-// openaiShim test extraction seam 036 start: parent signal abort still reaches OpenAI SSE converter
 test('parent signal abort still reaches OpenAI SSE converter', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2785,10 +2717,7 @@ test('parent signal abort still reaches OpenAI SSE converter', async () => {
     stalled.close()
   }
 })
-// openaiShim test extraction seam 036 end
 
-
-// openaiShim test extraction seam 037 start: parent signal abort cancels OpenAI SSE before iteration starts
 test('parent signal abort cancels OpenAI SSE before iteration starts', async () => {
   const stalled = makeStallingResponse(
     makeOpenAIStreamFrame({ role: 'assistant', content: 'partial' }),
@@ -2829,10 +2758,7 @@ test('parent signal abort cancels OpenAI SSE before iteration starts', async () 
     stalled.close()
   }
 })
-// openaiShim test extraction seam 037 end
 
-
-// openaiShim test extraction seam 038 start: controller abort reaches Codex responses stream converter
 test('controller abort reaches Codex responses stream converter', async () => {
   const stalled = makeStallingResponse(
     `event: response.output_text.delta\ndata: ${JSON.stringify({ delta: 'partial' })}\n\n`,
@@ -2866,10 +2792,7 @@ test('controller abort reaches Codex responses stream converter', async () => {
     stalled.close()
   }
 })
-// openaiShim test extraction seam 038 end
 
-
-// openaiShim test extraction seam 039 start: controller abort cancels Codex responses stream when paused after message_start
 test('controller abort cancels Codex responses stream when paused after message_start', async () => {
   const stalled = makeStallingResponse(
     `event: response.output_text.delta\ndata: ${JSON.stringify({ delta: 'partial' })}\n\n`,
@@ -2899,10 +2822,7 @@ test('controller abort cancels Codex responses stream when paused after message_
     stalled.close()
   }
 })
-// openaiShim test extraction seam 039 end
 
-
-// openaiShim test extraction seam 040 start: controller abort reaches Gemini SSE converter
 test('controller abort reaches Gemini SSE converter', async () => {
   const stalled = makeStallingResponse(
     `data: ${JSON.stringify({
@@ -2945,10 +2865,7 @@ test('controller abort reaches Gemini SSE converter', async () => {
     stalled.close()
   }
 })
-// openaiShim test extraction seam 040 end
 
-
-// openaiShim test extraction seam 041 start: controller abort stops buffered Gemini SSE events
 test('controller abort stops buffered Gemini SSE events', async () => {
   const makeGeminiFrame = (text: string) =>
     `data: ${JSON.stringify({
@@ -2990,12 +2907,9 @@ test('controller abort stops buffered Gemini SSE events', async () => {
     stalled.close()
   }
 })
-// openaiShim test extraction seam 041 end
-
 
 // Extraction seam: Gemini stream conversion | native Ollama stream adaptation.
 
-// openaiShim test extraction seam 042 start: controller abort reaches native Ollama converted stream
 test('controller abort reaches native Ollama converted stream', async () => {
   const previousBaseUrl = process.env.OPENAI_BASE_URL
   let stalled: StallingResponse | undefined
@@ -3040,10 +2954,7 @@ test('controller abort reaches native Ollama converted stream', async () => {
     restoreEnv('OPENAI_BASE_URL', previousBaseUrl)
   }
 })
-// openaiShim test extraction seam 042 end
 
-
-// openaiShim test extraction seam 043 start: normal OpenAI SSE stream still completes after controller wiring
 test('normal OpenAI SSE stream still completes after controller wiring', async () => {
   globalThis.fetch = (async () =>
     makeSseResponse(makeStreamChunks([
@@ -3094,10 +3005,7 @@ test('normal OpenAI SSE stream still completes after controller wiring', async (
   expect(textDeltas.join('')).toBe('complete')
   expect((result.data as unknown as ShimStream).controller.signal.aborted).toBe(false)
 })
-// openaiShim test extraction seam 043 end
 
-
-// openaiShim test extraction seam 044 start: uses max_tokens instead of max_completion_tokens for local providers
 test('uses max_tokens instead of max_completion_tokens for local providers', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
@@ -3136,7 +3044,6 @@ test('uses max_tokens instead of max_completion_tokens for local providers', asy
     stream: false,
   })
 })
-// openaiShim test extraction seam 044 end
 
 test('does not send stream_options to local OpenAI-compatible servers', async () => {
   process.env.OPENAI_BASE_URL = 'http://127.0.0.1:8000/v1'
@@ -3159,7 +3066,6 @@ test('does not send stream_options to local OpenAI-compatible servers', async ()
   })
 })
 
-// openaiShim test extraction seam 045 start: keeps max_completion_tokens for non-local non-github providers
 test('keeps max_completion_tokens for non-local non-github providers', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
 
@@ -3204,10 +3110,7 @@ test('keeps max_completion_tokens for non-local non-github providers', async () 
     stream: false,
   })
 })
-// openaiShim test extraction seam 045 end
 
-
-// openaiShim test extraction seam 046 start: uses route-specific credential env vars for descriptor-backed openai-compatible routes
 test('uses route-specific credential env vars for descriptor-backed openai-compatible routes', async () => {
   let capturedHeaders: Headers | undefined
 
@@ -3257,20 +3160,178 @@ test('uses route-specific credential env vars for descriptor-backed openai-compa
 
   expect(capturedHeaders?.get('authorization')).toBe('Bearer or-route-key')
 })
-// openaiShim test extraction seam 046 end
 
+test('preserves Gemini tool call extra_content in follow-up requests', async () => {
+  let requestBody: Record<string, unknown> | undefined
 
-// openaiShim test extraction seam 047 start: preserves Gemini tool call extra_content in follow-up requests
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
 
-// openaiShim test extraction seam 047 end
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'done',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+          total_tokens: 16,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
 
-// openaiShim test extraction seam 048 start: replays Gemini tool signatures for OpenGateway Gemini models
+  await client.beta.messages.create({
+    model: 'google/gemini-3.1-pro-preview',
+    system: 'test system',
+    messages: [
+      { role: 'user', content: 'Use Bash' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'Bash',
+            input: { command: 'pwd' },
+            extra_content: {
+              google: {
+                thought_signature: 'sig-123',
+              },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_1',
+            content: 'D:\\repo',
+          },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
 
-// openaiShim test extraction seam 048 end
+  const assistantWithToolCall = (requestBody?.messages as Array<Record<string, unknown>>).find(
+    message => Array.isArray(message.tool_calls),
+  ) as { tool_calls?: Array<Record<string, unknown>> } | undefined
 
+  expect(assistantWithToolCall?.tool_calls?.[0]).toMatchObject({
+    id: 'call_1',
+    type: 'function',
+    function: {
+      name: 'Bash',
+      arguments: JSON.stringify({ command: 'pwd' }),
+    },
+    extra_content: {
+      google: {
+        thought_signature: 'sig-123',
+      },
+    },
+  })
+})
 
-// openaiShim test extraction seam 049 start: OpenGateway MiMo replays real reasoning_content without adding empty fallback
+test('replays Gemini tool signatures for OpenGateway Gemini models', async () => {
+  process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'google/gemini-3.1-flash-lite',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'done',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+          total_tokens: 16,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'google/gemini-3.1-flash-lite',
+    messages: [
+      { role: 'user', content: 'Use Write' },
+      {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'call_1',
+            name: 'Write',
+            input: { file_path: 'todo.md', content: 'todo' },
+            signature: 'sig-opengateway',
+          },
+        ],
+      },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_1',
+            content: 'created',
+          },
+        ],
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const assistantWithToolCall = (requestBody?.messages as Array<Record<string, unknown>>).find(
+    message => Array.isArray(message.tool_calls),
+  ) as { tool_calls?: Array<Record<string, unknown>> } | undefined
+
+  expect(assistantWithToolCall?.tool_calls?.[0]).toMatchObject({
+    id: 'call_1',
+    extra_content: {
+      google: {
+        thought_signature: 'sig-opengateway',
+      },
+    },
+  })
+})
+
 test('OpenGateway MiMo replays real reasoning_content without adding empty fallback', async () => {
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
   process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
@@ -3351,10 +3412,7 @@ test('OpenGateway MiMo replays real reasoning_content without adding empty fallb
   )
   expect(requestBody).not.toHaveProperty('store')
 })
-// openaiShim test extraction seam 049 end
 
-
-// openaiShim test extraction seam 050 start: Xiaomi MiMo replays real reasoning_content without adding empty fallback
 test('Xiaomi MiMo replays real reasoning_content without adding empty fallback', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.xiaomimimo.com/v1'
   process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
@@ -3437,10 +3495,7 @@ test('Xiaomi MiMo replays real reasoning_content without adding empty fallback',
   )
   expect(requestBody).not.toHaveProperty('store')
 })
-// openaiShim test extraction seam 050 end
 
-
-// openaiShim test extraction seam 051 start: OpenGateway MiMo does not synthesize empty reasoning_content when missing
 test('OpenGateway MiMo does not synthesize empty reasoning_content when missing', async () => {
   process.env.OPENAI_BASE_URL = 'https://opengateway.gitlawb.com/v1'
   process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
@@ -3515,10 +3570,7 @@ test('OpenGateway MiMo does not synthesize empty reasoning_content when missing'
   expect(assistantWithToolCall).not.toHaveProperty('reasoning_content')
   expect(requestBody).not.toHaveProperty('store')
 })
-// openaiShim test extraction seam 051 end
 
-
-// openaiShim test extraction seam 052 start: strips unsupported stream_options for Xiaomi MiMo streams
 test('strips unsupported stream_options for Xiaomi MiMo streams', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.xiaomimimo.com/v1'
   process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
@@ -3575,28 +3627,131 @@ test('strips unsupported stream_options for Xiaomi MiMo streams', async () => {
   expect(requestBody).not.toHaveProperty('stream_options')
   expect(requestBody).not.toHaveProperty('store')
 })
-// openaiShim test extraction seam 052 end
 
+test('preserves Grep tool pattern field in OpenAI-compatible schemas', async () => {
+  let requestBody: Record<string, unknown> | undefined
 
-// openaiShim test extraction seam 053 start: preserves Grep tool pattern field in OpenAI-compatible schemas
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
 
-// openaiShim test extraction seam 053 end
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-grep-schema',
+        model: 'qwen/qwen3.6-plus',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'done',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+          total_tokens: 16,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
 
-// openaiShim test extraction seam 054 start: does not infer Gemini mode from OPENAI_BASE_URL path substrings
+  await client.beta.messages.create({
+    model: 'qwen/qwen3.6-plus',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'Use Grep' }],
+    tools: [
+      {
+        name: 'Grep',
+        description: 'Search file contents',
+        input_schema: {
+          type: 'object',
+          properties: {
+            pattern: { type: 'string', description: 'Search pattern' },
+            path: { type: 'string' },
+          },
+          required: ['pattern'],
+          additionalProperties: false,
+        },
+      },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
 
-// openaiShim test extraction seam 054 end
+  const tools = requestBody?.tools as Array<Record<string, unknown>> | undefined
+  const grepTool = tools?.find(tool => (tool.function as Record<string, unknown>)?.name === 'Grep') as
+    | { function?: { parameters?: { properties?: Record<string, unknown>; required?: string[] } } }
+    | undefined
 
+  expect(Object.keys(grepTool?.function?.parameters?.properties ?? {})).toContain('pattern')
+  expect(grepTool?.function?.parameters?.required).toContain('pattern')
+})
 
-// openaiShim test extraction seam 055 start: the OpenAI shim façade exposes the beta.messages namespace
+test('does not infer Gemini mode from OPENAI_BASE_URL path substrings', async () => {
+  let capturedAuthorization: string | null = null
+
+  process.env.OPENAI_BASE_URL =
+    'https://evil.example/generativelanguage.googleapis.com/v1beta/openai'
+  delete process.env.OPENAI_API_KEY
+  process.env.GEMINI_API_KEY = 'gemini-secret'
+
+  globalThis.fetch = (async (_input, init) => {
+    const headers = init?.headers as Record<string, string> | undefined
+    capturedAuthorization =
+      headers?.Authorization ?? headers?.authorization ?? null
+
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'fake-model',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'ok',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+          total_tokens: 16,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'fake-model',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(capturedAuthorization).toBeNull()
+})
+
 test('the OpenAI shim façade exposes the beta.messages namespace', () => {
   const client = createOpenAIShimClient({}) as OpenAIShimClient
   expect(client.beta.messages).toBeDefined()
 })
-// openaiShim test extraction seam 055 end
 
-
-// openaiShim test extraction seam 056 start: preserves image tool results as placeholders in follow-up requests
 test('preserves image tool results as placeholders in follow-up requests', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -3699,10 +3854,7 @@ test('preserves image tool results as placeholders in follow-up requests', async
     },
   ])
 })
-// openaiShim test extraction seam 056 end
 
-
-// openaiShim test extraction seam 057 start: adds text part for image-only user messages
 test('adds text part for image-only user messages', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -3778,10 +3930,7 @@ test('adds text part for image-only user messages', async () => {
     },
   ])
 })
-// openaiShim test extraction seam 057 end
 
-
-// openaiShim test extraction seam 058 start: preserves mixed text and image tool results as multipart content
 test('preserves mixed text and image tool results as multipart content', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -3876,10 +4025,7 @@ test('preserves mixed text and image tool results as multipart content', async (
     image_url: { url: 'data:image/png;base64,ZmFrZQ==' },
   })
 })
-// openaiShim test extraction seam 058 end
 
-
-// openaiShim test extraction seam 059 start: uses GEMINI_ACCESS_TOKEN for Gemini OpenAI-compatible requests
 test('uses GEMINI_ACCESS_TOKEN for Gemini OpenAI-compatible requests', async () => {
   let capturedAuthorization: string | null = null
   let capturedProject: string | null = null
@@ -3951,10 +4097,7 @@ test('uses GEMINI_ACCESS_TOKEN for Gemini OpenAI-compatible requests', async () 
   expect<string | null>(capturedAuthorization).toBe('Bearer gemini-access-token')
   expect<string | null>(capturedProject).toBe('gemini-project')
 })
-// openaiShim test extraction seam 059 end
 
-
-// openaiShim test extraction seam 060 start: uses NVIDIA_API_KEY for NVIDIA NIM requests without OPENAI_API_KEY
 test('uses NVIDIA_API_KEY for NVIDIA NIM requests without OPENAI_API_KEY', async () => {
   let capturedAuthorization: string | null = null
 
@@ -4008,10 +4151,7 @@ test('uses NVIDIA_API_KEY for NVIDIA NIM requests without OPENAI_API_KEY', async
 
   expect<string | null>(capturedAuthorization).toBe('Bearer nvidia-live-key')
 })
-// openaiShim test extraction seam 060 end
 
-
-// openaiShim test extraction seam 061 start: does not use stale NVIDIA_API_KEY for non-NVIDIA OpenAI-compatible routes
 test('does not use stale NVIDIA_API_KEY for non-NVIDIA OpenAI-compatible routes', async () => {
   let capturedAuthorization: string | null = null
 
@@ -4061,10 +4201,7 @@ test('does not use stale NVIDIA_API_KEY for non-NVIDIA OpenAI-compatible routes'
 
   expect(capturedAuthorization).toBeNull()
 })
-// openaiShim test extraction seam 061 end
 
-
-// openaiShim test extraction seam 062 start: does not use MINIMAX_API_KEY for non-MiniMax OpenAI-compatible routes
 test('does not use MINIMAX_API_KEY for non-MiniMax OpenAI-compatible routes', async () => {
   let capturedAuthorization: string | null = null
 
@@ -4113,10 +4250,7 @@ test('does not use MINIMAX_API_KEY for non-MiniMax OpenAI-compatible routes', as
 
   expect(capturedAuthorization).toBeNull()
 })
-// openaiShim test extraction seam 062 end
 
-
-// openaiShim test extraction seam 063 start: xiaomi mimo route uses api-key auth header and max_completion_tokens
 test('xiaomi mimo route uses api-key auth header and max_completion_tokens', async () => {
   let capturedHeaders: Record<string, string> | undefined
   let capturedBody: Record<string, unknown> | undefined
@@ -4167,9 +4301,6 @@ test('xiaomi mimo route uses api-key auth header and max_completion_tokens', asy
   expect(capturedBody).toMatchObject({ max_completion_tokens: 32 })
   expect(capturedBody).not.toHaveProperty('max_tokens')
 })
-// openaiShim test extraction seam 063 end
-
-// openaiShim test extraction seam 064 start: xiaomi mimo token plan uses raw api-key and OpenAI-compatible reasoning_effort
 test('xiaomi mimo token plan uses raw api-key and OpenAI-compatible reasoning_effort', async () => {
   let capturedHeaders: Record<string, string> | undefined
   let capturedBody: Record<string, unknown> | undefined
@@ -4208,8 +4339,6 @@ test('xiaomi mimo token plan uses raw api-key and OpenAI-compatible reasoning_ef
   expect(capturedBody).not.toHaveProperty('store')
   expect(capturedBody).not.toHaveProperty('stream_options')
 })
-// openaiShim test extraction seam 064 end
-
 
 test.each([
   'minimax-m3',
@@ -4292,7 +4421,6 @@ test.each([
   expect(capturedBody).not.toHaveProperty('store')
 })
 
-// openaiShim test extraction seam 065 start: opencode go messages endpoint rotates raw x-api-key credentials after rate-limit failure
 test('opencode go messages endpoint rotates raw x-api-key credentials after rate-limit failure', async () => {
   const capturedUrls: string[] = []
   const capturedKeys: Array<string | null> = []
@@ -4353,10 +4481,7 @@ test('opencode go messages endpoint rotates raw x-api-key credentials after rate
   ])
   expect(capturedKeys).toEqual(['fake-opencode-a', 'fake-opencode-b'])
 })
-// openaiShim test extraction seam 065 end
 
-
-// openaiShim test extraction seam 066 start: gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY as bearer auth despite stale generic base URL
 test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY as bearer auth despite stale generic base URL', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_MODEL = 'gpt-5.5'
@@ -4371,10 +4496,7 @@ test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY as bearer auth
   expect(captured.url).toBe('https://opengateway.gitlawb.com/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
-// openaiShim test extraction seam 066 end
 
-
-// openaiShim test extraction seam 067 start: gitlawb opengateway provider flag accepts OPENAI_API_KEY compatibility fallback
 test('gitlawb opengateway provider flag accepts OPENAI_API_KEY compatibility fallback', async () => {
   delete process.env.OPENAI_BASE_URL
   delete process.env.OPENGATEWAY_API_KEY
@@ -4387,10 +4509,7 @@ test('gitlawb opengateway provider flag accepts OPENAI_API_KEY compatibility fal
 
   expect(captured.authorization).toBe('Bearer fake-openai-fallback')
 })
-// openaiShim test extraction seam 067 end
 
-
-// openaiShim test extraction seam 068 start: gitlawb opengateway provider flag sends OPENAI_API_KEY fallback despite stale generic base URL
 test('gitlawb opengateway provider flag sends OPENAI_API_KEY fallback despite stale generic base URL', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'fake-openai-fallback'
@@ -4404,10 +4523,7 @@ test('gitlawb opengateway provider flag sends OPENAI_API_KEY fallback despite st
   expect(captured.url).toBe('https://opengateway.gitlawb.com/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-openai-fallback')
 })
-// openaiShim test extraction seam 068 end
 
-
-// openaiShim test extraction seam 069 start: gitlawb opengateway provider flag trims OPENGATEWAY_API_KEY before bearer auth
 test('gitlawb opengateway provider flag trims OPENGATEWAY_API_KEY before bearer auth', async () => {
   process.env.OPENGATEWAY_API_KEY = ' fake-ogw-key '
   delete process.env.OPENAI_API_KEY
@@ -4419,10 +4535,7 @@ test('gitlawb opengateway provider flag trims OPENGATEWAY_API_KEY before bearer 
 
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
-// openaiShim test extraction seam 069 end
 
-
-// openaiShim test extraction seam 070 start: gitlawb opengateway provider flag ignores blank OPENGATEWAY_API_KEY and uses OPENAI_API_KEY fallback
 test('gitlawb opengateway provider flag ignores blank OPENGATEWAY_API_KEY and uses OPENAI_API_KEY fallback', async () => {
   process.env.OPENGATEWAY_API_KEY = '   '
   process.env.OPENAI_API_KEY = 'fake-openai-fallback'
@@ -4434,10 +4547,7 @@ test('gitlawb opengateway provider flag ignores blank OPENGATEWAY_API_KEY and us
 
   expect(captured.authorization).toBe('Bearer fake-openai-fallback')
 })
-// openaiShim test extraction seam 070 end
 
-
-// openaiShim test extraction seam 071 start: gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to OPENGATEWAY_BASE_URL override
 test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to OPENGATEWAY_BASE_URL override', async () => {
   process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
@@ -4451,10 +4561,7 @@ test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to OPENGATEWAY
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
-// openaiShim test extraction seam 071 end
 
-
-// openaiShim test extraction seam 072 start: gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to custom OPENAI_BASE_URL fallback
 test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to custom OPENAI_BASE_URL fallback', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
@@ -4469,10 +4576,7 @@ test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY to custom OPEN
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
-// openaiShim test extraction seam 072 end
 
-
-// openaiShim test extraction seam 073 start: gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEY for custom base URL
 test('gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEY for custom base URL', async () => {
   process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
@@ -4486,10 +4590,7 @@ test('gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
-// openaiShim test extraction seam 073 end
 
-
-// openaiShim test extraction seam 074 start: gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEYS pool
 test('gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic OPENAI_API_KEYS pool', async () => {
   process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENGATEWAY_API_KEY = 'fake-ogw-key'
@@ -4504,200 +4605,7 @@ test('gitlawb opengateway provider flag prefers OPENGATEWAY_API_KEY over generic
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-ogw-key')
 })
-// openaiShim test extraction seam 074 end
 
-test('longcat provider flag prefers LONGCAT_API_KEY over generic OPENAI_API_KEYS pool', async () => {
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  process.env.OPENAI_API_KEYS = 'fake-openai-pool-a,fake-openai-pool-b'
-  delete process.env.OPENAI_BASE_URL
-  delete process.env.OPENAI_API_KEY
-
-  const result = applyProviderFlag('longcat', [])
-  expect(result.error).toBeUndefined()
-
-  const captured = await captureChatCompletionRequest()
-
-  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
-  expect(captured.authorization).toBe('Bearer fake-longcat-key')
-})
-
-test('longcat provider flag strips unsupported tool definitions', async () => {
-  let requestBody: Record<string, unknown> | undefined
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>
-    return makeChatCompletionResponse('LongCat-2.0')
-  }) as unknown as FetchType
-
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  delete process.env.OPENAI_BASE_URL
-  delete process.env.OPENAI_API_KEY
-
-  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  await client.beta.messages.create({
-    model: 'LongCat-2.0',
-    messages: [
-      { role: 'user', content: 'List files' },
-    ],
-    tools: [{
-      name: 'Bash',
-      description: 'Run a shell command',
-      input_schema: {
-        type: 'object',
-        properties: { command: { type: 'string' } },
-        required: ['command'],
-      },
-    }],
-    max_tokens: 32,
-    stream: false,
-  })
-
-  expect(requestBody?.tools).toBeUndefined()
-})
-
-test('longcat rejects image input before dispatch', async () => {
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  delete process.env.OPENAI_BASE_URL
-  delete process.env.OPENAI_API_KEY
-
-  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  await expect(client.beta.messages.create({
-    model: 'LongCat-2.0',
-    messages: [{
-      role: 'user',
-      content: [
-        { type: 'text', text: 'Describe this image.' },
-        { type: 'image', source: { type: 'url', url: 'https://example.com/image.png' } },
-      ],
-    }],
-    max_tokens: 32,
-    stream: false,
-  })).rejects.toThrow('does not support image inputs')
-})
-
-test('longcat rejects image tool results before dispatch', async () => {
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  delete process.env.OPENAI_BASE_URL
-  delete process.env.OPENAI_API_KEY
-  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  await expect(client.beta.messages.create({
-    model: 'LongCat-2.0',
-    messages: [
-      { role: 'user', content: 'Inspect the screenshot' },
-      { role: 'assistant', content: [{ type: 'tool_use', id: 'call_screenshot', name: 'Screenshot', input: {} }] },
-      { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_screenshot', content: [{ type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'aGVsbG8=' } }] }] },
-    ],
-    tools: [{ name: 'Screenshot', description: 'Capture a screenshot', input_schema: { type: 'object', properties: {} } }],
-    max_tokens: 32,
-    stream: false,
-  })).rejects.toThrow('does not support image inputs')
-})
-
-test('longcat accepts the documented bare OpenAI SDK base URL', async () => {
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai'
-  delete process.env.OPENAI_API_KEY
-
-  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
-
-  const captured = await captureChatCompletionRequest()
-
-  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
-  expect(captured.authorization).toBe('Bearer fake-longcat-key')
-})
-
-test('longcat accepts the documented bare OpenAI SDK base URL with a trailing slash', async () => {
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/'
-  delete process.env.OPENAI_API_KEY
-
-  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
-
-  const captured = await captureChatCompletionRequest()
-
-  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
-  expect(captured.authorization).toBe('Bearer fake-longcat-key')
-})
-
-test('longcat does not append chat completions to a configured endpoint URL', async () => {
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/v1/chat/completions'
-  delete process.env.OPENAI_API_KEY
-
-  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
-
-  const captured = await captureChatCompletionRequest()
-
-  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
-  expect(captured.authorization).toBe('Bearer fake-longcat-key')
-})
-
-test('longcat normalizes a configured endpoint URL with a trailing slash', async () => {
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/v1/chat/completions/'
-  delete process.env.OPENAI_API_KEY
-
-  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
-  const captured = await captureChatCompletionRequest()
-  expect(captured.url).toBe('https://api.longcat.chat/openai/v1/chat/completions')
-})
-
-test('longcat accepts the documented CodeBuddy endpoint URL', async () => {
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/chat/completions'
-  delete process.env.OPENAI_API_KEY
-
-  expect(applyProviderFlag('longcat', []).error).toBeUndefined()
-  const captured = await captureChatCompletionRequest()
-  expect(captured.url).toBe('https://api.longcat.chat/openai/chat/completions')
-})
-
-test('longcat prefers its dedicated credential over a copied key from another provider', async () => {
-  process.env.LONGCAT_API_KEY = 'fake-longcat-key'
-  process.env.MIMO_API_KEY = 'fake-mimo-key'
-  process.env.OPENAI_API_KEY = 'fake-mimo-key'
-  process.env.OPENAI_BASE_URL = 'https://api.longcat.chat/openai/v1'
-
-  const captured = await captureChatCompletionRequest('LongCat-2.0')
-
-  expect(captured.authorization).toBe('Bearer fake-longcat-key')
-})
-
-test('longcat provider flag never falls back to an OPENAI_API_KEYS pool', async () => {
-  process.env.OPENAI_API_KEYS = 'other-provider-secret'
-  delete process.env.LONGCAT_API_KEY
-  delete process.env.OPENAI_BASE_URL
-  delete process.env.OPENAI_API_KEY
-
-  const result = applyProviderFlag('longcat', [])
-  expect(result.error).toBeUndefined()
-
-  const captured = await captureChatCompletionRequest()
-
-  expect(captured.authorization).not.toBe('Bearer other-provider-secret')
-})
-
-test('dedicated-only ClinePass route never falls back to generic OpenAI credentials', async () => {
-  process.env.CLAUDE_CODE_USE_OPENAI = '1'
-  process.env.OPENAI_BASE_URL = 'https://api.cline.bot/api/v1'
-  process.env.OPENAI_MODEL = 'cline-pass/deepseek-v4-flash'
-  process.env.OPENAI_API_KEY = 'generic-openai-key'
-  process.env.OPENAI_API_KEYS = 'generic-openai-pool-a,generic-openai-pool-b'
-  delete process.env.CLINE_API_KEY
-
-  const captured = await captureChatCompletionRequest(
-    'cline-pass/deepseek-v4-flash',
-  )
-
-  expect(captured.authorization).toBeNull()
-})
-
-// openaiShim test extraction seam 075 start: gitlawb opengateway provider flag uses generic OPENAI_API_KEYS pool before generic OPENAI_API_KEY fallback
 test('gitlawb opengateway provider flag uses generic OPENAI_API_KEYS pool before generic OPENAI_API_KEY fallback', async () => {
   process.env.OPENGATEWAY_BASE_URL = 'http://localhost:8181/v1'
   process.env.OPENAI_API_KEYS = 'fake-openai-pool-a,fake-openai-pool-b'
@@ -4712,10 +4620,7 @@ test('gitlawb opengateway provider flag uses generic OPENAI_API_KEYS pool before
   expect(captured.url).toBe('http://localhost:8181/v1/chat/completions')
   expect(captured.authorization).toBe('Bearer fake-openai-pool-a')
 })
-// openaiShim test extraction seam 075 end
 
-
-// openaiShim test extraction seam 076 start: gitlawb opengateway stored provider profile key becomes bearer auth
 test('gitlawb opengateway stored provider profile key becomes bearer auth', async () => {
   delete process.env.OPENAI_API_KEY
   delete process.env.OPENGATEWAY_API_KEY
@@ -4733,10 +4638,7 @@ test('gitlawb opengateway stored provider profile key becomes bearer auth', asyn
 
   expect(captured.authorization).toBe('Bearer fake-profile-key')
 })
-// openaiShim test extraction seam 076 end
 
-
-// openaiShim test extraction seam 077 start: openai route still sends OPENAI_API_KEY as bearer auth
 test('openai route still sends OPENAI_API_KEY as bearer auth', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
@@ -4748,10 +4650,7 @@ test('openai route still sends OPENAI_API_KEY as bearer auth', async () => {
 
   expect(captured.authorization).toBe('Bearer fake-openai-key')
 })
-// openaiShim test extraction seam 077 end
 
-
-// openaiShim test extraction seam 078 start: OPENAI_API_KEYS rejects placeholder values before sending requests
 test('OPENAI_API_KEYS rejects placeholder values before sending requests', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4779,9 +4678,6 @@ test('OPENAI_API_KEYS rejects placeholder values before sending requests', async
 
   expect(authorizations).toEqual([])
 })
-// openaiShim test extraction seam 078 end
-
-// openaiShim test extraction seam 079 start: OPENAI_API_KEYS rotates to the next key on rate-limit failure
 test('OPENAI_API_KEYS rotates to the next key on rate-limit failure', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4815,10 +4711,7 @@ test('OPENAI_API_KEYS rotates to the next key on rate-limit failure', async () =
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
-// openaiShim test extraction seam 079 end
 
-
-// openaiShim test extraction seam 080 start: OPENAI_API_KEYS does not reuse a cooled-down key after every key is rate-limited
 test('OPENAI_API_KEYS does not reuse a cooled-down key after every key is rate-limited', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4849,10 +4742,7 @@ test('OPENAI_API_KEYS does not reuse a cooled-down key after every key is rate-l
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
-// openaiShim test extraction seam 080 end
 
-
-// openaiShim test extraction seam 081 start: comma-separated OPENAI_API_KEY rotates to the next key on rate-limit failure
 test('comma-separated OPENAI_API_KEY rotates to the next key on rate-limit failure', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4886,10 +4776,7 @@ test('comma-separated OPENAI_API_KEY rotates to the next key on rate-limit failu
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
-// openaiShim test extraction seam 081 end
 
-
-// openaiShim test extraction seam 082 start: OPENAI_API_KEYS does not rotate through pool on provider 5xx outage
 test('OPENAI_API_KEYS does not rotate through pool on provider 5xx outage', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4921,9 +4808,6 @@ test('OPENAI_API_KEYS does not rotate through pool on provider 5xx outage', asyn
 
   expect(authorizations).toEqual(['Bearer key-a'])
 })
-// openaiShim test extraction seam 082 end
-
-// openaiShim test extraction seam 083 start: OPENAI_API_KEYS preserves cooldown state across client requests
 test('OPENAI_API_KEYS preserves cooldown state across client requests', async () => {
   const authorizations: Array<string | null> = []
 
@@ -4962,10 +4846,7 @@ test('OPENAI_API_KEYS preserves cooldown state across client requests', async ()
     'Bearer key-b',
   ])
 })
-// openaiShim test extraction seam 083 end
 
-
-// openaiShim test extraction seam 084 start: OPENAI_API_KEYS rotates Azure api-key auth on auth failure
 test('OPENAI_API_KEYS rotates Azure api-key auth on auth failure', async () => {
   const apiKeys: Array<string | null> = []
 
@@ -4998,10 +4879,7 @@ test('OPENAI_API_KEYS rotates Azure api-key auth on auth failure', async () => {
 
   expect(apiKeys).toEqual(['azure-key-a', 'azure-key-b'])
 })
-// openaiShim test extraction seam 084 end
 
-
-// openaiShim test extraction seam 085 start: OPENAI_API_KEYS does not reuse auth-disabled credentials across client requests
 test('OPENAI_API_KEYS does not reuse auth-disabled credentials across client requests', async () => {
   const authorizations: Array<string | null> = []
 
@@ -5042,10 +4920,7 @@ test('OPENAI_API_KEYS does not reuse auth-disabled credentials across client req
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
-// openaiShim test extraction seam 085 end
 
-
-// openaiShim test extraction seam 086 start: OPENAI_API_KEYS permanently evicts 403 auth failures
 test('OPENAI_API_KEYS permanently evicts 403 auth failures', async () => {
   const authorizations: Array<string | null> = []
 
@@ -5086,9 +4961,6 @@ test('OPENAI_API_KEYS permanently evicts 403 auth failures', async () => {
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-b'])
 })
-// openaiShim test extraction seam 086 end
-
-// openaiShim test extraction seam 087 start: does not use BNKR_API_KEY for non-Bankr OpenAI-compatible routes
 test('does not use BNKR_API_KEY for non-Bankr OpenAI-compatible routes', async () => {
   let capturedAuthorization: string | null = null
 
@@ -5137,27 +5009,250 @@ test('does not use BNKR_API_KEY for non-Bankr OpenAI-compatible routes', async (
 
   expect(capturedAuthorization).toBeNull()
 })
-// openaiShim test extraction seam 087 end
 
+test('preserves Gemini tool call extra_content from streaming chunks', async () => {
+  globalThis.fetch = (async (_input, _init) => {
+    const chunks = makeStreamChunks([
+      {
+        id: 'chatcmpl-1',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: 'assistant',
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'function-call-1',
+                  type: 'function',
+                  extra_content: {
+                    google: {
+                      thought_signature: 'sig-stream',
+                    },
+                  },
+                  function: {
+                    name: 'Bash',
+                    arguments: '{"command":"pwd"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-1',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-pro-preview',
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    ])
 
-// openaiShim test extraction seam 088 start: preserves Gemini tool call extra_content from streaming chunks
+    return makeSseResponse(chunks)
+  }) as unknown as FetchType
 
-// openaiShim test extraction seam 088 end
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
 
+  const result = await client.beta.messages
+    .create({
+      model: 'google/gemini-3.1-pro-preview',
+      system: 'test system',
+      messages: [{ role: 'user', content: 'Use Bash' }],
+      max_tokens: 64,
+      stream: true,
+    })
+    .withResponse()
 
-// openaiShim test extraction seam 089 start: preserves Gemini thought signature from streaming delta extra_content
+  const events: Array<Record<string, unknown>> = []
+  for await (const event of result.data) {
+    events.push(event)
+  }
 
-// openaiShim test extraction seam 089 end
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      typeof event.content_block === 'object' &&
+      event.content_block !== null &&
+      (event.content_block as Record<string, unknown>).type === 'tool_use',
+  ) as { content_block?: Record<string, unknown> } | undefined
 
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    id: 'function-call-1',
+    name: 'Bash',
+    extra_content: {
+      google: {
+        thought_signature: 'sig-stream',
+      },
+    },
+  })
+})
 
-// openaiShim test extraction seam 090 start: preserves Gemini thought signature from non-streaming message extra_content
+test('preserves Gemini thought signature from streaming delta extra_content', async () => {
+  globalThis.fetch = (async (_input, _init) => {
+    const chunks = makeStreamChunks([
+      {
+        id: 'chatcmpl-1',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-flash-lite',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              role: 'assistant',
+              extra_content: {
+                google: {
+                  thought_signature: 'sig-delta',
+                },
+              },
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'function-call-1',
+                  type: 'function',
+                  function: {
+                    name: 'Write',
+                    arguments: '{"file_path":"todo.md","content":"todo"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      },
+      {
+        id: 'chatcmpl-1',
+        object: 'chat.completion.chunk',
+        model: 'google/gemini-3.1-flash-lite',
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'tool_calls',
+          },
+        ],
+      },
+    ])
 
-// openaiShim test extraction seam 090 end
+    return makeSseResponse(chunks)
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const result = await client.beta.messages
+    .create({
+      model: 'google/gemini-3.1-flash-lite',
+      messages: [{ role: 'user', content: 'Use Write' }],
+      max_tokens: 64,
+      stream: true,
+    })
+    .withResponse()
+
+  const events: Array<Record<string, unknown>> = []
+  for await (const event of result.data) {
+    events.push(event)
+  }
+
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      typeof event.content_block === 'object' &&
+      event.content_block !== null &&
+      (event.content_block as Record<string, unknown>).type === 'tool_use',
+  ) as { content_block?: Record<string, unknown> } | undefined
+
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    id: 'function-call-1',
+    name: 'Write',
+    extra_content: {
+      google: {
+        thought_signature: 'sig-delta',
+      },
+    },
+    signature: 'sig-delta',
+  })
+})
+
+test('preserves Gemini thought signature from non-streaming message extra_content', async () => {
+  globalThis.fetch = (async (_input, _init) => {
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'google/gemini-3.1-flash-lite',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              extra_content: {
+                google: {
+                  thought_signature: 'sig-message',
+                },
+              },
+              tool_calls: [
+                {
+                  id: 'function-call-1',
+                  type: 'function',
+                  function: {
+                    name: 'Write',
+                    arguments: '{"file_path":"todo.md","content":"todo"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+          total_tokens: 16,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const message = await client.beta.messages.create({
+    model: 'google/gemini-3.1-flash-lite',
+    messages: [{ role: 'user', content: 'Use Write' }],
+    max_tokens: 64,
+    stream: false,
+  }) as {
+    content?: Array<Record<string, unknown>>
+  }
+
+  expect(message.content?.[0]).toMatchObject({
+    type: 'tool_use',
+    id: 'function-call-1',
+    name: 'Write',
+    extra_content: {
+      google: {
+        thought_signature: 'sig-message',
+      },
+    },
+    signature: 'sig-message',
+  })
+})
 
 // Extraction seam: provider signature metadata | raw streaming tool fallback.
 
-// openaiShim test extraction seam 091 start: converts Gemini raw tool-call text into streaming tool_use blocks
 test('converts Gemini raw tool-call text into streaming tool_use blocks', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5264,12 +5359,9 @@ test('converts Gemini raw tool-call text into streaming tool_use blocks', async 
     | undefined
   expect(stop?.delta?.stop_reason).toBe('tool_use')
 })
-// openaiShim test extraction seam 091 end
-
 
 // Extraction seam: streaming conversion | non-streaming response conversion.
 
-// openaiShim test extraction seam 092 start: converts Gemini raw tool-call text into non-streaming tool_use blocks
 test('converts Gemini raw tool-call text into non-streaming tool_use blocks', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -5326,10 +5418,7 @@ test('converts Gemini raw tool-call text into non-streaming tool_use blocks', as
     },
   ])
 })
-// openaiShim test extraction seam 092 end
 
-
-// openaiShim test extraction seam 093 start: normalizes plain string Bash tool arguments from OpenAI-compatible responses
 test('normalizes plain string Bash tool arguments from OpenAI-compatible responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -5391,10 +5480,7 @@ test('normalizes plain string Bash tool arguments from OpenAI-compatible respons
     },
   ])
 })
-// openaiShim test extraction seam 093 end
 
-
-// openaiShim test extraction seam 094 start: normalizes Bash tool arguments that are valid JSON strings
 test('normalizes Bash tool arguments that are valid JSON strings', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -5454,8 +5540,6 @@ test('normalizes Bash tool arguments that are valid JSON strings', async () => {
     },
   ])
 })
-// openaiShim test extraction seam 094 end
-
 
 test.each([
   ['false', false],
@@ -5524,7 +5608,6 @@ test.each([
   },
 )
 
-// openaiShim test extraction seam 095 start: keeps terminal empty Bash tool arguments invalid in non-streaming responses
 test('keeps terminal empty Bash tool arguments invalid in non-streaming responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -5584,12 +5667,9 @@ test('keeps terminal empty Bash tool arguments invalid in non-streaming response
     },
   ])
 })
-// openaiShim test extraction seam 095 end
-
 
 // Extraction seam: completed tool parsing | streamed tool normalization.
 
-// openaiShim test extraction seam 096 start: normalizes plain string Bash tool arguments in streaming responses
 test('normalizes plain string Bash tool arguments in streaming responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5665,10 +5745,7 @@ test('normalizes plain string Bash tool arguments in streaming responses', async
 
   expect(normalizedInput).toBe('{"command":"pwd"}')
 })
-// openaiShim test extraction seam 096 end
 
-
-// openaiShim test extraction seam 097 start: normalizes plain string Bash tool arguments when streaming starts with an empty chunk
 test('normalizes plain string Bash tool arguments when streaming starts with an empty chunk', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5766,10 +5843,7 @@ test('normalizes plain string Bash tool arguments when streaming starts with an 
 
   expect(normalizedInput).toBe('{"command":"pwd"}')
 })
-// openaiShim test extraction seam 097 end
 
-
-// openaiShim test extraction seam 098 start: normalizes plain string Bash tool arguments when streaming starts with whitespace
 test('normalizes plain string Bash tool arguments when streaming starts with whitespace', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5867,10 +5941,7 @@ test('normalizes plain string Bash tool arguments when streaming starts with whi
 
   expect(normalizedInput).toBe('{"command":" pwd"}')
 })
-// openaiShim test extraction seam 098 end
 
-
-// openaiShim test extraction seam 099 start: keeps terminal whitespace-only Bash arguments invalid in streaming responses
 test('keeps terminal whitespace-only Bash arguments invalid in streaming responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -5946,10 +6017,7 @@ test('keeps terminal whitespace-only Bash arguments invalid in streaming respons
 
   expect(normalizedInput).toBe('{}')
 })
-// openaiShim test extraction seam 099 end
 
-
-// openaiShim test extraction seam 100 start: normalizes streaming Bash arguments that begin with bracket syntax
 test('normalizes streaming Bash arguments that begin with bracket syntax', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6025,10 +6093,7 @@ test('normalizes streaming Bash arguments that begin with bracket syntax', async
 
   expect(normalizedInput).toBe('{"command":"[ -f package.json ] && pwd"}')
 })
-// openaiShim test extraction seam 100 end
 
-
-// openaiShim test extraction seam 101 start: normalizes streaming Bash arguments when the first chunk is only an opening brace
 test('normalizes streaming Bash arguments when the first chunk is only an opening brace', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6126,10 +6191,7 @@ test('normalizes streaming Bash arguments when the first chunk is only an openin
 
   expect(normalizedInput).toBe('{"command":"{ pwd; }"}')
 })
-// openaiShim test extraction seam 101 end
 
-
-// openaiShim test extraction seam 102 start: repairs truncated structured Bash JSON in streaming responses
 test('repairs truncated structured Bash JSON in streaming responses', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6205,10 +6267,7 @@ test('repairs truncated structured Bash JSON in streaming responses', async () =
 
   expect(normalizedInput).toBe('{"command":"pwd"}')
 })
-// openaiShim test extraction seam 102 end
 
-
-// openaiShim test extraction seam 103 start: does not normalize incomplete streamed Bash commands when finish_reason is length
 test('does not normalize incomplete streamed Bash commands when finish_reason is length', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6284,10 +6343,7 @@ test('does not normalize incomplete streamed Bash commands when finish_reason is
 
   expect(streamedInput).toBe('rg --fi')
 })
-// openaiShim test extraction seam 103 end
 
-
-// openaiShim test extraction seam 104 start: repairs truncated JSON objects even without command field
 test('repairs truncated JSON objects even without command field', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -6363,12 +6419,9 @@ test('repairs truncated JSON objects even without command field', async () => {
 
   expect(streamedInput).toBe('{"cwd":"/tmp"}')
 })
-// openaiShim test extraction seam 104 end
-
 
 // Extraction seam: streamed tool normalization | schema and tool conversion.
 
-// openaiShim test extraction seam 105 start: preserves raw input for unknown plain string tool arguments
 test('preserves raw input for unknown plain string tool arguments', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6428,10 +6481,7 @@ test('preserves raw input for unknown plain string tool arguments', async () => 
     },
   ])
 })
-// openaiShim test extraction seam 105 end
 
-
-// openaiShim test extraction seam 106 start: preserves parsed string input for unknown JSON string tool arguments
 test('preserves parsed string input for unknown JSON string tool arguments', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6491,12 +6541,9 @@ test('preserves parsed string input for unknown JSON string tool arguments', asy
     },
   ])
 })
-// openaiShim test extraction seam 106 end
-
 
 // Extraction seam: argument parsing | schema sanitation.
 
-// openaiShim test extraction seam 107 start: sanitizes malformed MCP tool schemas before sending them to OpenAI
 test('sanitizes malformed MCP tool schemas before sending them to OpenAI', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -6571,10 +6618,7 @@ test('sanitizes malformed MCP tool schemas before sending them to OpenAI', async
   expect(properties?.priority?.enum).toEqual([0, 1, 2, 3])
   expect(properties?.priority).not.toHaveProperty('default')
 })
-// openaiShim test extraction seam 107 end
 
-
-// openaiShim test extraction seam 108 start: optional tool properties are not added to required[] — fixes Groq/Azure 400 tool_use_failed
 test('optional tool properties are not added to required[] — fixes Groq/Azure 400 tool_use_failed', async () => {
   // Regression test for: all optional properties being sent as required in strict mode,
   // causing providers like Groq to reject valid tool calls where the model omits optional args.
@@ -6631,8 +6675,6 @@ test('optional tool properties are not added to required[] — fixes Groq/Azure 
   expect(required).not.toContain('pages')
   expect(parameters?.additionalProperties).toBe(false)
 })
-// openaiShim test extraction seam 108 end
-
 
 // Extraction seam: schema sanitation | message conversion façade.
 
@@ -6645,13 +6687,10 @@ test('optional tool properties are not added to required[] — fixes Groq/Azure 
 //
 // ---------------------------------------------------------------------------
 
-// openaiShim test extraction seam 109 start: the OpenAI shim façade exposes the messages.create contract
 test('the OpenAI shim façade exposes the messages.create contract', () => {
   const client = createOpenAIShimClient({}) as OpenAIShimClient
   expect(typeof client.beta.messages.create).toBe('function')
 })
-// openaiShim test extraction seam 109 end
-
 
 function makeNonStreamResponse(content = 'ok'): Response {
   return new Response(
@@ -6665,7 +6704,6 @@ function makeNonStreamResponse(content = 'ok'): Response {
   )
 }
 
-// openaiShim test extraction seam 110 start: coalesces consecutive user messages to avoid alternation errors (issue #202)
 test('coalesces consecutive user messages to avoid alternation errors (issue #202)', async () => {
   let sentMessages: Array<{ role: string; content: unknown }> | undefined
 
@@ -6694,10 +6732,7 @@ test('coalesces consecutive user messages to avoid alternation errors (issue #20
   expect(userContent).toContain('first message')
   expect(userContent).toContain('second message')
 })
-// openaiShim test extraction seam 110 end
 
-
-// openaiShim test extraction seam 111 start: coalesces consecutive assistant messages preserving tool_calls (issue #202)
 test('coalesces consecutive assistant messages preserving tool_calls (issue #202)', async () => {
   let sentMessages: Array<{ role: string; content: unknown; tool_calls?: unknown[] }> | undefined
 
@@ -6728,8 +6763,6 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
   expect(assistantMsgs?.length).toBe(1)
   expect(assistantMsgs?.[0]?.tool_calls?.length).toBeGreaterThan(0)
 })
-// openaiShim test extraction seam 111 end
-
 
 // ---------------------------------------------------------------------------
 // Extraction boundary: message conversion | non-streaming response conversion
@@ -6740,26 +6773,10 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
 //
 // ---------------------------------------------------------------------------
 
-// openaiShim test extraction seam 112 start: the OpenAI shim façade creates independent client instances
 test('the OpenAI shim façade creates independent client instances', () => {
-  const first = createOpenAIShimClient({}) as OpenAIShimClient
-  const second = createOpenAIShimClient({}) as OpenAIShimClient
-  expect(first).not.toBe(second)
-  expect(first.beta).not.toBe(second.beta)
-  expect(first.beta.messages).not.toBe(second.beta.messages)
-})
-// openaiShim test extraction seam 112 end
-
-test('raw-text and XML fallback tool calls use one unique sequence', () => {
-  const text = parseTextToolCalls('{"name":"from_text","arguments":{}}')
-  const xml = parseXmlToolCalls('<tool_call>{"name":"from_xml","arguments":{}}</tool_call>')
-  expect(text.calls[0]?.id).toMatch(/^ollama_tc_\d+$/)
-  expect(xml.calls[0]?.id).toMatch(/^xml_tc_\d+$/)
-  expect(text.calls[0]?.id?.replace(/^\D+/, '')).not.toBe(xml.calls[0]?.id?.replace(/^\D+/, ''))
+  expect(createOpenAIShimClient({})).not.toBe(createOpenAIShimClient({}))
 })
 
-// ---------------------------------------------------------------------------
-// openaiShim test extraction seam 113 start: non-streaming: reasoning_content emitted as thinking block only when content is null
 test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6804,10 +6821,7 @@ test('non-streaming: reasoning_content emitted as thinking block only when conte
     { type: 'thinking', thinking: 'Let me think about this step by step.' },
   ])
 })
-// openaiShim test extraction seam 113 end
 
-
-// openaiShim test extraction seam 114 start: non-streaming: empty string content does not fall through to reasoning_content as text
 test('non-streaming: empty string content does not fall through to reasoning_content as text', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6852,10 +6866,7 @@ test('non-streaming: empty string content does not fall through to reasoning_con
     { type: 'thinking', thinking: 'Chain of thought here.' },
   ])
 })
-// openaiShim test extraction seam 114 end
 
-
-// openaiShim test extraction seam 115 start: non-streaming: real content takes precedence over reasoning_content
 test('non-streaming: real content takes precedence over reasoning_content', async () => {
   globalThis.fetch = (async (_input, _init) => {
     return new Response(
@@ -6901,10 +6912,7 @@ test('non-streaming: real content takes precedence over reasoning_content', asyn
     { type: 'text', text: 'The answer is 42.' },
   ])
 })
-// openaiShim test extraction seam 115 end
 
-
-// openaiShim test extraction seam 116 start: non-streaming: preserves response body when usage parsing fails
 test('non-streaming: preserves response body when usage parsing fails', async () => {
   const json = JSON as unknown as { parse: typeof JSON.parse }
   const originalJSONParse = json.parse
@@ -6972,10 +6980,7 @@ test('non-streaming: preserves response body when usage parsing fails', async ()
     json.parse = originalJSONParse
   }
 })
-// openaiShim test extraction seam 116 end
 
-
-// openaiShim test extraction seam 117 start: non-streaming: preserves response.url routing metadata after body read
 test('non-streaming: preserves response.url routing metadata after body read', async () => {
   // _doRequest reads the body for usage extraction and recreates the
   // Response with new Response(bodyText, ...). That drops response.url to
@@ -7023,10 +7028,7 @@ test('non-streaming: preserves response.url routing metadata after body read', a
   // and content would not match.
   expect(result.content).toEqual([{ type: 'text', text: 'passthrough ok' }])
 })
-// openaiShim test extraction seam 117 end
 
-
-// openaiShim test extraction seam 118 start: non-streaming: strips <think> tag block from assistant content
 test('non-streaming: strips <think> tag block from assistant content', async () => {
   globalThis.fetch = asMockFetch(mock(async () => {
     return new Response(
@@ -7066,12 +7068,9 @@ test('non-streaming: strips <think> tag block from assistant content', async () 
     { type: 'text', text: 'Hey! How can I help you today?' },
   ])
 })
-// openaiShim test extraction seam 118 end
-
 
 // Extraction seam: non-streaming response conversion | streaming event conversion.
 
-// openaiShim test extraction seam 119 start: streaming: thinking block closed before tool call
 test('streaming: thinking block closed before tool call', async () => {
   globalThis.fetch = (async (_input, _init) => {
     const chunks = makeStreamChunks([
@@ -7163,10 +7162,7 @@ test('streaming: thinking block closed before tool call', async () => {
   }
   expect(thinkingStart?.content_block?.type).toBe('thinking')
 })
-// openaiShim test extraction seam 119 end
 
-
-// openaiShim test extraction seam 120 start: streaming: strips <think> tag block from assistant content deltas
 test('streaming: strips <think> tag block from assistant content deltas', async () => {
   globalThis.fetch = asMockFetch(mock(async () => {
     const chunks = makeStreamChunks([
@@ -7224,10 +7220,7 @@ test('streaming: strips <think> tag block from assistant content deltas', async 
 
   expect(textDeltas.join('')).toBe('Hey! How can I help you today?')
 })
-// openaiShim test extraction seam 120 end
 
-
-// openaiShim test extraction seam 121 start: streaming: strips <think> tag split across multiple content chunks
 test('streaming: strips <think> tag split across multiple content chunks', async () => {
   globalThis.fetch = asMockFetch(mock(async () => {
     const chunks = makeStreamChunks([
@@ -7313,10 +7306,7 @@ test('streaming: strips <think> tag split across multiple content chunks', async
 
   expect(textDeltas.join('')).toBe('Hey! How can I help you today?')
 })
-// openaiShim test extraction seam 121 end
 
-
-// openaiShim test extraction seam 122 start: streaming: preserves prose without tags (no phrase-based false positive)
 test('streaming: preserves prose without tags (no phrase-based false positive)', async () => {
   // Regression: older phrase-based sanitizer would strip "I should..." prose.
   // The tag-based approach leaves legitimate assistant output alone.
@@ -7378,13 +7368,10 @@ test('streaming: preserves prose without tags (no phrase-based false positive)',
     'I should note that the user role requires a briefly concise friendly response format.',
   )
 })
-// openaiShim test extraction seam 122 end
-
 
 // Extraction boundary: response conversion | executor network behavior.
 // The executor suite owns the contiguous network-classification block below.
 // Keep this marker stable for independent adjacent test migrations.
-// openaiShim test extraction seam 123 start: strips credentials and query params from URL in fetch network error message
 test('strips credentials and query params from URL in fetch network error message', async () => {
   process.env.OPENAI_BASE_URL =
     'https://user:password@internal.example.test/v1?token=abc123'
@@ -7417,75 +7404,7 @@ test('strips credentials and query params from URL in fetch network error messag
   expect(message).not.toContain('user:')
   expect(message).not.toContain('token=abc123')
 })
-// openaiShim test extraction seam 123 end
 
-test('redacts configured secret substrings from fetch network error messages', async () => {
-  const secret = 'route/key+AbC123'
-  process.env.OPENAI_API_KEY = secret
-
-  globalThis.fetch = asMockFetch(mock(async () => {
-    throw new TypeError(`fetch failed while routing ${secret}`)
-  }))
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  await expect(
-    client.beta.messages.create({
-      model: 'test-model',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 64,
-      stream: false,
-    }),
-  ).rejects.not.toThrow(secret)
-})
-
-test('redacts encoded configured secrets from non-URL transport error messages', async () => {
-  const secret = 'route/key+AbC123'
-  const encodedSecret = encodeURIComponent(secret)
-  const doubleEncodedSecret = encodeURIComponent(encodedSecret)
-  const fullyEncodedSecret = Array.from(new TextEncoder().encode(secret))
-    .map(byte => `%${byte.toString(16).padStart(2, '0')}`)
-    .join('')
-  const malformedAdjacentSecret = `%E0%A4${encodedSecret}`
-  const encodedCategoryMarker = '%5Bopenai_category%3Dauth_invalid%5D'
-  const encodedControlSequence = '%1B%5B31m'
-  process.env.OPENAI_API_KEY = secret
-
-  globalThis.fetch = asMockFetch(mock(async () => {
-    throw new TypeError(
-      `proxy failed ${encodedCategoryMarker} ${encodedControlSequence} for path /v1/${encodedSecret}?nested=${doubleEncodedSecret}&fully=${fullyEncodedSecret}&malformed=${malformedAdjacentSecret}`,
-    )
-  }))
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  let caught: unknown
-  try {
-    await client.beta.messages.create({
-      model: 'test-model',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 64,
-      stream: false,
-    })
-  } catch (error) {
-    caught = error
-  }
-
-  expect(caught).toBeDefined()
-  const message = (caught as Error).message
-  expect(message).toContain('proxy failed')
-  expect(message).toContain(encodedCategoryMarker)
-  expect(message).toContain(encodedControlSequence)
-  expect(message).not.toContain('\u001B')
-  expect(extractOpenAICategoryMarker(message)).toBe('network_error')
-  expect(message).not.toContain(secret)
-  expect(message).not.toContain(encodedSecret)
-  expect(message).not.toContain(doubleEncodedSecret)
-  expect(message).not.toContain(fullyEncodedSecret)
-  expect(message).not.toContain(malformedAdjacentSecret)
-})
-
-// openaiShim test extraction seam 124 start: classifies localhost transport failures with actionable category marker
 test('classifies localhost transport failures with actionable category marker', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
@@ -7517,10 +7436,7 @@ test('classifies localhost transport failures with actionable category marker', 
     }),
   ).rejects.toThrow('local server is running')
 })
-// openaiShim test extraction seam 124 end
 
-
-// openaiShim test extraction seam 125 start: transport failures are not labeled with HTTP status 503
 test('transport failures are not labeled with HTTP status 503', async () => {
   // Issue #971: ENETDOWN (and other transport errors) are emitted before any
   // HTTP response is received. Reporting them as "503" makes users believe the
@@ -7558,10 +7474,8 @@ test('transport failures are not labeled with HTTP status 503', async () => {
   expect(err.message).toContain('code=ENETDOWN')
   expect(err.message).toContain('openai_category=network_error')
 })
-// openaiShim test extraction seam 125 end
 
-test('propagates caller AbortError without wrapping it as transport failure', async () => {
-// openaiShim test extraction seam 126 start: propagates AbortError without wrapping it as transport failure
+test('propagates AbortError without wrapping it as transport failure', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
   const abortError = new DOMException('The operation was aborted.', 'AbortError')
@@ -7570,8 +7484,7 @@ test('propagates caller AbortError without wrapping it as transport failure', as
   }))
 
   const controller = new AbortController()
-  const callerReason = new DOMException('Cancelled by caller', 'AbortError')
-  controller.abort(callerReason)
+  controller.abort()
 
   const client = createOpenAIShimClient({}) as OpenAIShimClient
 
@@ -7585,519 +7498,9 @@ test('propagates caller AbortError without wrapping it as transport failure', as
       },
       { signal: controller.signal },
     ),
-  ).rejects.toBe(callerReason)
+  ).rejects.toBe(abortError)
 })
 
-test('classifies a pre-header API timeout without replaying the request', async () => {
-  process.env.API_TIMEOUT_MS = '20'
-  const pathSecret = 'route/key+AbC123'
-  const encodedPathSecret = encodeURIComponent(pathSecret)
-  const doubleEncodedPathSecret = encodeURIComponent(encodedPathSecret)
-  const escapeLookingSecret = 'abc%2FdefLONG'
-  const encodedEscapeLookingSecret = encodeURIComponent(escapeLookingSecret)
-  const decodedEscapeLookingSecret = decodeURIComponent(escapeLookingSecret)
-  const malformedUtf8Secret = 'éSECRET_VALUE_123'
-  const encodedMalformedUtf8Secret = encodeURIComponent(malformedUtf8Secret)
-  process.env.OPENAI_API_KEY = pathSecret
-  process.env.OPENROUTER_API_KEY = escapeLookingSecret
-  process.env.DEEPSEEK_API_KEY = malformedUtf8Secret
-  process.env.OPENAI_BASE_URL =
-    `https://user:password@slow.example.test/v1/invalid%ZZ/${doubleEncodedPathSecret}/${encodedEscapeLookingSecret}/%E0%A4${encodedMalformedUtf8Secret}` +
-    `?prompt=${encodedPathSecret}&nested=${doubleEncodedPathSecret}` +
-    `&escape=${encodedEscapeLookingSecret}&malformed=%E0%A4${encodedMalformedUtf8Secret}` +
-    '&token=secret'
-  let fetchCalls = 0
-  let completedGenerations = 0
-  const receivedBodies: string[] = []
-  globalThis.fetch = (async (_input, init) => {
-    fetchCalls++
-    receivedBodies.push(String(init?.body))
-    return new Promise<Response>((resolve, reject) => {
-      setTimeout(() => {
-        completedGenerations++
-        resolve(makeChatCompletionResponse('gpt-4o-mini'))
-      }, 50)
-      const signal = init?.signal
-      if (!signal) return
-      const rejectFromAbort = () => {
-        reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
-      }
-      signal.addEventListener('abort', rejectFromAbort, { once: true })
-      if (signal.aborted) rejectFromAbort()
-    })
-  }) as unknown as FetchType
-
-  const safety = new AbortController()
-  const safetyTimer = setTimeout(() => safety.abort(), 500)
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  let caught: unknown
-  try {
-    await waitForPromise(
-      client.beta.messages.create(
-        {
-          model: 'gpt-4o-mini',
-          messages: [{ role: 'user', content: 'hello' }],
-          max_tokens: 64,
-          stream: false,
-        },
-        { signal: safety.signal },
-      ),
-      750,
-      'pre-header timeout did not settle',
-    )
-  } catch (error) {
-    caught = error
-  } finally {
-    clearTimeout(safetyTimer)
-  }
-  await new Promise(resolve => setTimeout(resolve, 60))
-
-  expect(caught).toBeDefined()
-  const error = caught as Error & { constructor: { name: string } }
-  expect(error.constructor.name).toBe('APIConnectionError')
-  expect(isOpenAIRequestNonReplayable(error)).toBe(true)
-  expect(error.message).toContain('no response headers within 20ms (API_TIMEOUT_MS)')
-  expect(error.message).toContain('slow.example.test')
-  expect(error.message).toContain('openai_category=request_timeout')
-  expect(error.message).not.toContain('password')
-  expect(error.message).not.toContain('token=secret')
-  expect(error.message).not.toContain(pathSecret)
-  expect(error.message).not.toContain(encodedPathSecret)
-  expect(error.message).not.toContain(doubleEncodedPathSecret)
-  expect(error.message).not.toContain(escapeLookingSecret)
-  expect(error.message).not.toContain(encodedEscapeLookingSecret)
-  expect(error.message).not.toContain(decodedEscapeLookingSecret)
-  expect(error.message).not.toContain(malformedUtf8Secret)
-  expect(error.message).not.toContain(encodedMalformedUtf8Secret)
-  expect(fetchCalls).toBe(1)
-  expect(receivedBodies).toHaveLength(1)
-  expect(completedGenerations).toBe(1)
-})
-
-test('does not proxy-retry when a deadline abort surfaces as fetch failed', async () => {
-  process.env.API_TIMEOUT_MS = '20'
-  let fetchCalls = 0
-  globalThis.fetch = (async (_input, init) => {
-    fetchCalls++
-    return new Promise<Response>((_resolve, reject) => {
-      const signal = init?.signal
-      const rejectFromAbort = () => reject(new TypeError('fetch failed'))
-      signal?.addEventListener('abort', rejectFromAbort, { once: true })
-      if (signal?.aborted) rejectFromAbort()
-    })
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  await expect(
-    client.beta.messages.create({
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 64,
-      stream: false,
-    }),
-  ).rejects.toThrow('no response headers within 20ms (API_TIMEOUT_MS)')
-
-  expect(fetchCalls).toBe(1)
-})
-
-test('deadline wins when an abort-ignoring fetch resolves 504 afterward', async () => {
-  process.env.API_TIMEOUT_MS = '20'
-  let fetchCalls = 0
-  globalThis.fetch = (async (_input, init) => {
-    fetchCalls++
-    return new Promise<Response>(resolve => {
-      const resolveAfterAbort = () => {
-        resolve(new Response('Gateway Timeout', { status: 504 }))
-      }
-      init?.signal?.addEventListener('abort', resolveAfterAbort, { once: true })
-      if (init?.signal?.aborted) resolveAfterAbort()
-    })
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  await expect(
-    client.beta.messages.create({
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 64,
-      stream: false,
-    }),
-  ).rejects.toThrow('no response headers within 20ms (API_TIMEOUT_MS)')
-
-  expect(fetchCalls).toBe(1)
-})
-
-test('gives a proxy retry its own response-header deadline', async () => {
-  process.env.API_TIMEOUT_MS = '50'
-  let fetchCalls = 0
-  globalThis.fetch = (async () => {
-    fetchCalls++
-    if (fetchCalls === 1) {
-      await new Promise(resolve => setTimeout(resolve, 30))
-      return new Response('Gateway Timeout', { status: 504 })
-    }
-    await new Promise(resolve => setTimeout(resolve, 30))
-    return makeChatCompletionResponse('gpt-4o-mini')
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  const response = await client.beta.messages.create({
-    model: 'gpt-4o-mini',
-    messages: [{ role: 'user', content: 'hello' }],
-    max_tokens: 64,
-    stream: false,
-  })
-
-  expect(response).toBeDefined()
-  expect(fetchCalls).toBe(2)
-})
-
-test('bounds nested URL decoding while retaining encoded secret redaction', async () => {
-  const secret = 'route/key+AbC123'
-  const secretVariants = [secret]
-  for (let layer = 0; layer < 4; layer++) {
-    secretVariants.push(
-      encodeURIComponent(secretVariants[secretVariants.length - 1]!),
-    )
-  }
-  const deeplyNestedValue = `%${'25'.repeat(200)}`
-  process.env.OPENAI_API_KEY = secret
-  process.env.OPENAI_BASE_URL =
-    `https://slow.example.test/v1/${deeplyNestedValue}/${secretVariants[4]}`
-  globalThis.fetch = asMockFetch(mock(async () => {
-    throw new TypeError('fetch failed')
-  }))
-
-  const originalDecodeURIComponent = globalThis.decodeURIComponent
-  let decodeCalls = 0
-  globalThis.decodeURIComponent = ((value: string) => {
-    decodeCalls++
-    return originalDecodeURIComponent(value)
-  }) as typeof decodeURIComponent
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  let caught: unknown
-  try {
-    await client.beta.messages.create({
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 64,
-      stream: false,
-    })
-  } catch (error) {
-    caught = error
-  } finally {
-    globalThis.decodeURIComponent = originalDecodeURIComponent
-  }
-
-  expect(caught).toBeDefined()
-  for (const secretVariant of secretVariants) {
-    expect((caught as Error).message).not.toContain(secretVariant)
-  }
-  expect(decodeCalls).toBeLessThanOrEqual(32)
-})
-
-test('decodes malformed URL escape runs in linear work', async () => {
-  const secret = 'route/key+AbC123'
-  const encodedSecret = encodeURIComponent(secret)
-  const malformedEscapeCount = 200
-  const malformedUtf8Run = '%80'.repeat(malformedEscapeCount)
-  process.env.OPENAI_API_KEY = secret
-  process.env.OPENAI_BASE_URL =
-    `https://slow.example.test/v1/${malformedUtf8Run}/${encodedSecret}`
-  globalThis.fetch = asMockFetch(mock(async () => {
-    throw new TypeError('fetch failed')
-  }))
-
-  const originalDecodeURIComponent = globalThis.decodeURIComponent
-  let malformedDecodeCalls = 0
-  globalThis.decodeURIComponent = ((value: string) => {
-    if (value.includes('%80')) malformedDecodeCalls++
-    return originalDecodeURIComponent(value)
-  }) as typeof decodeURIComponent
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  let caught: unknown
-  try {
-    await client.beta.messages.create({
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 64,
-      stream: false,
-    })
-  } catch (error) {
-    caught = error
-  } finally {
-    globalThis.decodeURIComponent = originalDecodeURIComponent
-  }
-
-  expect(caught).toBeDefined()
-  expect((caught as Error).message).not.toContain(secret)
-  expect((caught as Error).message).not.toContain(encodedSecret)
-  expect(malformedDecodeCalls).toBeLessThanOrEqual(malformedEscapeCount * 10)
-})
-
-test('preserves caller cancellation while waiting for response headers without retrying', async () => {
-  process.env.API_TIMEOUT_MS = '200'
-  let fetchCalls = 0
-  globalThis.fetch = (async (_input, init) => {
-    fetchCalls++
-    return pendingFetchUntilAbort(init)
-  }) as unknown as FetchType
-
-  const caller = new AbortController()
-  const callerReason = new DOMException('Cancelled by user', 'AbortError')
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  const originalAbortSignalAny = Object.getOwnPropertyDescriptor(
-    AbortSignal,
-    'any',
-  )
-  Object.defineProperty(AbortSignal, 'any', {
-    value: undefined,
-    configurable: true,
-  })
-  try {
-    const request = client.beta.messages.create(
-      {
-        model: 'gpt-4o-mini',
-        messages: [{ role: 'user', content: 'hello' }],
-        max_tokens: 64,
-        stream: false,
-      },
-      { signal: caller.signal },
-    )
-
-    setTimeout(() => caller.abort(callerReason), 10)
-
-    await expect(
-      waitForPromise(request, 500, 'caller abort did not settle'),
-    ).rejects.toBe(callerReason)
-    expect(fetchCalls).toBe(1)
-  } finally {
-    if (originalAbortSignalAny) {
-      Object.defineProperty(AbortSignal, 'any', originalAbortSignalAny)
-    }
-  }
-})
-
-test('native signal composition preserves the caller abort reason when fetch rejects AbortError', async () => {
-  expect(typeof AbortSignal.any).toBe('function')
-  process.env.API_TIMEOUT_MS = '200'
-  let fetchCalls = 0
-  const fetchAbortError = new DOMException(
-    'The operation was aborted.',
-    'AbortError',
-  )
-  globalThis.fetch = (async (_input, init) => {
-    fetchCalls++
-    return new Promise<Response>((_resolve, reject) => {
-      const signal = init?.signal
-      if (!signal) return
-      const rejectFromAbort = () => reject(fetchAbortError)
-      signal.addEventListener('abort', rejectFromAbort, { once: true })
-      if (signal.aborted) rejectFromAbort()
-    })
-  }) as unknown as FetchType
-
-  const caller = new AbortController()
-  const callerReason = new DOMException('Cancelled by user', 'AbortError')
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  const request = client.beta.messages.create(
-    {
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 64,
-      stream: false,
-    },
-    { signal: caller.signal },
-  )
-
-  const abortTimer = setTimeout(() => caller.abort(callerReason), 10)
-
-  try {
-    await expect(
-      waitForPromise(request, 500, 'caller abort did not settle'),
-    ).rejects.toBe(callerReason)
-  } finally {
-    clearTimeout(abortTimer)
-  }
-  expect(fetchCalls).toBe(1)
-})
-
-test('caller abort winning the timeout catch race prevents a retry', async () => {
-  process.env.API_TIMEOUT_MS = '20'
-  let fetchCalls = 0
-  const caller = new AbortController()
-  const callerReason = new DOMException('Cancelled by user', 'AbortError')
-  globalThis.fetch = (async (_input, init) => {
-    fetchCalls++
-    return new Promise<Response>((_resolve, reject) => {
-      const signal = init?.signal
-      if (!signal) return
-      const rejectFromAbort = () => {
-        reject(signal.reason ?? new DOMException('Aborted', 'AbortError'))
-        if (fetchCalls === 1) {
-          queueMicrotask(() => caller.abort(callerReason))
-        }
-      }
-      signal.addEventListener('abort', rejectFromAbort, { once: true })
-      if (signal.aborted) rejectFromAbort()
-    })
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  await expect(
-    waitForPromise(
-      client.beta.messages.create(
-        {
-          model: 'gpt-4o-mini',
-          messages: [{ role: 'user', content: 'hello' }],
-          max_tokens: 64,
-          stream: false,
-        },
-        { signal: caller.signal },
-      ),
-      500,
-      'caller abort race did not settle',
-    ),
-  ).rejects.toBe(callerReason)
-  expect(fetchCalls).toBe(1)
-})
-
-test('manual signal fallback preserves caller cancellation after headers arrive', async () => {
-  process.env.API_TIMEOUT_MS = '200'
-  const fetchSignals: AbortSignal[] = []
-  const stalled = makeStallingResponse(
-    makeOpenAIStreamFrame({ role: 'assistant', content: 'started' }),
-  )
-  globalThis.fetch = (async (_input, init) => {
-    if (init?.signal) fetchSignals.push(init.signal)
-    return stalled.response
-  }) as unknown as FetchType
-
-  const caller = new AbortController()
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  const originalAbortSignalAny = Object.getOwnPropertyDescriptor(
-    AbortSignal,
-    'any',
-  )
-  Object.defineProperty(AbortSignal, 'any', {
-    value: undefined,
-    configurable: true,
-  })
-  try {
-    const result = await client.beta.messages
-      .create(
-        {
-          model: 'gpt-4o-mini',
-          messages: [{ role: 'user', content: 'hello' }],
-          max_tokens: 64,
-          stream: true,
-        },
-        { signal: caller.signal },
-      )
-      .withResponse()
-
-    await expectAbortStopsStream({
-      abort: () => caller.abort(),
-      cancelReasons: stalled.cancelReasons,
-      expectedEventsBeforeAbort: 1,
-      label: 'manual combined signal after headers',
-      stream: result.data as ShimStream,
-    })
-
-    expect(fetchSignals).toHaveLength(1)
-    expect(fetchSignals[0].aborted).toBe(true)
-  } finally {
-    stalled.close()
-    if (originalAbortSignalAny) {
-      Object.defineProperty(AbortSignal, 'any', originalAbortSignalAny)
-    }
-  }
-})
-
-test('manual signal fallback removes caller forwarding after the body settles', async () => {
-  process.env.API_TIMEOUT_MS = '200'
-  globalThis.fetch = asMockFetch(mock(async () =>
-    makeChatCompletionResponse('gpt-4o-mini')))
-
-  const caller = new AbortController()
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  const originalAbortSignalAny = Object.getOwnPropertyDescriptor(
-    AbortSignal,
-    'any',
-  )
-  Object.defineProperty(AbortSignal, 'any', {
-    value: undefined,
-    configurable: true,
-  })
-  try {
-    for (let request = 0; request < 2; request++) {
-      await client.beta.messages.create(
-        {
-          model: 'gpt-4o-mini',
-          messages: [{ role: 'user', content: 'hello' }],
-          max_tokens: 64,
-          stream: false,
-        },
-        { signal: caller.signal },
-      )
-      expect(getEventListeners(caller.signal, 'abort')).toHaveLength(0)
-    }
-  } finally {
-    if (originalAbortSignalAny) {
-      Object.defineProperty(AbortSignal, 'any', originalAbortSignalAny)
-    }
-  }
-})
-
-test('disarms the API timeout after headers arrive while the body keeps streaming', async () => {
-  process.env.API_TIMEOUT_MS = '20'
-  const fetchSignals: AbortSignal[] = []
-  const encoder = new TextEncoder()
-  globalThis.fetch = (async (_input, init) => {
-    if (init?.signal) fetchSignals.push(init.signal)
-    return new Response(
-      new ReadableStream<Uint8Array>({
-        start(controller) {
-          setTimeout(() => {
-            controller.enqueue(encoder.encode(makeOpenAIStreamFrame(
-              { role: 'assistant', content: 'late body' },
-              'stop',
-            )))
-            controller.enqueue(encoder.encode('data: [DONE]\n\n'))
-            controller.close()
-          }, 50)
-        },
-      }),
-      { headers: { 'Content-Type': 'text/event-stream' } },
-    )
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  const result = await client.beta.messages
-    .create({
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 64,
-      stream: true,
-    })
-    .withResponse()
-
-  const events: Array<Record<string, unknown>> = []
-  for await (const event of result.data) events.push(event)
-
-  expect(events.length).toBeGreaterThan(0)
-  expect(fetchSignals).toHaveLength(1)
-  expect(fetchSignals[0].aborted).toBe(false)
-})
-// openaiShim test extraction seam 126 end
-
-
-// openaiShim test extraction seam 127 start: classifies chat-completions endpoint 404 failures with endpoint_not_found marker
 test('classifies chat-completions endpoint 404 failures with endpoint_not_found marker', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434'
 
@@ -8120,9 +7523,6 @@ test('classifies chat-completions endpoint 404 failures with endpoint_not_found 
     }),
   ).rejects.toThrow('openai_category=endpoint_not_found')
 })
-// openaiShim test extraction seam 127 end
-
-// openaiShim test extraction seam 128 start: self-heals localhost resolution failures by retrying local loopback base URL
 test('self-heals localhost resolution failures by retrying local loopback base URL', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
@@ -8180,13 +7580,10 @@ test('self-heals localhost resolution failures by retrying local loopback base U
   expect(requestUrls[0]).toBe('http://localhost:11434/api/chat')
   expect(requestUrls).toContain('http://127.0.0.1:11434/api/chat')
 })
-// openaiShim test extraction seam 128 end
-
 
 // Extraction boundary: executor network behavior | native Ollama routing.
 // Native Ollama endpoint selection remains an adapter/facade integration concern.
 // Keep this marker stable for independent adjacent test migrations.
-// openaiShim test extraction seam 129 start: uses native Ollama chat endpoint when local base URL omits /v1
 test('uses native Ollama chat endpoint when local base URL omits /v1', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434'
 
@@ -8229,10 +7626,7 @@ test('uses native Ollama chat endpoint when local base URL omits /v1', async () 
 
   expect(requestUrls).toEqual(['http://localhost:11434/api/chat'])
 })
-// openaiShim test extraction seam 129 end
 
-
-// openaiShim test extraction seam 130 start: keeps remote Ollama-named gateways on chat completions
 test('keeps remote Ollama-named gateways on chat completions', async () => {
   process.env.OPENAI_BASE_URL = 'https://ollama-gateway.example.com/v1'
 
@@ -8262,10 +7656,7 @@ test('keeps remote Ollama-named gateways on chat completions', async () => {
     'https://ollama-gateway.example.com/v1/chat/completions',
   ])
 })
-// openaiShim test extraction seam 130 end
 
-
-// openaiShim test extraction seam 131 start: keeps HTTPS localhost Ollama-port proxies on chat completions
 test('keeps HTTPS localhost Ollama-port proxies on chat completions', async () => {
   process.env.OPENAI_BASE_URL = 'https://localhost:11434/v1'
 
@@ -8295,13 +7686,10 @@ test('keeps HTTPS localhost Ollama-port proxies on chat completions', async () =
     'https://localhost:11434/v1/chat/completions',
   ])
 })
-// openaiShim test extraction seam 131 end
-
 
 // Extraction boundary: native Ollama routing | executor tool self-healing.
 // The single retry test below moves with request execution.
 // Keep this marker stable for independent adjacent test migrations.
-// openaiShim test extraction seam 132 start: self-heals tool-call incompatibility by retrying local Ollama requests without tools
 test('self-heals tool-call incompatibility by retrying local Ollama requests without tools', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1'
 
@@ -8381,13 +7769,10 @@ test('self-heals tool-call incompatibility by retrying local Ollama requests wit
   expect(requestBodies[1]?.tool_choice).toBeUndefined()
   expect(requestBodies[1]?.tool_stream).toBeUndefined()
 })
-// openaiShim test extraction seam 132 end
-
 
 // Extraction boundary: executor tool self-healing | message conversion.
 // Message-history normalization below belongs to the message converter.
 // Keep this marker stable for independent adjacent test migrations.
-// openaiShim test extraction seam 133 start: preserves valid tool_result and drops orphan tool_result
 test('preserves valid tool_result and drops orphan tool_result', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -8483,10 +7868,7 @@ test('preserves valid tool_result and drops orphan tool_result', async () => {
   const assistantMessages = messages.filter(m => m.role === 'assistant')
   expect(assistantMessages.some(m => m.content === '[Tool results received]')).toBe(true)
 })
-// openaiShim test extraction seam 133 end
 
-
-// openaiShim test extraction seam 134 start: drops empty assistant message when only thinking block was present and stripped
 test('drops empty assistant message when only thinking block was present and stripped', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -8523,10 +7905,7 @@ test('drops empty assistant message when only thinking block was present and str
   expect(String(messages[0].content)).toContain('Initial')
   expect(String(messages[0].content)).toContain('Interrupting query')
 })
-// openaiShim test extraction seam 134 end
 
-
-// openaiShim test extraction seam 135 start: drops empty assistant message when only redacted_thinking block was present and stripped
 test('drops empty assistant message when only redacted_thinking block was present and stripped', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -8563,10 +7942,7 @@ test('drops empty assistant message when only redacted_thinking block was presen
   expect(String(messages[0].content)).toContain('Initial')
   expect(String(messages[0].content)).toContain('Interrupting query')
 })
-// openaiShim test extraction seam 135 end
 
-
-// openaiShim test extraction seam 136 start: injects semantic assistant message when tool result is followed by user message
 test('injects semantic assistant message when tool result is followed by user message', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -8614,13 +7990,10 @@ test('injects semantic assistant message when tool result is followed by user me
   expect(semanticMsg.content).not.toContain('interrupted')
   expect(semanticMsg.content).not.toContain('user')
 })
-// openaiShim test extraction seam 136 end
-
 
 // Extraction boundary: executor tool self-healing | message/provider shaping.
 // Provider request shaping below is not owned by the executor.
 // Keep this marker stable for independent adjacent test migrations.
-// openaiShim test extraction seam 137 start: Moonshot: uses max_tokens (not max_completion_tokens) and strips store
 test('Moonshot: uses max_tokens (not max_completion_tokens) and strips store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.ai/v1'
   process.env.OPENAI_API_KEY = 'sk-moonshot-test'
@@ -8654,10 +8027,7 @@ test('Moonshot: uses max_tokens (not max_completion_tokens) and strips store', a
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 137 end
 
-
-// openaiShim test extraction seam 138 start: Cerebras: strips unsupported store on chat_completions (#1023)
 test('Cerebras: strips unsupported store on chat_completions (#1023)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.cerebras.ai/v1'
   process.env.OPENAI_API_KEY = 'csk-test'
@@ -8689,10 +8059,7 @@ test('Cerebras: strips unsupported store on chat_completions (#1023)', async () 
 
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 138 end
 
-
-// openaiShim test extraction seam 139 start: Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_completions (#672)
 test('Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_completions (#672)', async () => {
   process.env.OPENAI_BASE_URL = 'http://localhost:8000/v1'
   process.env.OPENAI_API_KEY = 'sk-local'
@@ -8724,10 +8091,7 @@ test('Local provider (vLLM/Ollama/etc.): strips unsupported store on chat_comple
 
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 139 end
 
-
-// openaiShim test extraction seam 140 start: Mistral: strips unsupported store on chat_completions (#739)
 test('Mistral: strips unsupported store on chat_completions (#739)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.mistral.ai/v1'
   process.env.OPENAI_API_KEY = 'mistral-test'
@@ -8759,10 +8123,7 @@ test('Mistral: strips unsupported store on chat_completions (#739)', async () =>
 
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 140 end
 
-
-// openaiShim test extraction seam 141 start: Mistral host fallback: strips store on an unresolved Mistral-host route (#739)
 test('Mistral host fallback: strips store on an unresolved Mistral-host route (#739)', async () => {
   // `api.mistral.ai/v1` resolves to the Mistral descriptor route, whose
   // removeBodyFields already strips `store` — so the test above passes even
@@ -8807,15 +8168,19 @@ test('Mistral host fallback: strips store on an unresolved Mistral-host route (#
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.max_tokens).toBe(64)
 })
-// openaiShim test extraction seam 141 end
 
+test('hasMistralApiHost matches the Mistral host and its subdomains only', () => {
+  expect(hasMistralApiHost('https://api.mistral.ai/v1')).toBe(true)
+  expect(hasMistralApiHost('https://proxy.mistral.ai/v1')).toBe(true)
+  expect(hasMistralApiHost('https://eu.mistral.ai/v1')).toBe(true)
+  // Non-Mistral hosts (and look-alikes) must keep `store`.
+  expect(hasMistralApiHost('https://api.openai.com/v1')).toBe(false)
+  expect(hasMistralApiHost('https://notmistral.ai/v1')).toBe(false)
+  expect(hasMistralApiHost('https://api.mistral.ai.evil.com/v1')).toBe(false)
+  expect(hasMistralApiHost(undefined)).toBe(false)
+  expect(hasMistralApiHost('not a url')).toBe(false)
+})
 
-// openaiShim test extraction seam 142 start: hasMistralApiHost matches the Mistral host and its subdomains only
-
-// openaiShim test extraction seam 142 end
-
-
-// openaiShim test extraction seam 143 start: Groq: keeps max_completion_tokens and strips unsupported store
 test('Groq: keeps max_completion_tokens and strips unsupported store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.groq.com/openai/v1'
   process.env.OPENAI_API_KEY = 'gsk-test'
@@ -8849,11 +8214,8 @@ test('Groq: keeps max_completion_tokens and strips unsupported store', async () 
   expect(requestBody?.max_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 143 end
 
 
-
-// openaiShim test extraction seam 144 start: Groq: strips reasoning_effort even when compat inference matches the model
 test('Groq: strips reasoning_effort even when compat inference matches the model', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.groq.com/openai/v1'
   process.env.OPENAI_API_KEY = 'gsk-test'
@@ -8888,9 +8250,6 @@ test('Groq: strips reasoning_effort even when compat inference matches the model
   expect(requestBody?.reasoning_effort).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 144 end
-
-// openaiShim test extraction seam 145 start: Moonshot: echoes reasoning_content on assistant tool-call messages
 test('Moonshot: echoes reasoning_content on assistant tool-call messages', async () => {
   // Regression for: "API Error: 400 {"error":{"message":"thinking is enabled
   // but reasoning_content is missing in assistant tool call message at index
@@ -8962,10 +8321,7 @@ test('Moonshot: echoes reasoning_content on assistant tool-call messages', async
     'Need to inspect logs via Bash; running a cat.',
   )
 })
-// openaiShim test extraction seam 145 end
 
-
-// openaiShim test extraction seam 146 start: DeepSeek echoes reasoning_content on assistant tool-call messages
 test('DeepSeek echoes reasoning_content on assistant tool-call messages', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -9023,10 +8379,7 @@ test('DeepSeek echoes reasoning_content on assistant tool-call messages', async 
   expect(assistantWithToolCall).toBeDefined()
   expect(assistantWithToolCall?.reasoning_content).toBe('thought')
 })
-// openaiShim test extraction seam 146 end
 
-
-// openaiShim test extraction seam 147 start: generic OpenAI-compatible providers do not echo reasoning_content on assistant tool-call messages
 test('generic OpenAI-compatible providers do not echo reasoning_content on assistant tool-call messages', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'sk-openai-test'
@@ -9084,10 +8437,7 @@ test('generic OpenAI-compatible providers do not echo reasoning_content on assis
   expect(assistantWithToolCall).toBeDefined()
   expect(assistantWithToolCall?.reasoning_content).toBeUndefined()
 })
-// openaiShim test extraction seam 147 end
 
-
-// openaiShim test extraction seam 148 start: gateway-routed DeepSeek models inherit descriptor-backed reasoning and token shaping
 test('gateway-routed DeepSeek models inherit descriptor-backed reasoning and token shaping', async () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   process.env.OPENAI_BASE_URL = 'https://openrouter.ai/api/v1'
@@ -9154,10 +8504,7 @@ test('gateway-routed DeepSeek models inherit descriptor-backed reasoning and tok
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 148 end
 
-
-// openaiShim test extraction seam 149 start: Moonshot: cn host is also detected
 test('Moonshot: cn host is also detected', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.moonshot.cn/v1'
   process.env.OPENAI_API_KEY = 'sk-moonshot-test'
@@ -9189,10 +8536,7 @@ test('Moonshot: cn host is also detected', async () => {
 
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 149 end
 
-
-// openaiShim test extraction seam 150 start: Kimi Code endpoint inherits Moonshot max_tokens/store compatibility
 test('Kimi Code endpoint inherits Moonshot max_tokens/store compatibility', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.kimi.com/coding/v1'
   process.env.OPENAI_API_KEY = 'sk-kimi-test'
@@ -9226,10 +8570,7 @@ test('Kimi Code endpoint inherits Moonshot max_tokens/store compatibility', asyn
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 150 end
 
-
-// openaiShim test extraction seam 151 start: Kimi Code endpoint echoes reasoning_content on assistant tool-call messages
 test('Kimi Code endpoint echoes reasoning_content on assistant tool-call messages', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.kimi.com/coding/v1'
   process.env.OPENAI_API_KEY = 'sk-kimi-test'
@@ -9296,10 +8637,7 @@ test('Kimi Code endpoint echoes reasoning_content on assistant tool-call message
     'Need to inspect logs via Bash; running a cat.',
   )
 })
-// openaiShim test extraction seam 151 end
 
-
-// openaiShim test extraction seam 152 start: DeepSeek sends thinking toggle and normalized reasoning effort
 test('DeepSeek sends thinking toggle and normalized reasoning effort', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -9338,20 +8676,82 @@ test('DeepSeek sends thinking toggle and normalized reasoning effort', async () 
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 152 end
 
+test('NVIDIA NIM DeepSeek sends chat template thinking kwargs', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
 
-// openaiShim test extraction seam 153 start: NVIDIA NIM DeepSeek sends chat template thinking kwargs
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'deepseek-ai/deepseek-v4-pro',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+        usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
 
-// openaiShim test extraction seam 153 end
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-ai/deepseek-v4-pro',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+    thinking: { type: 'enabled' },
+  })
 
+  expect(requestBody?.thinking).toEqual({ type: 'enabled' })
+  expect(requestBody?.reasoning_effort).toBe('max')
+  expect(requestBody?.chat_template_kwargs).toEqual({
+    thinking: true,
+    enable_thinking: true,
+  })
+})
 
-// openaiShim test extraction seam 154 start: NVIDIA NIM DeepSeek omits chat template thinking kwargs when thinking is disabled
+test('NVIDIA NIM DeepSeek omits chat template thinking kwargs when thinking is disabled', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
 
-// openaiShim test extraction seam 154 end
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'deepseek-ai/deepseek-v4-pro',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'deepseek-ai/deepseek-v4-pro?thinking=disabled',
+    system: 'test',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
 
-// openaiShim test extraction seam 155 start: DeepSeek omits thinking controls when the Anthropic-side request does not set them
+  expect(requestBody?.thinking).toBeUndefined()
+  expect(requestBody?.reasoning_effort).toBeUndefined()
+  expect(requestBody?.chat_template_kwargs).toBeUndefined()
+})
+
 test('DeepSeek omits thinking controls when the Anthropic-side request does not set them', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -9384,10 +8784,7 @@ test('DeepSeek omits thinking controls when the Anthropic-side request does not 
   expect(requestBody?.thinking).toBeUndefined()
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
-// openaiShim test extraction seam 155 end
 
-
-// openaiShim test extraction seam 156 start: DeepSeek forwards an explicit thinking disable toggle for V4 models
 test('DeepSeek forwards an explicit thinking disable toggle for V4 models', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -9421,11 +8818,8 @@ test('DeepSeek forwards an explicit thinking disable toggle for V4 models', asyn
   expect(requestBody?.thinking).toEqual({ type: 'disabled' })
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
-// openaiShim test extraction seam 156 end
 
 
-
-// openaiShim test extraction seam 157 start: collapses multiple text blocks in tool_result to string for DeepSeek compatibility (issue #774)
 test('collapses multiple text blocks in tool_result to string for DeepSeek compatibility (issue #774)', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -9502,10 +8896,7 @@ test('collapses multiple text blocks in tool_result to string for DeepSeek compa
   expect(typeof toolMessages[0].content).toBe('string')
   expect(toolMessages[0].content).toBe('line one\n\nline two')
 })
-// openaiShim test extraction seam 157 end
 
-
-// openaiShim test extraction seam 158 start: collapses multiple text blocks into a single string for DeepSeek compatibility (issue #774)
 test('collapses multiple text blocks into a single string for DeepSeek compatibility (issue #774)', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -9563,10 +8954,7 @@ test('collapses multiple text blocks into a single string for DeepSeek compatibi
   expect(typeof messages[1].content).toBe('string')
   expect(messages[1].content).toBe('Hello!\n\nHow are you?')
 })
-// openaiShim test extraction seam 158 end
 
-
-// openaiShim test extraction seam 159 start: preserves mixed text and image tool results as multipart content
 test('preserves mixed text and image tool results as multipart content', async () => {
   let requestBody: Record<string, unknown> | undefined
 
@@ -9652,10 +9040,7 @@ test('preserves mixed text and image tool results as multipart content', async (
   expect(content[0].type).toBe('text')
   expect(content[1].type).toBe('image_url')
 })
-// openaiShim test extraction seam 159 end
 
-
-// openaiShim test extraction seam 160 start: Z.AI: uses max_tokens (not max_completion_tokens) and strips store
 test('Z.AI: uses max_tokens (not max_completion_tokens) and strips store', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9689,10 +9074,7 @@ test('Z.AI: uses max_tokens (not max_completion_tokens) and strips store', async
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.store).toBeUndefined()
 })
-// openaiShim test extraction seam 160 end
 
-
-// openaiShim test extraction seam 161 start: Z.AI: thinking mode enabled when requested
 test('Z.AI: thinking mode enabled when requested', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9734,10 +9116,7 @@ test('Z.AI: thinking mode enabled when requested', async () => {
   expect(requestBody?.max_completion_tokens).toBeUndefined()
   expect(requestBody?.max_tokens).toBe(1024)
 })
-// openaiShim test extraction seam 161 end
 
-
-// openaiShim test extraction seam 162 start: Z.AI GLM-5.2: default request relies on provider thinking defaults
 test('Z.AI GLM-5.2: default request relies on provider thinking defaults', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9769,10 +9148,7 @@ test('Z.AI GLM-5.2: default request relies on provider thinking defaults', async
   expect(requestBody?.thinking).toBeUndefined()
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
-// openaiShim test extraction seam 162 end
 
-
-// openaiShim test extraction seam 163 start: Z.AI GLM-5.2: user-selected xhigh effort maps to provider max effort
 test('Z.AI GLM-5.2: user-selected xhigh effort maps to provider max effort', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9806,8 +9182,6 @@ test('Z.AI GLM-5.2: user-selected xhigh effort maps to provider max effort', asy
   expect(requestBody?.thinking).toEqual({ type: 'enabled' })
   expect(requestBody?.reasoning_effort).toBe('max')
 })
-// openaiShim test extraction seam 163 end
-
 
 test.each([
   ['glm-5.2?reasoning=low', 'high'],
@@ -9886,7 +9260,6 @@ test.each([
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
 
-// openaiShim test extraction seam 164 start: Z.AI GLM-5.2: model-query thinking disable omits reasoning effort
 test('Z.AI GLM-5.2: model-query thinking disable omits reasoning effort', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9918,10 +9291,7 @@ test('Z.AI GLM-5.2: model-query thinking disable omits reasoning effort', async 
   expect(requestBody?.thinking).toEqual({ type: 'disabled' })
   expect(requestBody?.reasoning_effort).toBeUndefined()
 })
-// openaiShim test extraction seam 164 end
 
-
-// openaiShim test extraction seam 165 start: Z.AI GLM-5.2: per-turn thinking overrides model-query default
 test('Z.AI GLM-5.2: per-turn thinking overrides model-query default', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -9953,23 +9323,109 @@ test('Z.AI GLM-5.2: per-turn thinking overrides model-query default', async () =
   expect(requestBody?.thinking).toEqual({ type: 'enabled' })
   expect(requestBody?.reasoning_effort).toBe('high')
 })
-// openaiShim test extraction seam 165 end
 
+test('NVIDIA NIM Z.AI GLM sends chat template thinking kwargs', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
 
-// openaiShim test extraction seam 166 start: NVIDIA NIM Z.AI GLM sends chat template thinking kwargs
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'z-ai/glm-5.2',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
 
-// openaiShim test extraction seam 166 end
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'z-ai/glm-5.2',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
 
+  expect(requestBody?.thinking).toEqual({ type: 'enabled' })
+  expect(requestBody?.reasoning_effort).toBe('max')
+  expect(requestBody?.chat_template_kwargs).toEqual({
+    thinking: true,
+    enable_thinking: true,
+  })
+})
 
-// openaiShim test extraction seam 167 start: NVIDIA NIM Z.AI GLM omits chat template thinking kwargs without a reasoning request
+test('NVIDIA NIM Z.AI GLM omits chat template thinking kwargs without a reasoning request', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
 
-// openaiShim test extraction seam 167 end
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'z-ai/glm-5.2',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'z-ai/glm-5.2',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
 
-// openaiShim test extraction seam 168 start: NVIDIA NIM Z.AI GLM omits chat template thinking kwargs when thinking is disabled
+  expect(requestBody?.thinking).toBeUndefined()
+  expect(requestBody?.reasoning_effort).toBeUndefined()
+  expect(requestBody?.chat_template_kwargs).toBeUndefined()
+})
 
-// openaiShim test extraction seam 168 end
+test('NVIDIA NIM Z.AI GLM omits chat template thinking kwargs when thinking is disabled', async () => {
+  process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+  process.env.NVIDIA_API_KEY = 'nvapi-test'
 
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'z-ai/glm-5.2',
+        choices: [
+          { message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' },
+        ],
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }) as unknown as FetchType
+
+  const client = createOpenAIShimClient({
+    reasoningEffort: 'xhigh',
+  }) as OpenAIShimClient
+  await client.beta.messages.create({
+    model: 'z-ai/glm-5.2?thinking=disabled',
+    messages: [{ role: 'user', content: 'hi' }],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  expect(requestBody?.thinking).toEqual({ type: 'disabled' })
+  expect(requestBody?.reasoning_effort).toBeUndefined()
+  expect(requestBody?.chat_template_kwargs).toBeUndefined()
+})
 
 // Extraction boundary: provider reasoning compatibility | tool-stream routing.
 // The gateway emission regression below remains provider/request-shaping coverage.
@@ -9979,7 +9435,6 @@ test('Z.AI GLM-5.2: per-turn thinking overrides model-query default', async () =
 // `tool_stream` parameter. Streaming tool calls are simply not streamed on
 // this gateway; sending the parameter aborts the request with
 // `400 Unsupported parameter(s): tool_stream`.
-// openaiShim test extraction seam 169 start: NVIDIA NIM Z.AI GLM streaming request with tools does not send tool_stream (regression #1950)
 test('NVIDIA NIM Z.AI GLM streaming request with tools does not send tool_stream (regression #1950)', async () => {
   process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
   process.env.NVIDIA_API_KEY = 'nvapi-test'
@@ -10027,8 +9482,6 @@ test('NVIDIA NIM Z.AI GLM streaming request with tools does not send tool_stream
   // aren't streamed on this gateway.
   expect(requestBody?.tool_stream).toBeUndefined()
 })
-// openaiShim test extraction seam 169 end
-
 
 // Extraction boundary: provider tool-stream shaping | executor tool-stream retry.
 // The three retry-state tests below move together with request execution.
@@ -10039,7 +9492,6 @@ test('NVIDIA NIM Z.AI GLM streaming request with tools does not send tool_stream
 // Here we exercise the generic self-heal using a Z.AI-contract gateway that
 // actually sends `tool_stream`, then rejects it — proving the retry drops the
 // parameter rather than surfacing a hard error.
-// openaiShim test extraction seam 170 start: Shim self-heals a JSON `tool_stream` rejection by retrying without it (#1950)
 test('Shim self-heals a JSON `tool_stream` rejection by retrying without it (#1950)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -10098,10 +9550,7 @@ test('Shim self-heals a JSON `tool_stream` rejection by retrying without it (#19
   // Tools are preserved across the retry.
   expect(Array.isArray(requestBodies[1]?.tools)).toBe(true)
 })
-// openaiShim test extraction seam 170 end
 
-
-// openaiShim test extraction seam 171 start: Shim stops after one tool_stream self-heal retry when the retry also fails (#1950)
 test('Shim stops after one tool_stream self-heal retry when the retry also fails (#1950)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -10138,10 +9587,7 @@ test('Shim stops after one tool_stream self-heal retry when the retry also fails
   expect(requestBodies[0]?.tool_stream).toBe(true)
   expect(requestBodies[1]?.tool_stream).toBeUndefined()
 })
-// openaiShim test extraction seam 171 end
 
-
-// openaiShim test extraction seam 172 start: Shim retries a tool_stream rejection with the same pooled credential (#1950)
 test('Shim retries a tool_stream rejection with the same pooled credential (#1950)', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEYS = 'key-a,key-b'
@@ -10190,13 +9636,10 @@ test('Shim retries a tool_stream rejection with the same pooled credential (#195
 
   expect(authorizations).toEqual(['Bearer key-a', 'Bearer key-a'])
 })
-// openaiShim test extraction seam 172 end
-
 
 // Extraction boundary: executor tool-stream retry | provider tool-stream shaping.
 // Provider emission rules below remain with compatibility/request planning.
 // Keep this marker stable for independent adjacent test migrations.
-// openaiShim test extraction seam 173 start: Z.AI GLM-5.2: streaming requests with tools send tool_stream
 test('Z.AI GLM-5.2: streaming requests with tools send tool_stream', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -10241,10 +9684,7 @@ test('Z.AI GLM-5.2: streaming requests with tools send tool_stream', async () =>
 
   expect(requestBody?.tool_stream).toBe(true)
 })
-// openaiShim test extraction seam 173 end
 
-
-// openaiShim test extraction seam 174 start: Hicap GLM-5.2: uses Z.AI-compatible request shaping
 test('Hicap GLM-5.2: uses Z.AI-compatible request shaping', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.hicap.ai/v1'
   process.env.HICAP_API_KEY = 'sk-hicap-test'
@@ -10295,9 +9735,6 @@ test('Hicap GLM-5.2: uses Z.AI-compatible request shaping', async () => {
   expect(requestBody?.reasoning_effort).toBe('max')
   expect(requestBody?.tool_stream).toBe(true)
 })
-// openaiShim test extraction seam 174 end
-
-// openaiShim test extraction seam 175 start: Z.AI GLM-5.2: remote tool incompatibility does not use local toolless retry
 test('Z.AI GLM-5.2: remote tool incompatibility does not use local toolless retry', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -10335,8 +9772,6 @@ test('Z.AI GLM-5.2: remote tool incompatibility does not use local toolless retr
   expect(requestBodies).toHaveLength(1)
   expect(requestBodies[0]?.tool_stream).toBe(true)
 })
-// openaiShim test extraction seam 175 end
-
 
 test.each([
   ['non-streaming Z.AI request with tools', 'https://api.z.ai/api/coding/paas/v4', false, true, 'glm-5.2'],
@@ -10401,7 +9836,6 @@ test.each([
   expect(requestBody?.tool_stream).toBeUndefined()
 })
 
-// openaiShim test extraction seam 176 start: Z.AI GLM-5.2: preserved thinking round-trips with tool calls
 test('Z.AI GLM-5.2: preserved thinking round-trips with tool calls', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.z.ai/api/coding/paas/v4'
   process.env.OPENAI_API_KEY = 'sk-zai-test'
@@ -10468,10 +9902,7 @@ test('Z.AI GLM-5.2: preserved thinking round-trips with tool calls', async () =>
     },
   ])
 })
-// openaiShim test extraction seam 176 end
 
-
-// openaiShim test extraction seam 177 start: strips Anthropic attribution header block from chat-completions system prompt (#607)
 test('strips Anthropic attribution header block from chat-completions system prompt (#607)', async () => {
   let capturedBody: Record<string, unknown> | undefined
 
@@ -10521,10 +9952,7 @@ test('strips Anthropic attribution header block from chat-completions system pro
   expect(sysMsg?.content).toContain('You are Claude Code, helpful assistant.')
   expect(sysMsg?.content).toContain('Project context: bun + react.')
 })
-// openaiShim test extraction seam 177 end
 
-
-// openaiShim test extraction seam 178 start: strips Anthropic attribution header block from responses-API instructions (#607)
 test('strips Anthropic attribution header block from responses-API instructions (#607)', async () => {
   process.env.OPENAI_API_FORMAT = 'responses'
   let capturedBody: Record<string, unknown> | undefined
@@ -10570,10 +9998,7 @@ test('strips Anthropic attribution header block from responses-API instructions 
   expect(instructions).not.toContain('cc_version=')
   expect(instructions).toContain('You are Claude Code.')
 })
-// openaiShim test extraction seam 178 end
 
-
-// openaiShim test extraction seam 179 start: emits reasoning_effort on chat_completions when reasoningEffort is passed
 test('emits reasoning_effort on chat_completions when reasoningEffort is passed', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'test-key'
@@ -10614,10 +10039,7 @@ test('emits reasoning_effort on chat_completions when reasoningEffort is passed'
 
   expect(requestBody?.reasoning_effort).toBe('xhigh')
 })
-// openaiShim test extraction seam 179 end
 
-
-// openaiShim test extraction seam 180 start: omits reasoning_effort on chat_completions when no override and model has no alias default
 test('omits reasoning_effort on chat_completions when no override and model has no alias default', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'test-key'
@@ -10653,10 +10075,7 @@ test('omits reasoning_effort on chat_completions when no override and model has 
 
   expect(requestBody && 'reasoning_effort' in requestBody).toBe(false)
 })
-// openaiShim test extraction seam 180 end
 
-
-// openaiShim test extraction seam 181 start: emits reasoning_effort from codex alias default when no override is passed
 test('emits reasoning_effort from codex alias default when no override is passed', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.openai.com/v1'
   process.env.OPENAI_API_KEY = 'test-key'
@@ -10695,10 +10114,7 @@ test('emits reasoning_effort from codex alias default when no override is passed
 
   expect(requestBody?.reasoning_effort).toBe('high')
 })
-// openaiShim test extraction seam 181 end
 
-
-// openaiShim test extraction seam 182 start: DeepSeek: redacted_thinking block preserves continuity with reasoning_content: ""
 test('DeepSeek: redacted_thinking block preserves continuity with reasoning_content: ""', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -10759,10 +10175,7 @@ test('DeepSeek: redacted_thinking block preserves continuity with reasoning_cont
   // message carries a tool_call, so it falls back to reasoning_content: ""
   expect(assistantWithToolCall?.reasoning_content).toBe('')
 })
-// openaiShim test extraction seam 182 end
 
-
-// openaiShim test extraction seam 183 start: DeepSeek: redacted_thinking block with non-empty data propagates data into reasoning_content
 test('DeepSeek: redacted_thinking block with non-empty data propagates data into reasoning_content', async () => {
   process.env.OPENAI_BASE_URL = 'https://api.deepseek.com/v1'
   process.env.OPENAI_API_KEY = 'sk-deepseek'
@@ -10829,103 +10242,6 @@ test('DeepSeek: redacted_thinking block with non-empty data propagates data into
     'encrypted_chain_of_thought_payload_v1',
   )
 })
-// openaiShim test extraction seam 183 end
-
-
-// openaiShim test extraction seam 184 start: renders tool_reference blocks as text on the chat/completions path
-test('renders tool_reference blocks as text on the chat/completions path', async () => {
-  const { __test } = await import('./openaiShim.ts')
-
-  const messages = __test.convertMessages(
-    [
-      {
-        role: 'assistant',
-        content: [
-          { type: 'tool_use', id: 'call_ts1', name: 'ToolSearch', input: { query: 'memory' } },
-        ],
-      },
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'tool_result',
-            tool_use_id: 'call_ts1',
-            content: [
-              { type: 'tool_reference', tool_name: 'mcp__example__memory_search' },
-              { type: 'tool_reference', tool_name: 'mcp__example__memory_store' },
-            ],
-          },
-        ],
-      },
-    ],
-    undefined,
-  )
-
-  const toolMsg = messages.find(m => m.role === 'tool')
-  expect(toolMsg).toBeDefined()
-  // The rendering contract is plain text: text-only parts collapse to a string.
-  expect(typeof toolMsg!.content).toBe('string')
-  const content = toolMsg!.content as string
-  expect(content).toContain('mcp__example__memory_search')
-  expect(content).toContain('mcp__example__memory_store')
-})
-// openaiShim test extraction seam 184 end
-
-
-// openaiShim test extraction seam 185 start: preserves valid tool pairs after history pruning while dropping orphaned tool calls
-test('preserves valid tool pairs after history pruning while dropping orphaned tool calls', async () => {
-  const { __test } = await import('./openaiShim.ts')
-
-  const messages = __test.convertMessages(
-    [
-      { role: 'user', content: 'compacted summary of previous work' },
-      {
-        role: 'assistant',
-        content: [
-          {
-            type: 'tool_use',
-            id: 'call_pruned_without_result',
-            name: 'Read',
-            input: { file_path: 'old.ts' },
-          },
-        ],
-      },
-      { role: 'user', content: 'continue with retained context' },
-      {
-        role: 'assistant',
-        content: [
-          { type: 'text', text: 'Reading the current file.' },
-          {
-            type: 'tool_use',
-            id: 'call_retained',
-            name: 'Read',
-            input: { file_path: 'current.ts' },
-          },
-        ],
-      },
-      {
-        role: 'user',
-        content: [
-          {
-            type: 'tool_result',
-            tool_use_id: 'call_retained',
-            content: 'current contents',
-          },
-        ],
-      },
-    ],
-    undefined,
-  )
-
-  const toolCalls = messages.flatMap(message => message.tool_calls ?? [])
-  expect(toolCalls.map(toolCall => toolCall.id)).toEqual(['call_retained'])
-
-  const toolMessages = messages.filter(message => message.role === 'tool')
-  expect(toolMessages).toHaveLength(1)
-  expect(toolMessages[0]?.tool_call_id).toBe('call_retained')
-})
-// openaiShim test extraction seam 185 end
-
 
 // Extraction boundary: history pruning | executor Copilot refresh behavior.
 // The contiguous Copilot authentication retry block below moves with execution.
@@ -10935,196 +10251,6 @@ function makeCodexSseResponse(responseData: Record<string, unknown>): Response {
   return makeSseResponse([`event: response.completed\ndata: ${data}\n\n`])
 }
 
-test('GitHub Copilot codex responses transport does not replay after a pre-header timeout', async () => {
-  process.env.CLAUDE_CODE_USE_GITHUB = '1'
-  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
-  process.env.OPENAI_API_KEY = 'test-token'
-  process.env.API_TIMEOUT_MS = '20'
-  let fetchCalls = 0
-  const requestUrls: string[] = []
-
-  globalThis.fetch = (async (input, init) => {
-    fetchCalls++
-    requestUrls.push(String(input))
-    return pendingFetchUntilAbort(init)
-  }) as unknown as FetchType
-
-  const safety = new AbortController()
-  const safetyTimer = setTimeout(() => safety.abort(), 500)
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  let caught: unknown
-  try {
-    await waitForPromise(
-      client.beta.messages.create(
-        {
-          model: 'gpt-5',
-          messages: [{ role: 'user', content: 'hello' }],
-          max_tokens: 32,
-          stream: false,
-        },
-        { signal: safety.signal },
-      ),
-      750,
-      'GitHub codex responses timeout did not settle',
-    )
-  } catch (error) {
-    caught = error
-  } finally {
-    clearTimeout(safetyTimer)
-  }
-
-  expect(caught).toBeDefined()
-  const error = caught as Error & { constructor: { name: string } }
-  expect(error.constructor.name).toBe('APIConnectionError')
-  expect(isOpenAIRequestNonReplayable(error)).toBe(true)
-  expect(fetchCalls).toBe(1)
-  expect(requestUrls).toEqual([
-    'https://api.githubcopilot.com/responses',
-  ])
-})
-
-test('GitHub Copilot responses fallback does not replay after a pre-header timeout', async () => {
-  process.env.CLAUDE_CODE_USE_GITHUB = '1'
-  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
-  process.env.OPENAI_API_KEY = 'test-token'
-  process.env.API_TIMEOUT_MS = '20'
-  const requestUrls: string[] = []
-
-  globalThis.fetch = (async (input, init) => {
-    const url = String(input)
-    requestUrls.push(url)
-    if (url.endsWith('/chat/completions')) {
-      return makeGithubChatFallbackResponse()
-    }
-    return pendingFetchUntilAbort(init)
-  }) as unknown as FetchType
-
-  const safety = new AbortController()
-  const safetyTimer = setTimeout(() => safety.abort(), 500)
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  let caught: unknown
-  try {
-    await waitForPromise(
-      client.beta.messages.create(
-        {
-          model: 'gpt-4',
-          messages: [{ role: 'user', content: 'hello' }],
-          max_tokens: 32,
-          stream: false,
-        },
-        { signal: safety.signal },
-      ),
-      750,
-      'GitHub responses fallback timeout did not settle',
-    )
-  } catch (error) {
-    caught = error
-  } finally {
-    clearTimeout(safetyTimer)
-  }
-
-  expect(caught).toBeDefined()
-  const error = caught as Error & { constructor: { name: string } }
-  expect(error.constructor.name).toBe('APIConnectionError')
-  expect(isOpenAIRequestNonReplayable(error)).toBe(true)
-  expect(requestUrls).toEqual([
-    'https://api.githubcopilot.com/chat/completions',
-    'https://api.githubcopilot.com/responses',
-  ])
-})
-
-test('GitHub Copilot responses fallback preserves caller abort without retrying', async () => {
-  process.env.CLAUDE_CODE_USE_GITHUB = '1'
-  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
-  process.env.OPENAI_API_KEY = 'test-token'
-  process.env.API_TIMEOUT_MS = '200'
-  let fetchCalls = 0
-
-  globalThis.fetch = (async (input, init) => {
-    fetchCalls++
-    if (String(input).endsWith('/chat/completions')) {
-      return makeGithubChatFallbackResponse()
-    }
-    return pendingFetchUntilAbort(init)
-  }) as unknown as FetchType
-
-  const caller = new AbortController()
-  const callerReason = new DOMException('Cancelled by user', 'AbortError')
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  const request = client.beta.messages.create(
-    {
-      model: 'gpt-4',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 32,
-      stream: false,
-    },
-    { signal: caller.signal },
-  )
-  setTimeout(() => caller.abort(callerReason), 10)
-
-  await expect(
-    waitForPromise(request, 500, 'GitHub responses fallback abort did not settle'),
-  ).rejects.toBe(callerReason)
-  expect(fetchCalls).toBe(2)
-})
-
-test('GitHub Copilot responses fallback preserves non-caller transport aborts', async () => {
-  process.env.CLAUDE_CODE_USE_GITHUB = '1'
-  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
-  process.env.OPENAI_API_KEY = 'test-token'
-  let fetchCalls = 0
-  const transportAbort = new DOMException('Proxy aborted request', 'AbortError')
-
-  globalThis.fetch = (async input => {
-    fetchCalls++
-    if (String(input).endsWith('/chat/completions')) {
-      return makeGithubChatFallbackResponse()
-    }
-    throw transportAbort
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  await expect(
-    client.beta.messages.create({
-      model: 'gpt-4',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 32,
-      stream: false,
-    }),
-  ).rejects.toBe(transportAbort)
-  expect(fetchCalls).toBe(2)
-})
-
-test('GitHub Copilot responses fallback does not retry non-retryable HTTP failures', async () => {
-  process.env.CLAUDE_CODE_USE_GITHUB = '1'
-  process.env.OPENAI_BASE_URL = 'https://api.githubcopilot.com'
-  process.env.OPENAI_API_KEY = 'test-token'
-  let fetchCalls = 0
-
-  globalThis.fetch = (async input => {
-    fetchCalls++
-    if (String(input).endsWith('/chat/completions')) {
-      return makeGithubChatFallbackResponse()
-    }
-    return new Response(
-      JSON.stringify({ error: { message: 'invalid token' } }),
-      { status: 401, headers: { 'Content-Type': 'application/json' } },
-    )
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  await expect(
-    client.beta.messages.create({
-      model: 'gpt-4',
-      messages: [{ role: 'user', content: 'hello' }],
-      max_tokens: 32,
-      stream: false,
-    }),
-  ).rejects.toMatchObject({ status: 401 })
-  expect(fetchCalls).toBe(2)
-})
-
-// openaiShim test extraction seam 186 start: GitHub Copilot 401 chat_completions retries with refreshed token
 test('GitHub Copilot 401 chat_completions retries with refreshed token', async () => {
   const realModule = realGithubModelsCredentials
   try {
@@ -11194,10 +10320,7 @@ test('GitHub Copilot 401 chat_completions retries with refreshed token', async (
     mock.module('../../utils/githubModelsCredentials.js', () => realModule)
   }
 })
-// openaiShim test extraction seam 186 end
 
-
-// openaiShim test extraction seam 187 start: GitHub Copilot 401 codex_responses retries with refreshed token
 test('GitHub Copilot 401 codex_responses retries with refreshed token', async () => {
   const realGithubModule = realGithubModelsCredentials
   const realCodexModule = realCodexShim
@@ -11274,10 +10397,7 @@ test('GitHub Copilot 401 codex_responses retries with refreshed token', async ()
     mock.module('./codexShim.js', () => realCodexModule)
   }
 })
-// openaiShim test extraction seam 187 end
 
-
-// openaiShim test extraction seam 188 start: GitHub Copilot 401 with credential pool uses refreshed token not pool key
 test('GitHub Copilot 401 with credential pool uses refreshed token not pool key', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -11339,10 +10459,7 @@ test('GitHub Copilot 401 with credential pool uses refreshed token not pool key'
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
-// openaiShim test extraction seam 188 end
 
-
-// openaiShim test extraction seam 189 start: GitHub Copilot 401 with "token has expired" triggers refresh
 test('GitHub Copilot 401 with "token has expired" triggers refresh', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -11398,10 +10515,7 @@ test('GitHub Copilot 401 with "token has expired" triggers refresh', async () =>
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
-// openaiShim test extraction seam 189 end
 
-
-// openaiShim test extraction seam 190 start: GitHub Copilot 401 without expired-token message does not trigger refresh
 test('GitHub Copilot 401 without expired-token message does not trigger refresh', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -11449,10 +10563,7 @@ test('GitHub Copilot 401 without expired-token message does not trigger refresh'
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
-// openaiShim test extraction seam 190 end
 
-
-// openaiShim test extraction seam 191 start: GitHub Copilot 401 refresh returning same token does not update auth
 test('GitHub Copilot 401 refresh returning same token does not update auth', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -11509,10 +10620,7 @@ test('GitHub Copilot 401 refresh returning same token does not update auth', asy
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
-// openaiShim test extraction seam 191 end
 
-
-// openaiShim test extraction seam 192 start: GitHub Copilot 401 codex_responses with providerOverride does not trigger refresh
 test('GitHub Copilot 401 codex_responses with providerOverride does not trigger refresh', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -11563,10 +10671,7 @@ test('GitHub Copilot 401 codex_responses with providerOverride does not trigger 
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
-// openaiShim test extraction seam 192 end
 
-
-// openaiShim test extraction seam 193 start: GitHub Copilot 401 chat_completions with providerOverride does not trigger refresh
 test('GitHub Copilot 401 chat_completions with providerOverride does not trigger refresh', async () => {
   const realGithubModule = realGithubModelsCredentials
   try {
@@ -11616,8 +10721,6 @@ test('GitHub Copilot 401 chat_completions with providerOverride does not trigger
     mock.module('../../utils/githubModelsCredentials.js', () => realGithubModule)
   }
 })
-// openaiShim test extraction seam 193 end
-
 
 // Extraction boundary: executor Copilot refresh behavior | JSON fallback conversion.
 // JSON fallback response conversion below is not owned by request execution.
@@ -11662,7 +10765,6 @@ async function collectFallbackEvents(
   }
 }
 
-// openaiShim test extraction seam 194 start: JSON fallback: preserves tool_calls as a tool_use block
 test('JSON fallback: preserves tool_calls as a tool_use block', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-tool',
@@ -11714,10 +10816,7 @@ test('JSON fallback: preserves tool_calls as a tool_use block', async () => {
     | undefined
   expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
 })
-// openaiShim test extraction seam 194 end
 
-
-// openaiShim test extraction seam 195 start: JSON fallback: maps finish_reason=length to max_tokens
 test('JSON fallback: maps finish_reason=length to max_tokens', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-len',
@@ -11731,10 +10830,7 @@ test('JSON fallback: maps finish_reason=length to max_tokens', async () => {
     | undefined
   expect(stopEvent?.delta?.stop_reason).toBe('max_tokens')
 })
-// openaiShim test extraction seam 195 end
 
-
-// openaiShim test extraction seam 196 start: JSON fallback: preserves OpenCode Go quota error guidance
 test('JSON fallback: preserves OpenCode Go quota error guidance', async () => {
   process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
   const previousFetch = globalThis.fetch
@@ -11783,10 +10879,7 @@ test('JSON fallback: preserves OpenCode Go quota error guidance', async () => {
     globalThis.fetch = previousFetch
   }
 })
-// openaiShim test extraction seam 196 end
 
-
-// openaiShim test extraction seam 197 start: JSON fallback: strips <think> tags from emitted text
 test('JSON fallback: strips <think> tags from emitted text', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-think',
@@ -11808,10 +10901,7 @@ test('JSON fallback: strips <think> tags from emitted text', async () => {
   expect(textDelta?.delta?.text).toBe('visible answer')
   expect(textDelta?.delta?.text).not.toContain('private plan')
 })
-// openaiShim test extraction seam 197 end
 
-
-// openaiShim test extraction seam 198 start: JSON fallback: normalizes array content into a text string
 test('JSON fallback: normalizes array content into a text string', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-array',
@@ -11839,10 +10929,7 @@ test('JSON fallback: normalizes array content into a text string', async () => {
   expect(typeof textDelta?.delta?.text).toBe('string')
   expect(textDelta?.delta?.text).toBe('line one\nline two')
 })
-// openaiShim test extraction seam 198 end
 
-
-// openaiShim test extraction seam 199 start: JSON fallback: recovers raw-text tool call into tool_use block
 test('JSON fallback: recovers raw-text tool call into tool_use block', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-raw',
@@ -11878,10 +10965,7 @@ test('JSON fallback: recovers raw-text tool call into tool_use block', async () 
   expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
 
 })
-// openaiShim test extraction seam 199 end
 
-
-// openaiShim test extraction seam 200 start: JSON fallback façade terminates converted messages
 test('JSON fallback façade terminates converted messages', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-boundary',
@@ -11894,10 +10978,7 @@ test('JSON fallback façade terminates converted messages', async () => {
 
   expect(events.at(-1)?.type).toBe('message_stop')
 })
-// openaiShim test extraction seam 200 end
 
-
-// openaiShim test extraction seam 201 start: JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks
 test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks', async () => {
   const events = await collectFallbackEvents({
     id: 'chatcmpl-json-hy3',
@@ -11940,10 +11021,7 @@ test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks',
     | undefined
   expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
 })
-// openaiShim test extraction seam 201 end
 
-
-// openaiShim test extraction seam 202 start: JSON fallback: preserves HY3-looking text for non-Tencent model names
 test('JSON fallback: preserves HY3-looking text for non-Tencent model names', async () => {
   const text =
     '<tool_call:example>TaskCreate\nsubject: merely a documentation example\n</tool_call:example>'
@@ -11975,10 +11053,7 @@ test('JSON fallback: preserves HY3-looking text for non-Tencent model names', as
   expect(toolStart).toBeUndefined()
   expect(textDelta?.delta?.text).toBe(text)
 })
-// openaiShim test extraction seam 202 end
 
-
-// openaiShim test extraction seam 203 start: JSON fallback: empty tool_calls array does not block raw-text recovery
 test('JSON fallback: empty tool_calls array does not block raw-text recovery', async () => {
   // tool_calls: [] is truthy; it must be treated as "no structured tool calls"
   // so the raw "Tool calls requested" recovery still runs.
@@ -12010,10 +11085,7 @@ test('JSON fallback: empty tool_calls array does not block raw-text recovery', a
     name: 'Bash',
   })
 })
-// openaiShim test extraction seam 203 end
 
-
-// openaiShim test extraction seam 204 start: JSON fallback: empty tool_calls does not block raw-text recovery on array content
 test('JSON fallback: empty tool_calls does not block raw-text recovery on array content', async () => {
   // Companion to the string-content case above: the array-content branch must
   // also treat tool_calls: [] as "no structured tool calls" so raw recovery runs.
@@ -12047,4 +11119,3 @@ test('JSON fallback: empty tool_calls does not block raw-text recovery on array 
     name: 'Bash',
   })
 })
-// openaiShim test extraction seam 204 end

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -159,6 +159,10 @@ import {
   getOllamaNumCtx,
   normalizeOllamaNativeMessages,
 } from './openaiShim/ollamaAdapter.js'
+import {
+  convertMessages as convertAnthropicMessages,
+  convertSystemPrompt as convertSystemPromptImpl,
+} from './openaiShim/messageConversion.js'
 
 const GITHUB_429_MAX_RETRIES = 3
 const GITHUB_429_BASE_DELAY_SEC = 1
@@ -617,47 +621,12 @@ interface OpenAITool {
   }
 }
 
-function convertSystemPrompt(
-  system: unknown,
-): string {
-  if (!system) return ''
-  if (typeof system === 'string') return system
-  if (Array.isArray(system)) {
-    return system
-      .map((block: { type?: string; text?: string }) =>
-        block.type === 'text' ? block.text ?? '' : '',
-      )
-      // Drop the Anthropic billing/attribution block — it's only meaningful to
-      // Anthropic's `_parse_cc_header` and is dead weight (plus a churning
-      // per-build fingerprint that busts prefix KV cache) for OpenAI-compat
-      // providers like local Ollama / llama.cpp / Codex pass-throughs.
-      .filter(text => !text.startsWith('x-anthropic-billing-header'))
-      .join('\n\n')
-  }
-  return String(system)
-}
-
-function ensureTextPartForImageContent(
-  parts: OpenAIContentPart[],
-): OpenAIContentPart[] {
-  const hasImage = parts.some(part => part.type === 'image_url')
-  if (!hasImage) {
-    return parts
-  }
-
-  const hasText = parts.some(
-    part => part.type === 'text' && (part.text ?? '').trim().length > 0,
-  )
-  if (hasText) {
-    return parts
-  }
-
-  return [{ type: 'text', text: 'Image attached.' }, ...parts]
+function convertSystemPrompt(system: unknown): string {
+  return convertSystemPromptImpl(system)
 }
 
 function contentBlocksContainImages(content: unknown): boolean {
   if (!Array.isArray(content)) return false
-
   return content.some(block => {
     if (!block || typeof block !== 'object') return false
     const record = block as Record<string, unknown>
@@ -665,9 +634,7 @@ function contentBlocksContainImages(content: unknown): boolean {
       record.type === 'image' ||
       record.type === 'image_url' ||
       record.type === 'input_image'
-    ) {
-      return true
-    }
+    ) return true
     return record.type === 'tool_result' && contentBlocksContainImages(record.content)
   })
 }
@@ -676,34 +643,18 @@ function requestBodyContainsImages(
   payload: Record<string, unknown> | undefined,
 ): boolean {
   if (!payload) return false
-
   const messages = payload.messages
-  if (
-    Array.isArray(messages) &&
-    messages.some(message => {
-      if (!message || typeof message !== 'object') return false
-      const record = message as Record<string, unknown>
-      return (
-        contentBlocksContainImages(record.content) ||
-        (Array.isArray(record.images) && record.images.length > 0)
-      )
-    })
-  ) {
-    return true
-  }
-
+  if (Array.isArray(messages) && messages.some(message => {
+    if (!message || typeof message !== 'object') return false
+    const record = message as Record<string, unknown>
+    return contentBlocksContainImages(record.content) ||
+      (Array.isArray(record.images) && record.images.length > 0)
+  })) return true
   const input = payload.input
-  if (
-    Array.isArray(input) &&
-    input.some(item =>
-      item &&
-      typeof item === 'object' &&
-      contentBlocksContainImages((item as Record<string, unknown>).content),
-    )
-  ) {
-    return true
-  }
-
+  if (Array.isArray(input) && input.some(item =>
+    item && typeof item === 'object' &&
+    contentBlocksContainImages((item as Record<string, unknown>).content),
+  )) return true
   const contents = payload.contents
   return Array.isArray(contents) && contents.some(item => {
     if (!item || typeof item !== 'object') return false
@@ -720,160 +671,6 @@ function requestBodyContainsImages(
       })
     })
   })
-}
-
-function joinTextContentParts(parts: OpenAIContentPart[]): string {
-  return parts.map(part => part.type === 'text' ? part.text : '').join('')
-}
-
-function convertToolResultContent(
-  content: unknown,
-  isError?: boolean,
-  options?: { supportsImageInputs?: boolean },
-): string | OpenAIContentPart[] {
-  if (typeof content === 'string') {
-    return isError ? `Error: ${content}` : content
-  }
-  if (!Array.isArray(content)) {
-    const text = JSON.stringify(content ?? '')
-    return isError ? `Error: ${text}` : text
-  }
-
-  const parts: OpenAIContentPart[] = []
-  for (const block of content) {
-    if (block?.type === 'text' && typeof block.text === 'string') {
-      parts.push({ type: 'text', text: block.text })
-      continue
-    }
-
-    // ToolSearch results are tool_reference blocks with no text payload —
-    // render them so the model learns which deferred tools were loaded
-    // (their schemas arrive in the next request's tools array).
-    if (block?.type === 'tool_reference' && typeof block.tool_name === 'string') {
-      parts.push({
-        type: 'text',
-        text: `Tool "${block.tool_name}" is now loaded and available to call.`,
-      })
-      continue
-    }
-
-    if (block?.type === 'image') {
-      if (options?.supportsImageInputs === false) {
-        throw new Error(
-          'The active provider accepts text-only messages and does not support image inputs.',
-        )
-      }
-      const source = block.source
-      if (source?.type === 'url' && source.url) {
-        parts.push({ type: 'image_url', image_url: { url: source.url } })
-      } else if (source?.type === 'base64' && source.media_type && source.data) {
-        parts.push({
-          type: 'image_url',
-          image_url: {
-            url: `data:${source.media_type};base64,${source.data}`,
-          },
-        })
-      }
-      continue
-    }
-
-    if (typeof block?.text === 'string') {
-      parts.push({ type: 'text', text: block.text })
-    }
-  }
-
-  if (parts.length === 0) return ''
-  if (parts.length === 1 && parts[0].type === 'text') {
-    const text = parts[0].text ?? ''
-    return isError ? `Error: ${text}` : text
-  }
-
-  // Collapse arrays of only text blocks into a single string for DeepSeek
-  // compatibility (issue #774). DeepSeek rejects arrays in role: "tool" messages.
-  const allText = parts.every(p => p.type === 'text')
-  if (allText) {
-    const text = parts.map(p => p.text ?? '').join('\n\n')
-    return isError ? `Error: ${text}` : text
-  }
-
-  if (isError && parts[0]?.type === 'text') {
-    parts[0] = { ...parts[0], text: `Error: ${parts[0].text ?? ''}` }
-  } else if (isError) {
-    parts.unshift({ type: 'text', text: 'Error:' })
-  }
-
-  // Defense in depth (issue #1421): some OpenAI-compatible providers (e.g.
-  // Xiaomi Mimo) reject `role: "tool"` messages whose `content` is image-only
-  // with a 400 "text is not set". Prepend a placeholder text part so the
-  // payload always carries a text component alongside any images, mirroring
-  // the existing behavior for user-role messages.
-  return ensureTextPartForImageContent(parts)
-}
-
-function convertContentBlocks(
-  content: unknown,
-  options?: { supportsImageInputs?: boolean },
-): string | OpenAIContentPart[] {
-  if (typeof content === 'string') return content
-  if (!Array.isArray(content)) return String(content ?? '')
-
-  const parts: OpenAIContentPart[] = []
-  for (const block of content) {
-    switch (block.type) {
-      case 'text':
-        parts.push({ type: 'text', text: block.text ?? '' })
-        break
-      case 'image': {
-        if (options?.supportsImageInputs === false) {
-          throw new Error(
-            'The active provider accepts text-only messages and does not support image inputs.',
-          )
-        }
-        const src = block.source
-        if (src?.type === 'base64') {
-          parts.push({
-            type: 'image_url',
-            image_url: {
-              url: `data:${src.media_type};base64,${src.data}`,
-            },
-          })
-        } else if (src?.type === 'url') {
-          parts.push({ type: 'image_url', image_url: { url: src.url } })
-        }
-        break
-      }
-      case 'tool_use':
-        // handled separately
-        break
-      case 'tool_result':
-        // handled separately
-        break
-      case 'thinking':
-      case 'redacted_thinking':
-        // Strip thinking blocks for OpenAI-compatible providers.
-        // These are Anthropic-specific content types that 3P providers
-        // don't understand. Serializing them as <thinking> text corrupts
-        // multi-turn context: the model sees the tags as part of its
-        // previous reply and may mimic or misattribute them.
-        break
-      default:
-        if (block.text) {
-          parts.push({ type: 'text', text: block.text })
-        }
-    }
-  }
-
-  if (parts.length === 0) return ''
-  if (parts.length === 1 && parts[0].type === 'text') return parts[0].text ?? ''
-
-  // Collapse arrays of only text blocks into a single string for DeepSeek
-  // compatibility (issue #774).
-  const allText = parts.every(p => p.type === 'text')
-  if (allText) {
-    return parts.map(p => p.text ?? '').join('\n\n')
-  }
-
-  return ensureTextPartForImageContent(parts)
 }
 
 function isGeminiMode(): boolean {
@@ -932,11 +729,7 @@ function hydrateOpenAIShimCompatibilityEnv(
 }
 
 function convertMessages(
-  messages: Array<{
-    role: string
-    message?: { role?: string; content?: unknown }
-    content?: unknown
-  }>,
+  messages: Array<{ role: string; message?: { role?: string; content?: unknown }; content?: unknown }>,
   system: unknown,
   options?: {
     preserveReasoningContent?: boolean
@@ -945,319 +738,13 @@ function convertMessages(
     supportsImageInputs?: boolean
   },
 ): OpenAIMessage[] {
-  const preserveReasoningContent = options?.preserveReasoningContent === true
-  const reasoningContentFallback = options?.reasoningContentFallback
-  const preserveGeminiThoughtSignature = options?.preserveGeminiThoughtSignature === true
-  const supportsImageInputs = options?.supportsImageInputs
-  const result: OpenAIMessage[] = []
-  const knownToolCallIds = new Set<string>()
-
-  // Pre-scan for all tool results in the history to identify valid tool calls
-  const toolResultIds = new Set<string>()
-  for (const msg of messages) {
-    const inner = msg.message ?? msg
-    const content = (inner as { content?: unknown }).content
-    if (Array.isArray(content)) {
-      for (const block of content) {
-        if (
-          (block as { type?: string }).type === 'tool_result' &&
-          (block as { tool_use_id?: string }).tool_use_id
-        ) {
-          toolResultIds.add((block as { tool_use_id: string }).tool_use_id)
-        }
-      }
-    }
-  }
-
-  // System message first
-  const sysText = convertSystemPrompt(system)
-  if (sysText) {
-    result.push({ role: 'system', content: sysText })
-  }
-
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i]
-    const isLastInHistory = i === messages.length - 1
-
-    // Claude Code wraps messages in { role, message: { role, content } }
-    const inner = msg.message ?? msg
-    const role = (inner as { role?: string }).role ?? msg.role
-    const content = (inner as { content?: unknown }).content
-
-    if (role === 'user') {
-      // Check for tool_result blocks in user messages
-      if (Array.isArray(content)) {
-        let otherContent: unknown[] | undefined
-
-        // Emit tool results as tool messages, but ONLY if we have a matching tool_use ID.
-        // Mistral/OpenAI strictly require tool messages to follow an assistant message with tool_calls.
-        // If the user interrupted (ESC) and a synthetic tool_result was generated without a recorded tool_use,
-        // emitting it here would cause a "role must alternate" or "unexpected role" error.
-        for (const block of content) {
-          const blockType = (block as { type?: string }).type
-          if (blockType === 'tool_result') {
-            const tr = block as {
-              tool_use_id?: string
-              content?: unknown
-              is_error?: boolean
-            }
-            const id = tr.tool_use_id ?? 'unknown'
-            if (knownToolCallIds.has(id)) {
-              result.push({
-                role: 'tool',
-                tool_call_id: id,
-                content: convertToolResultContent(tr.content, tr.is_error, { supportsImageInputs }),
-              })
-            } else {
-              logForDebugging(
-                `Dropping orphan tool_result for ID: ${id} to prevent API error`,
-              )
-            }
-          } else {
-            otherContent ??= []
-            otherContent.push(block)
-          }
-        }
-
-        // Emit remaining user content
-        if (otherContent && otherContent.length > 0) {
-          result.push({
-            role: 'user',
-            content: convertContentBlocks(otherContent, { supportsImageInputs }),
-          })
-        }
-      } else {
-        result.push({
-          role: 'user',
-          content: convertContentBlocks(content, { supportsImageInputs }),
-        })
-      }
-    } else if (role === 'assistant') {
-      // Check for tool_use blocks
-      if (Array.isArray(content)) {
-        let toolUses: Array<{
-          id?: string
-          name?: string
-          input?: unknown
-          extra_content?: Record<string, unknown>
-          signature?: string
-        }> | undefined
-        let thinkingBlock:
-          | { type?: string; thinking?: string; data?: string; signature?: string }
-          | undefined
-        let textContent: unknown[] | undefined
-
-        for (const block of content) {
-          const blockType = (block as { type?: string }).type
-          if (blockType === 'tool_use') {
-            toolUses ??= []
-            toolUses.push(
-              block as {
-                id?: string
-                name?: string
-                input?: unknown
-                extra_content?: Record<string, unknown>
-                signature?: string
-              },
-            )
-          } else if (
-            blockType === 'thinking' ||
-            blockType === 'redacted_thinking'
-          ) {
-            thinkingBlock ??= block as {
-              type?: string
-              thinking?: string
-              data?: string
-              signature?: string
-            }
-          } else {
-            textContent ??= []
-            textContent.push(block)
-          }
-        }
-
-        const assistantMsg: OpenAIMessage = {
-          role: 'assistant',
-          content: (() => {
-            const c = convertContentBlocks(textContent ?? [], { supportsImageInputs })
-            return typeof c === 'string'
-              ? c
-              : Array.isArray(c)
-                ? joinTextContentParts(c)
-                : ''
-          })(),
-        }
-
-        // Providers that validate reasoning continuity (Moonshot/Kimi Code: "thinking
-        // is enabled but reasoning_content is missing in assistant tool call
-        // message at index N" 400) need the original chain-of-thought echoed
-        // back on each assistant message that carries a tool_call. We kept
-        // the thinking block on the Anthropic side; re-attach it here as the
-        // `reasoning_content` field on the outgoing OpenAI-shaped message.
-        // Gated per-provider because other endpoints either ignore the field
-        // (harmless) or strict-reject unknown fields (harmful).
-        if (preserveReasoningContent) {
-          // `thinking` blocks carry their content in `.thinking`; `redacted_thinking`
-          // blocks carry it in `.data` (see token estimation and message-size
-          // accounting). Read the right field per type so a real redacted block
-          // with non-empty content is not silently dropped to "".
-          const thinkingText =
-            thinkingBlock?.type === 'redacted_thinking'
-              ? thinkingBlock?.data
-              : thinkingBlock?.thinking
-          if (typeof thinkingText === 'string' && thinkingText.trim().length > 0) {
-            assistantMsg.reasoning_content = thinkingText
-          } else if (
-            (toolUses?.length ?? 0) > 0 &&
-            reasoningContentFallback === ''
-          ) {
-            assistantMsg.reasoning_content = ''
-          }
-        }
-
-        if (toolUses && toolUses.length > 0) {
-          const mappedToolCalls: NonNullable<OpenAIMessage['tool_calls']> = []
-          for (const tu of toolUses) {
-            const id = tu.id ?? `call_${crypto.randomUUID().replace(/-/g, '')}`
-
-            // Only keep tool calls that have a corresponding result in the history,
-            // or if it's the last message (prefill scenario).
-            // Orphaned tool calls (e.g. from user interruption) cause 400 errors.
-            if (!toolResultIds.has(id) && !isLastInHistory) {
-              continue
-            }
-
-            knownToolCallIds.add(id)
-            const toolCall: NonNullable<
-              OpenAIMessage['tool_calls']
-            >[number] = {
-              id,
-              type: 'function' as const,
-              function: {
-                name: tu.name ?? 'unknown',
-                arguments:
-                  typeof tu.input === 'string'
-                    ? tu.input
-                    : JSON.stringify(tu.input ?? {}),
-              },
-            }
-
-            // Preserve existing extra_content if present
-            if (tu.extra_content) {
-              toolCall.extra_content = { ...tu.extra_content }
-            }
-
-            // Gemini OpenAI-compatible endpoints require Google's
-            // thought_signature to be replayed with prior function-call
-            // parts. Preserve only real signatures received from the
-            // provider; synthetic placeholders are rejected by GMI.
-            if (preserveGeminiThoughtSignature) {
-              const signature =
-                tu.signature ??
-                geminiThoughtSignatureFromExtraContent(tu.extra_content) ??
-                thinkingBlock?.signature
-
-              toolCall.extra_content = mergeGeminiThoughtSignature(
-                toolCall.extra_content,
-                signature,
-              )
-            }
-
-            mappedToolCalls.push(toolCall)
-          }
-
-          if (mappedToolCalls.length > 0) {
-            assistantMsg.tool_calls = mappedToolCalls
-          }
-        }
-
-        // Only push assistant message if it has content or tool calls.
-        // Stripped thinking-only blocks from user interruptions are empty and cause 400s.
-        if (assistantMsg.content || assistantMsg.tool_calls?.length) {
-          result.push(assistantMsg)
-        }
-      } else {
-        const assistantMsg: OpenAIMessage = {
-          role: 'assistant',
-          content: (() => {
-            const c = convertContentBlocks(content, { supportsImageInputs })
-            return typeof c === 'string'
-              ? c
-              : Array.isArray(c)
-                ? joinTextContentParts(c)
-                : ''
-          })(),
-        }
-
-        if (assistantMsg.content) {
-          result.push(assistantMsg)
-        }
-      }
-    }
-  }
-
-  // Coalescing pass: merge consecutive messages of the same role.
-  // OpenAI/vLLM/Ollama require strict user↔assistant alternation.
-  // Multiple consecutive tool messages are allowed (assistant → tool* → user).
-  // Consecutive user or assistant messages must be merged to avoid Jinja
-  // template errors like "roles must alternate" (Devstral, Mistral models).
-  const coalesced: OpenAIMessage[] = []
-  for (const msg of result) {
-    const prev = coalesced[coalesced.length - 1]
-
-    // Mistral/Devstral: 'tool' message must be followed by an 'assistant' message.
-    // If a 'tool' result is followed by a 'user' message, inject a neutral
-    // assistant boundary to satisfy the strict role sequence without implying
-    // that the user interrupted or cancelled anything:
-    // ... -> assistant (calls) -> tool (results) -> assistant (semantic) -> user (next)
-    if (prev && prev.role === 'tool' && msg.role === 'user') {
-      coalesced.push({
-        role: 'assistant',
-        content: '[Tool results received]',
-      })
-    }
-
-    const lastAfterPossibleInjection = coalesced[coalesced.length - 1]
-    if (
-      lastAfterPossibleInjection &&
-      lastAfterPossibleInjection.role === msg.role &&
-      msg.role !== 'tool' &&
-      msg.role !== 'system'
-    ) {
-      const prevContent = lastAfterPossibleInjection.content
-      const curContent = msg.content
-
-      if (typeof prevContent === 'string' && typeof curContent === 'string') {
-        lastAfterPossibleInjection.content =
-          prevContent + (prevContent && curContent ? '\n' : '') + curContent
-      } else {
-        const toArray = (
-          c: string | OpenAIContentPart[] | undefined,
-        ): OpenAIContentPart[] => {
-          if (!c) return []
-          if (typeof c === 'string') return c ? [{ type: 'text', text: c }] : []
-          return c
-        }
-        lastAfterPossibleInjection.content = [
-          ...toArray(prevContent),
-          ...toArray(curContent),
-        ]
-      }
-
-      if (msg.tool_calls?.length) {
-        lastAfterPossibleInjection.tool_calls = [
-          ...(lastAfterPossibleInjection.tool_calls ?? []),
-          ...msg.tool_calls,
-        ]
-      }
-    } else {
-      coalesced.push(msg)
-    }
-  }
-
-  return coalesced
+  return convertAnthropicMessages(messages, system, {
+    ...options,
+    getGeminiThoughtSignature: geminiThoughtSignatureFromExtraContent,
+    mergeGeminiThoughtSignature,
+    log: message => logForDebugging(message),
+  })
 }
-
 function getChatMessagesForTransport<T>(
   transport: string,
   convert: () => T,

--- a/src/services/api/openaiShim/messageConversion.test.ts
+++ b/src/services/api/openaiShim/messageConversion.test.ts
@@ -58,6 +58,14 @@ test('adds text part for image-only user messages', () => {
   ])
 })
 
+test('rejects image content for text-only providers', () => {
+  expect(() => convertMessages(
+    [{ role: 'user', content: [{ type: 'image', source: { type: 'url', url: 'https://example.test/image.png' } }] }],
+    undefined,
+    { supportsImageInputs: false },
+  )).toThrow('does not support image inputs')
+})
+
 test('preserves mixed text and image tool results as multipart content', () => {
   const messages = convert(toolExchange([
     { type: 'text', text: 'Screenshot captured' },

--- a/src/services/api/openaiShim/messageConversion.test.ts
+++ b/src/services/api/openaiShim/messageConversion.test.ts
@@ -66,7 +66,7 @@ test('rejects image content for text-only providers', () => {
   )).toThrow('does not support image inputs')
 })
 
-test('preserves mixed text and image tool results as multipart content', () => {
+test('reports multipart shape for text+image tool results', () => {
   const messages = convert(toolExchange([
     { type: 'text', text: 'Screenshot captured' },
     {
@@ -80,6 +80,11 @@ test('preserves mixed text and image tool results as multipart content', () => {
     { type: 'text', text: 'Screenshot captured' },
     { type: 'image_url', image_url: { url: 'data:image/png;base64,ZmFrZQ==' } },
   ])
+})
+
+test('skips malformed image and non-object content blocks', () => {
+  expect(convert([{ role: 'user', content: [null, { type: 'image', source: { type: 'base64' } }] }], undefined))
+    .toEqual([{ role: 'user', content: '' }])
 })
 
 test('coalesces consecutive user messages to avoid alternation errors (issue #202)', () => {

--- a/src/services/api/openaiShim/messageConversion.test.ts
+++ b/src/services/api/openaiShim/messageConversion.test.ts
@@ -1,0 +1,281 @@
+import { expect, test } from 'bun:test'
+import {
+  convertMessages,
+  convertSystemPrompt,
+  convertToolResultContent,
+} from './messageConversion.js'
+
+type InputMessage = Parameters<typeof convertMessages>[0][number]
+
+function convert(messages: InputMessage[], system: unknown = '') {
+  return convertMessages(messages, system)
+}
+
+function toolExchange(
+  resultContent: unknown,
+  id = 'call_1',
+): InputMessage[] {
+  return [
+    { role: 'user', content: 'Run the tool' },
+    {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id, name: 'Read', input: { file_path: 'image.png' } }],
+    },
+    {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: id, content: resultContent }],
+    },
+  ]
+}
+
+test('preserves image tool results as placeholders in follow-up requests', () => {
+  const messages = convert(toolExchange([
+    {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'ZmFrZQ==' },
+    },
+  ]))
+  const tool = messages.find(message => message.role === 'tool')
+
+  expect(tool?.content).toEqual([
+    { type: 'text', text: 'Image attached.' },
+    { type: 'image_url', image_url: { url: 'data:image/png;base64,ZmFrZQ==' } },
+  ])
+})
+
+test('adds text part for image-only user messages', () => {
+  const messages = convert([{
+    role: 'user',
+    content: [{
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'aW1hZ2U=' },
+    }],
+  }])
+
+  expect(messages[0]?.content).toEqual([
+    { type: 'text', text: 'Image attached.' },
+    { type: 'image_url', image_url: { url: 'data:image/png;base64,aW1hZ2U=' } },
+  ])
+})
+
+test('preserves mixed text and image tool results as multipart content', () => {
+  const messages = convert(toolExchange([
+    { type: 'text', text: 'Screenshot captured' },
+    {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'ZmFrZQ==' },
+    },
+  ], 'call_image_2'))
+  const tool = messages.find(message => message.role === 'tool')
+
+  expect(tool?.content).toEqual([
+    { type: 'text', text: 'Screenshot captured' },
+    { type: 'image_url', image_url: { url: 'data:image/png;base64,ZmFrZQ==' } },
+  ])
+})
+
+test('coalesces consecutive user messages to avoid alternation errors (issue #202)', () => {
+  const messages = convert([
+    { role: 'user', content: 'First' },
+    { role: 'user', content: 'Second' },
+  ])
+
+  expect(messages).toEqual([{ role: 'user', content: 'First\nSecond' }])
+})
+
+test('coalesces consecutive assistant messages preserving tool_calls (issue #202)', () => {
+  const messages = convert([
+    { role: 'assistant', content: 'First response' },
+    {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'Second response' },
+        { type: 'tool_use', id: 'call_last', name: 'Bash', input: { command: 'pwd' } },
+      ],
+    },
+  ])
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0]?.content).toBe('First response\nSecond response')
+  expect(messages[0]?.tool_calls?.[0]).toMatchObject({
+    id: 'call_last',
+    function: { name: 'Bash', arguments: '{"command":"pwd"}' },
+  })
+})
+
+test('preserves valid tool_result and drops orphan tool_result', () => {
+  const logs: string[] = []
+  const messages = convertMessages([
+    {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 'valid_call_1', name: 'Search', input: { query: 'openclaude' } }],
+    },
+    {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'valid_call_1', content: 'Found it!' },
+        { type: 'tool_result', tool_use_id: 'orphan_call_2', content: 'Interrupted result' },
+        { type: 'text', text: 'What happened?' },
+      ],
+    },
+  ], '', { log: message => logs.push(message) })
+  const tools = messages.filter(message => message.role === 'tool')
+
+  expect(tools).toHaveLength(1)
+  expect(tools[0]?.tool_call_id).toBe('valid_call_1')
+  expect(messages.some(message => message.content === '[Tool results received]')).toBe(true)
+  expect(logs).toContain('Dropping orphan tool_result for ID: orphan_call_2 to prevent API error')
+})
+
+test('drops empty assistant message when only thinking block was present and stripped', () => {
+  const messages = convert([
+    { role: 'user', content: 'Initial' },
+    { role: 'assistant', content: [{ type: 'thinking', thinking: 'I am thinking...', signature: 'sig' }] },
+    { role: 'user', content: 'Interrupting query' },
+  ])
+
+  expect(messages).toEqual([{ role: 'user', content: 'Initial\nInterrupting query' }])
+})
+
+test('drops empty assistant message when only redacted_thinking block was present and stripped', () => {
+  const messages = convert([
+    { role: 'user', content: 'Initial' },
+    { role: 'assistant', content: [{ type: 'redacted_thinking', data: '[thinking hidden]' }] },
+    { role: 'user', content: 'Interrupting query' },
+  ])
+
+  expect(messages).toEqual([{ role: 'user', content: 'Initial\nInterrupting query' }])
+})
+
+test('injects semantic assistant message when tool result is followed by user message', () => {
+  const messages = convert([
+    {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 'call_1', name: 'search', input: {} }],
+    },
+    {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'Result' }],
+    },
+    { role: 'user', content: 'Next user query' },
+  ])
+
+  expect(messages.map(message => message.role)).toEqual(['assistant', 'tool', 'assistant', 'user'])
+  expect(messages[2]?.content).toBe('[Tool results received]')
+  expect(messages[2]?.content).not.toContain('interrupted')
+})
+
+test('collapses multiple text blocks in tool_result to string for DeepSeek compatibility (issue #774)', () => {
+  const messages = convert(toolExchange([
+    { type: 'text', text: 'line one' },
+    { type: 'text', text: 'line two' },
+  ]))
+  const tool = messages.find(message => message.role === 'tool')
+
+  expect(typeof tool?.content).toBe('string')
+  expect(tool?.content).toBe('line one\n\nline two')
+})
+
+test('collapses multiple text blocks into a single string for DeepSeek compatibility (issue #774)', () => {
+  const messages = convert([{
+    role: 'user',
+    content: [
+      { type: 'text', text: 'Hello!' },
+      { type: 'text', text: 'How are you?' },
+    ],
+  }], 'test system')
+
+  expect(messages).toEqual([
+    { role: 'system', content: 'test system' },
+    { role: 'user', content: 'Hello!\n\nHow are you?' },
+  ])
+})
+
+test('preserves mixed text and image tool results as multipart content', () => {
+  const messages = convert(toolExchange([
+    { type: 'text', text: 'Here is the image:' },
+    {
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'iVBORw0KGgo=' },
+    },
+  ]))
+  const tool = messages.find(message => message.role === 'tool')
+  const content = tool?.content
+
+  expect(Array.isArray(content)).toBe(true)
+  expect(content).toHaveLength(2)
+  expect(content?.[0]).toMatchObject({ type: 'text' })
+  expect(content?.[1]).toMatchObject({ type: 'image_url' })
+})
+
+test('strips Anthropic attribution header block from chat-completions system prompt (#607)', () => {
+  expect(convertSystemPrompt([
+    { type: 'text', text: 'You are useful.' },
+    { type: 'text', text: 'x-anthropic-billing-header: cc_version=1.0.0' },
+  ])).toBe('You are useful.')
+})
+
+test('strips Anthropic attribution header block from responses-API instructions (#607)', () => {
+  expect(convertSystemPrompt([
+    { type: 'text', text: 'Follow these instructions.' },
+    { type: 'text', text: 'x-anthropic-billing-header: cc_version=1.0.0; cc_entrypoint=cli' },
+  ])).toBe('Follow these instructions.')
+})
+
+test('DeepSeek: redacted_thinking block preserves continuity with reasoning_content: ""', () => {
+  const messages = convertMessages([{
+    role: 'assistant',
+    content: [
+      { type: 'redacted_thinking', data: '' },
+      { type: 'tool_use', id: 'call_1', name: 'Bash', input: {} },
+    ],
+  }], '', {
+    preserveReasoningContent: true,
+    reasoningContentFallback: '',
+  })
+
+  expect(messages[0]?.reasoning_content).toBe('')
+  expect(messages[0]?.tool_calls).toHaveLength(1)
+})
+
+test('DeepSeek: redacted_thinking block with non-empty data propagates data into reasoning_content', () => {
+  const messages = convertMessages([{
+    role: 'assistant',
+    content: [
+      { type: 'redacted_thinking', data: 'preserved reasoning' },
+      { type: 'tool_use', id: 'call_1', name: 'Bash', input: {} },
+    ],
+  }], '', { preserveReasoningContent: true })
+
+  expect(messages[0]?.reasoning_content).toBe('preserved reasoning')
+})
+
+test('renders tool_reference blocks as text on the chat/completions path', () => {
+  expect(convertToolResultContent([
+    { type: 'tool_reference', tool_name: 'mcp__github__search_code' },
+  ])).toBe('Tool "mcp__github__search_code" is now loaded and available to call.')
+})
+
+test('preserves valid tool pairs after history pruning while dropping orphaned tool calls', () => {
+  const logs: string[] = []
+  const messages = convertMessages([
+    {
+      role: 'assistant',
+      content: [
+        { type: 'tool_use', id: 'valid', name: 'Read', input: { file_path: 'a.ts' } },
+        { type: 'tool_use', id: 'orphan', name: 'Read', input: { file_path: 'b.ts' } },
+      ],
+    },
+    {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'valid', content: 'contents' },
+        { type: 'tool_result', tool_use_id: 'missing-call', content: 'stale' },
+      ],
+    },
+  ], '', { log: message => logs.push(message) })
+
+  expect(messages[0]?.tool_calls?.map(call => call.id)).toEqual(['valid'])
+  expect(messages.filter(message => message.role === 'tool').map(message => message.tool_call_id)).toEqual(['valid'])
+  expect(logs).toContain('Dropping orphan tool_result for ID: missing-call to prevent API error')
+})

--- a/src/services/api/openaiShim/messageConversion.ts
+++ b/src/services/api/openaiShim/messageConversion.ts
@@ -95,6 +95,7 @@ export function convertContentBlocks(
   if (!Array.isArray(content)) return String(content ?? '')
   const parts: OpenAIContentPart[] = []
   for (const block of content) {
+    if (!block || typeof block !== 'object') continue
     switch (block.type) {
       case 'text':
         parts.push({ type: 'text', text: block.text ?? '' })
@@ -106,13 +107,18 @@ export function convertContentBlocks(
           )
         }
         const source = block.source
-        if (source?.type === 'base64') {
+        if (
+          source?.type === 'base64' &&
+          typeof source.media_type === 'string' &&
+          typeof source.data === 'string'
+        ) {
           parts.push({
             type: 'image_url',
             image_url: { url: `data:${source.media_type};base64,${source.data}` },
           })
+        } else if (source?.type === 'url' && typeof source.url === 'string') {
+          parts.push({ type: 'image_url', image_url: { url: source.url } })
         }
-        else if (source?.type === 'url') parts.push({ type: 'image_url', image_url: { url: source.url } })
         break
       }
       case 'tool_use':
@@ -121,7 +127,9 @@ export function convertContentBlocks(
       case 'redacted_thinking':
         break
       default:
-        if (block.text) parts.push({ type: 'text', text: block.text })
+        if (typeof block.text === 'string') {
+          parts.push({ type: 'text', text: block.text })
+        }
     }
   }
   if (parts.length === 0) return ''

--- a/src/services/api/openaiShim/messageConversion.ts
+++ b/src/services/api/openaiShim/messageConversion.ts
@@ -1,0 +1,280 @@
+export type OpenAIContentPart =
+  | { type: 'text'; text: string }
+  | { type: 'image_url'; image_url: { url: string } }
+
+export type ConvertedOpenAIMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool'
+  content?: string | OpenAIContentPart[]
+  tool_calls?: Array<{
+    id: string
+    type: 'function'
+    function: { name: string; arguments: string }
+    extra_content?: Record<string, unknown>
+  }>
+  tool_call_id?: string
+  name?: string
+  reasoning_content?: string
+}
+
+export function convertSystemPrompt(system: unknown): string {
+  if (!system) return ''
+  if (typeof system === 'string') return system
+  if (Array.isArray(system)) {
+    return system
+      .map((block: { type?: string; text?: string }) =>
+        block.type === 'text' ? block.text ?? '' : '',
+      )
+      .filter(text => !text.startsWith('x-anthropic-billing-header'))
+      .join('\n\n')
+  }
+  return String(system)
+}
+
+function ensureTextPartForImageContent(
+  parts: OpenAIContentPart[],
+): OpenAIContentPart[] {
+  if (!parts.some(part => part.type === 'image_url')) return parts
+  if (parts.some(part => part.type === 'text' && part.text.trim().length > 0)) return parts
+  return [{ type: 'text', text: 'Image attached.' }, ...parts]
+}
+
+export function joinTextContentParts(parts: OpenAIContentPart[]): string {
+  return parts.map(part => part.type === 'text' ? part.text : '').join('')
+}
+
+export function convertToolResultContent(
+  content: unknown,
+  isError?: boolean,
+  options?: { supportsImageInputs?: boolean },
+): string | OpenAIContentPart[] {
+  if (typeof content === 'string') return isError ? `Error: ${content}` : content
+  if (!Array.isArray(content)) {
+    const text = JSON.stringify(content ?? '')
+    return isError ? `Error: ${text}` : text
+  }
+  const parts: OpenAIContentPart[] = []
+  for (const block of content) {
+    if (block?.type === 'text' && typeof block.text === 'string') {
+      parts.push({ type: 'text', text: block.text })
+    } else if (block?.type === 'tool_reference' && typeof block.tool_name === 'string') {
+      parts.push({ type: 'text', text: `Tool "${block.tool_name}" is now loaded and available to call.` })
+    } else if (block?.type === 'image') {
+      if (options?.supportsImageInputs === false) {
+        throw new Error(
+          'The active provider accepts text-only messages and does not support image inputs.',
+        )
+      }
+      const source = block.source
+      if (source?.type === 'url' && source.url) parts.push({ type: 'image_url', image_url: { url: source.url } })
+      else if (source?.type === 'base64' && source.media_type && source.data) {
+        parts.push({
+          type: 'image_url',
+          image_url: { url: `data:${source.media_type};base64,${source.data}` },
+        })
+      }
+    } else if (typeof block?.text === 'string') {
+      parts.push({ type: 'text', text: block.text })
+    }
+  }
+  if (parts.length === 0) return ''
+  if (parts.length === 1 && parts[0].type === 'text') return isError ? `Error: ${parts[0].text}` : parts[0].text
+  if (parts.every(part => part.type === 'text')) {
+    const text = parts.map(part => part.text).join('\n\n')
+    return isError ? `Error: ${text}` : text
+  }
+  if (isError && parts[0]?.type === 'text') parts[0] = { ...parts[0], text: `Error: ${parts[0].text}` }
+  else if (isError) parts.unshift({ type: 'text', text: 'Error:' })
+  return ensureTextPartForImageContent(parts)
+}
+
+export function convertContentBlocks(
+  content: unknown,
+  options?: { supportsImageInputs?: boolean },
+): string | OpenAIContentPart[] {
+  if (typeof content === 'string') return content
+  if (!Array.isArray(content)) return String(content ?? '')
+  const parts: OpenAIContentPart[] = []
+  for (const block of content) {
+    switch (block.type) {
+      case 'text':
+        parts.push({ type: 'text', text: block.text ?? '' })
+        break
+      case 'image': {
+        if (options?.supportsImageInputs === false) {
+          throw new Error(
+            'The active provider accepts text-only messages and does not support image inputs.',
+          )
+        }
+        const source = block.source
+        if (source?.type === 'base64') {
+          parts.push({
+            type: 'image_url',
+            image_url: { url: `data:${source.media_type};base64,${source.data}` },
+          })
+        }
+        else if (source?.type === 'url') parts.push({ type: 'image_url', image_url: { url: source.url } })
+        break
+      }
+      case 'tool_use':
+      case 'tool_result':
+      case 'thinking':
+      case 'redacted_thinking':
+        break
+      default:
+        if (block.text) parts.push({ type: 'text', text: block.text })
+    }
+  }
+  if (parts.length === 0) return ''
+  if (parts.length === 1 && parts[0].type === 'text') return parts[0].text
+  if (parts.every(part => part.type === 'text')) return parts.map(part => part.text).join('\n\n')
+  return ensureTextPartForImageContent(parts)
+}
+
+export function convertMessages(
+  messages: Array<{ role: string; message?: { role?: string; content?: unknown }; content?: unknown }>,
+  system: unknown,
+  options: {
+    preserveReasoningContent?: boolean
+    reasoningContentFallback?: '' | 'omit'
+    preserveGeminiThoughtSignature?: boolean
+    supportsImageInputs?: boolean
+    getGeminiThoughtSignature?: (extraContent: unknown) => string | undefined
+    mergeGeminiThoughtSignature?: (
+      extraContent: Record<string, unknown> | undefined,
+      signature: string | undefined,
+    ) => Record<string, unknown> | undefined
+    log?: (message: string) => void
+  } = {},
+): ConvertedOpenAIMessage[] {
+  const result: ConvertedOpenAIMessage[] = []
+  const knownToolCallIds = new Set<string>()
+  const toolResultIds = new Set<string>()
+  for (const msg of messages) {
+    const content = (msg.message ?? msg).content
+    if (!Array.isArray(content)) continue
+    for (const block of content) {
+      if (block?.type === 'tool_result' && block.tool_use_id) toolResultIds.add(block.tool_use_id)
+    }
+  }
+
+  const sysText = convertSystemPrompt(system)
+  if (sysText) result.push({ role: 'system', content: sysText })
+
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]
+    const isLastInHistory = i === messages.length - 1
+    const inner = msg.message ?? msg
+    const role = inner.role ?? msg.role
+    const content = inner.content
+    if (role === 'user') {
+      if (!Array.isArray(content)) {
+        result.push({ role: 'user', content: convertContentBlocks(content, options) })
+        continue
+      }
+      let otherContent: unknown[] | undefined
+      for (const block of content) {
+        if (block?.type !== 'tool_result') {
+          otherContent ??= []
+          otherContent.push(block)
+          continue
+        }
+        const id = block.tool_use_id ?? 'unknown'
+        if (knownToolCallIds.has(id)) {
+          result.push({
+            role: 'tool',
+            tool_call_id: id,
+            content: convertToolResultContent(block.content, block.is_error, options),
+          })
+        } else {
+          options.log?.(`Dropping orphan tool_result for ID: ${id} to prevent API error`)
+        }
+      }
+      if (otherContent?.length) result.push({ role: 'user', content: convertContentBlocks(otherContent, options) })
+      continue
+    }
+    if (role !== 'assistant') continue
+    if (!Array.isArray(content)) {
+      const converted = convertContentBlocks(content, options)
+      const text = typeof converted === 'string' ? converted : joinTextContentParts(converted)
+      if (text) result.push({ role: 'assistant', content: text })
+      continue
+    }
+    const toolUses: Array<{
+      id?: string
+      name?: string
+      input?: unknown
+      extra_content?: Record<string, unknown>
+      signature?: string
+    }> = []
+    let thinkingBlock: { type?: string; thinking?: string; data?: string; signature?: string } | undefined
+    const textContent: unknown[] = []
+    for (const block of content) {
+      if (block?.type === 'tool_use') toolUses.push(block)
+      else if (block?.type === 'thinking' || block?.type === 'redacted_thinking') thinkingBlock ??= block
+      else textContent.push(block)
+    }
+    const converted = convertContentBlocks(textContent, options)
+    const assistantMsg: ConvertedOpenAIMessage = {
+      role: 'assistant',
+      content: typeof converted === 'string' ? converted : joinTextContentParts(converted),
+    }
+    if (options.preserveReasoningContent) {
+      const thinking = thinkingBlock?.type === 'redacted_thinking' ? thinkingBlock.data : thinkingBlock?.thinking
+      if (typeof thinking === 'string' && thinking.trim()) assistantMsg.reasoning_content = thinking
+      else if (toolUses.length && options.reasoningContentFallback === '') assistantMsg.reasoning_content = ''
+    }
+    const mappedToolCalls: NonNullable<ConvertedOpenAIMessage['tool_calls']> = []
+    for (const toolUse of toolUses) {
+      const id = toolUse.id ?? `call_${crypto.randomUUID().replace(/-/g, '')}`
+      if (!toolResultIds.has(id) && !isLastInHistory) continue
+      knownToolCallIds.add(id)
+      const toolCall: NonNullable<ConvertedOpenAIMessage['tool_calls']>[number] = {
+        id, type: 'function', function: {
+          name: toolUse.name ?? 'unknown',
+          arguments: typeof toolUse.input === 'string' ? toolUse.input : JSON.stringify(toolUse.input ?? {}),
+        },
+      }
+      if (toolUse.extra_content) toolCall.extra_content = { ...toolUse.extra_content }
+      if (options.preserveGeminiThoughtSignature) {
+        const signature =
+          toolUse.signature ??
+          options.getGeminiThoughtSignature?.(toolUse.extra_content) ??
+          thinkingBlock?.signature
+        toolCall.extra_content =
+          options.mergeGeminiThoughtSignature?.(toolCall.extra_content, signature) ??
+          toolCall.extra_content
+      }
+      mappedToolCalls.push(toolCall)
+    }
+    if (mappedToolCalls.length) assistantMsg.tool_calls = mappedToolCalls
+    if (assistantMsg.content || assistantMsg.tool_calls?.length) result.push(assistantMsg)
+  }
+
+  const coalesced: ConvertedOpenAIMessage[] = []
+  for (const msg of result) {
+    const prev = coalesced[coalesced.length - 1]
+    if (prev?.role === 'tool' && msg.role === 'user') {
+      coalesced.push({ role: 'assistant', content: '[Tool results received]' })
+    }
+    const last = coalesced[coalesced.length - 1]
+    if (!last || last.role !== msg.role || msg.role === 'tool' || msg.role === 'system') {
+      coalesced.push(msg)
+      continue
+    }
+    const previous = last.content
+    const current = msg.content
+    if (typeof previous === 'string' && typeof current === 'string') {
+      last.content = previous + (previous && current ? '\n' : '') + current
+    } else {
+      const asParts = (value: typeof previous): OpenAIContentPart[] =>
+        !value
+          ? []
+          : typeof value === 'string'
+            ? [{ type: 'text', text: value }]
+            : value
+      last.content = [...asParts(previous), ...asParts(current)]
+    }
+    if (msg.tool_calls?.length) last.tool_calls = [...(last.tool_calls ?? []), ...msg.tool_calls]
+  }
+  return coalesced
+}


### PR DESCRIPTION
## Summary

Extracts Anthropic-to-OpenAI message normalization from `openaiShim.ts` into `openaiShim/messageConversion.ts`.

The module owns multipart/image tool results, message coalescing, tool-result pairing, reasoning-history normalization, attribution stripping, and provider-specific content shaping. The façade delegates conversion and retains orchestration.

Stable shared source/test seams make all accumulated merge orders deterministic.

## Independent merge

- Upstream base: `0effa0f42b6dbc6a4800e19f4b2d8d588269906b`.
- Fork branch: `jatmn/openclaude:de-mono1-message-conversion`.
- Exact head: `17ac5ce62a1d7927d541813bae06e40e93083dcd`.
- All 45 pairwise combinations and full forward/reverse ten-branch merges are clean.
- Submitted as a draft upstream.

## Source-file budget

`openaiShim.ts`: **+50 / -500 = 550 changed lines**, below the 1,500-line cap. Tests are excluded.

## Test migration

- Monolithic test: **+691 / -1,039**; all 18 owned test bodies are removed.
- `messageConversion.test.ts`: **281 lines / 18 focused tests**.
- Focused conversion plus retained façade suites: **225 passed / 594 assertions**.
- All ten PRs together leave only three façade-contract tests in the monolithic test.

## Validation

- `git diff --check`, typecheck, type-test check, and build: passed.
- Exact-head host `bun run check`: **7,186 passed / 2 skipped**; only 10 pre-existing PowerShell governance failures remain on Linux.

Prepared according to `CONTRIBUTING.md` and `AGENTS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved conversation compatibility for images, tool interactions, and provider-specific reasoning/system prompt formatting.
* **Bug Fixes**
  * Filtered out orphan tool results while preserving valid tool-call/result pairs.
  * Added clearer handling for image-only inputs (and rejects image inputs when unsupported).
  * Better message coalescing, including tool-result markers and reasoning/thinking cleanup; enhanced provider-specific text shaping.
* **Tests**
  * Added a Bun test suite covering message conversion, tool lifecycles, image handling, and provider variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->