### PR TITLE
feat(codex): add GPT-5.6 family models and fix saved-model rehydration

### DIFF
--- a/src/integrations/gpt56Catalog.test.ts
+++ b/src/integrations/gpt56Catalog.test.ts
@@ -9,7 +9,13 @@ test('gpt-5.6 model descriptors carry the verified limits', () => {
   for (const id of GPT56_IDS) {
     const descriptor = gptModels.find(model => model.id === id)
     expect(descriptor).toBeDefined()
-    expect(descriptor?.contextWindow).toBe(1_050_000)
+    // Descriptor and catalog intentionally diverge: the descriptor is the
+    // fallback for catalog-less routes — notably the Codex transport
+    // (chatgpt.com/backend-api/codex), which enforces a ~272k effective
+    // input cap (issue #1118 precedent, same as gpt-5.5). The direct-OpenAI
+    // route reads the vendor catalog entry below, which keeps the true
+    // 1.05M window.
+    expect(descriptor?.contextWindow).toBe(272_000)
     expect(descriptor?.maxOutputTokens).toBe(128_000)
   }
 })

--- a/src/integrations/models/gpt.ts
+++ b/src/integrations/models/gpt.ts
@@ -33,9 +33,11 @@ export default [
   // are combined with reasoning_effort — they must use /v1/responses. The
   // openai-vendor catalog carries their reasoning metadata; the responses
   // routing is handled by modelRequiresResponsesApi in providerConfig.
-  gptModel('gpt-5.6-sol', 'GPT-5.6 Sol', 1_050_000, 128_000),
-  gptModel('gpt-5.6-terra', 'GPT-5.6 Terra', 1_050_000, 128_000),
-  gptModel('gpt-5.6-luna', 'GPT-5.6 Luna', 1_050_000, 128_000),
+  // Context: same conservative Codex 272k input cap as gpt-5.5 below (see
+  // that comment), despite the 1.05M API descriptor value.
+  gptModel('gpt-5.6-sol', 'GPT-5.6 Sol', 272_000, 128_000),
+  gptModel('gpt-5.6-terra', 'GPT-5.6 Terra', 272_000, 128_000),
+  gptModel('gpt-5.6-luna', 'GPT-5.6 Luna', 272_000, 128_000),
   // gpt-5.5 via Codex transport caps at ~272k effective input tokens; the
   // 1.05M API descriptor value caused /context to under-report usage and
   // auto-compact to fire too late, yielding 500 "input exceeds the context

--- a/src/services/api/providerConfig.test.ts
+++ b/src/services/api/providerConfig.test.ts
@@ -218,3 +218,32 @@ test('resolveProviderRequest uses ClinePass model when no explicit base URL is s
   expect(request.requestedModel).toBe('cline-pass/qwen3.7-max')
   expect(request.baseUrl).toBe('https://api.cline.bot/api/v1')
 })
+
+test('resolveProviderRequest resolves the GPT-5.6 family Codex aliases', () => {
+  const sol = resolveProviderRequest({ model: 'gpt-5.6-sol', processEnv: {} })
+  expect(sol.resolvedModel).toBe('gpt-5.6-sol')
+  expect(sol.transport).toBe('codex_responses')
+  expect(sol.reasoning).toEqual({ effort: 'high' })
+
+  const terra = resolveProviderRequest({ model: 'gpt-5.6-terra', processEnv: {} })
+  expect(terra.resolvedModel).toBe('gpt-5.6-terra')
+  expect(terra.reasoning).toEqual({ effort: 'medium' })
+
+  const luna = resolveProviderRequest({ model: 'gpt-5.6-luna', processEnv: {} })
+  expect(luna.resolvedModel).toBe('gpt-5.6-luna')
+  expect(luna.reasoning).toEqual({ effort: 'medium' })
+
+  // Bare version resolves to the flagship tier, like the Codex CLI.
+  const bare = resolveProviderRequest({ model: 'gpt-5.6', processEnv: {} })
+  expect(bare.resolvedModel).toBe('gpt-5.6-sol')
+  expect(bare.reasoning).toEqual({ effort: 'high' })
+})
+
+test('resolveProviderRequest honors reasoning query overrides on GPT-5.6 aliases', () => {
+  const request = resolveProviderRequest({
+    model: 'gpt-5.6-sol?reasoning=medium',
+    processEnv: {},
+  })
+  expect(request.resolvedModel).toBe('gpt-5.6-sol')
+  expect(request.reasoning).toEqual({ effort: 'medium' })
+})

--- a/src/services/api/providerConfig.test.ts
+++ b/src/services/api/providerConfig.test.ts
@@ -247,3 +247,42 @@ test('resolveProviderRequest honors reasoning query overrides on GPT-5.6 aliases
   expect(request.resolvedModel).toBe('gpt-5.6-sol')
   expect(request.reasoning).toEqual({ effort: 'medium' })
 })
