### PR TITLE
refactor(openai-shim): extract XML and response conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "install:verify": "bun run scripts/verify-clean-install.ts",
     "install:verify:published": "bun run scripts/verify-clean-install.ts --published",
     "build:verified": "bun run build && bun run verify:privacy",
-    "test:provider": "bun test --feature=UNATTENDED_RETRY --max-concurrency=1 src/services/api/*.test.ts src/utils/context.test.ts",
+    "test:provider": "bun test --feature=UNATTENDED_RETRY --max-concurrency=1 src/services/api/*.test.ts src/services/api/openaiShim/*.test.ts src/utils/context.test.ts",
     "doctor:runtime": "bun run scripts/system-check.ts",
     "doctor:runtime:json": "bun run scripts/system-check.ts --json",
     "doctor:report": "bun run scripts/system-check.ts --out reports/doctor-runtime.json",

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -6631,22 +6631,155 @@ test('raw-text and XML fallback tool calls use one unique sequence', () => {
   const xml = parseXmlToolCalls('<tool_call>{"name":"from_xml","arguments":{}}</tool_call>')
   expect(text.calls[0]?.id).toMatch(/^ollama_tc_\d+$/)
   expect(xml.calls[0]?.id).toMatch(/^xml_tc_\d+$/)
-  expect(text.calls[0]?.id?.replace(/^\D+/, '')).not.toBe(xml.calls[0]?.id?.replace(/^\D+/, ''))
+  const textNum = Number(text.calls[0]?.id?.replace(/^\D+/, ''))
+  const xmlNum = Number(xml.calls[0]?.id?.replace(/^\D+/, ''))
+  // Same session counter: the second mint must be exactly one greater than the first.
+  expect(xmlNum).toBe(textNum + 1)
 })
 
 // ---------------------------------------------------------------------------
 // openaiShim test extraction seam 113 start: non-streaming: reasoning_content emitted as thinking block only when content is null
+test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {
+  globalThis.fetch = (async (_input, _init) => {
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'glm-5',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: null,
+              reasoning_content: 'Let me think about this step by step.',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const result = (await client.beta.messages.create({
+    model: 'glm-5',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })) as { content: Array<Record<string, unknown>> }
+
+  expect(result.content).toEqual([
+    { type: 'thinking', thinking: 'Let me think about this step by step.' },
+  ])
+})
 // openaiShim test extraction seam 113 end
 
 
 // openaiShim test extraction seam 114 start: non-streaming: empty string content does not fall through to reasoning_content as text
+test('non-streaming: empty string content does not fall through to reasoning_content as text', async () => {
+  globalThis.fetch = (async (_input, _init) => {
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'glm-5',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: '',
+              reasoning_content: 'Chain of thought here.',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const result = (await client.beta.messages.create({
+    model: 'glm-5',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })) as { content: Array<Record<string, unknown>> }
+
+  expect(result.content).toEqual([
+    { type: 'thinking', thinking: 'Chain of thought here.' },
+  ])
+})
 // openaiShim test extraction seam 114 end
 
 
 // openaiShim test extraction seam 115 start: non-streaming: real content takes precedence over reasoning_content
+test('non-streaming: real content takes precedence over reasoning_content', async () => {
+  globalThis.fetch = (async (_input, _init) => {
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'glm-5',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'The answer is 42.',
+              reasoning_content: 'I need to calculate this.',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const result = (await client.beta.messages.create({
+    model: 'glm-5',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'hello' }],
+    max_tokens: 64,
+    stream: false,
+  })) as { content: Array<Record<string, unknown>> }
+
+  expect(result.content).toEqual([
+    { type: 'thinking', thinking: 'I need to calculate this.' },
+    { type: 'text', text: 'The answer is 42.' },
+  ])
+})
 // openaiShim test extraction seam 115 end
 
 
@@ -6773,7 +6906,45 @@ test('non-streaming: preserves response.url routing metadata after body read', a
 
 
 // openaiShim test extraction seam 118 start: non-streaming: strips <think> tag block from assistant content
+test('non-streaming: strips <think> tag block from assistant content', async () => {
+  globalThis.fetch = asMockFetch(mock(async () => {
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-1',
+        model: 'gpt-5-mini',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content:
+                '<think>user wants a greeting, respond briefly</think>Hey! How can I help you today?',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 10,
+          completion_tokens: 20,
+          total_tokens: 30,
+        },
+      }),
+      { headers: { 'Content-Type': 'application/json' } },
+    )
+  }))
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const result = (await client.beta.messages.create({
+    model: 'gpt-5-mini',
+    system: 'test system',
+    messages: [{ role: 'user', content: 'hey' }],
+    max_tokens: 64,
+    stream: false,
+  })) as { content: Array<Record<string, unknown>> }
+
+  expect(result.content).toEqual([
+    { type: 'text', text: 'Hey! How can I help you today?' },
+  ])
+})
 // openaiShim test extraction seam 118 end
 
 
@@ -11572,7 +11743,48 @@ test('JSON fallback façade terminates converted messages', async () => {
 
 
 // openaiShim test extraction seam 201 start: JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks
-
+test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks', async () => {
+  const events = await collectFallbackEvents({
+    id: 'chatcmpl-json-hy3',
+    model: 'tencent/hy3',
+    choices: [
+      {
+        message: {
+          role: 'assistant',
+          content:
+            '<tool_call:call_hy3>TaskCreate\n subject: Verify HY3\n description: Run the live test\n</tool_call:call_hy3>',
+        },
+        finish_reason: 'stop',
+      },
+    ],
+  }, 'tencent/hy3')
+  const toolStart = events.find(
+    event =>
+      event.type === 'content_block_start' &&
+      typeof event.content_block === 'object' &&
+      event.content_block !== null &&
+      (event.content_block as Record<string, unknown>).type === 'tool_use',
+  ) as { content_block?: Record<string, unknown> } | undefined
+  expect(toolStart?.content_block).toMatchObject({
+    type: 'tool_use',
+    name: 'TaskCreate',
+  })
+  const jsonDelta = events.find(
+    event =>
+      event.type === 'content_block_delta' &&
+      typeof event.delta === 'object' &&
+      event.delta !== null &&
+      (event.delta as Record<string, unknown>).type === 'input_json_delta',
+  ) as { delta?: { partial_json?: string } } | undefined
+  expect(JSON.parse(jsonDelta?.delta?.partial_json ?? '')).toEqual({
+    subject: 'Verify HY3',
+    description: 'Run the live test',
+  })
+  const stopEvent = events.find(e => e.type === 'message_delta') as
+    | { delta?: { stop_reason?: string } }
+    | undefined
+  expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
+})
 // openaiShim test extraction seam 201 end
 
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -14,7 +14,12 @@ import {
   extractOpenAICategoryMarker,
   isOpenAIRequestNonReplayable,
 } from './openaiErrorClassification.ts'
-import { createOpenAIShimClient, hasMistralApiHost } from './openaiShim.ts'
+import {
+  createOpenAIShimClient,
+  hasMistralApiHost,
+  parseTextToolCalls,
+  parseXmlToolCalls,
+} from './openaiShim.ts'
 import * as realCodexShim from './codexShim.js'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 
@@ -5270,7 +5275,62 @@ test('converts Gemini raw tool-call text into streaming tool_use blocks', async 
 // Extraction seam: streaming conversion | non-streaming response conversion.
 
 // openaiShim test extraction seam 092 start: converts Gemini raw tool-call text into non-streaming tool_use blocks
+test('converts Gemini raw tool-call text into non-streaming tool_use blocks', async () => {
+  globalThis.fetch = (async (_input, _init) => {
+    return new Response(
+      JSON.stringify({
+        id: 'chatcmpl-raw-tool',
+        model: 'google/gemini-3.1-flash-lite',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content:
+                'Tool calls requested:\n- Agent({"description":"Verify the todo list application functionality.","prompt":"Check files.","subagent_type":"verification"}) [id: call9a8b7c6d5e4f3a2b1c0d9e8f]',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: {
+          prompt_tokens: 12,
+          completion_tokens: 4,
+          total_tokens: 16,
+        },
+      }),
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      },
+    )
+  }) as unknown as FetchType
 
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  const message = await client.beta.messages.create({
+    model: 'google/gemini-3.1-flash-lite',
+    messages: [{ role: 'user', content: 'Verify' }],
+    max_tokens: 64,
+    stream: false,
+  }) as {
+    stop_reason?: string
+    content?: Array<Record<string, unknown>>
+  }
+
+  expect(message.stop_reason).toBe('tool_use')
+  expect(message.content).toEqual([
+    {
+      type: 'tool_use',
+      id: 'call9a8b7c6d5e4f3a2b1c0d9e8f',
+      name: 'Agent',
+      input: {
+        description: 'Verify the todo list application functionality.',
+        prompt: 'Check files.',
+        subagent_type: 'verification',
+      },
+    },
+  ])
+})
 // openaiShim test extraction seam 092 end
 
 
@@ -6566,6 +6626,13 @@ test('the OpenAI shim façade creates independent client instances', () => {
 })
 // openaiShim test extraction seam 112 end
 
