### PR TITLE
fix(cache-probe): omit unsupported cache request fields

### DIFF
--- a/src/commands/cache-probe/cache-probe.test.ts
+++ b/src/commands/cache-probe/cache-probe.test.ts
@@ -76,6 +76,18 @@ test('cache-probe retains cache extensions for supported Chat and Responses endp
       prompt_cache_retention: '24h',
     })
     expect(responsesBody).toHaveProperty('prompt_cache_key')
+
+    const compatResponsesBody = await captureFirstProbeBody({
+      CLAUDE_CODE_USE_OPENAI: '1',
+      OPENAI_BASE_URL: 'https://api.openai.com/v1',
+      OPENAI_MODEL: 'gpt-4o',
+      OPENAI_API_FORMAT: 'responses_compat',
+      OPENAI_API_KEY: 'test-key',
+    })
+    expect(compatResponsesBody).toMatchObject({
+      input: [{ content: [{ type: 'text', text: 'Say "hello" and nothing else.' }] }],
+      prompt_cache_retention: '24h',
+    })
   } finally {
     releaseSharedMutationLock()
   }

--- a/src/commands/cache-probe/cache-probe.test.ts
+++ b/src/commands/cache-probe/cache-probe.test.ts
@@ -15,6 +15,12 @@ test('cache-probe only sends OpenAI cache extensions to direct OpenAI API hosts 
   expect(supportsCacheProbeFields('https://api.openai.com/v1')).toBe(true)
   expect(supportsCacheProbeFields('https://eu.api.openai.com/v1')).toBe(true)
   expect(supportsCacheProbeFields('https://resource.openai.azure.com/openai/v1')).toBe(true)
+  expect(supportsCacheProbeFields('https://resource.services.ai.azure.com/v1')).toBe(true)
+  expect(
+    supportsCacheProbeFields('https://azure-proxy.example.test/v1', {
+      OPENAI_AZURE_STYLE: '1',
+    }),
+  ).toBe(true)
   expect(supportsCacheProbeFields('https://integrate.api.nvidia.com/v1')).toBe(false)
   expect(supportsCacheProbeFields('https://compatible.example.test/v1')).toBe(false)
 })

--- a/src/commands/cache-probe/cache-probe.test.ts
+++ b/src/commands/cache-probe/cache-probe.test.ts
@@ -23,6 +23,62 @@ test('cache-probe only sends OpenAI cache extensions to direct OpenAI API hosts 
   ).toBe(true)
   expect(supportsCacheProbeFields('https://integrate.api.nvidia.com/v1')).toBe(false)
   expect(supportsCacheProbeFields('https://compatible.example.test/v1')).toBe(false)