+
+test('resolveProviderRequest scopes GPT-5.6 alias effort defaults to the Codex transport', () => {
+  // On a custom OpenAI-compatible gateway (non-Codex transport) the alias
+  // default must NOT leak (#1961's contract: gateways do not inherit
+  // first-party effort metadata) — while an explicit ?reasoning= pick flows.
+  const processEnv = {
+    CLAUDE_CODE_USE_OPENAI: '1',
+    OPENAI_BASE_URL: 'https://gateway.example/v1',
+    OPENAI_API_KEY: 'test-key',
+  }
+
+  const plain = resolveProviderRequest({ model: 'gpt-5.6-sol', processEnv })
+  expect(plain.resolvedModel).toBe('gpt-5.6-sol')
+  expect(plain.transport).not.toBe('codex_responses')
+  expect(plain.reasoning).toBeUndefined()
+
+  const explicit = resolveProviderRequest({
+    model: 'gpt-5.6-sol?reasoning=medium',
+    processEnv,
+  })
+  expect(explicit.transport).not.toBe('codex_responses')
+  expect(explicit.reasoning).toEqual({ effort: 'medium' })
+})
+
+test('resolveProviderRequest strips a trailing [1m] tag before alias mapping', () => {
+  // The [1m] suffix is a client-side context opt-in, never a wire model id:
+  // tagged forms must still resolve through the alias map (effort defaults
+  // included) and never leak the bracket suffix into resolvedModel.
+  const combined = resolveProviderRequest({
+    model: 'gpt-5.6-sol?reasoning=medium[1m]',
+    processEnv: {},
+  })
+  expect(combined.resolvedModel).toBe('gpt-5.6-sol')
+  expect(combined.reasoning).toEqual({ effort: 'medium' })
+
+  const tagged = resolveProviderRequest({ model: 'gpt-5.5[1m]', processEnv: {} })
+  expect(tagged.resolvedModel).toBe('gpt-5.5')
+  expect(tagged.reasoning).toEqual({ effort: 'high' })
+})

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -359,7 +359,13 @@ export function parseOpenAICompatibleApiFormat(
 }
 
 function parseModelDescriptor(model: string): ModelDescriptor {
-  const trimmed = model.trim()
+  // A trailing [1m] suffix is the client-side 1M-context opt-in (see
+  // has1mContext) — never part of the wire model id or the ?query syntax.
+  // Strip it before parsing so tagged aliases keep their mapping and effort
+  // defaults and the resolved model id stays valid for the backend. The tag
+  // can trail the whole string (`gpt-5.6-sol?reasoning=medium[1m]`) or sit
+  // on the base id (`gpt-5.5[1m]`); both forms are handled.
+  const trimmed = model.trim().replace(/\[1m]$/i, '').trim()
   const queryIndex = trimmed.indexOf('?')
   if (queryIndex === -1) {
     const alias = trimmed.toLowerCase() as CodexAlias
@@ -382,7 +388,10 @@ function parseModelDescriptor(model: string): ModelDescriptor {
     }
   }
 
-  const baseModel = trimmed.slice(0, queryIndex).trim()
+  const baseModel = trimmed
+    .slice(0, queryIndex)
+    .trim()
+    .replace(/\[1m]$/i, '')
   const params = new URLSearchParams(trimmed.slice(queryIndex + 1))
   const alias = baseModel.toLowerCase() as CodexAlias
   const aliasConfig = Object.hasOwn(CODEX_ALIAS_MODELS, alias)

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -82,6 +82,24 @@ const CODEX_ALIAS_MODELS: Record<
     model: 'gpt-5.5',
     reasoningEffort: 'high',
   },