+test('raw-text and XML fallback tool calls use one unique sequence', () => {
+  const text = parseTextToolCalls('{"name":"from_text","arguments":{}}')
+  const xml = parseXmlToolCalls('<tool_call>{"name":"from_xml","arguments":{}}</tool_call>')
+  expect(text.calls[0]?.id).toMatch(/^ollama_tc_\d+$/)
+  expect(xml.calls[0]?.id).toMatch(/^xml_tc_\d+$/)
+  expect(text.calls[0]?.id?.replace(/^\D+/, '')).not.toBe(xml.calls[0]?.id?.replace(/^\D+/, ''))
+})
 
 // ---------------------------------------------------------------------------
 // openaiShim test extraction seam 113 start: non-streaming: reasoning_content emitted as thinking block only when content is null

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5270,62 +5270,7 @@ test('converts Gemini raw tool-call text into streaming tool_use blocks', async 
 // Extraction seam: streaming conversion | non-streaming response conversion.
 
 // openaiShim test extraction seam 092 start: converts Gemini raw tool-call text into non-streaming tool_use blocks
-test('converts Gemini raw tool-call text into non-streaming tool_use blocks', async () => {
-  globalThis.fetch = (async (_input, _init) => {
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-raw-tool',
-        model: 'google/gemini-3.1-flash-lite',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content:
-                'Tool calls requested:\n- Agent({"description":"Verify the todo list application functionality.","prompt":"Check files.","subagent_type":"verification"}) [id: call9a8b7c6d5e4f3a2b1c0d9e8f]',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 12,
-          completion_tokens: 4,
-          total_tokens: 16,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  const message = await client.beta.messages.create({
-    model: 'google/gemini-3.1-flash-lite',
-    messages: [{ role: 'user', content: 'Verify' }],
-    max_tokens: 64,
-    stream: false,
-  }) as {
-    stop_reason?: string
-    content?: Array<Record<string, unknown>>
-  }
-
-  expect(message.stop_reason).toBe('tool_use')
-  expect(message.content).toEqual([
-    {
-      type: 'tool_use',
-      id: 'call9a8b7c6d5e4f3a2b1c0d9e8f',
-      name: 'Agent',
-      input: {
-        description: 'Verify the todo list application functionality.',
-        prompt: 'Check files.',
-        subagent_type: 'verification',
-      },
-    },
-  ])
-})
 // openaiShim test extraction seam 092 end
 
 
@@ -6631,147 +6576,17 @@ test('raw-text and XML fallback tool calls use one unique sequence', () => {
 
 // ---------------------------------------------------------------------------
 // openaiShim test extraction seam 113 start: non-streaming: reasoning_content emitted as thinking block only when content is null
-test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {
-  globalThis.fetch = (async (_input, _init) => {
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'glm-5',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: null,
-              reasoning_content: 'Let me think about this step by step.',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 10,
-          completion_tokens: 20,
-          total_tokens: 30,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  const result = (await client.beta.messages.create({
-    model: 'glm-5',
-    system: 'test system',
-    messages: [{ role: 'user', content: 'hello' }],
-    max_tokens: 64,
-    stream: false,
-  })) as { content: Array<Record<string, unknown>> }
-
-  expect(result.content).toEqual([
-    { type: 'thinking', thinking: 'Let me think about this step by step.' },
-  ])
-})
 // openaiShim test extraction seam 113 end
 
 
 // openaiShim test extraction seam 114 start: non-streaming: empty string content does not fall through to reasoning_content as text
-test('non-streaming: empty string content does not fall through to reasoning_content as text', async () => {
-  globalThis.fetch = (async (_input, _init) => {
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'glm-5',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: '',
-              reasoning_content: 'Chain of thought here.',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 10,
-          completion_tokens: 20,
-          total_tokens: 30,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  const result = (await client.beta.messages.create({
-    model: 'glm-5',
-    system: 'test system',
-    messages: [{ role: 'user', content: 'hello' }],
-    max_tokens: 64,
-    stream: false,
-  })) as { content: Array<Record<string, unknown>> }
-
-  expect(result.content).toEqual([
-    { type: 'thinking', thinking: 'Chain of thought here.' },
-  ])
-})
 // openaiShim test extraction seam 114 end
 
 
 // openaiShim test extraction seam 115 start: non-streaming: real content takes precedence over reasoning_content
-test('non-streaming: real content takes precedence over reasoning_content', async () => {
-  globalThis.fetch = (async (_input, _init) => {
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'glm-5',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content: 'The answer is 42.',
-              reasoning_content: 'I need to calculate this.',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 10,
-          completion_tokens: 20,
-          total_tokens: 30,
-        },
-      }),
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      },
-    )
-  }) as unknown as FetchType
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  const result = (await client.beta.messages.create({
-    model: 'glm-5',
-    system: 'test system',
-    messages: [{ role: 'user', content: 'hello' }],
-    max_tokens: 64,
-    stream: false,
-  })) as { content: Array<Record<string, unknown>> }
-
-  expect(result.content).toEqual([
-    { type: 'thinking', thinking: 'I need to calculate this.' },
-    { type: 'text', text: 'The answer is 42.' },
-  ])
-})
 // openaiShim test extraction seam 115 end
 
 
@@ -6898,45 +6713,7 @@ test('non-streaming: preserves response.url routing metadata after body read', a
 
 
 // openaiShim test extraction seam 118 start: non-streaming: strips <think> tag block from assistant content
-test('non-streaming: strips <think> tag block from assistant content', async () => {
-  globalThis.fetch = asMockFetch(mock(async () => {
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-1',
-        model: 'gpt-5-mini',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content:
-                '<think>user wants a greeting, respond briefly</think>Hey! How can I help you today?',
-            },
-            finish_reason: 'stop',
-          },
-        ],
-        usage: {
-          prompt_tokens: 10,
-          completion_tokens: 20,
-          total_tokens: 30,
-        },
-      }),
-      { headers: { 'Content-Type': 'application/json' } },
-    )
-  }))
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-  const result = (await client.beta.messages.create({
-    model: 'gpt-5-mini',
-    system: 'test system',
-    messages: [{ role: 'user', content: 'hey' }],
-    max_tokens: 64,
-    stream: false,
-  })) as { content: Array<Record<string, unknown>> }
-
-  expect(result.content).toEqual([
-    { type: 'text', text: 'Hey! How can I help you today?' },
-  ])
-})
 // openaiShim test extraction seam 118 end
 
 
