### PR TITLE
fix(fs): tolerate EPERM from mkdir on Windows drive roots

### DIFF
--- a/src/utils/fsOperations.mkdir.test.ts
+++ b/src/utils/fsOperations.mkdir.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import * as fs from 'fs'
+import * as fsPromises from 'fs/promises'
+import { NodeFsOperations } from './fsOperations.js'
+
+// Regression test: on Windows, writing a file directly at a drive root
+// (e.g. D:\foo) makes recursive mkdir walk up to the root itself, where the
+// kernel cannot "create" a root that already exists and libuv maps that to
+// EPERM rather than EEXIST. mkdir must treat EACCES/EPERM as a no-op when
+// the directory already exists, and must keep propagating them when it does
+// not (genuine permission failures).
+//
+// Uses spyOn + mock.restore() rather than mock.module(): module mocks are
+// process-global and leak across test files in the same bun process, and
+// neither mock.restore() nor re-registering the real module clears them.
+
+function eperm(): NodeJS.ErrnoException {
+  return Object.assign(new Error("EPERM: operation not permitted, mkdir 'D:\\'"), {
+    code: 'EPERM',
+    path: 'D:\\',
+  })
+}
+
+function mockMkdir(dirExists: boolean) {
+  spyOn(fsPromises, 'mkdir').mockRejectedValue(eperm())
+  spyOn(fs, 'existsSync').mockReturnValue(dirExists)
+  spyOn(fs, 'mkdirSync').mockImplementation(() => {
+    throw eperm()
+  })
+}
+
+describe('NodeFsOperations mkdir EPERM handling', () => {
+  afterEach(() => {
+    mock.restore()
+  })
+
+  test('async mkdir swallows EPERM when the directory already exists', async () => {
+    mockMkdir(true)
+    await expect(NodeFsOperations.mkdir('D:\\')).resolves.toBeUndefined()
+  })
+
+  test('async mkdir propagates EPERM when the directory does not exist', async () => {
+    mockMkdir(false)
+    await expect(NodeFsOperations.mkdir('D:\\')).rejects.toMatchObject({
+      code: 'EPERM',
+    })
+  })
+
+  test('sync mkdirSync swallows EPERM when the directory already exists', () => {
+    mockMkdir(true)
+    expect(() => NodeFsOperations.mkdirSync('D:\\')).not.toThrow()
+  })
+
+  test('sync mkdirSync propagates EPERM when the directory does not exist', () => {
+    mockMkdir(false)
+    expect(() => NodeFsOperations.mkdirSync('D:\\')).toThrow(/EPERM/)
+  })
+})

--- a/src/utils/fsOperations.ts
+++ b/src/utils/fsOperations.ts
@@ -456,7 +456,18 @@ export const NodeFsOperations: FsOperations = {
       // permissions, systemd private tmp namespaces). If the directory
       // already exists via a prior mkdir call, treat it as a no-op. This
       // prevents the error from propagating to callers that don't catch it.
-      if (code === 'EACCES' && fs.existsSync(dirPath)) return
+      // EPERM gets the same treatment: on Windows, mkdir on a drive root
+      // ('D:\') maps the kernel's "cannot create a root that already exists"
+      // to EPERM rather than EEXIST — not an actual permissions failure.
+      // The existsSync guard keeps genuine "cannot create this directory"
+      // failures (dir absent, or dir present but not writable — the
+      // subsequent file write surfaces the real EACCES) propagating.
+      if (
+        (code === 'EACCES' || code === 'EPERM') &&
+        fs.existsSync(dirPath)
+      ) {
+        return
+      }
       throw e
     }
   },
@@ -596,7 +607,17 @@ export const NodeFsOperations: FsOperations = {
       // refuse writes (e.g. /tmp in container environments with restricted
       // permissions, systemd private tmp namespaces). If the directory
       // already exists via a prior mkdir call, treat it as a no-op.
-      if (code === 'EACCES' && fs.existsSync(dirPath)) return
+      // EPERM gets the same treatment: on Windows, mkdir on a drive root
+      // ('D:\') maps the kernel's "cannot create a root that already exists"
+      // to EPERM rather than EEXIST — not an actual permissions failure.
+      // The existsSync guard keeps genuine "cannot create this directory"
+      // failures propagating.
+      if (
+        (code === 'EACCES' || code === 'EPERM') &&
+        fs.existsSync(dirPath)
+      ) {
+        return
+      }
       throw e
     }
   },


### PR DESCRIPTION
## Problem

On Windows, using the Write tool on a file directly at a drive root (e.g. writing content to `D:\foo`) fails with a spurious permission error:

```
EPERM: operation not permitted, mkdir 'D:\'
```

`FileWriteTool.call` runs `mkdir(dir, { recursive: true })` on the file's parent directory. When the file sits at a drive root, that parent *is* the root: `dirname('D:\foo') === 'D:\'`. The Windows kernel cannot "create" a root that already exists, and libuv maps that failure to `EPERM` rather than `EEXIST`. `NodeFsOperations.mkdir`/`mkdirSync` only tolerated `EEXIST` and `EACCES`-with-existing-dir, so the error propagated to the user as "no permission to mkdir D:\".

## Fix

Treat `EPERM` the same as `EACCES` in `NodeFsOperations.mkdir`/`mkdirSync`: swallow it **only when `existsSync(dirPath)` confirms the directory already exists**.

Genuine permission failures are unaffected:

- dir missing + EPERM/EACCES → still throws (covered by test)
- dir present but not writable → mkdir is skipped, but the subsequent file write surfaces the real EACCES

## Testing

- Reproduced `mkdir('D:/', { recursive: true })` → `EPERM` on Windows with both Node and Bun; verified the guarded swallow resolves it and writing a file at the drive root (`D:\foo`) succeeds
- Added `src/utils/fsOperations.mkdir.test.ts` (4 cases: async/sync × dir-exists/dir-missing) — all pass
- `src/utils/permissions` suite: 157 pass, 1 failure is pre-existing on a clean tree (`plan mode mechanical read-only policy > denies a plan-file exception whose active path is a symlink`)
- `tsc --noEmit` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory creation on Windows by treating `EPERM` as non-fatal when the target directory already exists, for both async and sync flows.
* **Tests**
  * Added regression coverage for Windows-specific permission error handling, verifying behavior when the directory exists versus when it does not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->