### PR TITLE
refactor(openai-shim): extract tool conversion

### DIFF
--- a/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
+++ b/src/services/api/openaiShim.ollamaTextToolCalls.test.ts
@@ -10,7 +10,8 @@
  *   5. P1 context guard — bare JSON in explanatory prose is skipped
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { createOpenAIShimClient, parseTextToolCalls } from './openaiShim.js'
+import { createOpenAIShimClient } from './openaiShim.js'
+import { parseTextToolCalls } from './openaiShim/rawToolCallParsing.js'
 
 type FetchType = typeof globalThis.fetch
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6730,7 +6730,6 @@ test('coalesces consecutive assistant messages preserving tool_calls (issue #202
 })
 // openaiShim test extraction seam 111 end
 
-
 // ---------------------------------------------------------------------------
 // Extraction boundary: message conversion | non-streaming response conversion
 //

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6497,140 +6497,12 @@ test('preserves parsed string input for unknown JSON string tool arguments', asy
 // Extraction seam: argument parsing | schema sanitation.
 
 // openaiShim test extraction seam 107 start: sanitizes malformed MCP tool schemas before sending them to OpenAI
-test('sanitizes malformed MCP tool schemas before sending them to OpenAI', async () => {
-  let requestBody: Record<string, unknown> | undefined
 
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
-
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'gpt-4o',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: 'ok',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 10,
-          completion_tokens: 1,
-          total_tokens: 11,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  await client.beta.messages.create({
-    model: 'gpt-4o',
-    system: 'test system',
-    messages: [{ role: 'user', content: 'hello' }],
-    tools: [
-      {
-        name: 'mcp__clientry__create_task',
-        description: 'Create a task',
-        input_schema: {
-          type: 'object',
-          properties: {
-            priority: {
-              type: 'integer',
-              description: 'Priority: 0=low, 1=medium, 2=high, 3=urgent',
-              default: true,
-              enum: [false, 0, 1, 2, 3],
-            },
-          },
-        },
-      },
-    ],
-    max_tokens: 64,
-    stream: false,
-  })
-
-  const parameters = (
-    requestBody?.tools as Array<{ function?: { parameters?: Record<string, unknown> } }>
-  )?.[0]?.function?.parameters
-  const properties = parameters?.properties as
-    | Record<string, { default?: unknown; enum?: unknown[]; type?: string }>
-    | undefined
-
-  expect(parameters?.additionalProperties).toBe(false)
-  // No required[] in the original schema → none added (optional properties must not be forced required)
-  expect(parameters?.required).toEqual([])
-  expect(properties?.priority?.type).toBe('integer')
-  expect(properties?.priority?.enum).toEqual([0, 1, 2, 3])
-  expect(properties?.priority).not.toHaveProperty('default')
-})
 // openaiShim test extraction seam 107 end
 
 
 // openaiShim test extraction seam 108 start: optional tool properties are not added to required[] — fixes Groq/Azure 400 tool_use_failed
-test('optional tool properties are not added to required[] — fixes Groq/Azure 400 tool_use_failed', async () => {
-  // Regression test for: all optional properties being sent as required in strict mode,
-  // causing providers like Groq to reject valid tool calls where the model omits optional args.
-  let requestBody: Record<string, unknown> | undefined
 
-  globalThis.fetch = (async (_input, init) => {
-    requestBody = JSON.parse(String(init?.body))
-
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-4',
-        model: 'gpt-4o',
-        choices: [{ message: { role: 'assistant', content: 'ok' }, finish_reason: 'stop' }],
-        usage: { prompt_tokens: 5, completion_tokens: 2, total_tokens: 7 },
-      }),
-      { headers: { 'Content-Type': 'application/json' } },
-    )
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  await client.beta.messages.create({
-    model: 'gpt-4o',
-    messages: [{ role: 'user', content: 'read a file' }],
-    tools: [
-      {
-        name: 'Read',
-        description: 'Read a file',
-        input_schema: {
-          type: 'object',
-          properties: {
-            file_path: { type: 'string', description: 'Absolute path to file' },
-            offset: { type: 'number', description: 'Line to start from' },
-            limit: { type: 'number', description: 'Max lines to read' },
-            pages: { type: 'string', description: 'Page range for PDFs' },
-          },
-          required: ['file_path'],
-        },
-      },
-    ],
-    max_tokens: 16,
-    stream: false,
-  })
-
-  const parameters = (
-    requestBody?.tools as Array<{ function?: { parameters?: Record<string, unknown> } }>
-  )?.[0]?.function?.parameters
-
-  expect(parameters?.required).toEqual(['file_path'])
-
-  const required = parameters?.required as string[] | undefined
-  expect(required).not.toContain('offset')
-  expect(required).not.toContain('limit')
-  expect(required).not.toContain('pages')
-  expect(parameters?.additionalProperties).toBe(false)
-})
 // openaiShim test extraction seam 108 end
 
 