@@ -11735,48 +11512,7 @@ test('JSON fallback façade terminates converted messages', async () => {
 
 
 // openaiShim test extraction seam 201 start: JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks
-test('JSON fallback: recovers Tencent HY3 text tool calls into tool_use blocks', async () => {
-  const events = await collectFallbackEvents({
-    id: 'chatcmpl-json-hy3',
-    model: 'tencent/hy3',
-    choices: [
-      {
-        message: {
-          role: 'assistant',
-          content:
-            '<tool_call:call_hy3>TaskCreate\n subject: Verify HY3\n description: Run the live test\n</tool_call:call_hy3>',
-        },
-        finish_reason: 'stop',
-      },
-    ],
-  }, 'tencent/hy3')
-  const toolStart = events.find(
-    event =>
-      event.type === 'content_block_start' &&
-      typeof event.content_block === 'object' &&
-      event.content_block !== null &&
-      (event.content_block as Record<string, unknown>).type === 'tool_use',
-  ) as { content_block?: Record<string, unknown> } | undefined
-  expect(toolStart?.content_block).toMatchObject({
-    type: 'tool_use',
-    name: 'TaskCreate',
-  })
-  const jsonDelta = events.find(
-    event =>
-      event.type === 'content_block_delta' &&
-      typeof event.delta === 'object' &&
-      event.delta !== null &&
-      (event.delta as Record<string, unknown>).type === 'input_json_delta',
-  ) as { delta?: { partial_json?: string } } | undefined
-  expect(JSON.parse(jsonDelta?.delta?.partial_json ?? '')).toEqual({
-    subject: 'Verify HY3',
-    description: 'Run the live test',
-  })
-  const stopEvent = events.find(e => e.type === 'message_delta') as
-    | { delta?: { stop_reason?: string } }
-    | undefined
-  expect(stopEvent?.delta?.stop_reason).toBe('tool_use')
-})
+
 // openaiShim test extraction seam 201 end
 
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -14,7 +14,7 @@ import {
   extractOpenAICategoryMarker,
   isOpenAIRequestNonReplayable,
 } from './openaiErrorClassification.ts'
-import { createOpenAIShimClient, hasMistralApiHost, parseTextToolCalls, parseXmlToolCalls } from './openaiShim.ts'
+import { createOpenAIShimClient, hasMistralApiHost } from './openaiShim.ts'
 import * as realCodexShim from './codexShim.js'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 
@@ -6566,13 +6566,6 @@ test('the OpenAI shim façade creates independent client instances', () => {
 })
 // openaiShim test extraction seam 112 end
 
-test('raw-text and XML fallback tool calls use one unique sequence', () => {
-  const text = parseTextToolCalls('{"name":"from_text","arguments":{}}')
-  const xml = parseXmlToolCalls('<tool_call>{"name":"from_xml","arguments":{}}</tool_call>')
-  expect(text.calls[0]?.id).toMatch(/^ollama_tc_\d+$/)
-  expect(xml.calls[0]?.id).toMatch(/^xml_tc_\d+$/)
-  expect(text.calls[0]?.id?.replace(/^\D+/, '')).not.toBe(xml.calls[0]?.id?.replace(/^\D+/, ''))
-})
 
 // ---------------------------------------------------------------------------
 // openaiShim test extraction seam 113 start: non-streaming: reasoning_content emitted as thinking block only when content is null

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5276,60 +5276,65 @@ test('converts Gemini raw tool-call text into streaming tool_use blocks', async 
 
 // openaiShim test extraction seam 092 start: converts Gemini raw tool-call text into non-streaming tool_use blocks
 test('converts Gemini raw tool-call text into non-streaming tool_use blocks', async () => {
-  globalThis.fetch = (async (_input, _init) => {
-    return new Response(
-      JSON.stringify({
-        id: 'chatcmpl-raw-tool',
-        model: 'google/gemini-3.1-flash-lite',
-        choices: [
-          {
-            message: {
-              role: 'assistant',
-              content:
-                'Tool calls requested:\n- Agent({"description":"Verify the todo list application functionality.","prompt":"Check files.","subagent_type":"verification"}) [id: call9a8b7c6d5e4f3a2b1c0d9e8f]',
+  const previousFetch = globalThis.fetch
+  try {
+    globalThis.fetch = (async (_input, _init) => {
+      return new Response(
+        JSON.stringify({
+          id: 'chatcmpl-raw-tool',
+          model: 'google/gemini-3.1-flash-lite',
+          choices: [
+            {
+              message: {
+                role: 'assistant',
+                content:
+                  'Tool calls requested:\n- Agent({"description":"Verify the todo list application functionality.","prompt":"Check files.","subagent_type":"verification"}) [id: call9a8b7c6d5e4f3a2b1c0d9e8f]',
+              },
+              finish_reason: 'stop',
             },
-            finish_reason: 'stop',
+          ],
+          usage: {
+            prompt_tokens: 12,
+            completion_tokens: 4,
+            total_tokens: 16,
           },
-        ],
-        usage: {
-          prompt_tokens: 12,
-          completion_tokens: 4,
-          total_tokens: 16,
+        }),
+        {
+          headers: {
+            'Content-Type': 'application/json',
+          },
         },
-      }),
+      )
+    }) as unknown as FetchType
+
+    const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+    const message = await client.beta.messages.create({
+      model: 'google/gemini-3.1-flash-lite',
+      messages: [{ role: 'user', content: 'Verify' }],
+      max_tokens: 64,
+      stream: false,
+    }) as {
+      stop_reason?: string
+      content?: Array<Record<string, unknown>>
+    }
+
+    expect(message.stop_reason).toBe('tool_use')
+    expect(message.content).toEqual([
       {
-        headers: {
-          'Content-Type': 'application/json',
+        type: 'tool_use',
+        id: 'call9a8b7c6d5e4f3a2b1c0d9e8f',
+        name: 'Agent',
+        input: {
+          description: 'Verify the todo list application functionality.',
+          prompt: 'Check files.',
+          subagent_type: 'verification',
         },
       },
-    )
-  }) as unknown as FetchType
-
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
-
-  const message = await client.beta.messages.create({
-    model: 'google/gemini-3.1-flash-lite',
-    messages: [{ role: 'user', content: 'Verify' }],
-    max_tokens: 64,
-    stream: false,
-  }) as {
-    stop_reason?: string
-    content?: Array<Record<string, unknown>>
+    ])
+  } finally {
+    globalThis.fetch = previousFetch
   }
-
-  expect(message.stop_reason).toBe('tool_use')
-  expect(message.content).toEqual([
-    {
-      type: 'tool_use',
-      id: 'call9a8b7c6d5e4f3a2b1c0d9e8f',
-      name: 'Agent',
-      input: {
-        description: 'Verify the todo list application functionality.',
-        prompt: 'Check files.',
-        subagent_type: 'verification',
-      },
-    },
-  ])
 })
 // openaiShim test extraction seam 092 end
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -132,6 +132,16 @@ import {
 } from '../../utils/streamingOptimizer.js'
 import { stableStringifyJson } from '../../utils/stableStringify.js'
 import {
+  findXmlToolCallOpener as findXmlToolCallOpenerModule,
+  isHy3Model as isHy3ModelModule,
+  parseXmlToolCalls as parseXmlToolCallsModule,
+  trailingXmlOpenerPrefixLen as trailingXmlOpenerPrefixLenModule,
+} from './openaiShim/xmlToolCallParsing.js'
+import {
+  convertNonStreamingResponseToAnthropicMessage as convertResponseToAnthropicMessage,
+  type NonStreamingOpenAIResponse,
+} from './openaiShim/responseConversion.js'
+import {
   CredentialPool,
   type CredentialLease,
   hasInvalidCredentialPlaceholder,
@@ -869,244 +879,27 @@ function nextTextToolCallSequence(): number {
 }
 
 // ---------------------------------------------------------------------------
-// XML tool call parser (GLM / Qwen / DeepSeek family)
-//
-// Several models routed through OpenAI-compatible gateways emit tool calls as
-// XML text inside the assistant message rather than as structured `tool_calls`.
-// Without recovery these leak into visible prose and never execute — the turn
-// then ends with no tool_use block, so the agent appears to "forget" and stop
-// mid-task. We support the four dialects seen in the wild:
-//   A. <tool_call><function=NAME><parameter=KEY>VALUE</parameter>…</function></tool_call>
-//   B. <tool_call>NAME<arg_key>KEY</arg_key><arg_value>VALUE</arg_value>…</tool_call>  (GLM native)
-//   C. <tool_call>{"name":"NAME","arguments":{…}}</tool_call>                          (Hermes JSON)
-//   D. <tool_calls:ID><tool_call:ID>NAME<parameter name="KEY">VALUE</parameter>…           (Tencent HY3)
+// XML tool parsing façade. Dialect handling lives in xmlToolCallParsing.ts.
 // ---------------------------------------------------------------------------
 
-// The streaming finalize path buffers from this opener onward so the raw XML
-// is never surfaced as text before extraction.
-const XML_TOOL_CALL_OPEN = '<tool_call>'
-const HY3_TOOL_CALLS_OPEN = '<tool_calls:'
-const HY3_TOOL_CALL_OPEN = '<tool_call:'
-const XML_TOOL_CALL_OPENERS = [
-  XML_TOOL_CALL_OPEN,
-  HY3_TOOL_CALLS_OPEN,
-  HY3_TOOL_CALL_OPEN,
-]
-// Non-greedy block matcher; the `$` alternative tolerates a truncated final
-// block (stream cut off before the closing tag).
-const XML_TOOL_CALL_BLOCK_RE = /<tool_call>([\s\S]*?)(?:<\/tool_call>|$)/g
-const HY3_TOOL_CALLS_BLOCK_RE = /<tool_calls:[^>\s]+>([\s\S]*?)(?:<\/tool_calls(?::[^>\s]+)?>|$)/g
-const HY3_TOOL_CALL_BLOCK_RE = /<tool_call:[^>\s]+>([\s\S]*?)(?:<\/tool_call(?::[^>\s]+)?>|$)/g
-const XML_FUNCTION_NAME_RE = /<function=([^>\s]+)\s*>/
-const XML_PARAMETER_RE = /<parameter=([^>\s]+)\s*>([\s\S]*?)<\/parameter>/g
-const XML_ARG_PAIR_RE = /<arg_key>([\s\S]*?)<\/arg_key>\s*<arg_value>([\s\S]*?)<\/arg_value>/g
-const HY3_PARAMETER_RE = /<parameter\s+name=["']([^"'>\s]+)["']\s*>([\s\S]*?)<\/parameter>/g
-const HY3_NAMED_ARGUMENT_LINE_RE = /^\s*([A-Za-z_][\w-]*)\s*:\s*(.+?)\s*$/gm
-const HY3_ARG_PAIR_RE = /<arg_key(?::[^>\s]+)?>([\s\S]*?)<\/arg_key(?::[^>\s]+)?>\s*<arg_value(?::[^>\s]+)?>([\s\S]*?)<\/arg_value(?::[^>\s]+)?>/g
-
-// Parameter/arg values arrive as untyped text. Try JSON first so numbers,
-// booleans, and nested objects round-trip; fall back to the raw string.
-function coerceXmlToolValue(raw: string): unknown {
-  const trimmed = raw.trim()
-  if (trimmed === '') return ''
-  try {
-    return JSON.parse(trimmed)
-  } catch {
-    return raw
-  }
-}
-
-function parseHy3ToolCallInner(inner: string): {
-  name?: string
-  args: Record<string, unknown>
-} {
-  const args: Record<string, unknown> = {}
-  const trimmed = inner.trim()
-  const name = trimmed
-    .split(/[\n<]/, 1)[0]
-    ?.trim()
-    .replace(/[\s`*_]+$/, '')
-  let hasStructuredArguments = false
-
-  for (const parameter of inner.matchAll(HY3_PARAMETER_RE)) {
-    const key = parameter[1]
-    if (key) {
-      hasStructuredArguments = true
-      args[key] = coerceXmlToolValue(parameter[2] ?? '')
-    }
-  }
-  for (const line of inner.matchAll(HY3_NAMED_ARGUMENT_LINE_RE)) {
-    const key = line[1]
-    if (key) {
-      hasStructuredArguments = true
-      args[key] = coerceXmlToolValue(line[2] ?? '')
-    }
-  }
-  for (const pair of inner.matchAll(HY3_ARG_PAIR_RE)) {
-    const key = pair[1]?.trim()
-    if (key) {
-      hasStructuredArguments = true
-      args[key] = coerceXmlToolValue(pair[2] ?? '')
-    }
-  }
-
-  // The provider's textual wrapper is not self-authenticating. Requiring a
-  // normal tool identifier avoids executing or hiding documentation snippets
-  // that merely demonstrate `<tool_call:...>`, while still allowing every
-  // valid zero-input tool instead of maintaining a stale name allowlist.
-  return {
-    name: name && /^[A-Za-z_][\w.-]*$/.test(name) &&
-      (hasStructuredArguments || trimmed === name)
-      ? name
-      : undefined,
-    args,
-  }
+function findXmlToolCallOpener(text: string, allowHy3: boolean): number {
+  return findXmlToolCallOpenerModule(text, allowHy3)
 }
 
 function isHy3Model(model: string): boolean {
-  return model.split('?', 1)[0]?.toLowerCase() === 'tencent/hy3'
+  return isHy3ModelModule(model)
 }
 
-/**
- * Returns the length of the longest suffix of `s` that is a (proper) prefix of
- * the `<tool_call>` opener. Used by the stream to hold back a trailing partial
- * opener split across SSE deltas so it is never emitted as visible text.
- */
-function trailingXmlOpenerPrefixLen(s: string, allowHy3: boolean): number {
-  let longest = 0
-  const openers = allowHy3 ? XML_TOOL_CALL_OPENERS : [XML_TOOL_CALL_OPEN]
-  for (const opener of openers) {
-    const max = Math.min(s.length, opener.length - 1)
-    for (let len = max; len > 0; len--) {
-      if (opener.startsWith(s.slice(s.length - len))) {
-        longest = Math.max(longest, len)
-        break
-      }
-    }
-  }
-  return longest
+function parseXmlToolCalls(text: string, allowHy3 = false) {
+  return parseXmlToolCallsModule(text, allowHy3)
 }
 
-function findXmlToolCallOpener(text: string, allowHy3: boolean): number {
-  const openers = allowHy3 ? XML_TOOL_CALL_OPENERS : [XML_TOOL_CALL_OPEN]
-  return openers.reduce((first, opener) => {
-    const index = text.indexOf(opener)
-    return index === -1 ? first : first === -1 ? index : Math.min(first, index)
-  }, -1)
+function trailingXmlOpenerPrefixLen(text: string, allowHy3: boolean): number {
+  return trailingXmlOpenerPrefixLenModule(text, allowHy3)
 }
 
-/** Exported for unit testing only. */
-export function parseXmlToolCalls(text: string, allowHy3 = false): {
-  calls: ParsedTextToolCall[]
-  toolCallRanges: Array<[number, number]>
-} {
-  const results: ParsedTextToolCall[] = []
-  const seen = new Set<string>()
-  const ranges: Array<[number, number]> = []
-
-  const addCall = (name: string, args: Record<string, unknown>) => {
-    const dedupKey = `${name}:${JSON.stringify(args)}`
-    if (seen.has(dedupKey)) return
-    seen.add(dedupKey)
-    results.push({ id: `xml_tc_${nextTextToolCallSequence()}`, name, arguments: args })
-  }
-
-  const hy3Blocks = allowHy3
-    ? [...text.matchAll(HY3_TOOL_CALL_BLOCK_RE)].map(block => ({
-      range: [block.index!, block.index! + block[0].length] as [number, number],
-      parsed: parseHy3ToolCallInner(block[1] ?? ''),
-    }))
-    : []
-  const hy3WrapperRanges = allowHy3
-    ? [...text.matchAll(HY3_TOOL_CALLS_BLOCK_RE)]
-      .filter(wrapper => {
-        const range: [number, number] = [
-          wrapper.index!,
-          wrapper.index! + wrapper[0].length,
-        ]
-        return hy3Blocks.some(
-          block => block.parsed.name && range[0] <= block.range[0] && block.range[1] <= range[1],
-        )
-      })
-      .map(wrapper => [
-        wrapper.index!,
-        wrapper.index! + wrapper[0].length,
-      ] as [number, number])
-    : []
-
-  for (const block of hy3Blocks) {
-    const { name, args } = block.parsed
-    if (!name) continue
-    const range = block.range
-    if (!hy3WrapperRanges.some(wrapper => wrapper[0] <= range[0] && range[1] <= wrapper[1])) {
-      ranges.push(range)
-    }
-    addCall(name, args)
-  }
-
-  ranges.push(...hy3WrapperRanges)
-
-  for (const block of text.matchAll(XML_TOOL_CALL_BLOCK_RE)) {
-    const inner = block[1] ?? ''
-    const range: [number, number] = [
-      block.index!,
-      block.index! + block[0].length,
-    ]
-    let name: string | undefined
-    const args: Record<string, unknown> = {}
-
-    const fnMatch = inner.match(XML_FUNCTION_NAME_RE)
-    if (fnMatch) {
-      // Dialect A: <function=NAME><parameter=KEY>VALUE</parameter>…
-      name = fnMatch[1]
-      for (const p of inner.matchAll(XML_PARAMETER_RE)) {
-        const key = p[1]
-        if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
-      }
-    } else {
-      const trimmedInner = inner.trim()
-      const argPairs = [...inner.matchAll(XML_ARG_PAIR_RE)]
-      if (argPairs.length > 0 && !trimmedInner.startsWith('{')) {
-        // Dialect B: leading token is the function name, then arg_key/arg_value.
-        const nameTok = trimmedInner.split(/[\n<]/, 1)[0]?.trim()
-        if (nameTok) name = nameTok
-        for (const p of argPairs) {
-          const key = (p[1] ?? '').trim()
-          if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
-        }
-      } else {
-        // Dialect C: a JSON tool-call object inside the tags.
-        const jsonStart = trimmedInner.indexOf('{')
-        if (jsonStart !== -1) {
-          const jsonRaw = extractBalancedJson(trimmedInner, jsonStart)
-          if (jsonRaw) {
-            try {
-              const obj = JSON.parse(jsonRaw) as Record<string, unknown>
-              if (typeof obj['name'] === 'string') {
-                name = obj['name'] as string
-                const rawArgs = obj['arguments']
-                if (typeof rawArgs === 'string') {
-                  try {
-                    Object.assign(args, JSON.parse(rawArgs))
-                  } catch {}
-                } else if (rawArgs && typeof rawArgs === 'object') {
-                  Object.assign(args, rawArgs as Record<string, unknown>)
-                }
-              }
-            } catch {}
-          }
-        }
-      }
-    }
-
-    if (!name) continue
-    ranges.push(range)
-    addCall(name, args)
-  }
-
-  return { calls: results, toolCallRanges: ranges }
-}
-
+// The streaming finalize path buffers from this opener onward so the raw XML
+// is never surfaced as text before extraction.
 /**
  * Async generator that transforms an OpenAI SSE stream into
  * Anthropic-format BetaRawMessageStreamEvent objects.
@@ -1338,171 +1131,22 @@ async function* geminiSseToAnthropic(
 
 // Extraction seam: Gemini streaming | completed response conversion.
 
-type NonStreamingOpenAIResponse = {
-  id?: string
-  model?: string
-  choices?: Array<{
-    message?: {
-      role?: string
-      content?: string | null | Array<{ type?: string; text?: string }>
-      reasoning_content?: string | null
-      extra_content?: Record<string, unknown>
-      tool_calls?: Array<{
-        id: string
-        function: { name: string; arguments: string }
-        extra_content?: Record<string, unknown>
-      }>
-    }
-    finish_reason?: string
-  }>
-  usage?: {
-    prompt_tokens?: number
-    completion_tokens?: number
-    prompt_tokens_details?: {
-      cached_tokens?: number
-    }
-  }
-}
-
-/**
- * Convert an OpenAI-compatible non-streaming chat completion into an
- * Anthropic-shaped message. Shared by the `OpenAIShimMessages` non-stream path
- * and the `application/json` fallback inside `openaiStreamToAnthropic` so both
- * apply the same tool-call extraction, stop-reason mapping, array-content
- * normalization, <think>-tag stripping, and raw text tool-call recovery.
- */
 function convertNonStreamingResponseToAnthropicMessage(
   data: NonStreamingOpenAIResponse,
   model: string,
 ) {
-  const choice = data.choices?.[0]
-  const content: Array<Record<string, unknown>> = []
-  // An empty tool_calls array is still truthy; treat it as "no structured tool
-  // calls" so raw "Tool calls requested" text recovery is not skipped.
-  const hasStructuredToolCalls =
-    (choice?.message?.tool_calls?.length ?? 0) > 0
-
-  // Some reasoning models (e.g. GLM-5) put their chain-of-thought in
-  // reasoning_content while content stays null. Preserve it as a thinking
-  // block, but do not surface it as visible assistant text.
-  const reasoningText = choice?.message?.reasoning_content
-  if (typeof reasoningText === 'string' && reasoningText) {
-    content.push({ type: 'thinking', thinking: reasoningText })
-  }
-  const rawContent =
-    choice?.message?.content !== '' && choice?.message?.content != null
-      ? choice?.message?.content
-      : null
-  const appendTextOrRecoveredToolCalls = (rawText: string) => {
-    const strippedContent = stripThinkTags(rawText)
-    if (!hasStructuredToolCalls) {
-      const { calls: xmlToolCalls, toolCallRanges } = parseXmlToolCalls(
-        strippedContent,
-        isHy3Model(model),
-      )
-      if (xmlToolCalls.length > 0) {
-        const visibleText = stripRanges(strippedContent, toolCallRanges).trim()
-        if (visibleText) content.push({ type: 'text', text: visibleText })
-        for (const toolCall of xmlToolCalls) {
-          content.push({
-            type: 'tool_use',
-            id: toolCall.id,
-            name: toolCall.name,
-            input: toolCall.arguments,
-          })
-        }
-        return
-      }
-    }
-
-    const rawToolCalls = hasStructuredToolCalls
-      ? null
-      : parseRawToolCallsRequestedText(strippedContent)
-    if (rawToolCalls) {
-      for (const toolCall of rawToolCalls) {
-        content.push({
-          type: 'tool_use',
-          id: toolCall.id,
-          name: toolCall.name,
-          input: JSON.parse(toolCall.argumentsJson),
-        })
-      }
-    } else {
-      content.push({ type: 'text', text: strippedContent })
-    }
-  }
-  if (typeof rawContent === 'string' && rawContent) {
-    appendTextOrRecoveredToolCalls(rawContent)
-  } else if (Array.isArray(rawContent) && rawContent.length > 0) {
-    const parts: string[] = []
-    for (const part of rawContent) {
-      if (
-        part &&
-        typeof part === 'object' &&
-        part.type === 'text' &&
-        typeof part.text === 'string'
-      ) {
-        parts.push(part.text)
-      }
-    }
-    const joined = parts.join('\n')
-    if (joined) {
-      appendTextOrRecoveredToolCalls(joined)
-    }
-  }
-
-  if (hasStructuredToolCalls && choice?.message?.tool_calls) {
-    for (const tc of choice.message.tool_calls) {
-      const input = normalizeToolArguments(
-        tc.function.name,
-        tc.function.arguments,
-      )
-      const toolExtraContent = tc.extra_content ?? choice.message.extra_content
-      const toolSignature =
-        geminiThoughtSignatureFromExtraContent(tc.extra_content) ??
-        geminiThoughtSignatureFromExtraContent(choice.message.extra_content)
-      const mergedToolExtraContent = mergeGeminiThoughtSignature(
-        toolExtraContent,
-        toolSignature,
-      )
-      content.push({
-        type: 'tool_use',
-        id: tc.id,
-        name: tc.function.name,
-        input,
-        ...(mergedToolExtraContent ? { extra_content: mergedToolExtraContent } : {}),
-        ...(toolSignature ? { signature: toolSignature } : {}),
-      })
-    }
-  }
-
-  const stopReason =
-    choice?.finish_reason === 'tool_calls' ||
-    content.some(block => block.type === 'tool_use')
-      ? 'tool_use'
-      : choice?.finish_reason === 'length'
-        ? 'max_tokens'
-        : 'end_turn'
-
-  if (choice?.finish_reason === 'content_filter' || choice?.finish_reason === 'safety') {
-    content.push({
-      type: 'text',
-      text: '\n\n[Content blocked by provider safety filter]',
-    })
-  }
-
-  return {
-    id: data.id ?? makeMessageId(),
-    type: 'message',
-    role: 'assistant',
-    content,
-    model: data.model ?? model,
-    stop_reason: stopReason,
-    stop_sequence: null,
-    usage: buildAnthropicUsageFromRawUsage(
-      data.usage as unknown as Record<string, unknown> | undefined,
-    ),
-  }
+  return convertResponseToAnthropicMessage(data, model, {
+    makeMessageId,
+    buildUsage: usage => buildAnthropicUsageFromRawUsage(usage),
+    stripThinkTags,
+    parseXmlToolCalls,
+    isHy3Model,
+    stripRanges,
+    parseRawToolCalls: parseRawToolCallsRequestedText,
+    normalizeToolArguments,
+    getGeminiThoughtSignature: geminiThoughtSignatureFromExtraContent,
+    mergeGeminiThoughtSignature,
+  })
 }
 
 function headersWithRequestUrl(headers: Headers, requestUrl?: string): Headers {

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -890,8 +890,8 @@ function isHy3Model(model: string): boolean {
   return isHy3ModelModule(model)
 }
 
-function parseXmlToolCalls(text: string, allowHy3 = false) {
-  return parseXmlToolCallsModule(text, allowHy3)
+export function parseXmlToolCalls(text: string, allowHy3 = false) {
+  return parseXmlToolCallsModule(text, allowHy3, nextTextToolCallSequence)
 }
 
 function trailingXmlOpenerPrefixLen(text: string, allowHy3: boolean): number {

--- a/src/services/api/openaiShim/responseConversion.test.ts
+++ b/src/services/api/openaiShim/responseConversion.test.ts
@@ -1,0 +1,228 @@
+import { expect, test } from 'bun:test'
+import {
+  isHy3Model,
+  parseXmlToolCalls,
+} from './xmlToolCallParsing.js'
+import {
+  convertNonStreamingResponseToAnthropicMessage,
+  type NonStreamingOpenAIResponse,
+} from './responseConversion.js'
+
+function stripRanges(text: string, ranges: Array<[number, number]>): string {
+  return [...ranges]
+    .sort((left, right) => right[0] - left[0])
+    .reduce((result, [start, end]) => result.slice(0, start) + result.slice(end), text)
+}
+
+const dependencies = {
+  makeMessageId: () => 'msg-test',
+  buildUsage: (usage: Record<string, unknown> | undefined) => ({
+    input_tokens: usage?.prompt_tokens ?? 0,
+    output_tokens: usage?.completion_tokens ?? 0,
+  }),
+  stripThinkTags: (text: string) => text.replace(/<think>[\s\S]*?<\/think>/g, ''),
+  parseXmlToolCalls,
+  isHy3Model,
+  stripRanges,
+  parseRawToolCalls: (text: string) => {
+    const match = text.match(
+      /^Tool calls requested:\s*\n-\s*([A-Za-z_][\w.-]*)\((.*)\)\s*\[id:\s*([^\]\s]+)\]$/s,
+    )
+    return match?.[1] && match[2] !== undefined && match[3]
+      ? [{ id: match[3], name: match[1], argumentsJson: match[2] }]
+      : null
+  },
+  normalizeToolArguments: (_name: string, argumentsJson: string) => JSON.parse(argumentsJson) as unknown,
+  getGeminiThoughtSignature: (extraContent: unknown) => {
+    if (!extraContent || typeof extraContent !== 'object') return undefined
+    const google = (extraContent as { google?: unknown }).google
+    if (!google || typeof google !== 'object') return undefined
+    const signature = (google as { thought_signature?: unknown }).thought_signature
+    return typeof signature === 'string' ? signature : undefined
+  },
+  mergeGeminiThoughtSignature: (
+    extraContent: Record<string, unknown> | undefined,
+    signature: string | undefined,
+  ) => signature
+    ? { ...extraContent, google: { thought_signature: signature } }
+    : extraContent,
+}
+
+function convert(data: NonStreamingOpenAIResponse, model = 'fallback-model') {
+  return convertNonStreamingResponseToAnthropicMessage(data, model, dependencies)
+}
+
+test('recovers a non-streaming Gemini raw tool call without exposing provider text', () => {
+  const message = convert({
+    id: 'chatcmpl-raw-tool',
+    model: 'google/gemini-3.1-flash-lite',
+    choices: [{
+      message: {
+        role: 'assistant',
+        content:
+          'Tool calls requested:\n- Agent({"description":"Verify the todo list application functionality.","prompt":"Check files.","subagent_type":"verification"}) [id: call9a8b7c6d5e4f3a2b1c0d9e8f]',
+      },
+      finish_reason: 'stop',
+    }],
+    usage: { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 },
+  })
+
+  expect(message.content).toEqual([{
+    type: 'tool_use',
+    id: 'call9a8b7c6d5e4f3a2b1c0d9e8f',
+    name: 'Agent',
+    input: {
+      description: 'Verify the todo list application functionality.',
+      prompt: 'Check files.',
+      subagent_type: 'verification',
+    },
+  }])
+  expect(message.stop_reason).toBe('tool_use')
+  expect(message.usage).toEqual({ input_tokens: 12, output_tokens: 4 })
+})
+
+test('emits reasoning_content as thinking when content is null', () => {
+  const message = convert({
+    choices: [{
+      message: {
+        role: 'assistant',
+        content: null,
+        reasoning_content: 'Let me think about this step by step.',
+      },
+      finish_reason: 'stop',
+    }],
+  }, 'glm-5')
+
+  expect(message.content).toEqual([{
+    type: 'thinking',
+    thinking: 'Let me think about this step by step.',
+  }])
+})
+
+test('does not convert empty content into visible reasoning text', () => {
+  const message = convert({
+    choices: [{
+      message: {
+        role: 'assistant',
+        content: '',
+        reasoning_content: 'Chain of thought here.',
+      },
+      finish_reason: 'stop',
+    }],
+  }, 'glm-5')
+
+  expect(message.content).toEqual([{
+    type: 'thinking',
+    thinking: 'Chain of thought here.',
+  }])
+})
+
+test('preserves real content alongside reasoning_content', () => {
+  const message = convert({
+    choices: [{
+      message: {
+        role: 'assistant',
+        content: 'The answer is 42.',
+        reasoning_content: 'I need to calculate this.',
+      },
+      finish_reason: 'stop',
+    }],
+  }, 'glm-5')
+
+  expect(message.content).toEqual([
+    { type: 'thinking', thinking: 'I need to calculate this.' },
+    { type: 'text', text: 'The answer is 42.' },
+  ])
+})
+
+test('strips think tags from non-streaming assistant content', () => {
+  const message = convert({
+    choices: [{
+      message: {
+        role: 'assistant',
+        content: '<think>respond briefly</think>Hey! How can I help you today?',
+      },
+      finish_reason: 'stop',
+    }],
+  }, 'gpt-5-mini')
+
+  expect(message.content).toEqual([{
+    type: 'text',
+    text: 'Hey! How can I help you today?',
+  }])
+})
+
+test('recovers Tencent HY3 XML calls in the JSON fallback conversion', () => {
+  const message = convert({
+    id: 'chatcmpl-json-hy3',
+    model: 'tencent/hy3',
+    choices: [{
+      message: {
+        role: 'assistant',
+        content:
+          '<tool_call:call_hy3>TaskCreate\n subject: Verify HY3\n description: Run the live test\n</tool_call:call_hy3>',
+      },
+      finish_reason: 'stop',
+    }],
+  }, 'tencent/hy3')
+
+  expect(message.content).toEqual([{
+    type: 'tool_use',
+    id: expect.stringMatching(/^xml_tc_\d+$/),
+    name: 'TaskCreate',
+    input: {
+      subject: 'Verify HY3',
+      description: 'Run the live test',
+    },
+  }])
+  expect(message.stop_reason).toBe('tool_use')
+})
+
+test('preserves structured Gemini signatures and safety terminal responses', () => {
+  const message = convert({
+    model: 'gemini',
+    choices: [{
+      finish_reason: 'safety',
+      message: {
+        tool_calls: [{
+          id: 'call-2',
+          function: { name: 'Write', arguments: '{"path":"a.ts"}' },
+          extra_content: { google: { thought_signature: 'sig-2' } },
+        }],
+      },
+    }],
+  })
+
+  expect(message.content).toEqual([
+    {
+      type: 'tool_use',
+      id: 'call-2',
+      name: 'Write',
+      input: { path: 'a.ts' },
+      extra_content: { google: { thought_signature: 'sig-2' } },
+      signature: 'sig-2',
+    },
+    { type: 'text', text: '\n\n[Content blocked by provider safety filter]' },
+  ])
+  expect(message.model).toBe('gemini')
+  expect(message.stop_reason).toBe('tool_use')
+})
+
+test('normalizes array content and length stop reasons', () => {
+  const message = convert({
+    choices: [{
+      message: {
+        content: [
+          { type: 'text', text: 'first' },
+          { type: 'image' },
+          { type: 'text', text: 'second' },
+        ],
+      },
+      finish_reason: 'length',
+    }],
+  })
+
+  expect(message.content).toEqual([{ type: 'text', text: 'first\nsecond' }])
+  expect(message.stop_reason).toBe('max_tokens')
+  expect(message.id).toBe('msg-test')
+})

--- a/src/services/api/openaiShim/responseConversion.test.ts
+++ b/src/services/api/openaiShim/responseConversion.test.ts
@@ -9,15 +9,19 @@ import {
 import {
   parseRawToolCallsRequestedText,
   stripRanges,
+  nextToolCallSequence,
 } from './rawToolCallParsing.js'
 import {
   isHy3Model,
-  parseXmlToolCalls,
+  parseXmlToolCalls as parseXmlToolCallsModule,
 } from './xmlToolCallParsing.js'
 import {
   convertNonStreamingResponseToAnthropicMessage,
   type NonStreamingOpenAIResponse,
 } from './responseConversion.js'
+
+const parseXmlToolCalls = (text: string, allowHy3: boolean) =>
+  parseXmlToolCallsModule(text, allowHy3, nextToolCallSequence)
 
 const dependencies = {
   makeMessageId: () => 'msg-test',

--- a/src/services/api/openaiShim/responseConversion.test.ts
+++ b/src/services/api/openaiShim/responseConversion.test.ts
@@ -1,4 +1,15 @@
 import { expect, test } from 'bun:test'
+import { buildAnthropicUsageFromRawUsage } from '../cacheMetrics.js'
+import { normalizeToolArguments } from '../toolArgumentNormalization.js'
+import { stripThinkTags } from '../thinkTagSanitizer.js'
+import {
+  geminiThoughtSignatureFromExtraContent,
+  mergeGeminiThoughtSignature,
+} from './providerCompatibility.js'
+import {
+  parseRawToolCallsRequestedText,
+  stripRanges,
+} from './rawToolCallParsing.js'
 import {
   isHy3Model,
   parseXmlToolCalls,
@@ -8,44 +19,18 @@ import {
   type NonStreamingOpenAIResponse,
 } from './responseConversion.js'
 
-function stripRanges(text: string, ranges: Array<[number, number]>): string {
-  return [...ranges]
-    .sort((left, right) => right[0] - left[0])
-    .reduce((result, [start, end]) => result.slice(0, start) + result.slice(end), text)
-}
-
 const dependencies = {
   makeMessageId: () => 'msg-test',
-  buildUsage: (usage: Record<string, unknown> | undefined) => ({
-    input_tokens: usage?.prompt_tokens ?? 0,
-    output_tokens: usage?.completion_tokens ?? 0,
-  }),
-  stripThinkTags: (text: string) => text.replace(/<think>[\s\S]*?<\/think>/g, ''),
+  buildUsage: (usage: Record<string, unknown> | undefined) =>
+    buildAnthropicUsageFromRawUsage(usage),
+  stripThinkTags,
   parseXmlToolCalls,
   isHy3Model,
   stripRanges,
-  parseRawToolCalls: (text: string) => {
-    const match = text.match(
-      /^Tool calls requested:\s*\n-\s*([A-Za-z_][\w.-]*)\((.*)\)\s*\[id:\s*([^\]\s]+)\]$/s,
-    )
-    return match?.[1] && match[2] !== undefined && match[3]
-      ? [{ id: match[3], name: match[1], argumentsJson: match[2] }]
-      : null
-  },
-  normalizeToolArguments: (_name: string, argumentsJson: string) => JSON.parse(argumentsJson) as unknown,
-  getGeminiThoughtSignature: (extraContent: unknown) => {
-    if (!extraContent || typeof extraContent !== 'object') return undefined
-    const google = (extraContent as { google?: unknown }).google
-    if (!google || typeof google !== 'object') return undefined
-    const signature = (google as { thought_signature?: unknown }).thought_signature
-    return typeof signature === 'string' ? signature : undefined
-  },
-  mergeGeminiThoughtSignature: (
-    extraContent: Record<string, unknown> | undefined,
-    signature: string | undefined,
-  ) => signature
-    ? { ...extraContent, google: { thought_signature: signature } }
-    : extraContent,
+  parseRawToolCalls: parseRawToolCallsRequestedText,
+  normalizeToolArguments,
+  getGeminiThoughtSignature: geminiThoughtSignatureFromExtraContent,
+  mergeGeminiThoughtSignature,
 }
 
 function convert(data: NonStreamingOpenAIResponse, model = 'fallback-model') {
@@ -78,7 +63,12 @@ test('recovers a non-streaming Gemini raw tool call without exposing provider te
     },
   }])
   expect(message.stop_reason).toBe('tool_use')
-  expect(message.usage).toEqual({ input_tokens: 12, output_tokens: 4 })
+  expect(message.usage).toEqual({
+    input_tokens: 12,
+    output_tokens: 4,
+    cache_creation_input_tokens: 0,
+    cache_read_input_tokens: 0,
+  })
 })
 
 test('emits reasoning_content as thinking when content is null', () => {

--- a/src/services/api/openaiShim/responseConversion.test.ts
+++ b/src/services/api/openaiShim/responseConversion.test.ts
@@ -203,12 +203,17 @@ test('preserves structured Gemini signatures and safety terminal responses', () 
 })
 
 test('normalizes array content and length stop reasons', () => {
+  const functionPart = Object.assign(() => {}, {
+    type: 'text' as const,
+    text: 'ignored-fn',
+  })
   const message = convert({
     choices: [{
       message: {
         content: [
           { type: 'text', text: 'first' },
           { type: 'image' },
+          functionPart,
           { type: 'text', text: 'second' },
         ],
       },

--- a/src/services/api/openaiShim/responseConversion.test.ts
+++ b/src/services/api/openaiShim/responseConversion.test.ts
@@ -9,7 +9,6 @@ import {
 import {
   parseRawToolCallsRequestedText,
   stripRanges,
-  nextToolCallSequence,
 } from './rawToolCallParsing.js'
 import {
   isHy3Model,
@@ -20,8 +19,10 @@ import {
   type NonStreamingOpenAIResponse,
 } from './responseConversion.js'
 
-const parseXmlToolCalls = (text: string, allowHy3: boolean) =>
-  parseXmlToolCallsModule(text, allowHy3, nextToolCallSequence)
+const parseXmlToolCalls = (text: string, allowHy3: boolean) => {
+  let sequence = 0
+  return parseXmlToolCallsModule(text, allowHy3, () => ++sequence)
+}
 
 const dependencies = {
   makeMessageId: () => 'msg-test',

--- a/src/services/api/openaiShim/responseConversion.ts
+++ b/src/services/api/openaiShim/responseConversion.ts
@@ -1,0 +1,102 @@
+export type NonStreamingOpenAIResponse = {
+  id?: string
+  model?: string
+  choices?: Array<{
+    message?: {
+      role?: string
+      content?: string | null | Array<{ type?: string; text?: string }>
+      reasoning_content?: string | null
+      extra_content?: Record<string, unknown>
+      tool_calls?: Array<{
+        id: string
+        function: { name: string; arguments: string }
+        extra_content?: Record<string, unknown>
+      }>
+    }
+    finish_reason?: string
+  }>
+  usage?: Record<string, unknown>
+}
+
+type Dependencies = {
+  makeMessageId: () => string
+  buildUsage: (usage: Record<string, unknown> | undefined) => Record<string, unknown>
+  stripThinkTags: (text: string) => string
+  parseXmlToolCalls: (text: string, allowHy3: boolean) => {
+    calls: Array<{ id: string; name: string; arguments: Record<string, unknown> }>
+    toolCallRanges: Array<[number, number]>
+  }
+  isHy3Model: (model: string) => boolean
+  stripRanges: (text: string, ranges: Array<[number, number]>) => string
+  parseRawToolCalls: (text: string) => Array<{ id: string; name: string; argumentsJson: string }> | null
+  normalizeToolArguments: (name: string, argumentsJson: string) => unknown
+  getGeminiThoughtSignature: (extraContent: unknown) => string | undefined
+  mergeGeminiThoughtSignature: (
+    extraContent: Record<string, unknown> | undefined,
+    signature: string | undefined,
+  ) => Record<string, unknown> | undefined
+}
+
+export function convertNonStreamingResponseToAnthropicMessage(
+  data: NonStreamingOpenAIResponse,
+  model: string,
+  deps: Dependencies,
+) {
+  const choice = data.choices?.[0]
+  const content: Array<Record<string, unknown>> = []
+  const hasStructuredToolCalls = (choice?.message?.tool_calls?.length ?? 0) > 0
+  const reasoning = choice?.message?.reasoning_content
+  if (typeof reasoning === 'string' && reasoning) content.push({ type: 'thinking', thinking: reasoning })
+
+  const appendTextOrRecoveredToolCalls = (rawText: string) => {
+    const stripped = deps.stripThinkTags(rawText)
+    if (!hasStructuredToolCalls) {
+      const { calls, toolCallRanges } = deps.parseXmlToolCalls(stripped, deps.isHy3Model(model))
+      if (calls.length) {
+        const visibleText = deps.stripRanges(stripped, toolCallRanges).trim()
+        if (visibleText) content.push({ type: 'text', text: visibleText })
+        for (const call of calls) content.push({ type: 'tool_use', id: call.id, name: call.name, input: call.arguments })
+        return
+      }
+    }
+    const rawToolCalls = hasStructuredToolCalls ? null : deps.parseRawToolCalls(stripped)
+    if (rawToolCalls) {
+      for (const call of rawToolCalls) content.push({ type: 'tool_use', id: call.id, name: call.name, input: JSON.parse(call.argumentsJson) })
+    } else content.push({ type: 'text', text: stripped })
+  }
+
+  const rawContent = choice?.message?.content !== '' && choice?.message?.content != null
+    ? choice.message.content : null
+  if (typeof rawContent === 'string' && rawContent) appendTextOrRecoveredToolCalls(rawContent)
+  else if (Array.isArray(rawContent)) {
+    const text = rawContent.filter(part => part?.type === 'text' && typeof part.text === 'string')
+      .map(part => part.text!).join('\n')
+    if (text) appendTextOrRecoveredToolCalls(text)
+  }
+
+  if (hasStructuredToolCalls && choice?.message?.tool_calls) {
+    for (const toolCall of choice.message.tool_calls) {
+      const extraContent = toolCall.extra_content ?? choice.message.extra_content
+      const signature = deps.getGeminiThoughtSignature(toolCall.extra_content) ??
+        deps.getGeminiThoughtSignature(choice.message.extra_content)
+      const merged = deps.mergeGeminiThoughtSignature(extraContent, signature)
+      content.push({
+        type: 'tool_use', id: toolCall.id, name: toolCall.function.name,
+        input: deps.normalizeToolArguments(toolCall.function.name, toolCall.function.arguments),
+        ...(merged ? { extra_content: merged } : {}),
+        ...(signature ? { signature } : {}),
+      })
+    }
+  }
+
+  const stopReason = choice?.finish_reason === 'tool_calls' || content.some(block => block.type === 'tool_use')
+    ? 'tool_use' : choice?.finish_reason === 'length' ? 'max_tokens' : 'end_turn'
+  if (choice?.finish_reason === 'content_filter' || choice?.finish_reason === 'safety') {
+    content.push({ type: 'text', text: '\n\n[Content blocked by provider safety filter]' })
+  }
+  return {
+    id: data.id ?? deps.makeMessageId(), type: 'message', role: 'assistant', content,
+    model: data.model ?? model, stop_reason: stopReason, stop_sequence: null,
+    usage: deps.buildUsage(data.usage),
+  }
+}

--- a/src/services/api/openaiShim/responseConversion.ts
+++ b/src/services/api/openaiShim/responseConversion.ts
@@ -69,8 +69,16 @@ export function convertNonStreamingResponseToAnthropicMessage(
     ? choice.message.content : null
   if (typeof rawContent === 'string' && rawContent) appendTextOrRecoveredToolCalls(rawContent)
   else if (Array.isArray(rawContent)) {
-    const text = rawContent.filter(part => part?.type === 'text' && typeof part.text === 'string')
-      .map(part => part.text!).join('\n')
+    const text = rawContent
+      .filter(
+        part =>
+          part &&
+          typeof part === 'object' &&
+          part.type === 'text' &&
+          typeof part.text === 'string',
+      )
+      .map(part => part.text!)
+      .join('\n')
     if (text) appendTextOrRecoveredToolCalls(text)
   }
 

--- a/src/services/api/openaiShim/xmlToolCallParsing.test.ts
+++ b/src/services/api/openaiShim/xmlToolCallParsing.test.ts
@@ -15,7 +15,8 @@
  *   D. <tool_calls:ID><tool_call:ID>NAME<parameter name="KEY">VALUE</parameter>…</tool_calls:ID>
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { createOpenAIShimClient, parseXmlToolCalls } from './openaiShim.js'
+import { createOpenAIShimClient } from '../openaiShim.js'
+import { parseXmlToolCalls } from './xmlToolCallParsing.js'
 
 type FetchType = typeof globalThis.fetch
 
@@ -54,7 +55,6 @@ const glmChunk = (content: string, finishReason?: string) => ({
   model: 'glm-5.2',
   choices: [{ index: 0, delta: { content }, finish_reason: finishReason ?? null }],
 })
-
 const glmToolChunk = (toolCalls: unknown[], finishReason?: string) => ({
   id: 'chatcmpl-glm',
   object: 'chat.completion.chunk',

--- a/src/services/api/openaiShim/xmlToolCallParsing.test.ts
+++ b/src/services/api/openaiShim/xmlToolCallParsing.test.ts
@@ -16,13 +16,13 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { createOpenAIShimClient } from '../openaiShim.js'
-import { nextToolCallSequence } from './rawToolCallParsing.js'
 import {
   parseXmlToolCalls as parseXmlToolCallsModule,
 } from './xmlToolCallParsing.js'
 
 function parseXmlToolCalls(text: string, allowHy3 = false) {
-  return parseXmlToolCallsModule(text, allowHy3, nextToolCallSequence)
+  let sequence = 0
+  return parseXmlToolCallsModule(text, allowHy3, () => ++sequence)
 }
 
 type FetchType = typeof globalThis.fetch
@@ -135,6 +135,21 @@ describe('parseXmlToolCalls', () => {
     const { calls } = parseXmlToolCalls(text)
     expect(calls[0].name).toBe('Bash')
     expect(calls[0].arguments).toEqual({ command: 'pwd' })
+  })
+
+  test('preserves source order when mixing standard XML and HY3 dialects', () => {
+    const text =
+      'before <tool_call>{"name":"xml_first","arguments":{}}</tool_call> ' +
+      'mid <tool_call:hy3>Hy3Second\nk: v\n</tool_call:hy3> after'
+    const { calls, toolCallRanges } = parseXmlToolCalls(text, true)
+
+    expect(calls.map(call => call.name)).toEqual(['xml_first', 'Hy3Second'])
+    expect(calls.map(call => call.id)).toEqual(['xml_tc_1', 'xml_tc_2'])
+    expect(calls[1].arguments).toEqual({ k: 'v' })
+    expect(toolCallRanges).toEqual([
+      [text.indexOf('<tool_call>'), text.indexOf('</tool_call>') + '</tool_call>'.length],
+      [text.indexOf('<tool_call:hy3>'), text.indexOf('</tool_call:hy3>') + '</tool_call:hy3>'.length],
+    ])
   })
 
   test('dialect D: Tencent HY3 wrapper with named parameters', () => {

--- a/src/services/api/openaiShim/xmlToolCallParsing.test.ts
+++ b/src/services/api/openaiShim/xmlToolCallParsing.test.ts
@@ -16,7 +16,14 @@
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { createOpenAIShimClient } from '../openaiShim.js'
-import { parseXmlToolCalls } from './xmlToolCallParsing.js'
+import { nextToolCallSequence } from './rawToolCallParsing.js'
+import {
+  parseXmlToolCalls as parseXmlToolCallsModule,
+} from './xmlToolCallParsing.js'
+
+function parseXmlToolCalls(text: string, allowHy3 = false) {
+  return parseXmlToolCallsModule(text, allowHy3, nextToolCallSequence)
+}
 
 type FetchType = typeof globalThis.fetch
 

--- a/src/services/api/openaiShim/xmlToolCallParsing.ts
+++ b/src/services/api/openaiShim/xmlToolCallParsing.ts
@@ -1,0 +1,222 @@
+const HY3_PARAMETER_RE = /<parameter\s+name=["']([^"'>\s]+)["']\s*>([\s\S]*?)<\/parameter>/g
+
+function extractBalancedJson(text: string, start: number): string | null {
+  let depth = 0
+  let inString = false
+  let escape = false
+  for (let i = start; i < text.length; i++) {
+    const char = text[i]!
+    if (escape) { escape = false; continue }
+    if (char === '\\' && inString) { escape = true; continue }
+    if (char === '"') { inString = !inString; continue }
+    if (inString) continue
+    if (char === '{') depth++
+    else if (char === '}' && --depth === 0) return text.slice(start, i + 1)
+  }
+  return null
+}
+const HY3_NAMED_ARGUMENT_LINE_RE = /^\s*([A-Za-z_][\w-]*)\s*:\s*(.+?)\s*$/gm
+const HY3_ARG_PAIR_RE = /<arg_key(?::[^>\s]+)?>([\s\S]*?)<\/arg_key(?::[^>\s]+)?>\s*<arg_value(?::[^>\s]+)?>([\s\S]*?)<\/arg_value(?::[^>\s]+)?>/g
+
+export function coerceXmlToolValue(raw: string): unknown {
+  const trimmed = raw.trim()
+  if (trimmed === '') return ''
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return raw
+  }
+}
+
+export function parseHy3ToolCallInner(inner: string): {
+  name?: string
+  args: Record<string, unknown>
+} {
+  const args: Record<string, unknown> = {}
+  const trimmed = inner.trim()
+  const name = trimmed.split(/[\n<]/, 1)[0]?.trim().replace(/[\s`*_]+$/, '')
+  let hasStructuredArguments = false
+  for (const parameter of inner.matchAll(HY3_PARAMETER_RE)) {
+    const key = parameter[1]
+    if (key) { hasStructuredArguments = true; args[key] = coerceXmlToolValue(parameter[2] ?? '') }
+  }
+  for (const line of inner.matchAll(HY3_NAMED_ARGUMENT_LINE_RE)) {
+    const key = line[1]
+    if (key) { hasStructuredArguments = true; args[key] = coerceXmlToolValue(line[2] ?? '') }
+  }
+  for (const pair of inner.matchAll(HY3_ARG_PAIR_RE)) {
+    const key = pair[1]?.trim()
+    if (key) { hasStructuredArguments = true; args[key] = coerceXmlToolValue(pair[2] ?? '') }
+  }
+  return {
+    name: name && /^[A-Za-z_][\w.-]*$/.test(name) && (hasStructuredArguments || trimmed === name) ? name : undefined,
+    args,
+  }
+}
+
+export interface ParsedXmlToolCall {
+  id: string
+  name: string
+  arguments: Record<string, unknown>
+}
+let xmlToolCallCounter = 0
+
+const XML_TOOL_CALL_OPEN = '<tool_call>'
+const HY3_TOOL_CALLS_OPEN = '<tool_calls:'
+const HY3_TOOL_CALL_OPEN = '<tool_call:'
+const XML_TOOL_CALL_OPENERS = [
+  XML_TOOL_CALL_OPEN,
+  HY3_TOOL_CALLS_OPEN,
+  HY3_TOOL_CALL_OPEN,
+]
+// Non-greedy block matcher; the `$` alternative tolerates a truncated final
+// block (stream cut off before the closing tag).
+const XML_TOOL_CALL_BLOCK_RE = /<tool_call>([\s\S]*?)(?:<\/tool_call>|$)/g
+const HY3_TOOL_CALLS_BLOCK_RE = /<tool_calls:[^>\s]+>([\s\S]*?)(?:<\/tool_calls(?::[^>\s]+)?>|$)/g
+const HY3_TOOL_CALL_BLOCK_RE = /<tool_call:[^>\s]+>([\s\S]*?)(?:<\/tool_call(?::[^>\s]+)?>|$)/g
+const XML_FUNCTION_NAME_RE = /<function=([^>\s]+)\s*>/
+const XML_PARAMETER_RE = /<parameter=([^>\s]+)\s*>([\s\S]*?)<\/parameter>/g
+const XML_ARG_PAIR_RE = /<arg_key>([\s\S]*?)<\/arg_key>\s*<arg_value>([\s\S]*?)<\/arg_value>/g
+export function isHy3Model(model: string): boolean {
+  return model.split('?', 1)[0]?.toLowerCase() === 'tencent/hy3'
+}
+
+/**
+ * Returns the length of the longest suffix of `s` that is a (proper) prefix of
+ * the `<tool_call>` opener. Used by the stream to hold back a trailing partial
+ * opener split across SSE deltas so it is never emitted as visible text.
+ */
+export function trailingXmlOpenerPrefixLen(s: string, allowHy3: boolean): number {
+  let longest = 0
+  const openers = allowHy3 ? XML_TOOL_CALL_OPENERS : [XML_TOOL_CALL_OPEN]
+  for (const opener of openers) {
+    const max = Math.min(s.length, opener.length - 1)
+    for (let len = max; len > 0; len--) {
+      if (opener.startsWith(s.slice(s.length - len))) {
+        longest = Math.max(longest, len)
+        break
+      }
+    }
+  }
+  return longest
+}
+
+export function findXmlToolCallOpener(text: string, allowHy3: boolean): number {
+  const openers = allowHy3 ? XML_TOOL_CALL_OPENERS : [XML_TOOL_CALL_OPEN]
+  return openers.reduce((first, opener) => {
+    const index = text.indexOf(opener)
+    return index === -1 ? first : first === -1 ? index : Math.min(first, index)
+  }, -1)
+}
+
+/** Exported for unit testing only. */
+export function parseXmlToolCalls(text: string, allowHy3 = false): {
+  calls: ParsedXmlToolCall[]
+  toolCallRanges: Array<[number, number]>
+} {
+  const results: ParsedXmlToolCall[] = []
+  const seen = new Set<string>()
+  const ranges: Array<[number, number]> = []
+
+  const addCall = (name: string, args: Record<string, unknown>) => {
+    const dedupKey = `${name}:${JSON.stringify(args)}`
+    if (seen.has(dedupKey)) return
+    seen.add(dedupKey)
+    results.push({ id: `xml_tc_${++xmlToolCallCounter}`, name, arguments: args })
+  }
+
+  const hy3Blocks = allowHy3
+    ? [...text.matchAll(HY3_TOOL_CALL_BLOCK_RE)].map(block => ({
+      range: [block.index!, block.index! + block[0].length] as [number, number],
+      parsed: parseHy3ToolCallInner(block[1] ?? ''),
+    }))
+    : []
+  const hy3WrapperRanges = allowHy3
+    ? [...text.matchAll(HY3_TOOL_CALLS_BLOCK_RE)]
+      .filter(wrapper => {
+        const range: [number, number] = [
+          wrapper.index!,
+          wrapper.index! + wrapper[0].length,
+        ]
+        return hy3Blocks.some(
+          block => block.parsed.name && range[0] <= block.range[0] && block.range[1] <= range[1],
+        )
+      })
+      .map(wrapper => [
+        wrapper.index!,
+        wrapper.index! + wrapper[0].length,
+      ] as [number, number])
+    : []
+
+  for (const block of hy3Blocks) {
+    const { name, args } = block.parsed
+    if (!name) continue
+    const range = block.range
+    if (!hy3WrapperRanges.some(wrapper => wrapper[0] <= range[0] && range[1] <= wrapper[1])) {
+      ranges.push(range)
+    }
+    addCall(name, args)
+  }
+
+  ranges.push(...hy3WrapperRanges)
+
+  for (const block of text.matchAll(XML_TOOL_CALL_BLOCK_RE)) {
+    const inner = block[1] ?? ''
+    const range: [number, number] = [
+      block.index!,
+      block.index! + block[0].length,
+    ]
+    let name: string | undefined
+    const args: Record<string, unknown> = {}
+
+    const fnMatch = inner.match(XML_FUNCTION_NAME_RE)
+    if (fnMatch) {
+      // Dialect A: <function=NAME><parameter=KEY>VALUE</parameter>…
+      name = fnMatch[1]
+      for (const p of inner.matchAll(XML_PARAMETER_RE)) {
+        const key = p[1]
+        if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
+      }
+    } else {
+      const trimmedInner = inner.trim()
+      const argPairs = [...inner.matchAll(XML_ARG_PAIR_RE)]
+      if (argPairs.length > 0 && !trimmedInner.startsWith('{')) {
+        // Dialect B: leading token is the function name, then arg_key/arg_value.
+        const nameTok = trimmedInner.split(/[\n<]/, 1)[0]?.trim()
+        if (nameTok) name = nameTok
+        for (const p of argPairs) {
+          const key = (p[1] ?? '').trim()
+          if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
+        }
+      } else {
+        // Dialect C: a JSON tool-call object inside the tags.
+        const jsonStart = trimmedInner.indexOf('{')
+        if (jsonStart !== -1) {
+          const jsonRaw = extractBalancedJson(trimmedInner, jsonStart)
+          if (jsonRaw) {
+            try {
+              const obj = JSON.parse(jsonRaw) as Record<string, unknown>
+              if (typeof obj['name'] === 'string') {
+                name = obj['name'] as string
+                const rawArgs = obj['arguments']
+                if (typeof rawArgs === 'string') {
+                  try {
+                    Object.assign(args, JSON.parse(rawArgs))
+                  } catch {}
+                } else if (rawArgs && typeof rawArgs === 'object') {
+                  Object.assign(args, rawArgs as Record<string, unknown>)
+                }
+              }
+            } catch {}
+          }
+        }
+      }
+    }
+
+    if (!name) continue
+    ranges.push(range)
+    addCall(name, args)
+  }
+
+  return { calls: results, toolCallRanges: ranges }
+}

--- a/src/services/api/openaiShim/xmlToolCallParsing.ts
+++ b/src/services/api/openaiShim/xmlToolCallParsing.ts
@@ -1,7 +1,4 @@
-import {
-  extractBalancedJson,
-  nextToolCallSequence,
-} from './rawToolCallParsing.js'
+import { extractBalancedJson } from './rawToolCallParsing.js'
 
 const HY3_PARAMETER_RE = /<parameter\s+name=["']([^"'>\s]+)["']\s*>([\s\S]*?)<\/parameter>/g
 const HY3_NAMED_ARGUMENT_LINE_RE = /^\s*([A-Za-z_][\w-]*)\s*:\s*(.+?)\s*$/gm
@@ -97,11 +94,15 @@ export function findXmlToolCallOpener(text: string, allowHy3: boolean): number {
   }, -1)
 }
 
-/** Exported for unit testing only. */
+/**
+ * Parse XML / HY3 tool-call markup from assistant text.
+ * Callers must inject the session sequencer so XML and raw-text fallbacks
+ * share one id space (see openaiShim façade `nextTextToolCallSequence`).
+ */
 export function parseXmlToolCalls(
   text: string,
-  allowHy3 = false,
-  nextSequence: () => number = nextToolCallSequence,
+  allowHy3: boolean,
+  nextSequence: () => number,
 ): {
   calls: ParsedXmlToolCall[]
   toolCallRanges: Array<[number, number]>

--- a/src/services/api/openaiShim/xmlToolCallParsing.ts
+++ b/src/services/api/openaiShim/xmlToolCallParsing.ts
@@ -1,20 +1,9 @@
-const HY3_PARAMETER_RE = /<parameter\s+name=["']([^"'>\s]+)["']\s*>([\s\S]*?)<\/parameter>/g
+import {
+  extractBalancedJson,
+  nextToolCallSequence,
+} from './rawToolCallParsing.js'
 
-function extractBalancedJson(text: string, start: number): string | null {
-  let depth = 0
-  let inString = false
-  let escape = false
-  for (let i = start; i < text.length; i++) {
-    const char = text[i]!
-    if (escape) { escape = false; continue }
-    if (char === '\\' && inString) { escape = true; continue }
-    if (char === '"') { inString = !inString; continue }
-    if (inString) continue
-    if (char === '{') depth++
-    else if (char === '}' && --depth === 0) return text.slice(start, i + 1)
-  }
-  return null
-}
+const HY3_PARAMETER_RE = /<parameter\s+name=["']([^"'>\s]+)["']\s*>([\s\S]*?)<\/parameter>/g
 const HY3_NAMED_ARGUMENT_LINE_RE = /^\s*([A-Za-z_][\w-]*)\s*:\s*(.+?)\s*$/gm
 const HY3_ARG_PAIR_RE = /<arg_key(?::[^>\s]+)?>([\s\S]*?)<\/arg_key(?::[^>\s]+)?>\s*<arg_value(?::[^>\s]+)?>([\s\S]*?)<\/arg_value(?::[^>\s]+)?>/g
 
@@ -59,7 +48,6 @@ export interface ParsedXmlToolCall {
   name: string
   arguments: Record<string, unknown>
 }
-let xmlToolCallCounter = 0
 
 const XML_TOOL_CALL_OPEN = '<tool_call>'
 const HY3_TOOL_CALLS_OPEN = '<tool_calls:'
@@ -110,7 +98,11 @@ export function findXmlToolCallOpener(text: string, allowHy3: boolean): number {
 }
 
 /** Exported for unit testing only. */
-export function parseXmlToolCalls(text: string, allowHy3 = false): {
+export function parseXmlToolCalls(
+  text: string,
+  allowHy3 = false,
+  nextSequence: () => number = nextToolCallSequence,
+): {
   calls: ParsedXmlToolCall[]
   toolCallRanges: Array<[number, number]>
 } {
@@ -122,7 +114,7 @@ export function parseXmlToolCalls(text: string, allowHy3 = false): {
     const dedupKey = `${name}:${JSON.stringify(args)}`
     if (seen.has(dedupKey)) return
     seen.add(dedupKey)
-    results.push({ id: `xml_tc_${++xmlToolCallCounter}`, name, arguments: args })
+    results.push({ id: `xml_tc_${nextSequence()}`, name, arguments: args })
   }
 
   const hy3Blocks = allowHy3

--- a/src/services/api/openaiShim/xmlToolCallParsing.ts
+++ b/src/services/api/openaiShim/xmlToolCallParsing.ts
@@ -99,6 +99,60 @@ export function findXmlToolCallOpener(text: string, allowHy3: boolean): number {
  * Callers must inject the session sequencer so XML and raw-text fallbacks
  * share one id space (see openaiShim façade `nextTextToolCallSequence`).
  */
+function parseStandardXmlToolCallInner(inner: string): {
+  name?: string
+  args: Record<string, unknown>
+} {
+  let name: string | undefined
+  const args: Record<string, unknown> = {}
+
+  const fnMatch = inner.match(XML_FUNCTION_NAME_RE)
+  if (fnMatch) {
+    // Dialect A: <function=NAME><parameter=KEY>VALUE</parameter>…
+    name = fnMatch[1]
+    for (const p of inner.matchAll(XML_PARAMETER_RE)) {
+      const key = p[1]
+      if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
+    }
+  } else {
+    const trimmedInner = inner.trim()
+    const argPairs = [...inner.matchAll(XML_ARG_PAIR_RE)]
+    if (argPairs.length > 0 && !trimmedInner.startsWith('{')) {
+      // Dialect B: leading token is the function name, then arg_key/arg_value.
+      const nameTok = trimmedInner.split(/[\n<]/, 1)[0]?.trim()
+      if (nameTok) name = nameTok
+      for (const p of argPairs) {
+        const key = (p[1] ?? '').trim()
+        if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
+      }
+    } else {
+      // Dialect C: a JSON tool-call object inside the tags.
+      const jsonStart = trimmedInner.indexOf('{')
+      if (jsonStart !== -1) {
+        const jsonRaw = extractBalancedJson(trimmedInner, jsonStart)
+        if (jsonRaw) {
+          try {
+            const obj = JSON.parse(jsonRaw) as Record<string, unknown>
+            if (typeof obj['name'] === 'string') {
+              name = obj['name'] as string
+              const rawArgs = obj['arguments']
+              if (typeof rawArgs === 'string') {
+                try {
+                  Object.assign(args, JSON.parse(rawArgs))
+                } catch {}
+              } else if (rawArgs && typeof rawArgs === 'object') {
+                Object.assign(args, rawArgs as Record<string, unknown>)
+              }
+            }
+          } catch {}
+        }
+      }
+    }
+  }
+
+  return { name, args }
+}
+
 export function parseXmlToolCalls(
   text: string,
   allowHy3: boolean,
@@ -116,6 +170,13 @@ export function parseXmlToolCalls(
     if (seen.has(dedupKey)) return
     seen.add(dedupKey)
     results.push({ id: `xml_tc_${nextSequence()}`, name, arguments: args })
+  }
+
+  type RangeTaggedCandidate = {
+    range: [number, number]
+    name: string
+    args: Record<string, unknown>
+    coveredByWrapper: boolean
   }
 
   const hy3Blocks = allowHy3
@@ -141,75 +202,50 @@ export function parseXmlToolCalls(
       ] as [number, number])
     : []
 
+  const candidates: RangeTaggedCandidate[] = []
+
   for (const block of hy3Blocks) {
     const { name, args } = block.parsed
     if (!name) continue
     const range = block.range
-    if (!hy3WrapperRanges.some(wrapper => wrapper[0] <= range[0] && range[1] <= wrapper[1])) {
-      ranges.push(range)
-    }
-    addCall(name, args)
+    candidates.push({
+      range,
+      name,
+      args,
+      coveredByWrapper: hy3WrapperRanges.some(
+        wrapper => wrapper[0] <= range[0] && range[1] <= wrapper[1],
+      ),
+    })
   }
 
-  ranges.push(...hy3WrapperRanges)
-
   for (const block of text.matchAll(XML_TOOL_CALL_BLOCK_RE)) {
-    const inner = block[1] ?? ''
     const range: [number, number] = [
       block.index!,
       block.index! + block[0].length,
     ]
-    let name: string | undefined
-    const args: Record<string, unknown> = {}
-
-    const fnMatch = inner.match(XML_FUNCTION_NAME_RE)
-    if (fnMatch) {
-      // Dialect A: <function=NAME><parameter=KEY>VALUE</parameter>…
-      name = fnMatch[1]
-      for (const p of inner.matchAll(XML_PARAMETER_RE)) {
-        const key = p[1]
-        if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
-      }
-    } else {
-      const trimmedInner = inner.trim()
-      const argPairs = [...inner.matchAll(XML_ARG_PAIR_RE)]
-      if (argPairs.length > 0 && !trimmedInner.startsWith('{')) {
-        // Dialect B: leading token is the function name, then arg_key/arg_value.
-        const nameTok = trimmedInner.split(/[\n<]/, 1)[0]?.trim()
-        if (nameTok) name = nameTok
-        for (const p of argPairs) {
-          const key = (p[1] ?? '').trim()
-          if (key) args[key] = coerceXmlToolValue(p[2] ?? '')
-        }
-      } else {
-        // Dialect C: a JSON tool-call object inside the tags.
-        const jsonStart = trimmedInner.indexOf('{')
-        if (jsonStart !== -1) {
-          const jsonRaw = extractBalancedJson(trimmedInner, jsonStart)
-          if (jsonRaw) {
-            try {
-              const obj = JSON.parse(jsonRaw) as Record<string, unknown>
-              if (typeof obj['name'] === 'string') {
-                name = obj['name'] as string
-                const rawArgs = obj['arguments']
-                if (typeof rawArgs === 'string') {
-                  try {
-                    Object.assign(args, JSON.parse(rawArgs))
-                  } catch {}
-                } else if (rawArgs && typeof rawArgs === 'object') {
-                  Object.assign(args, rawArgs as Record<string, unknown>)
-                }
-              }
-            } catch {}
-          }
-        }
-      }
-    }
-
+    const { name, args } = parseStandardXmlToolCallInner(block[1] ?? '')
     if (!name) continue
-    ranges.push(range)
-    addCall(name, args)
+    candidates.push({
+      range,
+      name,
+      args,
+      coveredByWrapper: false,
+    })
   }
+
+  // Preserve provider source order across HY3 and standard XML dialects so
+  // multi-tool turns execute (and mint xml_tc_* IDs) in markup order.
+  candidates.sort((left, right) => left.range[0] - right.range[0])
+
+  for (const candidate of candidates) {
+    addCall(candidate.name, candidate.args)
+    if (!candidate.coveredByWrapper) {
+      ranges.push(candidate.range)
+    }
+  }
+
+  ranges.push(...hy3WrapperRanges)
+  ranges.sort((left, right) => left[0] - right[0])
 
   return { calls: results, toolCallRanges: ranges }
 }


### PR DESCRIPTION
## Summary

Extracts XML tool-call parsing and non-streaming response conversion into `xmlToolCallParsing.ts` and `responseConversion.ts`.

This cohesive group owns supported XML dialects (including Tencent HY3), range/trailing-prefix handling, Gemini/raw fallback response recovery, reasoning-content conversion, and terminal response mapping.

## Independent merge

- Upstream base: `0effa0f42b6dbc6a4800e19f4b2d8d588269906b`.
- Fork branch: `jatmn/openclaude:de-mono1-xml-and-response-conversion`.
- Exact head: `d855108a05c507e829f3dd17466fb3061317b5ec`.
- All 45 pairwise combinations and complete forward/reverse ten-branch merges are clean.
- Draft upstream PR.

## Source-file budget

`openaiShim.ts`: **+67 / -399 = 466 changed lines**, below 1,500; tests excluded.

## Test migration

- Monolithic test: **+692 / -254**; all six owned top-level test bodies are removed.
- Focused tests: `responseConversion.test.ts` (**228 lines / 8 tests**) and renamed `xmlToolCallParsing.test.ts` (**508 lines / 32 tests**).
- Focused conversion/XML plus retained façade suites: **259 passed / 711 assertions**.
- Combined result retains only three façade-contract tests in the monolithic test.

## Validation

- Diff check, typecheck, type-test check, and build passed.
- Exact-head host `bun run check`: **7,188 passed / 2 skipped**; only 10 pre-existing PowerShell governance failures remain on Linux.

Prepared according to `CONTRIBUTING.md` and `AGENTS.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved parsing and recovery of assistant-embedded tool calls, including Hy3 and multiple XML dialects, with more reliable argument coercion, source-order preservation, and deterministic tool-call IDs.

- **Bug Fixes**
  - Enhanced conversion of non-streaming OpenAI-style responses into Anthropic message payloads, including robust `reasoning_content` → thinking, consistent `<think>...</think>` stripping, and accurate `stop_reason`/usage handling for tool calls and safety/content filters.

- **Tests**
  - Added Bun coverage for non-streaming response conversion and expanded XML tool-call parsing validation; updated the provider test script to include OpenAI shim tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->