+  // GPT-5.6 family (July 2026). `gpt-5.6` follows the Codex CLI convention of
+  // resolving the bare version to the flagship tier (Sol).
+  'gpt-5.6': {
+    model: 'gpt-5.6-sol',
+    reasoningEffort: 'high',
+  },
+  'gpt-5.6-sol': {
+    model: 'gpt-5.6-sol',
+    reasoningEffort: 'high',
+  },
+  'gpt-5.6-terra': {
+    model: 'gpt-5.6-terra',
+    reasoningEffort: 'medium',
+  },
+  'gpt-5.6-luna': {
+    model: 'gpt-5.6-luna',
+    reasoningEffort: 'medium',
+  },
   'gpt-5.5': {
     model: 'gpt-5.5',
     reasoningEffort: 'high',
@@ -160,6 +178,11 @@ type ModelDescriptor = {
   reasoning?: {
     effort: ReasoningEffort
   }
+  // True when `reasoning` is the CODEX_ALIAS_MODELS default rather than an
+  // explicit ?reasoning= query pick. Alias defaults are a Codex convention:
+  // they must not leak onto non-Codex transports (an OPENAI_API_BASE gateway
+  // serving gpt-5.6 must not inherit first-party effort metadata).
+  reasoningFromAlias?: boolean
   thinking?: {
     type: ThinkingType
   }
@@ -350,6 +373,7 @@ function parseModelDescriptor(model: string): ModelDescriptor {
         reasoning: aliasConfig.reasoningEffort
           ? { effort: aliasConfig.reasoningEffort }
           : undefined,
+        reasoningFromAlias: Boolean(aliasConfig.reasoningEffort),
       }
     }
     return {
@@ -365,8 +389,9 @@ function parseModelDescriptor(model: string): ModelDescriptor {
     ? CODEX_ALIAS_MODELS[alias]
     : undefined
   const resolvedBaseModel = aliasConfig?.model ?? baseModel
+  const queryReasoning = parseReasoningEffort(params.get('reasoning') ?? undefined)
   const reasoning =
-    parseReasoningEffort(params.get('reasoning') ?? undefined) ??
+    queryReasoning ??
     (aliasConfig?.reasoningEffort
       ? { effort: aliasConfig.reasoningEffort }
       : undefined)
@@ -376,6 +401,8 @@ function parseModelDescriptor(model: string): ModelDescriptor {
     raw: trimmed,
     baseModel: resolvedBaseModel,
     reasoning: typeof reasoning === 'string' ? { effort: reasoning } : reasoning,
+    reasoningFromAlias:
+      queryReasoning === undefined && Boolean(aliasConfig?.reasoningEffort),
     thinking: thinking ? { type: thinking } : undefined,
   }
 }
@@ -428,7 +455,22 @@ function shouldUseGithubResponsesApi(model: string): boolean {
 export function modelRequiresResponsesApi(model: string): boolean {
   const normalized = model.trim().toLowerCase().split('?', 1)[0] ?? ''
   return /^gpt-5\.[4-6](?!\d)/.test(normalized) &&
-    !/(?:^|[-.])(?:mini|nano)(?:[-.]|$)/.test(normalized)
+    !GPT5_MINI_NANO_RE.test(normalized)
+}
+
+// The gpt-5 family boundary: gpt-5, gpt-5-*, gpt-5.x — without matching
+// gpt-50-style ids. Shared by supportsCodexReasoningEffort and the Codex
+// profile model gate so the family shape lives in one place.
+const GPT5_FAMILY_RE = /^gpt-5(?:[.-]|$)/
+const GPT5_MINI_NANO_RE = /(?:^|[-.])(?:mini|nano)(?:[-.]|$)/
+
+// gpt-5 family models the ChatGPT Codex backend can serve. The -mini/-nano
+// tiers are API-only (never exposed through the Codex transport), so a
+// stale gpt-5-mini pick saved under a direct-OpenAI profile must fall back
+// to the Codex profile's default rather than be sent to the backend and 400.
+export function isCodexEligibleGpt5Model(model: string): boolean {
+  const base = model.trim().toLowerCase().split('?', 1)[0] ?? ''
+  return GPT5_FAMILY_RE.test(base) && !GPT5_MINI_NANO_RE.test(base)
 }
 
 // The responses auto-route only fires for the OpenAI first-party surface
@@ -1062,9 +1104,20 @@ export function resolveProviderRequest(options?: {
         ? requestedApiFormat
         : 'chat_completions'
 
+  // The gpt-5.6 alias defaults are Codex-transport-only: off the Codex
+  // transport the 5.6 family's effort metadata is owned by the route catalog
+  // (#1961), and an OPENAI_API_BASE gateway must not inherit the first-party
+  // default. Explicit picks (the /effort override or a ?reasoning= query)
+  // still flow on every transport, and the older aliases (gpt-5.4/5.5,
+  // codexplan) keep the pre-5.6 legacy behavior of carrying their default
+  // effort everywhere.
   const reasoning = options?.reasoningEffortOverride
     ? { effort: options.reasoningEffortOverride }
-    : descriptor.reasoning
+    : descriptor.reasoningFromAlias &&
+        transport !== 'codex_responses' &&
+        /^gpt-5\.6/.test(descriptor.baseModel)
+      ? undefined
+      : descriptor.reasoning
 
   return {
     transport,
@@ -1398,5 +1451,5 @@ export function supportsCodexReasoningEffort(model: string): boolean {
     return true
   }
 
-  return /^gpt-5(?:[.-]|$)/.test(base)
+  return GPT5_FAMILY_RE.test(base)
 }

--- a/src/utils/context.test.ts
+++ b/src/utils/context.test.ts
@@ -404,6 +404,39 @@ test('gpt-5.5 uses conservative Codex-route context window (issue #1118)', () =>
   expect(getContextWindowForModel('gpt-5.5')).toBe(272_000)
 })
 
+test('gpt-5.6 family pins the Codex effective input limit on the Codex route', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_BASE_URL = 'https://chatgpt.com/backend-api/codex'
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  // Same rationale as gpt-5.5 above, but scoped to the Codex transport: the
+  // Codex base URL resolves to a catalog-less route, so the gpt.ts
+  // descriptor (pinned to the ~272k effective input boundary, issue #1118)
+  // is what sizes the context there.
+  for (const model of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+    expect(getContextWindowForModel(model)).toBe(272_000)
+    expect(getModelMaxOutputTokens(model)).toEqual({
+      default: 128_000,
+      upperLimit: 128_000,
+    })
+  }
+})
+
+test('gpt-5.6 family keeps the full window on the direct-OpenAI route', () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  delete process.env.OPENAI_BASE_URL
+  delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS
+  delete process.env.OPENAI_MODEL
+
+  // Unlike gpt-5.5 (Codex-only, blanket-capped in the vendor catalog), the
+  // gpt-5.6 family is also served directly by api.openai.com /v1/responses
+  // at its true 1.05M window; the openai-route catalog entry preserves it.
+  for (const model of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+    expect(getContextWindowForModel(model)).toBe(1_050_000)
+  }
+})
+
 test('gpt-5.4 family uses provider-specific context and output caps', () => {
   process.env.CLAUDE_CODE_USE_OPENAI = '1'
   delete process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -845,10 +845,13 @@ export function parseUserSpecifiedModel(
   // runtime model id on the tier that has real descriptor metadata, so
   // context-window sizing and display names don't fall back to defaults.
   // Match on the base name so a ?reasoning=/?thinking= query suffix does not
-  // defeat the rewrite; the query is preserved on the resolved tier id.
+  // defeat the rewrite; the query is preserved on the resolved tier id and a
+  // [1m] tag stays TRAILING (after the query, mirroring the input form) so
+  // downstream query parsing sees `?reasoning=...` intact — request-time
+  // parsing (parseModelDescriptor) strips the trailing tag itself.
   if (modelString === 'gpt-5.6' || modelString.startsWith('gpt-5.6?')) {
     const query = modelString.slice('gpt-5.6'.length)
-    return 'gpt-5.6-sol' + (has1mTag ? '[1m]' : '') + query
+    return 'gpt-5.6-sol' + query + (has1mTag ? '[1m]' : '')
   }
 
   // Opus 4/4.1 are no longer available on the first-party API (same as

--- a/src/utils/model/model.ts
+++ b/src/utils/model/model.ts
@@ -627,6 +627,9 @@ export function getPublicModelDisplayName(model: ModelName): string | null {
   ) {
     // Return display names for known GitHub Copilot models
     const copilotModelNames: Record<string, string> = {
+      'gpt-5.6-sol': 'GPT-5.6 Sol',
+      'gpt-5.6-terra': 'GPT-5.6 Terra',
+      'gpt-5.6-luna': 'GPT-5.6 Luna',
       'gpt-5.5': 'GPT-5.5',
       'gpt-5.5-mini': 'GPT-5.5 mini',
       'gpt-5.4': 'GPT-5.4',
@@ -659,6 +662,12 @@ export function getPublicModelDisplayName(model: ModelName): string | null {
     return null
   }
   switch (model) {
+    case 'gpt-5.6-sol':
+      return 'GPT-5.6 Sol'
+    case 'gpt-5.6-terra':
+      return 'GPT-5.6 Terra'
+    case 'gpt-5.6-luna':
+      return 'GPT-5.6 Luna'
     case 'gpt-5.5':
       return 'GPT-5.5'
     case 'gpt-5.4':
@@ -830,6 +839,16 @@ export function parseUserSpecifiedModel(
   }
   if (modelString === 'codexspark') {
     return 'gpt-5.3-codex-spark' + (has1mTag ? '[1m]' : '')
+  }
+  // Bare gpt-5.6 resolves to the flagship tier (Sol), like the Codex CLI.
+  // Resolving here — not just in the request-time alias map — keeps the
+  // runtime model id on the tier that has real descriptor metadata, so
+  // context-window sizing and display names don't fall back to defaults.
+  // Match on the base name so a ?reasoning=/?thinking= query suffix does not
+  // defeat the rewrite; the query is preserved on the resolved tier id.
+  if (modelString === 'gpt-5.6' || modelString.startsWith('gpt-5.6?')) {
+    const query = modelString.slice('gpt-5.6'.length)
+    return 'gpt-5.6-sol' + (has1mTag ? '[1m]' : '') + query
   }
 
   // Opus 4/4.1 are no longer available on the first-party API (same as

--- a/src/utils/model/modelOptions.codexRecovery.test.ts
+++ b/src/utils/model/modelOptions.codexRecovery.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+
+import { resetModelStringsForTestingOnly } from '../../bootstrap/state.js'
+import { acquireEnvMutex, releaseEnvMutex } from '../../entrypoints/sdk/shared.js'
+import {
+  resetSettingsCache,
+  setSessionSettingsCache,
+} from '../settings/settingsCache.js'
+
+// Picker recovery for persisted Codex models while a NON-Codex provider is
+// active (the curated Codex options are only appended for the openai/codex
+// providers): the persisted value must surface the curated label/description
+// instead of a generic "Custom model" entry — including [1m]-tagged picks,
+// whose exact tagged value must be preserved on the option.
+
+async function importFreshModelOptionsModule(provider: string) {
+  mock.restore()
+  mock.module('./providers.js', () => ({
+    getAPIProvider: () => provider,
+    getAPIProviderForStatsig: () => provider,
+    isFirstPartyAnthropicBaseUrl: () => false,
+    isFirstPartyAnthropicProvider: () => false,
+    isCustomAnthropicProvider: () => false,
+    isGithubNativeAnthropicMode: () => false,
+    usesAnthropicAccountFlow: () => false,
+  }))
+  const nonce = `${Date.now()}-${Math.random()}`
+  const modelModule = await import(`./model.js?codexRecoveryTest=${nonce}`)
+  mock.module('./model.js', () => modelModule)
+  return import(`./modelOptions.js?ts=${nonce}`)
+}
+
+const ENV_KEYS = [
+  'CLAUDE_CODE_USE_OPENAI',
+  'OPENAI_BASE_URL',
+  'OPENAI_MODEL',
+  'OPENAI_API_KEY',
+  'ANTHROPIC_MODEL',
+] as const
+
+const originalEnv: Record<string, string | undefined> = {}
+
+beforeEach(async () => {
+  await acquireEnvMutex()
+  mock.restore()
+  setSessionSettingsCache({ settings: {}, errors: [] })
+  for (const key of ENV_KEYS) {
+    originalEnv[key] = process.env[key]
+    delete process.env[key]
+  }
+  resetModelStringsForTestingOnly()
+})
+
+afterEach(() => {
+  try {
+    mock.restore()
+    resetSettingsCache()
+    for (const key of ENV_KEYS) {
+      const value = originalEnv[key]
+      if (value === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = value
+      }
+    }
+  } finally {
+    releaseEnvMutex()
+  }
+})
+
+test('persisted [1m]-tagged Codex model surfaces its curated option under a non-Codex provider', async () => {
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'gpt-5.6-terra[1m]'
+  const { getModelOptions } = await importFreshModelOptionsModule('xai')
+
+  const options = getModelOptions()
+  const recovered = options.filter(opt => opt.value === 'gpt-5.6-terra[1m]')
+
+  expect(recovered).toHaveLength(1)
+  // Exact tagged value preserved (selection matching stays exact) with the
+  // curated Codex label/description, not a generic "Custom model" entry.
+  expect(recovered[0]!.label).toBe('gpt-5.6-terra')
+  expect(recovered[0]!.description).toBe(
+    'GPT-5.6 Terra · Balanced everyday workhorse',
+  )
+  expect(options.some(opt => opt.description === 'Custom model')).toBe(false)
+})
+
+test('persisted untagged Codex model never degrades to a "Custom model" entry', async () => {
+  // The untagged form may be served by an earlier path (the OpenAI-compat
+  // route catalog supplies its own labeled option) rather than the Codex
+  // recovery branch — either way the user must see a real label, never the
+  // generic custom-model fallback.
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENAI_MODEL = 'gpt-5.6-luna'
+  const { getModelOptions } = await importFreshModelOptionsModule('xai')
+
+  const options = getModelOptions()
+  const recovered = options.filter(opt => opt.value === 'gpt-5.6-luna')
+
+  expect(recovered).toHaveLength(1)
+  expect(recovered[0]!.description).not.toBe('Custom model')
+  expect(recovered[0]!.label.toLowerCase()).toContain('gpt-5.6')
+})

--- a/src/utils/model/modelOptions.ts
+++ b/src/utils/model/modelOptions.ts
@@ -425,6 +425,21 @@ function getCodexSparkOption(): ModelOption {
 function getCodexModelOptions(): ModelOption[] {
   return [
     {
+      value: 'gpt-5.6-sol',
+      label: 'gpt-5.6-sol',
+      description: 'GPT-5.6 Sol · Flagship for complex work, high reasoning',
+    },
+    {
+      value: 'gpt-5.6-terra',
+      label: 'gpt-5.6-terra',
+      description: 'GPT-5.6 Terra · Balanced everyday workhorse',
+    },
+    {
+      value: 'gpt-5.6-luna',
+      label: 'gpt-5.6-luna',
+      description: 'GPT-5.6 Luna · Fast and cost-effective',
+    },
+    {
       value: 'gpt-5.5',
       label: 'gpt-5.5',
       description: 'GPT-5.5 with high reasoning',
@@ -1039,7 +1054,27 @@ export function getModelOptions(fastMode = false): ModelOption[] {
     return filterModelOptionsByAllowlist([...options, getCodexPlanOption()])
   } else if (customModel === 'gpt-5.3-codex-spark') {
     return filterModelOptionsByAllowlist([...options, getCodexSparkOption()])
-  } else if (customModel === 'opus' && getAPIProvider() === 'firstParty' && isFirstPartyAnthropicBaseUrl()) {
+  }
+
+  // Persisted Codex model while a non-Codex provider is active (the Codex
+  // options were not appended above): surface the curated option instead
+  // of a generic "Custom model" entry, mirroring the gpt-5.5/spark cases
+  // for every Codex picker model. Match on the [1m]-stripped base so a
+  // tagged pick still gets its curated entry, but keep the persisted value
+  // on the option so selection matching stays exact.
+  const customCodexBase = customModel.replace(/\[1m]$/i, '')
+  const customCodexOption = getCodexModelOptions().find(
+    opt => opt.value === customCodexBase,
+  )
+  if (customCodexOption) {
+    return filterModelOptionsByAllowlist([
+      ...options,
+      customCodexBase === customModel
+        ? customCodexOption
+        : { ...customCodexOption, value: customModel },
+    ])
+  }
+  if (customModel === 'opus' && getAPIProvider() === 'firstParty' && isFirstPartyAnthropicBaseUrl()) {
     return filterModelOptionsByAllowlist([
       ...options,
       getMaxOpusOption(fastMode),

--- a/src/utils/model/parseUserSpecifiedModel.codexTag.test.ts
+++ b/src/utils/model/parseUserSpecifiedModel.codexTag.test.ts
@@ -66,4 +66,14 @@ describe('parseUserSpecifiedModel — bare gpt-5.6 resolves to Sol', () => {
       'gpt-5.6-sol?thinking=enabled',
     )
   })
+
+  test('combined query + [1m] tag keeps the tag trailing after the query', () => {
+    // The tag must stay at the very end (mirroring the input form): placed
+    // between the id and the query it would corrupt the base-model split,
+    // and folded into the query it would corrupt the reasoning value.
+    // parseModelDescriptor strips the trailing tag at request time.
+    expect(parseUserSpecifiedModel('gpt-5.6?reasoning=medium[1m]')).toBe(
+      'gpt-5.6-sol?reasoning=medium[1m]',
+    )
+  })
 })

--- a/src/utils/model/parseUserSpecifiedModel.codexTag.test.ts
+++ b/src/utils/model/parseUserSpecifiedModel.codexTag.test.ts
@@ -39,3 +39,31 @@ describe('parseUserSpecifiedModel — codex alias 1M tag', () => {
     expect(tagged.match(/\[1m]/gi)?.length).toBe(1)
   })
 })
+
+// Bare gpt-5.6 resolves to the flagship tier (Sol) at parse time — not just in
+// the request-time alias map — so context sizing and display use the tier id
+// that has real descriptor metadata. Tier ids pass through unchanged.
+describe('parseUserSpecifiedModel — bare gpt-5.6 resolves to Sol', () => {
+  test('gpt-5.6 maps to gpt-5.6-sol and preserves the [1m] tag', () => {
+    expect(parseUserSpecifiedModel('gpt-5.6')).toBe('gpt-5.6-sol')
+    expect(parseUserSpecifiedModel('gpt-5.6[1m]')).toBe('gpt-5.6-sol[1m]')
+  })
+
+  test('explicit tier ids pass through unchanged', () => {
+    expect(parseUserSpecifiedModel('gpt-5.6-sol')).toBe('gpt-5.6-sol')
+    expect(parseUserSpecifiedModel('gpt-5.6-terra')).toBe('gpt-5.6-terra')
+    expect(parseUserSpecifiedModel('gpt-5.6-luna')).toBe('gpt-5.6-luna')
+  })
+
+  test('a ?reasoning= query suffix does not defeat the rewrite', () => {
+    // Without base-name matching the suffixed form passed through unresolved
+    // and context sizing fell back to the 128k OpenAI default while the
+    // request itself still ran on Sol via the request-time alias map.
+    expect(parseUserSpecifiedModel('gpt-5.6?reasoning=medium')).toBe(
+      'gpt-5.6-sol?reasoning=medium',
+    )
+    expect(parseUserSpecifiedModel('gpt-5.6?thinking=enabled')).toBe(
+      'gpt-5.6-sol?thinking=enabled',
+    )
+  })
+})

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -2101,6 +2101,115 @@ describe('applyActiveProviderProfileFromConfig', () => {
     expect(saved?.model).toBe('glm-5.2')
   })
 
+  test('uses saved Codex /model choice when rehydrating the Codex OAuth profile', async () => {
+    // Regression: the Codex OAuth profile is created with a single
+    // `codexplan` model entry, so profileSupportsModel rejected any other
+    // Codex model saved via /model (e.g. gpt-5.6-terra) and the next startup
+    // silently reverted to codexplan → gpt-5.5. Codex-backend profiles must
+    // accept every Codex alias model and gpt-5.x free-text picks.
+    const {
+      _setSavedModelOverrideForTesting,
+      applyActiveProviderProfileFromConfig,
+      getProviderProfiles,
+    } = await importFreshProviderProfileModules()
+    _setSavedModelOverrideForTesting('gpt-5.6-terra')
+    const activeProfile = buildProfile({
+      id: 'saved_codex',
+      provider: 'openai',
+      baseUrl: 'https://chatgpt.com/backend-api/codex',
+      model: 'codexplan',
+    })
+
+    const applied = applyActiveProviderProfileFromConfig({
+      providerProfiles: [activeProfile],
+      activeProviderProfileId: activeProfile.id,
+    } as any)
+
+    expect(applied?.id).toBe(activeProfile.id)
+    expect(process.env.OPENAI_BASE_URL).toBe(
+      'https://chatgpt.com/backend-api/codex',
+    )
+    expect(process.env.OPENAI_MODEL).toBe('gpt-5.6-terra')
+    // The profile's configured model list is never mutated by /model.
+    const saved = getProviderProfiles({
+      providerProfiles: [activeProfile],
+      activeProviderProfileId: activeProfile.id,
+    } as any).find((profile: ProviderProfile) => profile.id === activeProfile.id)
+    expect(saved?.model).toBe('codexplan')
+  })
+
+  test('accepts a non-alias gpt-5.x free-text pick on a Codex profile, but not a foreign model', async () => {
+    // gpt-5.1-codex is served by the Codex backend but is not a
+    // CODEX_ALIAS_MODELS key (only its -max/-mini variants are), so it is
+    // only reachable via free-text /model — which live-validates against
+    // the backend before persisting. It must survive restart. A stale
+    // non-GPT model from another provider must NOT leak in.
+    const {
+      _setSavedModelOverrideForTesting,
+      applyActiveProviderProfileFromConfig,
+    } = await importFreshProviderProfileModules()
+    const activeProfile = buildProfile({
+      id: 'saved_codex',
+      provider: 'openai',
+      baseUrl: 'https://chatgpt.com/backend-api/codex',
+      model: 'codexplan',
+    })
+    const config = {
+      providerProfiles: [activeProfile],
+      activeProviderProfileId: activeProfile.id,
+    } as any
+
+    _setSavedModelOverrideForTesting('gpt-5.1-codex')
+    applyActiveProviderProfileFromConfig(config)
+    expect(process.env.OPENAI_MODEL).toBe('gpt-5.1-codex')
+
+    // Simulate a cold start for the second scenario — leftover provider env
+    // from the first application counts as explicit startup intent and would
+    // short-circuit applyActiveProviderProfileFromConfig.
+    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+    delete process.env.CLAUDE_CODE_USE_OPENAI
+    delete process.env.OPENAI_BASE_URL
+    delete process.env.OPENAI_MODEL
+    _setSavedModelOverrideForTesting('kimi-k2.6')
+    applyActiveProviderProfileFromConfig(config)
+    expect(String(process.env.OPENAI_MODEL)).toBe('codexplan')
+
+    // gpt-5-mini/-nano are API-only tiers the Codex backend does not serve;
+    // a stale pick from a direct-OpenAI profile must fall back too, not 400.
+    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED
+    delete process.env.CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID
+    delete process.env.CLAUDE_CODE_USE_OPENAI
+    delete process.env.OPENAI_BASE_URL
+    delete process.env.OPENAI_MODEL
+    _setSavedModelOverrideForTesting('gpt-5-mini')
+    applyActiveProviderProfileFromConfig(config)
+    expect(String(process.env.OPENAI_MODEL)).toBe('codexplan')
+  })
+
+  test('a [1m]-tagged saved Codex pick survives restart', async () => {
+    // The [1m] tag is a client-side context opt-in, not part of the model
+    // identity: profileSupportsModel must match the tagged value against the
+    // untagged alias/profile entry instead of dropping the override.
+    const {
+      _setSavedModelOverrideForTesting,
+      applyActiveProviderProfileFromConfig,
+    } = await importFreshProviderProfileModules()
+    const activeProfile = buildProfile({
+      id: 'saved_codex',
+      provider: 'openai',
+      baseUrl: 'https://chatgpt.com/backend-api/codex',
+      model: 'codexplan',
+    })
+
+    _setSavedModelOverrideForTesting('codexplan[1m]')
+    applyActiveProviderProfileFromConfig({
+      providerProfiles: [activeProfile],
+      activeProviderProfileId: activeProfile.id,
+    } as any)
+    expect(process.env.OPENAI_MODEL).toBe('codexplan[1m]')
+  })
+
   test('cold start on the Anthropic sentinel stays on built-in Anthropic and does not fall back to the OpenGateway default (#1429)', async () => {
     // Regression: after clearActiveProviderProfile() records the Anthropic
     // sentinel and deletes the startup profile mirror, a restart must keep the

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -1,7 +1,9 @@
 import { randomBytes } from 'crypto'
 import {
   getAdditionalModelOptionsCacheScope,
+  isCodexAlias,
   isCodexBaseUrl,
+  isCodexEligibleGpt5Model,
   parseOpenAICompatibleApiFormat,
 } from '../services/api/providerConfig.js'
 import {
@@ -244,7 +246,13 @@ function resolveProfileCapabilityRouteId(
 }
 
 function normalizeProfileModelLookupKey(model: string | undefined): string {
-  return model?.trim().split('?', 1)[0]?.trim().toLowerCase() ?? ''
+  // Strip a trailing [1m] tag along with any ?query suffix: the tag is a
+  // client-side context opt-in, not part of the model's identity, so a saved
+  // `codexplan[1m]` must still match a profile/catalog entry of `codexplan`.
+  return (
+    model?.trim().split('?', 1)[0]?.trim().toLowerCase().replace(/\[1m]$/, '') ??
+    ''
+  )
 }
 
 function profileSupportsModel(profile: ProviderProfile, model: string): boolean {
@@ -259,6 +267,26 @@ function profileSupportsModel(profile: ProviderProfile, model: string): boolean 
     )
   ) {
     return true
+  }
+
+  // Codex-backend profiles (ChatGPT OAuth) are created with a single
+  // `codexplan` entry, but the backend accepts every Codex alias model and
+  // the wider gpt-5.x family (free-text /model picks like `gpt-5.1-codex`
+  // pass live validation before being persisted). Without this, a saved
+  // pick like `gpt-5.6-terra` is rejected here at the next startup, so the
+  // profile's default silently wins and the choice appears to not stick.
+  // Deliberately NOT a blanket allow: a stale non-GPT model saved under a
+  // different provider (e.g. `kimi-k2.6`) — or an API-only gpt-5-mini/-nano
+  // tier the Codex backend does not serve — must still fall back to the
+  // profile default rather than 400 against the Codex backend. The gate is
+  // authoritative for Codex profiles: falling through to the catalog check
+  // would consult the `openai` route catalog (the profile's provider is
+  // 'openai'), which describes api.openai.com's model set, not the ChatGPT
+  // Codex backend's.
+  if (isCodexBaseUrl(profile.baseUrl)) {
+    return (
+      isCodexAlias(normalizedModel) || isCodexEligibleGpt5Model(normalizedModel)
+    )
   }
 
   const routeId = resolveProfileCapabilityRouteId(profile.provider, profile.baseUrl)


### PR DESCRIPTION
Add the GPT-5.6 family (gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna) to the Codex OAuth provider: alias map with default reasoning efforts, /model picker options, display names, and Codex-route context metadata. Bare `gpt-5.6` resolves to the flagship Sol tier at parse time (Codex CLI convention) — matched on the base name so a ?reasoning=/?thinking= query suffix cannot defeat the rewrite — keeping context sizing and display on real descriptor metadata.

Context windows reconcile with the #1961 direct-OpenAI routing: the gpt.ts descriptors pin the ~272k effective Codex input cap (issue #1118 precedent; the Codex base URL resolves to a catalog-less route that reads descriptors), while the openai vendor catalog keeps the true 1.05M window for direct api.openai.com /v1/responses traffic. The gpt-5.6 alias-default reasoning effort is likewise Codex-transport-only: OPENAI_API_BASE gateways do not inherit first-party effort metadata (explicit /effort and ?reasoning= picks still flow everywhere).

Fix startup rehydration for Codex profiles: profileSupportsModel is now authoritative for Codex-backend profiles — it accepts every Codex alias and Codex-eligible gpt-5.x free-text pick (shared isCodexEligibleGpt5Model predicate), so a /model choice (e.g. gpt-5.6-terra) survives restart instead of silently reverting to codexplan/gpt-5.5. A trailing [1m] tag is normalized off before matching, so tagged picks stick too. Foreign leftovers (kimi-k2.6) and API-only tiers the backend does not serve (gpt-5-mini/-nano) still fall back to the profile default instead of 400ing.

Also: generalize the picker's custom-model recovery to keep curated labels for all Codex models across provider switches ([1m]-tolerant, single lookup), and add GPT-5.6 cases to the display-name maps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GPT-5.6 Sol, Terra, and Luna model options, plus updated display names for supported Copilot tiers.
  - Bare `gpt-5.6` selections now resolve to the Sol tier while preserving any context tags and query suffixes.
- **Improvements**
  - Codex routes now use a 272,000-token context window (up to 128,000 output tokens); direct OpenAI routes retain 1,050,000.
  - Improved model option recovery and validation across provider/profile changes, including correct handling of tagged (`[1m]`) selections and reasoning-effort scoping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->