+  expect(supportsCacheProbeFields('not a URL')).toBe(false)
+})
+
+async function captureFirstProbeBody(
+  env: Record<string, string>,
+): Promise<Record<string, unknown>> {
+  const originalEnv = { ...process.env }
+  const originalFetch = globalThis.fetch
+  let sentBody: Record<string, unknown> | undefined
+  try {
+    for (const key of Object.keys(process.env)) delete process.env[key]
+    Object.assign(process.env, env)
+    const mockFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
+      sentBody = JSON.parse(String(init?.body))
+      return new Response('unsupported fields', { status: 400 })
+    }) as unknown as typeof globalThis.fetch
+    globalThis.fetch = mockFetch
+
+    await call('', {} as any)
+    expect(sentBody).toBeDefined()
+    return sentBody!
+  } finally {
+    globalThis.fetch = originalFetch
+    for (const key of Object.keys(process.env)) delete process.env[key]
+    Object.assign(process.env, originalEnv)
+  }
+}
+
+test('cache-probe retains cache extensions for supported Chat and Responses endpoints (#2042)', async () => {
+  await acquireSharedMutationLock('commands/cache-probe/cache-probe.test.ts')
+  try {
+    const chatBody = await captureFirstProbeBody({
+      CLAUDE_CODE_USE_OPENAI: '1',
+      OPENAI_BASE_URL: 'https://api.openai.com/v1',
+      OPENAI_MODEL: 'gpt-4o',
+      OPENAI_API_KEY: 'test-key',
+    })
+    expect(chatBody).toMatchObject({ store: false })
+    expect(chatBody).toHaveProperty('prompt_cache_key')
+    expect(chatBody).not.toHaveProperty('prompt_cache_retention')
+
+    const responsesBody = await captureFirstProbeBody({
+      CLAUDE_CODE_USE_OPENAI: '1',
+      OPENAI_BASE_URL: 'https://resource.openai.azure.com/openai/v1',
+      OPENAI_MODEL: 'gpt-5.4',
+      OPENAI_API_FORMAT: 'responses',
+      OPENAI_API_KEY: 'test-key',
+    })
+    expect(responsesBody).toMatchObject({
+      store: false,
+      prompt_cache_retention: '24h',
+    })
+    expect(responsesBody).toHaveProperty('prompt_cache_key')
+  } finally {
+    releaseSharedMutationLock()
+  }
 })
 
 test('cache-probe omits cache extensions from NVIDIA NIM requests (#2042)', async () => {
@@ -40,10 +96,11 @@ test('cache-probe omits cache extensions from NVIDIA NIM requests (#2042)', asyn
     process.env.OPENAI_API_KEY = 'test-key'
     process.env.NVIDIA_NIM = '1'
     process.env.NVIDIA_API_KEY = 'test-key'
-    globalThis.fetch = (async (_input, init) => {
+    const mockFetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
       sentBody = JSON.parse(String(init?.body))
       return new Response('unsupported fields', { status: 400 })
-    }) as typeof globalThis.fetch
+    }) as unknown as typeof globalThis.fetch
+    globalThis.fetch = mockFetch
 
     const result = await call('', {} as any)
 

--- a/src/commands/cache-probe/cache-probe.test.ts
+++ b/src/commands/cache-probe/cache-probe.test.ts
@@ -14,6 +14,7 @@ import {
 test('cache-probe only sends OpenAI cache extensions to direct OpenAI API hosts (#2042)', () => {
   expect(supportsCacheProbeFields('https://api.openai.com/v1')).toBe(true)
   expect(supportsCacheProbeFields('https://eu.api.openai.com/v1')).toBe(true)
+  expect(supportsCacheProbeFields('https://resource.openai.azure.com/openai/v1')).toBe(true)
   expect(supportsCacheProbeFields('https://integrate.api.nvidia.com/v1')).toBe(false)
   expect(supportsCacheProbeFields('https://compatible.example.test/v1')).toBe(false)
 })

--- a/src/commands/cache-probe/cache-probe.test.ts
+++ b/src/commands/cache-probe/cache-probe.test.ts
@@ -40,10 +40,10 @@ test('cache-probe omits cache extensions from NVIDIA NIM requests (#2042)', asyn
     process.env.OPENAI_API_KEY = 'test-key'
     process.env.NVIDIA_NIM = '1'
     process.env.NVIDIA_API_KEY = 'test-key'
-    globalThis.fetch = async (_input, init) => {
+    globalThis.fetch = (async (_input, init) => {
       sentBody = JSON.parse(String(init?.body))
       return new Response('unsupported fields', { status: 400 })
-    }
+    }) as typeof globalThis.fetch
 
     const result = await call('', {} as any)
 

--- a/src/commands/cache-probe/cache-probe.test.ts
+++ b/src/commands/cache-probe/cache-probe.test.ts
@@ -8,7 +8,52 @@ import {
   call,
   resolveCacheProbeApiKey,
   resolveCacheProbeRequestApiKey,
+  supportsCacheProbeFields,
 } from './cache-probe.js'
+
+test('cache-probe only sends OpenAI cache extensions to direct OpenAI API hosts (#2042)', () => {
+  expect(supportsCacheProbeFields('https://api.openai.com/v1')).toBe(true)
+  expect(supportsCacheProbeFields('https://eu.api.openai.com/v1')).toBe(true)
+  expect(supportsCacheProbeFields('https://integrate.api.nvidia.com/v1')).toBe(false)
+  expect(supportsCacheProbeFields('https://compatible.example.test/v1')).toBe(false)
+})
+
+test('cache-probe omits cache extensions from NVIDIA NIM requests (#2042)', async () => {
+  await acquireSharedMutationLock('commands/cache-probe/cache-probe.test.ts')
+  const originalEnv = { ...process.env }
+  const originalFetch = globalThis.fetch
+  let sentBody: Record<string, unknown> | undefined
+  try {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key]
+    }
+    process.env.CLAUDE_CODE_USE_OPENAI = '1'
+    process.env.OPENAI_BASE_URL = 'https://integrate.api.nvidia.com/v1'
+    process.env.OPENAI_MODEL = 'nvidia/llama-3.1-nemotron-70b-instruct'
+    process.env.OPENAI_API_KEY = 'test-key'
+    process.env.NVIDIA_NIM = '1'
+    process.env.NVIDIA_API_KEY = 'test-key'
+    globalThis.fetch = async (_input, init) => {
+      sentBody = JSON.parse(String(init?.body))
+      return new Response('unsupported fields', { status: 400 })
+    }
+
+    const result = await call('', {} as any)
+
+    expect(result.type).toBe('text')
+    expect(sentBody).toBeDefined()
+    expect(sentBody).not.toHaveProperty('prompt_cache_key')
+    expect(sentBody).not.toHaveProperty('prompt_cache_retention')
+    expect(sentBody).not.toHaveProperty('store')
+  } finally {
+    globalThis.fetch = originalFetch
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key]
+    }
+    Object.assign(process.env, originalEnv)
+    releaseSharedMutationLock()
+  }
+})
 
 test('resolveCacheProbeApiKey prefers the first usable OPENAI_API_KEYS entry', () => {
   expect(

--- a/src/commands/cache-probe/cache-probe.ts
+++ b/src/commands/cache-probe/cache-probe.ts
@@ -42,15 +42,17 @@ function getModelFamily(model: string | undefined): string {
 }
 
 /**
- * `prompt_cache_*` and `store` are OpenAI-specific request extensions. This
- * command sends requests directly (rather than through the OpenAI shim), so
- * descriptor-level `removeBodyFields` rules do not protect strict compatible
- * endpoints such as NVIDIA NIM.
+ * `prompt_cache_*` and `store` are OpenAI/Azure OpenAI request extensions.
+ * This command sends requests directly (rather than through the OpenAI shim),
+ * so descriptor-level `removeBodyFields` rules do not protect strict
+ * compatible endpoints such as NVIDIA NIM.
  */
 export function supportsCacheProbeFields(baseUrl: string): boolean {
   try {
     const hostname = new URL(baseUrl).hostname.toLowerCase()
-    return hostname === 'api.openai.com' || hostname.endsWith('.api.openai.com')
+    return hostname === 'api.openai.com' ||
+      hostname.endsWith('.api.openai.com') ||
+      hostname.endsWith('.openai.azure.com')
   } catch {
     return false
   }

--- a/src/commands/cache-probe/cache-probe.ts
+++ b/src/commands/cache-probe/cache-probe.ts
@@ -291,7 +291,10 @@ export const call: LocalCommandCall = async (args) => {
         {
           type: 'message',
           role: 'user',
-          content: [{ type: 'input_text', text: USER_MESSAGE }],
+          content: [{
+            type: request.transport === 'responses_compat' ? 'text' : 'input_text',
+            text: USER_MESSAGE,
+          }],
         },
       ],
       stream: true,

--- a/src/commands/cache-probe/cache-probe.ts
+++ b/src/commands/cache-probe/cache-probe.ts
@@ -262,7 +262,10 @@ export const call: LocalCommandCall = async (args) => {
     }
   }
 
-  const useResponses = request.transport === 'codex_responses'
+  const useResponses =
+    request.transport === 'codex_responses' ||
+    request.transport === 'responses' ||
+    request.transport === 'responses_compat'
   const endpoint = useResponses ? '/responses' : '/chat/completions'
   const url = `${request.baseUrl}${endpoint}`
   const family = getModelFamily(request.resolvedModel)

--- a/src/commands/cache-probe/cache-probe.ts
+++ b/src/commands/cache-probe/cache-probe.ts
@@ -41,6 +41,21 @@ function getModelFamily(model: string | undefined): string {
     .replace(/-preview$/, '')
 }
 
+/**
+ * `prompt_cache_*` and `store` are OpenAI-specific request extensions. This
+ * command sends requests directly (rather than through the OpenAI shim), so
+ * descriptor-level `removeBodyFields` rules do not protect strict compatible
+ * endpoints such as NVIDIA NIM.
+ */
+export function supportsCacheProbeFields(baseUrl: string): boolean {
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase()
+    return hostname === 'api.openai.com' || hostname.endsWith('.api.openai.com')
+  } catch {
+    return false
+  }
+}
+
 
 export function resolveCacheProbeApiKey(
   env: NodeJS.ProcessEnv = process.env,
@@ -244,6 +259,8 @@ export const call: LocalCommandCall = async (args) => {
   const url = `${request.baseUrl}${endpoint}`
   const family = getModelFamily(request.resolvedModel)
   const cacheKey = `${getSessionId()}:${family}`
+  const includeCacheProbeFields =
+    !noKey && supportsCacheProbeFields(request.baseUrl)
 
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -267,11 +284,13 @@ export const call: LocalCommandCall = async (args) => {
         },
       ],
       stream: true,
-      ...(noKey ? {} : {
-        store: false,
-        prompt_cache_key: cacheKey,
-        prompt_cache_retention: '24h',
-      }),
+      ...(includeCacheProbeFields
+        ? {
+            store: false,
+            prompt_cache_key: cacheKey,
+            prompt_cache_retention: '24h',
+          }
+        : {}),
     }
   } else {
     body = {
@@ -283,21 +302,23 @@ export const call: LocalCommandCall = async (args) => {
       stream: true,
       stream_options: { include_usage: true },
       max_tokens: 20,
-      ...(noKey ? {} : {
-        store: false,
-        prompt_cache_key: cacheKey,
-      }),
+      ...(includeCacheProbeFields
+        ? {
+            store: false,
+            prompt_cache_key: cacheKey,
+          }
+        : {}),
     }
   }
 
   // Log configuration
   const config = [
-    `[cache-probe] Starting cache probe${noKey ? ' (--no-key: cache params OMITTED)' : ''}`,
+    `[cache-probe] Starting cache probe${!includeCacheProbeFields ? ' (cache params OMITTED)' : ''}`,
     `  model: ${request.resolvedModel} (family: ${family})`,
     `  transport: ${request.transport}`,
     `  endpoint: ${url}`,
-    `  prompt_cache_key: ${noKey ? 'NOT SENT' : cacheKey}`,
-    `  store: ${noKey ? 'NOT SENT' : 'false'}`,
+    `  prompt_cache_key: ${includeCacheProbeFields ? cacheKey : 'NOT SENT'}`,
+    `  store: ${includeCacheProbeFields ? 'false' : 'NOT SENT'}`,
     `  system prompt: ~${Math.round(SYSTEM_PROMPT.length / 4)} tokens`,
     `  delay between calls: ${DELAY_MS}ms`,
   ].join('\n')

--- a/src/commands/cache-probe/cache-probe.ts
+++ b/src/commands/cache-probe/cache-probe.ts
@@ -1,7 +1,10 @@
 import { getSessionId } from '../../bootstrap/state.js'
 import { firstUsableCredential } from '../../services/api/credentialPool.js'
 import { resolveOpenAICredentialEnvState } from '../../utils/providerProfile.js'
-import { resolveProviderRequest } from '../../services/api/providerConfig.js'
+import {
+  isAzureStyleBaseUrl,
+  resolveProviderRequest,
+} from '../../services/api/providerConfig.js'
 import type { LocalCommandCall } from '../../types/command.js'
 import { logForDebugging } from '../../utils/debug.js'
 import { isEnvTruthy } from '../../utils/envUtils.js'
@@ -47,12 +50,15 @@ function getModelFamily(model: string | undefined): string {
  * so descriptor-level `removeBodyFields` rules do not protect strict
  * compatible endpoints such as NVIDIA NIM.
  */
-export function supportsCacheProbeFields(baseUrl: string): boolean {
+export function supportsCacheProbeFields(
+  baseUrl: string,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
   try {
     const hostname = new URL(baseUrl).hostname.toLowerCase()
     return hostname === 'api.openai.com' ||
       hostname.endsWith('.api.openai.com') ||
-      hostname.endsWith('.openai.azure.com')
+      isAzureStyleBaseUrl(baseUrl, env)
   } catch {
     return false
   }


### PR DESCRIPTION
## Summary

Fixes #2042.

`/cache-probe` bypassed the OpenAI shim and sent `store`, `prompt_cache_key`, and `prompt_cache_retention` to every OpenAI-compatible endpoint. Strict third-party endpoints such as NVIDIA NIM can reject those fields.

This change sends cache extensions only to direct OpenAI and Azure-style OpenAI endpoints, reusing the runtime Azure classifier; compatible endpoints now receive the probe request without those extensions.

## Validation

- `bun test src/commands/cache-probe/cache-probe.test.ts`
- `bun run build`
- `bun run smoke`
- `bun run integrations:check`
- `bun run scripts/pr-intent-scan.ts --base upstream/main`

The final reviewed SHA is `32f5e1977774952a812f03fe6b11b5e2a6ea841f`.

## Limitation

The existing cache-probe Azure API-key header behavior is outside this issue’s body-field scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Cache-probe requests now correctly omit cache extension fields on NVIDIA NIM and other endpoints that don’t support them.
  - Improved automatic detection of base URLs to decide when cache-probe fields (`store`, `prompt_cache_key`, `prompt_cache_retention`) should be included.
  - Applies consistently to both Responses API and Chat Completions request formats.
  - Debug output now clearly shows when cache-probe fields are not sent.

- **Tests**
  - Added coverage for cache-probe field support detection and for NVIDIA NIM request payload shaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->