@@ -11842,41 +11714,7 @@ test('JSON fallback: normalizes array content into a text string', async () => {
 
 
 // openaiShim test extraction seam 199 start: JSON fallback: recovers raw-text tool call into tool_use block
-test('JSON fallback: recovers raw-text tool call into tool_use block', async () => {
-  const events = await collectFallbackEvents({
-    id: 'chatcmpl-json-raw',
-    model: 'fake-model',
-    choices: [
-      {
-        message: {
-          role: 'assistant',
-          // Same "Tool calls requested:" recovery format the non-streaming
-          // converter already handles (parseRawToolCallsRequestedText).
-          content:
-            'Tool calls requested:\n- Bash({"command":"ls"}) [id: call_raw_1]',
-        },
-        finish_reason: 'stop',
-      },
-    ],
-  })
-  const toolStart = events.find(
-    event =>
-      event.type === 'content_block_start' &&
-      typeof event.content_block === 'object' &&
-      event.content_block !== null &&
-      (event.content_block as Record<string, unknown>).type === 'tool_use',
-  ) as { content_block?: Record<string, unknown> } | undefined
-  expect(toolStart?.content_block).toMatchObject({
-    type: 'tool_use',
-    id: 'call_raw_1',
-    name: 'Bash',
-  })
-  const stopEvent = events.find(e => e.type === 'message_delta') as
-    | { delta?: { stop_reason?: string } }
-    | undefined
-  expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
 
-})
 // openaiShim test extraction seam 199 end
 
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -162,6 +162,21 @@ import {
   convertMessages as convertAnthropicMessages,
   convertSystemPrompt as convertSystemPromptImpl,
 } from './openaiShim/messageConversion.js'
+import {
+  JSON_REPAIR_SUFFIXES,
+  couldBeRawToolCallsRequestedPrefix,
+  extractBalancedJson,
+  parseRawToolCallsRequestedText,
+  parseTextToolCalls as parseTextToolCallsModule,
+  repairPossiblyTruncatedObjectJson,
+  stripRanges,
+  type ParsedRawToolCall,
+  type ParsedTextToolCall,
+} from './openaiShim/rawToolCallParsing.js'
+import {
+  convertTools as convertToolsModule,
+  normalizeSchemaForOpenAI as normalizeSchemaForOpenAIModule,
+} from './openaiShim/toolConversion.js'
 
 const GITHUB_429_MAX_RETRIES = 3
 const GITHUB_429_BASE_DELAY_SEC = 1
@@ -769,11 +784,6 @@ function getCompressedMessagesForTransport<T>(
  * which causes 400 errors on OpenAI/Codex endpoints. This normalizes the
  * schema by ensuring `required` is a superset of `properties` keys.
  */
-import {
-  convertTools as convertToolsModule,
-  normalizeSchemaForOpenAI as normalizeSchemaForOpenAIModule,
-} from './openaiShim/toolConversion.js'
-
 function normalizeSchemaForOpenAI(
   schema: Record<string, unknown>,
   strict = true,
@@ -844,17 +854,6 @@ function convertChunkUsage(
   )
 }
 
-import {
-  JSON_REPAIR_SUFFIXES,
-  couldBeRawToolCallsRequestedPrefix,
-  extractBalancedJson,
-  parseRawToolCallsRequestedText,
-  parseTextToolCalls as parseTextToolCallsModule,
-  repairPossiblyTruncatedObjectJson,
-  stripRanges,
-  type ParsedRawToolCall,
-  type ParsedTextToolCall,
-} from './openaiShim/rawToolCallParsing.js'
 export function parseTextToolCalls(text: string): {
   calls: ParsedTextToolCall[]
   toolCallRanges: Array<[number, number]>

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -110,7 +110,6 @@ import {
   classifyOpenAINetworkFailure,
   markOpenAIRequestNonReplayable,
 } from './openaiErrorClassification.js'
-import { sanitizeSchemaForOpenAICompat } from '../../utils/schemaSanitizer.js'
 import { redactSecretValueForDisplay, type SecretValueSource } from '../../utils/providerProfile.js'
 import {
   redactEncodedSecretSubstringsForDisplay,
@@ -770,99 +769,28 @@ function getCompressedMessagesForTransport<T>(
  * which causes 400 errors on OpenAI/Codex endpoints. This normalizes the
  * schema by ensuring `required` is a superset of `properties` keys.
  */
+import {
+  convertTools as convertToolsModule,
+  normalizeSchemaForOpenAI as normalizeSchemaForOpenAIModule,
+} from './openaiShim/toolConversion.js'
+
 function normalizeSchemaForOpenAI(
   schema: Record<string, unknown>,
   strict = true,
 ): Record<string, unknown> {
-  const record = sanitizeSchemaForOpenAICompat(schema)
-
-  if (record.type === 'object' && record.properties) {
-    const properties = record.properties as Record<string, Record<string, unknown>>
-    const existingRequired = Array.isArray(record.required) ? record.required as string[] : []
-
-    // Recurse into each property
-    const normalizedProps: Record<string, unknown> = {}
-    for (const [key, value] of Object.entries(properties)) {
-      normalizedProps[key] = normalizeSchemaForOpenAI(
-        value as Record<string, unknown>,
-        strict,
-      )
-    }
-    record.properties = normalizedProps
-
-    if (strict) {
-      // Keep only the properties that were originally marked required in the schema.
-      // Adding every property to required[] (the previous behaviour) caused strict
-      // OpenAI-compatible providers (Groq, Azure, etc.) to reject tool calls because
-      // the model correctly omits optional arguments — but the provider treats them
-      // as missing required fields and returns a 400 / tool_use_failed error.
-      record.required = existingRequired.filter(k => k in normalizedProps)
-      // additionalProperties: false is still required by strict-mode providers.
-      record.additionalProperties = false
-    } else {
-      // For Gemini: keep only existing required keys that are present in properties
-      record.required = existingRequired.filter(k => k in normalizedProps)
-    }
-  }
-
-  // Recurse into array items
-  if ('items' in record) {
-    if (Array.isArray(record.items)) {
-      record.items = (record.items as unknown[]).map(
-        item => normalizeSchemaForOpenAI(item as Record<string, unknown>, strict),
-      )
-    } else {
-      record.items = normalizeSchemaForOpenAI(record.items as Record<string, unknown>, strict)
-    }
-  }
-
-  // Recurse into combinators
-  for (const key of ['anyOf', 'oneOf', 'allOf'] as const) {
-    if (key in record && Array.isArray(record[key])) {
-      record[key] = (record[key] as unknown[]).map(
-        item => normalizeSchemaForOpenAI(item as Record<string, unknown>, strict),
-      )
-    }
-  }
-
-  return record
+  return normalizeSchemaForOpenAIModule(schema, strict)
 }
 
 function convertTools(
   tools: Array<{ name: string; description?: string; input_schema?: Record<string, unknown> }>,
   options: { skipStrict?: boolean } = {},
 ): OpenAITool[] {
-  const isGemini = isGeminiMode()
-  const strict =
-    !isGemini &&
-    !isEnvTruthy(process.env.OPENCLAUDE_DISABLE_STRICT_TOOLS) &&
-    !options.skipStrict
-
-  return tools
-    .filter(t => t.name !== 'ToolSearchTool') // Not relevant for OpenAI
-    .map(t => {
-      const schema = { ...(t.input_schema ?? { type: 'object', properties: {} }) } as Record<string, unknown>
-
-      // For Codex/OpenAI: promote known Agent sub-fields into required[] only if
-      // they actually exist in properties (Gemini rejects required keys absent from properties).
-      if (t.name === 'Agent' && schema.properties) {
-        const props = schema.properties as Record<string, unknown>
-        if (!Array.isArray(schema.required)) schema.required = []
-        const req = schema.required as string[]
-        for (const key of ['message', 'subagent_type']) {
-          if (key in props && !req.includes(key)) req.push(key)
-        }
-      }
-
-      return {
-        type: 'function' as const,
-        function: {
-          name: t.name,
-          description: t.description ?? '',
-          parameters: normalizeSchemaForOpenAI(schema, strict),
-        },
-      }
-    })
+  return convertToolsModule(tools, {
+    isGemini: isGeminiMode(),
+    disableStrictTools: isEnvTruthy(process.env.OPENCLAUDE_DISABLE_STRICT_TOOLS),
+    skipStrict: options.skipStrict,
+    normalizeSchema: normalizeSchemaForOpenAI,
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -916,241 +844,22 @@ function convertChunkUsage(
   )
 }
 
-const JSON_REPAIR_SUFFIXES = [
-  '}', '"}', ']}', '"]}', '}}', '"}}', ']}}', '"]}}', '"]}]}', '}]}'
-]
-
-const RAW_TOOL_CALLS_REQUESTED_PREFIX = 'Tool calls requested:'
-
-type ParsedRawToolCall = {
-  id: string
-  name: string
-  argumentsJson: string
-}
-
-function couldBeRawToolCallsRequestedPrefix(text: string): boolean {
-  const trimmedStart = text.trimStart()
-  return (
-    RAW_TOOL_CALLS_REQUESTED_PREFIX.startsWith(trimmedStart) ||
-    trimmedStart.startsWith(RAW_TOOL_CALLS_REQUESTED_PREFIX)
-  )
-}
-
-function parseRawToolCallsRequestedText(text: string): ParsedRawToolCall[] | null {
-  const trimmed = text.trim()
-  if (!trimmed.startsWith(RAW_TOOL_CALLS_REQUESTED_PREFIX)) {
-    return null
-  }
-
-  const lines = trimmed
-    .slice(RAW_TOOL_CALLS_REQUESTED_PREFIX.length)
-    .split(/\r?\n/)
-    .map(line => line.trim())
-    .filter(Boolean)
-
-  if (lines.length === 0) return null
-
-  const toolCalls: ParsedRawToolCall[] = []
-  for (const line of lines) {
-    const match = line.match(
-      /^-\s*([A-Za-z_][A-Za-z0-9_.-]*)\(([\s\S]*)\)\s*\[id:\s*([^\]\s]+)\]\s*$/,
-    )
-    if (!match) return null
-
-    const [, name, rawArguments, id] = match
-    if (!name || !id || rawArguments === undefined) return null
-
-    const normalizedArguments = normalizeToolArguments(name, rawArguments)
-    toolCalls.push({
-      id,
-      name,
-      argumentsJson: JSON.stringify(normalizedArguments ?? {}),
-    })
-  }
-
-  return toolCalls.length > 0 ? toolCalls : null
-}
-
-function repairPossiblyTruncatedObjectJson(raw: string): string | null {
-  try {
-    const parsed = JSON.parse(raw)
-    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-      ? raw
-      : null
-  } catch {
-    for (const combo of JSON_REPAIR_SUFFIXES) {
-      try {
-        const repaired = raw + combo
-        const parsed = JSON.parse(repaired)
-        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-          return repaired
-        }
-      } catch {}
-    }
-    return null
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Ollama text-based tool call parser (fix for #1053)
-//
-// When Ollama models cannot emit structured tool_calls via the OpenAI-compat
-// API, they fall back to printing the call as a JSON block in the response
-// text. This parser extracts those calls so the agent loop can execute them.
-//
-// Supported formats emitted by qwen2.5-coder, llama3.x, phi-4, gemma:
-//   ```json\n{"name":"X","arguments":{...}}\n```
-//   {"name":"X","arguments":{...}}
-//   {"type":"function","function":{"name":"X","arguments":{...}}}
-// ---------------------------------------------------------------------------
-
-// Fenced code block arm: non-greedy is safe because ``` acts as terminator.
-const FENCED_TOOL_CALL_RE = /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```/g
-// Bare JSON arm: marks candidate start positions only; balanced extraction follows.
-// Allow optional whitespace (including newlines) before the property key so
-// pretty-printed objects like "{\n  \"name\":" are detected.
-const BARE_TOOL_CALL_START_RE = /\{\s*"(?:name|type)"\s*:/g
-
-interface ParsedTextToolCall {
-  id: string
-  name: string
-  arguments: Record<string, unknown>
-}
-
-// Walks forward from `start` (which must be `{`) tracking string/escape/brace
-// state and returns the substring up to and including the matching `}`, or
-// null if the braces are never balanced (truncated input).
-function extractBalancedJson(text: string, start: number): string | null {
-  let depth = 0
-  let inString = false
-  let escape = false
-  for (let i = start; i < text.length; i++) {
-    const c = text[i]!
-    if (escape) { escape = false; continue }
-    if (c === '\\' && inString) { escape = true; continue }
-    if (c === '"') { inString = !inString; continue }
-    if (inString) continue
-    if (c === '{') depth++
-    else if (c === '}') {
-      depth--
-      if (depth === 0) return text.slice(start, i + 1)
-    }
-  }
-  return null
-}
-
-function parseAndAdd(
-  raw: string,
-  results: ParsedTextToolCall[],
-  seen: Set<string>,
-): boolean {
-  let obj: Record<string, unknown>
-  try {
-    obj = JSON.parse(raw)
-  } catch {
-    return false
-  }
-
-  let name: string | undefined
-  let args: Record<string, unknown> = {}
-
-  if (typeof obj['name'] === 'string') {
-    // {"name": "X", "arguments": {...}}
-    name = obj['name'] as string
-    args = (obj['arguments'] as Record<string, unknown>) ?? {}
-  } else if (
-    obj['type'] === 'function' &&
-    typeof (obj['function'] as any)?.name === 'string'
-  ) {
-    // {"type":"function","function":{"name":"X","arguments":{...}}}
-    const fn = obj['function'] as { name: string; arguments?: unknown }
-    name = fn.name
-    const rawArgs = fn.arguments
-    args =
-      typeof rawArgs === 'string'
-        ? (() => {
-            try {
-              return JSON.parse(rawArgs)
-            } catch {
-              return {}
-            }
-          })()
-        : (rawArgs as Record<string, unknown>) ?? {}
-  }
-
-  if (!name) return false
-
-  const dedupKey = `${name}:${JSON.stringify(args)}`
-  if (seen.has(dedupKey)) return false
-  seen.add(dedupKey)
-
-  results.push({ id: `ollama_tc_${nextTextToolCallSequence()}`, name, arguments: args })
-  return true
-}
-
-/** Removes character ranges from `text`, returning the remaining content. */
-function stripRanges(text: string, ranges: Array<[number, number]>): string {
-  const sorted = [...ranges].sort((a, b) => a[0] - b[0])
-  let result = ''
-  let pos = 0
-  for (const [s, e] of sorted) {
-    result += text.slice(pos, s)
-    pos = e
-  }
-  return result + text.slice(pos)
-}
-
-/** Exported for unit testing only. */
+import {
+  JSON_REPAIR_SUFFIXES,
+  couldBeRawToolCallsRequestedPrefix,
+  extractBalancedJson,
+  parseRawToolCallsRequestedText,
+  parseTextToolCalls as parseTextToolCallsModule,
+  repairPossiblyTruncatedObjectJson,
+  stripRanges,
+  type ParsedRawToolCall,
+  type ParsedTextToolCall,
+} from './openaiShim/rawToolCallParsing.js'
 export function parseTextToolCalls(text: string): {
   calls: ParsedTextToolCall[]
   toolCallRanges: Array<[number, number]>
 } {
-  const results: ParsedTextToolCall[] = []
-  const seen = new Set<string>()
-  const fencedRanges: Array<[number, number]> = []
-  // acceptedRanges tracks only ranges where parseAndAdd confirmed a valid tool
-  // call was emitted — these are what callers strip from text.  fencedRanges
-  // (all fenced blocks regardless of acceptance) is kept separately so Pass 2
-  // can skip over them and avoid double-processing.
-  const acceptedRanges: Array<[number, number]> = []
-
-  // Pass 1: fenced code blocks — regex is safe, ``` bounds the non-greedy match.
-  // Context guard: same heuristic as Pass 2 — if non-whitespace, non-`{` text
-  // immediately follows the closing fence, the model is explaining a format rather
-  // than calling a tool; skip to avoid false positives on fenced examples.
-  for (const match of text.matchAll(FENCED_TOOL_CALL_RE)) {
-    const raw = (match[1] ?? '').trim()
-    const after = text.slice(match.index! + match[0].length).trimStart()
-    if (after.length > 0 && !after.startsWith('{')) continue
-    const range: [number, number] = [match.index!, match.index! + match[0].length]
-    fencedRanges.push(range)
-    if (raw && parseAndAdd(raw, results, seen)) {
-      acceptedRanges.push(range)
-    }
-  }
-
-  // Pass 2: bare JSON — use the brace scanner so nested objects are captured fully.
-  // processedRanges grows as we extract; inner objects nested inside an outer
-  // tool call are skipped because their start falls inside an already-extracted range.
-  const processedRanges: Array<[number, number]> = [...fencedRanges]
-  for (const match of text.matchAll(BARE_TOOL_CALL_START_RE)) {
-    const start = match.index!
-    if (processedRanges.some(([s, e]) => start >= s && start < e)) continue
-    const raw = extractBalancedJson(text, start)
-    if (raw) {
-      // Context guard: if non-whitespace, non-`{` text immediately follows the JSON
-      // the model is likely explaining, not calling — skip to avoid false positives.
-      const after = text.slice(start + raw.length).trimStart()
-      if (after.length > 0 && !after.startsWith('{')) continue
-      const range: [number, number] = [start, start + raw.length]
-      processedRanges.push(range)
-      if (parseAndAdd(raw, results, seen)) {
-        acceptedRanges.push(range)
-      }
-    }
-  }
-
-  return { calls: results, toolCallRanges: acceptedRanges }
+  return parseTextToolCallsModule(text, nextTextToolCallSequence)
 }
 
 // Shared façade state keeps raw-text and XML fallback IDs unique per session.

--- a/src/services/api/openaiShim/rawToolCallParsing.test.ts
+++ b/src/services/api/openaiShim/rawToolCallParsing.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'bun:test'
+import {
+  couldBeRawToolCallsRequestedPrefix,
+  parseRawToolCallsRequestedText,
+  repairPossiblyTruncatedObjectJson,
+} from './rawToolCallParsing.js'
+
+test('parses a Gemini raw tool call accumulated across stream chunks', () => {
+  const accumulated = [
+    'Tool calls',
+    ' requested:\n- Write({"file_path":"style.css","content":"ul { padding: 0; }"}) [id: call79435b5a26564619b0151197]',
+  ].join('')
+
+  expect(couldBeRawToolCallsRequestedPrefix('Tool calls')).toBe(true)
+  expect(parseRawToolCallsRequestedText(accumulated)).toEqual([{
+    id: 'call79435b5a26564619b0151197',
+    name: 'Write',
+    argumentsJson: JSON.stringify({
+      file_path: 'style.css',
+      content: 'ul { padding: 0; }',
+    }),
+  }])
+})
+
+test('parses a complete Gemini raw tool-call response', () => {
+  const parsed = parseRawToolCallsRequestedText(
+    'Tool calls requested:\n- Agent({"description":"Verify the todo list application functionality.","prompt":"Check files.","subagent_type":"verification"}) [id: call9a8b7c6d5e4f3a2b1c0d9e8f]',
+  )
+
+  expect(parsed).toEqual([{
+    id: 'call9a8b7c6d5e4f3a2b1c0d9e8f',
+    name: 'Agent',
+    argumentsJson: JSON.stringify({
+      description: 'Verify the todo list application functionality.',
+      prompt: 'Check files.',
+      subagent_type: 'verification',
+    }),
+  }])
+})
+
+test('JSON fallback: recovers raw-text tool call into tool_use block', () => {
+  expect(parseRawToolCallsRequestedText(
+    'Tool calls requested:\n- Bash({"command":"ls"}) [id: call_raw_1]',
+  )).toEqual([{
+    id: 'call_raw_1',
+    name: 'Bash',
+    argumentsJson: '{"command":"ls"}',
+  }])
+})
+
+test('rejects malformed raw tool-call request text atomically', () => {
+  expect(parseRawToolCallsRequestedText('ordinary prose')).toBeNull()
+  expect(parseRawToolCallsRequestedText('Tool calls requested:')).toBeNull()
+  expect(parseRawToolCallsRequestedText(
+    'Tool calls requested:\n- Bash({"command":"ls"}) [id: ok]\nmalformed',
+  )).toBeNull()
+})
+
+test('repairs only JSON objects with bounded suffixes', () => {
+  expect(repairPossiblyTruncatedObjectJson('{"command":"ls"')).toBe(
+    '{"command":"ls"}',
+  )
+  expect(repairPossiblyTruncatedObjectJson('[]')).toBeNull()
+  expect(repairPossiblyTruncatedObjectJson('false')).toBeNull()
+  expect(repairPossiblyTruncatedObjectJson('{not json')).toBeNull()
+})
+
+test('repairs truncated structured Bash JSON in streaming responses', () => {
+  expect(repairPossiblyTruncatedObjectJson('{"command":"pwd"')).toBe(
+    '{"command":"pwd"}',
+  )
+})
+
+test('repairs truncated JSON objects even without command field', () => {
+  expect(repairPossiblyTruncatedObjectJson('{"cwd":"/tmp"')).toBe(
+    '{"cwd":"/tmp"}',
+  )
+})

--- a/src/services/api/openaiShim/rawToolCallParsing.test.ts
+++ b/src/services/api/openaiShim/rawToolCallParsing.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'bun:test'
 import {
   couldBeRawToolCallsRequestedPrefix,
   parseRawToolCallsRequestedText,
+  parseTextToolCalls,
   repairPossiblyTruncatedObjectJson,
 } from './rawToolCallParsing.js'
 
@@ -12,6 +13,8 @@ test('parses a Gemini raw tool call accumulated across stream chunks', () => {
   ].join('')
 
   expect(couldBeRawToolCallsRequestedPrefix('Tool calls')).toBe(true)
+  expect(couldBeRawToolCallsRequestedPrefix('ordinary prose')).toBe(false)
+  expect(couldBeRawToolCallsRequestedPrefix('Tool cogs')).toBe(false)
   expect(parseRawToolCallsRequestedText(accumulated)).toEqual([{
     id: 'call79435b5a26564619b0151197',
     name: 'Write',
@@ -20,6 +23,28 @@ test('parses a Gemini raw tool call accumulated across stream chunks', () => {
       content: 'ul { padding: 0; }',
     }),
   }])
+})
+
+test('parses balanced JSON inside a fenced tool call', () => {
+  const text = '```json\n{"name":"Bash","arguments":{"command":"echo {ok}"}}\n```'
+
+  expect(parseTextToolCalls(text, () => 1)).toEqual({
+    calls: [{
+      id: 'ollama_tc_1',
+      name: 'Bash',
+      arguments: { command: 'echo {ok}' },
+    }],
+    toolCallRanges: [[0, text.length]],
+  })
+})
+
+test('does not parse a fenced JSON example with trailing prose before its fence', () => {
+  const text = '```json\n{"name":"Bash","arguments":{}}\nexample\n```'
+
+  expect(parseTextToolCalls(text, () => 1)).toEqual({
+    calls: [],
+    toolCallRanges: [],
+  })
 })
 
 test('parses a complete Gemini raw tool-call response', () => {

--- a/src/services/api/openaiShim/rawToolCallParsing.test.ts
+++ b/src/services/api/openaiShim/rawToolCallParsing.test.ts
@@ -4,6 +4,7 @@ import {
   parseRawToolCallsRequestedText,
   parseTextToolCalls,
   repairPossiblyTruncatedObjectJson,
+  stripRanges,
 } from './rawToolCallParsing.js'
 
 test('parses a Gemini raw tool call accumulated across stream chunks', () => {
@@ -45,6 +46,20 @@ test('does not parse a fenced JSON example with trailing prose before its fence'
     calls: [],
     toolCallRanges: [],
   })
+})
+
+test('parses stringified arguments in a bare-name tool call', () => {
+  const text = '{"name":"Bash","arguments":"{\\"command\\":\\"ls\\"}"}'
+
+  expect(parseTextToolCalls(text, () => 1).calls).toEqual([{
+    id: 'ollama_tc_1',
+    name: 'Bash',
+    arguments: { command: 'ls' },
+  }])
+})
+
+test('strips tool-call ranges regardless of input order', () => {
+  expect(stripRanges('a{one}b{two}c', [[7, 12], [1, 6]])).toBe('abc')
 })
 
 test('parses a complete Gemini raw tool-call response', () => {

--- a/src/services/api/openaiShim/rawToolCallParsing.test.ts
+++ b/src/services/api/openaiShim/rawToolCallParsing.test.ts
@@ -58,6 +58,21 @@ test('parses stringified arguments in a bare-name tool call', () => {
   }])
 })
 
+test('rejects non-object arguments in text tool calls', () => {
+  for (const argumentsValue of [[], null, 'text']) {
+    const text = JSON.stringify({ name: 'Bash', arguments: argumentsValue })
+
+    expect(parseTextToolCalls(text, () => 1).calls).toEqual([{
+      id: 'ollama_tc_1',
+      name: 'Bash',
+      arguments: {},
+    }])
+  }
+
+  const stringifiedArray = JSON.stringify({ name: 'Bash', arguments: '[]' })
+  expect(parseTextToolCalls(stringifiedArray, () => 1).calls[0]?.arguments).toEqual({})
+})
+
 test('strips tool-call ranges regardless of input order', () => {
   expect(stripRanges('a{one}b{two}c', [[7, 12], [1, 6]])).toBe('abc')
 })

--- a/src/services/api/openaiShim/rawToolCallParsing.ts
+++ b/src/services/api/openaiShim/rawToolCallParsing.ts
@@ -1,0 +1,239 @@
+import { normalizeToolArguments } from '../toolArgumentNormalization.js'
+
+export const JSON_REPAIR_SUFFIXES = [
+  '}',
+  '"}',
+  ']}',
+  '"]}',
+  '}}',
+  '"}}',
+  ']}}',
+  '"]}}',
+  '"]}]}',
+  '}]}',
+]
+
+const RAW_TOOL_CALLS_REQUESTED_PREFIX = 'Tool calls requested:'
+const FENCED_TOOL_CALL_RE = /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```/g
+const BARE_TOOL_CALL_START_RE = /\{\s*"(?:name|type)"\s*:/g
+
+export type ParsedRawToolCall = {
+  id: string
+  name: string
+  argumentsJson: string
+}
+
+export interface ParsedTextToolCall {
+  id: string
+  name: string
+  arguments: Record<string, unknown>
+}
+
+let toolCallCounter = 0
+
+export function nextToolCallSequence(): number {
+  return ++toolCallCounter
+}
+
+export function couldBeRawToolCallsRequestedPrefix(text: string): boolean {
+  const trimmedStart = text.trimStart()
+  return (
+    RAW_TOOL_CALLS_REQUESTED_PREFIX.startsWith(trimmedStart) ||
+    trimmedStart.startsWith(RAW_TOOL_CALLS_REQUESTED_PREFIX)
+  )
+}
+
+export function parseRawToolCallsRequestedText(
+  text: string,
+): ParsedRawToolCall[] | null {
+  const trimmed = text.trim()
+  if (!trimmed.startsWith(RAW_TOOL_CALLS_REQUESTED_PREFIX)) return null
+
+  const lines = trimmed
+    .slice(RAW_TOOL_CALLS_REQUESTED_PREFIX.length)
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+
+  if (lines.length === 0) return null
+
+  const toolCalls: ParsedRawToolCall[] = []
+  for (const line of lines) {
+    const match = line.match(
+      /^-\s*([A-Za-z_][A-Za-z0-9_.-]*)\(([\s\S]*)\)\s*\[id:\s*([^\]\s]+)\]\s*$/,
+    )
+    if (!match) return null
+
+    const [, name, rawArguments, id] = match
+    if (!name || !id || rawArguments === undefined) return null
+
+    const normalizedArguments = normalizeToolArguments(name, rawArguments)
+    toolCalls.push({
+      id,
+      name,
+      argumentsJson: JSON.stringify(normalizedArguments ?? {}),
+    })
+  }
+
+  return toolCalls
+}
+
+export function repairPossiblyTruncatedObjectJson(raw: string): string | null {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return isRecord(parsed) ? raw : null
+  } catch {
+    for (const suffix of JSON_REPAIR_SUFFIXES) {
+      try {
+        const repaired = raw + suffix
+        const parsed: unknown = JSON.parse(repaired)
+        if (isRecord(parsed)) return repaired
+      } catch {
+        // Try the next bounded suffix.
+      }
+    }
+    return null
+  }
+}
+
+export function extractBalancedJson(text: string, start: number): string | null {
+  let depth = 0
+  let inString = false
+  let escape = false
+
+  for (let index = start; index < text.length; index++) {
+    const character = text[index]!
+    if (escape) {
+      escape = false
+      continue
+    }
+    if (character === '\\' && inString) {
+      escape = true
+      continue
+    }
+    if (character === '"') {
+      inString = !inString
+      continue
+    }
+    if (inString) continue
+    if (character === '{') depth++
+    else if (character === '}') {
+      depth--
+      if (depth === 0) return text.slice(start, index + 1)
+    }
+  }
+
+  return null
+}
+
+export function stripRanges(
+  text: string,
+  ranges: Array<[number, number]>,
+): string {
+  const sorted = [...ranges].sort((left, right) => left[0] - right[0])
+  let result = ''
+  let position = 0
+  for (const [start, end] of sorted) {
+    result += text.slice(position, start)
+    position = end
+  }
+  return result + text.slice(position)
+}
+
+export function parseTextToolCalls(
+  text: string,
+  nextSequence: () => number = nextToolCallSequence,
+): {
+  calls: ParsedTextToolCall[]
+  toolCallRanges: Array<[number, number]>
+} {
+  const results: ParsedTextToolCall[] = []
+  const seen = new Set<string>()
+  const fencedRanges: Array<[number, number]> = []
+  const acceptedRanges: Array<[number, number]> = []
+
+  for (const match of text.matchAll(FENCED_TOOL_CALL_RE)) {
+    const raw = (match[1] ?? '').trim()
+    const after = text.slice(match.index! + match[0].length).trimStart()
+    if (after.length > 0 && !after.startsWith('{')) continue
+    const range: [number, number] = [match.index!, match.index! + match[0].length]
+    fencedRanges.push(range)
+    if (raw && parseAndAdd(raw, results, seen, nextSequence)) acceptedRanges.push(range)
+  }
+
+  const processedRanges: Array<[number, number]> = [...fencedRanges]
+  for (const match of text.matchAll(BARE_TOOL_CALL_START_RE)) {
+    const start = match.index!
+    if (processedRanges.some(([rangeStart, rangeEnd]) =>
+      start >= rangeStart && start < rangeEnd
+    )) {
+      continue
+    }
+
+    const raw = extractBalancedJson(text, start)
+    if (!raw) continue
+    const after = text.slice(start + raw.length).trimStart()
+    if (after.length > 0 && !after.startsWith('{')) continue
+
+    const range: [number, number] = [start, start + raw.length]
+    processedRanges.push(range)
+    if (parseAndAdd(raw, results, seen, nextSequence)) acceptedRanges.push(range)
+  }
+
+  return { calls: results, toolCallRanges: acceptedRanges }
+}
+
+function parseAndAdd(
+  raw: string,
+  results: ParsedTextToolCall[],
+  seen: Set<string>,
+  nextSequence: () => number,
+): boolean {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return false
+  }
+  if (!isRecord(parsed)) return false
+
+  let name: string | undefined
+  let argumentsValue: Record<string, unknown> = {}
+
+  if (typeof parsed.name === 'string') {
+    name = parsed.name
+    argumentsValue =
+      (parsed.arguments as Record<string, unknown> | undefined) ?? {}
+  } else if (parsed.type === 'function' && isRecord(parsed.function)) {
+    const functionValue = parsed.function
+    if (typeof functionValue.name !== 'string') return false
+    name = functionValue.name
+    argumentsValue = parseArguments(functionValue.arguments)
+  }
+
+  if (!name) return false
+  const deduplicationKey = `${name}:${JSON.stringify(argumentsValue)}`
+  if (seen.has(deduplicationKey)) return false
+  seen.add(deduplicationKey)
+  results.push({
+    id: `ollama_tc_${nextSequence()}`,
+    name,
+    arguments: argumentsValue,
+  })
+  return true
+}
+
+function parseArguments(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') {
+    try {
+      return JSON.parse(value) as Record<string, unknown>
+    } catch {
+      return {}
+    }
+  }
+  return (value as Record<string, unknown> | undefined) ?? {}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}

--- a/src/services/api/openaiShim/rawToolCallParsing.ts
+++ b/src/services/api/openaiShim/rawToolCallParsing.ts
@@ -14,7 +14,7 @@ export const JSON_REPAIR_SUFFIXES = [
 ]
 
 const RAW_TOOL_CALLS_REQUESTED_PREFIX = 'Tool calls requested:'
-const FENCED_TOOL_CALL_RE = /```(?:json)?\s*\n?\s*(\{[\s\S]*?\})\s*\n?\s*```/g
+const FENCED_TOOL_CALL_START_RE = /```(?:json)?\s*\n?\s*\{/g
 const BARE_TOOL_CALL_START_RE = /\{\s*"(?:name|type)"\s*:/g
 
 export type ParsedRawToolCall = {
@@ -152,13 +152,21 @@ export function parseTextToolCalls(
   const fencedRanges: Array<[number, number]> = []
   const acceptedRanges: Array<[number, number]> = []
 
-  for (const match of text.matchAll(FENCED_TOOL_CALL_RE)) {
-    const raw = (match[1] ?? '').trim()
-    const after = text.slice(match.index! + match[0].length).trimStart()
+  for (const match of text.matchAll(FENCED_TOOL_CALL_START_RE)) {
+    const fenceStart = match.index!
+    const rawStart = fenceStart + match[0].length - 1
+    const raw = extractBalancedJson(text, rawStart)
+    if (!raw) continue
+
+    const closingFence = text.slice(rawStart + raw.length).match(/^\s*```/)
+    if (!closingFence) continue
+
+    const fenceEnd = rawStart + raw.length + closingFence[0].length
+    const after = text.slice(fenceEnd).trimStart()
     if (after.length > 0 && !after.startsWith('{')) continue
-    const range: [number, number] = [match.index!, match.index! + match[0].length]
+    const range: [number, number] = [fenceStart, fenceEnd]
     fencedRanges.push(range)
-    if (raw && parseAndAdd(raw, results, seen, nextSequence)) acceptedRanges.push(range)
+    if (parseAndAdd(raw, results, seen, nextSequence)) acceptedRanges.push(range)
   }
 
   const processedRanges: Array<[number, number]> = [...fencedRanges]

--- a/src/services/api/openaiShim/rawToolCallParsing.ts
+++ b/src/services/api/openaiShim/rawToolCallParsing.ts
@@ -233,12 +233,13 @@ function parseAndAdd(
 function parseArguments(value: unknown): Record<string, unknown> {
   if (typeof value === 'string') {
     try {
-      return JSON.parse(value) as Record<string, unknown>
+      const parsed: unknown = JSON.parse(value)
+      return isRecord(parsed) ? parsed : {}
     } catch {
       return {}
     }
   }
-  return (value as Record<string, unknown> | undefined) ?? {}
+  return isRecord(value) ? value : {}
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/services/api/openaiShim/rawToolCallParsing.ts
+++ b/src/services/api/openaiShim/rawToolCallParsing.ts
@@ -210,8 +210,7 @@ function parseAndAdd(
 
   if (typeof parsed.name === 'string') {
     name = parsed.name
-    argumentsValue =
-      (parsed.arguments as Record<string, unknown> | undefined) ?? {}
+    argumentsValue = parseArguments(parsed.arguments)
   } else if (parsed.type === 'function' && isRecord(parsed.function)) {
     const functionValue = parsed.function
     if (typeof functionValue.name !== 'string') return false

--- a/src/services/api/openaiShim/toolConversion.test.ts
+++ b/src/services/api/openaiShim/toolConversion.test.ts
@@ -1,0 +1,97 @@
+import { expect, test } from 'bun:test'
+import { convertTools, normalizeSchemaForOpenAI } from './toolConversion.js'
+
+test('preserves Grep tool pattern field in OpenAI-compatible schemas', () => {
+  const tools = convertTools([{
+    name: 'Grep',
+    description: 'Search file contents',
+    input_schema: {
+      type: 'object',
+      properties: {
+        pattern: { type: 'string', description: 'Search pattern' },
+        path: { type: 'string' },
+      },
+      required: ['pattern'],
+      additionalProperties: false,
+    },
+  }], {
+    isGemini: false,
+    disableStrictTools: false,
+  })
+  const parameters = tools[0]?.function.parameters
+  const properties = parameters?.properties as Record<string, unknown>
+
+  expect(Object.keys(properties)).toContain('pattern')
+  expect(parameters?.required).toContain('pattern')
+})
+
+test('sanitizes malformed MCP tool schemas before sending them to OpenAI', () => {
+  const parameters = normalizeSchemaForOpenAI({
+    type: 'object',
+    properties: {
+      priority: {
+        type: 'integer',
+        description: 'Priority: 0=low, 1=medium, 2=high, 3=urgent',
+        default: true,
+        enum: [false, 0, 1, 2, 3],
+      },
+    },
+  })
+  const properties = parameters.properties as Record<
+    string,
+    { default?: unknown; enum?: unknown[]; type?: string }
+  >
+
+  expect(parameters.additionalProperties).toBe(false)
+  expect(parameters.required).toEqual([])
+  expect(properties.priority?.type).toBe('integer')
+  expect(properties.priority?.enum).toEqual([0, 1, 2, 3])
+  expect(properties.priority).not.toHaveProperty('default')
+})
+
+test('optional tool properties are not added to required[] — fixes Groq/Azure 400 tool_use_failed', () => {
+  const parameters = normalizeSchemaForOpenAI({
+    type: 'object',
+    properties: {
+      file_path: { type: 'string', description: 'Absolute path to file' },
+      offset: { type: 'number', description: 'Line to start from' },
+      limit: { type: 'number', description: 'Max lines to read' },
+      pages: { type: 'string', description: 'Page range for PDFs' },
+    },
+    required: ['file_path'],
+  })
+  const required = parameters.required as string[]
+
+  expect(required).toEqual(['file_path'])
+  expect(required).not.toContain('offset')
+  expect(required).not.toContain('limit')
+  expect(required).not.toContain('pages')
+  expect(parameters.additionalProperties).toBe(false)
+})
+
+test('omits deferred tool search and promotes known Agent fields', () => {
+  const tools = convertTools([
+    { name: 'ToolSearchTool' },
+    {
+      name: 'Agent',
+      input_schema: {
+        type: 'object',
+        properties: {
+          message: { type: 'string' },
+          subagent_type: { type: 'string' },
+          optional: { type: 'string' },
+        },
+      },
+    },
+  ], {
+    isGemini: false,
+    disableStrictTools: false,
+  })
+
+  expect(tools).toHaveLength(1)
+  expect(tools[0]?.function.name).toBe('Agent')
+  expect(tools[0]?.function.parameters.required).toEqual([
+    'message',
+    'subagent_type',
+  ])
+})

--- a/src/services/api/openaiShim/toolConversion.test.ts
+++ b/src/services/api/openaiShim/toolConversion.test.ts
@@ -70,18 +70,20 @@ test('optional tool properties are not added to required[] — fixes Groq/Azure 
 })
 
 test('omits deferred tool search and promotes known Agent fields', () => {
+  const inputSchema = {
+    type: 'object',
+    properties: {
+      message: { type: 'string' },
+      subagent_type: { type: 'string' },
+      optional: { type: 'string' },
+    },
+    required: ['optional'],
+  }
   const tools = convertTools([
     { name: 'ToolSearchTool' },
     {
       name: 'Agent',
-      input_schema: {
-        type: 'object',
-        properties: {
-          message: { type: 'string' },
-          subagent_type: { type: 'string' },
-          optional: { type: 'string' },
-        },
-      },
+      input_schema: inputSchema,
     },
   ], {
     isGemini: false,
@@ -91,7 +93,24 @@ test('omits deferred tool search and promotes known Agent fields', () => {
   expect(tools).toHaveLength(1)
   expect(tools[0]?.function.name).toBe('Agent')
   expect(tools[0]?.function.parameters.required).toEqual([
+    'optional',
     'message',
     'subagent_type',
   ])
+  expect(inputSchema.required).toEqual(['optional'])
+})
+
+test('Gemini mode omits strict schema fields', () => {
+  const tools = convertTools([{
+    name: 'Read',
+    input_schema: {
+      type: 'object',
+      properties: { path: { type: 'string' } },
+    },
+  }], {
+    isGemini: true,
+    disableStrictTools: false,
+  })
+
+  expect(tools[0]?.function.parameters.additionalProperties).toBeUndefined()
 })

--- a/src/services/api/openaiShim/toolConversion.ts
+++ b/src/services/api/openaiShim/toolConversion.ts
@@ -1,0 +1,105 @@
+import { sanitizeSchemaForOpenAICompat } from '../../../utils/schemaSanitizer.js'
+
+export type OpenAITool = {
+  type: 'function'
+  function: {
+    name: string
+    description: string
+    parameters: Record<string, unknown>
+  }
+}
+
+export function normalizeSchemaForOpenAI(
+  schema: Record<string, unknown>,
+  strict = true,
+): Record<string, unknown> {
+  const record = sanitizeSchemaForOpenAICompat(schema)
+
+  if (record.type === 'object' && record.properties) {
+    const properties = record.properties as Record<
+      string,
+      Record<string, unknown>
+    >
+    const existingRequired = Array.isArray(record.required)
+      ? record.required as string[]
+      : []
+    const normalizedProperties: Record<string, unknown> = {}
+
+    for (const [key, value] of Object.entries(properties)) {
+      normalizedProperties[key] = normalizeSchemaForOpenAI(value, strict)
+    }
+
+    record.properties = normalizedProperties
+    record.required = existingRequired.filter(key => key in normalizedProperties)
+    if (strict) record.additionalProperties = false
+  }
+
+  if ('items' in record) {
+    record.items = Array.isArray(record.items)
+      ? (record.items as unknown[]).map(item =>
+          normalizeSchemaForOpenAI(item as Record<string, unknown>, strict),
+        )
+      : normalizeSchemaForOpenAI(
+          record.items as Record<string, unknown>,
+          strict,
+        )
+  }
+
+  for (const key of ['anyOf', 'oneOf', 'allOf'] as const) {
+    if (Array.isArray(record[key])) {
+      record[key] = record[key].map(item =>
+        normalizeSchemaForOpenAI(item as Record<string, unknown>, strict),
+      )
+    }
+  }
+
+  return record
+}
+
+export function convertTools(
+  tools: Array<{
+    name: string
+    description?: string
+    input_schema?: Record<string, unknown>
+  }>,
+  options: {
+    isGemini: boolean
+    disableStrictTools: boolean
+    skipStrict?: boolean
+    normalizeSchema?: typeof normalizeSchemaForOpenAI
+  },
+): OpenAITool[] {
+  const strict =
+    !options.isGemini &&
+    !options.disableStrictTools &&
+    !options.skipStrict
+
+  return tools
+    .filter(tool => tool.name !== 'ToolSearchTool')
+    .map(tool => {
+      const schema = {
+        ...(tool.input_schema ?? { type: 'object', properties: {} }),
+      } as Record<string, unknown>
+
+      if (tool.name === 'Agent' && schema.properties) {
+        const properties = schema.properties as Record<string, unknown>
+        if (!Array.isArray(schema.required)) schema.required = []
+        const required = schema.required as string[]
+        for (const key of ['message', 'subagent_type']) {
+          if (key in properties && !required.includes(key)) required.push(key)
+        }
+      }
+
+      return {
+        type: 'function' as const,
+        function: {
+          name: tool.name,
+          description: tool.description ?? '',
+          parameters: (options.normalizeSchema ?? normalizeSchemaForOpenAI)(
+            schema,
+            strict,
+          ),
+        },
+      }
+    })
+}

--- a/src/services/api/openaiShim/toolConversion.ts
+++ b/src/services/api/openaiShim/toolConversion.ts
@@ -83,7 +83,7 @@ export function convertTools(
 
       if (tool.name === 'Agent' && schema.properties) {
         const properties = schema.properties as Record<string, unknown>
-        if (!Array.isArray(schema.required)) schema.required = []
+        schema.required = Array.isArray(schema.required) ? [...schema.required] : []
         const required = schema.required as string[]
         for (const key of ['message', 'subagent_type']) {
           if (key in properties && !required.includes(key)) required.push(key)


### PR DESCRIPTION
## Summary

Extracts tool-schema conversion and raw JSON tool-call parsing into `toolConversion.ts` and `rawToolCallParsing.ts`.

The group owns schema sanitization, deferred-tool filtering, raw Gemini/text tool-call parsing, and bounded truncated-JSON repair. The façade delegates these cohesive tool boundaries.

## Independent merge

- Upstream base: `0effa0f42b6dbc6a4800e19f4b2d8d588269906b`.
- Fork branch: `jatmn/openclaude:de-mono1-tools-and-json-parser`.
- Exact head: `554cef505b208e920d0b8e0a6a92878ed2d11a1f`.
- All 45 pairwise combinations and full forward/reverse ten-branch merges are clean.
- Draft upstream PR.

## Source-file budget

`openaiShim.ts`: **+59 / -326 = 385 changed lines**, below the 1,500-line cap; tests excluded.

## Test migration

- Monolithic test: **+693 / -153**; all three owned top-level test bodies are removed.
- Focused files: `toolConversion.test.ts` (**97 lines / 4 tests**) and `rawToolCallParsing.test.ts` (**78 lines / 7 tests**).
- Focused tool/parser, retained façade, and affected Ollama text-tool suites: **264 passed / 704 assertions**.
- Combined result: only three façade-contract tests remain in the monolithic test.

## Validation

- Diff check, typecheck, type-test check, and build passed.
- Exact-head host `bun run check`: **7,194 passed / 2 skipped**; only 10 pre-existing PowerShell governance failures remain on Linux.

Prepared according to `CONTRIBUTING.md` and `AGENTS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved recognition of tool calls embedded in free-form model text, including streamed content, “tool calls requested” sections, fenced JSON, and bare balanced-JSON fallbacks (with JSON repair for truncated objects).

- **Bug Fixes**
  - Enhanced OpenAI-compatible tool schema conversion with correct strict-schema behavior, proper `required` handling (no accidental optional promotion), and Gemini-mode adjustments, including better support for special tool definitions.

- **Tests**
  - Added Bun coverage for raw tool-call parsing, JSON repair/extraction, and tool/schema conversion edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->