### PR TITLE
fix: apply ultrathink effort to provider requests

### DIFF
--- a/src/query.ts
+++ b/src/query.ts
@@ -458,6 +458,41 @@ export type QueryParams = {
   deps?: QueryDeps
 }
 
+/**
+ * `ultrathink_effort` is emitted while processing the current user input.
+ * Its attachment is deliberately transient, but the request-level effort
+ * setting must follow it for providers that expose reasoning effort as a wire
+ * parameter. The attachment must follow the newest human turn without an
+ * intervening meta user message: historical attachments and system-generated
+ * prompts must not affect the request's effort. Image metadata is appended
+ * after attachments, so it remains eligible.
+ */
+function hasUltrathinkEffortForCurrentTurn(messages: readonly Message[]): boolean {
+  const latestHumanTurn = messages.findLastIndex(isHumanTurn)
+  if (latestHumanTurn === -1) {
+    return false
+  }
+
+  const ultrathinkAttachment = messages.findIndex(
+    (message, index) =>
+      index > latestHumanTurn &&
+      message.type === 'attachment' &&
+      message.attachment.type === 'ultrathink_effort',
+  )
+  if (ultrathinkAttachment === -1) {
+    return false
+  }
+
+  return !messages
+    .slice(latestHumanTurn + 1, ultrathinkAttachment)
+    .some(
+      message =>
+        message.type === 'user' &&
+        message.isMeta &&
+        message.toolUseResult === undefined,
+    )
+}
+
 function injectRequestOnlyMessages(
   messages: readonly Message[],
   requestOnlyMessages: readonly Message[] | undefined,
@@ -564,6 +599,9 @@ async function* queryLoop(
     skipCacheWrite,
   } = params
   const deps = params.deps ?? productionDeps()
+  const ultrathinkEffortForCurrentTurn = hasUltrathinkEffortForCurrentTurn(
+    params.messages,
+  )
 
   // Mutable cross-iteration state. The loop body destructures this at the top
   // of each iteration so reads stay bare-name (`messages`, `toolUseContext`).
@@ -1375,7 +1413,13 @@ async function* queryLoop(
               ),
               queryTracking,
               queryLifecycle: toolUseContext.queryLifecycle,
-              effortValue: appState.effortValue,
+              // Explicit /effort selection wins. When it is unset, carry the
+              // current turn's ultrathink attachment through to the API client
+              // so OpenAI-compatible providers receive reasoning_effort=high
+              // instead of only a natural-language system reminder.
+              effortValue:
+                appState.effortValue ??
+                (ultrathinkEffortForCurrentTurn ? 'high' : undefined),
               advisorModel: appState.advisorModel,
               skipCacheWrite,
               agentId: toolUseContext.agentId,

--- a/src/query/requestOnlyMessages.test.ts
+++ b/src/query/requestOnlyMessages.test.ts
@@ -9,10 +9,14 @@ import {
   createCompactBoundaryMessage,
   createUserMessage,
 } from '../utils/messages.js'
+import { createAttachmentMessage } from '../utils/attachments.js'
 import { INTERRUPTION_CORRECTION_REMINDER } from '../utils/interruptionCorrection.js'
 import { asSystemPrompt } from '../utils/systemPromptType.js'
 
-function makeToolUseContext(tools: Tools = []): QueryParams['toolUseContext'] {
+function makeToolUseContext(
+  tools: Tools = [],
+  effortValue: 'low' | 'medium' | 'high' | undefined = undefined,
+): QueryParams['toolUseContext'] {
   return {
     abortController: new AbortController(),
     getAppState: () => ({
@@ -21,7 +25,7 @@ function makeToolUseContext(tools: Tools = []): QueryParams['toolUseContext'] {
       toolPermissionContext: { mode: 'default' },
       sessionHooks: new Map(),
       mainLoopModel: 'test-model',
-      effortValue: undefined,
+      effortValue,
       advisorModel: undefined,
     }),
     options: {
@@ -185,6 +189,107 @@ test('leaves model messages unchanged when request-only context is absent', asyn
 
   expect(modelCalls).toHaveLength(1)
   expect(modelCalls[0]).toEqual(originalMessages)
+})
+
+test('sends high effort for an ultrathink attachment on the current user turn', async () => {
+  let requestEffort: unknown
+  const params = baseParams(
+    async function* ({ options }) {
+      requestEffort = options.effortValue
+      yield createAssistantMessage({ content: 'done' })
+    },
+    async () => ({ wasCompacted: false }),
+  )
+  params.messages = [
+    createUserMessage({ content: 'ultrathink solve this' }),
+    createAttachmentMessage({ type: 'ultrathink_effort', level: 'high' }),
+  ]
+
+  await collect(params)
+
+  expect(requestEffort).toBe('high')
+})
+
+test('does not let a historical ultrathink attachment affect a later user turn', async () => {
+  let requestEffort: unknown
+  const params = baseParams(
+    async function* ({ options }) {
+      requestEffort = options.effortValue
+      yield createAssistantMessage({ content: 'done' })
+    },
+    async () => ({ wasCompacted: false }),
+  )
+  params.messages = [
+    createUserMessage({ content: 'ultrathink solve this' }),
+    createAttachmentMessage({ type: 'ultrathink_effort', level: 'high' }),
+    createAssistantMessage({ content: 'done' }),
+    createUserMessage({ content: 'ordinary prompt' }),
+  ]
+
+  await collect(params)
+
+  expect(requestEffort).toBeUndefined()
+})
+
+test('does not apply ultrathink effort to a meta-originated prompt', async () => {
+  let requestEffort: unknown
+  const params = baseParams(
+    async function* ({ options }) {
+      requestEffort = options.effortValue
+      yield createAssistantMessage({ content: 'done' })
+    },
+    async () => ({ wasCompacted: false }),
+  )
+  params.messages = [
+    createUserMessage({ content: 'previous user turn' }),
+    createAssistantMessage({ content: 'done' }),
+    createUserMessage({ content: 'ultrathink scheduled task', isMeta: true }),
+    createAttachmentMessage({ type: 'ultrathink_effort', level: 'high' }),
+  ]
+
+  await collect(params)
+
+  expect(requestEffort).toBeUndefined()
+})
+
+test('keeps ultrathink effort when image metadata follows its attachment', async () => {
+  let requestEffort: unknown
+  const params = baseParams(
+    async function* ({ options }) {
+      requestEffort = options.effortValue
+      yield createAssistantMessage({ content: 'done' })
+    },
+    async () => ({ wasCompacted: false }),
+  )
+  params.messages = [
+    createUserMessage({ content: 'ultrathink inspect this image' }),
+    createAttachmentMessage({ type: 'ultrathink_effort', level: 'high' }),
+    createUserMessage({ content: [{ type: 'text', text: 'image metadata' }], isMeta: true }),
+  ]
+
+  await collect(params)
+
+  expect(requestEffort).toBe('high')
+})
+
+test('keeps an explicit effort selection over ultrathink', async () => {
+  let requestEffort: unknown
+  const params = baseParams(
+    async function* ({ options }) {
+      requestEffort = options.effortValue
+      yield createAssistantMessage({ content: 'done' })
+    },
+    async () => ({ wasCompacted: false }),
+  )
+  params.toolUseContext = makeToolUseContext([], 'low')
+  params.messages = [
+    createUserMessage({ content: 'ultrathink solve this' }),
+    createAttachmentMessage({ type: 'ultrathink_effort', level: 'high' }),
+  ]
+
+  await collect(params)
+
+  expect(requestEffort).toBe('low')
 })
 
 test('scopes model-request lifecycle callbacks to callModel', async () => {

--- a/src/services/PromptSuggestion/speculation.ts
+++ b/src/services/PromptSuggestion/speculation.ts
@@ -15,6 +15,10 @@ import { checkReadOnlyConstraints } from '../../tools/BashTool/readOnlyValidatio
 import type { SpeculationAcceptMessage } from '../../types/logs.js'
 import type { Message } from '../../types/message.js'
 import { createChildAbortController } from '../../utils/abortController.js'
+import {
+  createAttachmentMessage,
+  getUltrathinkEffortAttachment,
+} from '../../utils/attachments.js'
 import { count } from '../../utils/array.js'
 import { getGlobalConfig } from '../../utils/config.js'
 import { logForDebugging } from '../../utils/debug.js'
@@ -454,8 +458,16 @@ export async function startSpeculation(
   logForDebugging(`[Speculation] Starting speculation ${id}`)
 
   try {
+    const promptMessages = [
+      createUserMessage({ content: suggestionText }),
+      // Prefetch must carry the effort to its provider request but is not a
+      // user activation. handleSpeculationAccept logs the real submission.
+      ...getUltrathinkEffortAttachment(suggestionText, false).map(
+        createAttachmentMessage,
+      ),
+    ]
     const result = await runForkedAgent({
-      promptMessages: [createUserMessage({ content: suggestionText })],
+      promptMessages,
       cacheSafeParams: cacheSafeParams ?? createCacheSafeParams(context),
       skipTranscript: true,
       canUseTool: async (tool, input) => {
@@ -871,7 +883,13 @@ export async function handleSpeculationAccept(
 
     // Inject user message first for instant visual feedback before any async work
     const userMessage = createUserMessage({ content: input })
-    setMessages(prev => [...prev, userMessage])
+    // Accepted suggestions bypass processUserInput(), so create the same
+    // keyword attachment it normally would. This keeps the model reminder and
+    // the request-level effort override in query.ts aligned for this path.
+    const ultrathinkAttachments = getUltrathinkEffortAttachment(input).map(
+      createAttachmentMessage,
+    )
+    setMessages(prev => [...prev, userMessage, ...ultrathinkAttachments])
 
     const result = await acceptSpeculation(
       speculationState,
@@ -947,6 +965,7 @@ export async function handleSpeculationAccept(
         messages: [
           ...speculationState.contextRef.current.messages,
           createUserMessage({ content: input }),
+          ...ultrathinkAttachments,
           ...cleanMessages,
         ],
       }

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1517,6 +1517,14 @@ export function getUltrathinkEffortAttachment(
   input: string | null,
   logActivation: boolean = true,
 ): Attachment[] {
+  // This helper is also used by speculative paths, which do not call
+  // getAttachments(). Keep their behavior aligned with its global opt-out.
+  if (
+    isEnvTruthy(process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS) ||
+    isEnvTruthy(process.env.CLAUDE_CODE_SIMPLE)
+  ) {
+    return []
+  }
   // Gate the model-facing attachment behind the same rollout flag as the UI.
   // Without this, the hidden `ultrathink_effort` attachment would still raise
   // the turn to high effort even when the ULTRATHINK build flag / GrowthBook

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -1513,7 +1513,10 @@ export function getDateChangeAttachments(
   return [{ type: 'date_change', newDate: currentDate }]
 }
 
-function getUltrathinkEffortAttachment(input: string | null): Attachment[] {
+export function getUltrathinkEffortAttachment(
+  input: string | null,
+  logActivation: boolean = true,
+): Attachment[] {
   // Gate the model-facing attachment behind the same rollout flag as the UI.
   // Without this, the hidden `ultrathink_effort` attachment would still raise
   // the turn to high effort even when the ULTRATHINK build flag / GrowthBook
@@ -1521,7 +1524,9 @@ function getUltrathinkEffortAttachment(input: string | null): Attachment[] {
   if (!input || !isUltrathinkEnabled() || !hasUltrathinkKeyword(input)) {
     return []
   }
-  logEvent('tengu_ultrathink', {})
+  if (logActivation) {
+    logEvent('tengu_ultrathink', {})
+  }
   return [{ type: 'ultrathink_effort', level: 'high' }]
 }
 

--- a/src/utils/attachments.ultrathink.test.ts
+++ b/src/utils/attachments.ultrathink.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+
+const realThinking = await import(`./thinking.js?real=${Date.now()}-${Math.random()}`)
+mock.module('./thinking.js', () => ({
+  ...realThinking,
+  isUltrathinkEnabled: () => true,
+}))
+
+const { getUltrathinkEffortAttachment } = await import(
+  `./attachments.ts?test=${Date.now()}-${Math.random()}`
+)
+
+const savedEnv = {
+  disableAttachments: process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS,
+  simple: process.env.CLAUDE_CODE_SIMPLE,
+}
+
+beforeEach(() => {
+  delete process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS
+  delete process.env.CLAUDE_CODE_SIMPLE
+})
+
+afterEach(() => {
+  if (savedEnv.disableAttachments === undefined) {
+    delete process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS
+  } else {
+    process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS = savedEnv.disableAttachments
+  }
+  if (savedEnv.simple === undefined) {
+    delete process.env.CLAUDE_CODE_SIMPLE
+  } else {
+    process.env.CLAUDE_CODE_SIMPLE = savedEnv.simple
+  }
+})
+
+test('ultrathink helper honors global attachment opt-outs', () => {
+  expect(getUltrathinkEffortAttachment('ultrathink solve this', false)).toEqual([
+    { type: 'ultrathink_effort', level: 'high' },
+  ])
+
+  process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS = '1'
+  expect(getUltrathinkEffortAttachment('ultrathink solve this', false)).toEqual([])
+
+  delete process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS
+  process.env.CLAUDE_CODE_SIMPLE = '1'
+  expect(getUltrathinkEffortAttachment('ultrathink solve this', false)).toEqual([])
+})

--- a/src/utils/attachments.ultrathink.test.ts
+++ b/src/utils/attachments.ultrathink.test.ts
@@ -1,35 +1,50 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import {
+  acquireSharedMutationLock,
+  releaseSharedMutationLock,
+} from '../test/sharedMutationLock.js'
+import * as realThinking from './thinking.js'
 
-const realThinking = await import(`./thinking.js?real=${Date.now()}-${Math.random()}`)
-mock.module('./thinking.js', () => ({
-  ...realThinking,
-  isUltrathinkEnabled: () => true,
-}))
-
-const { getUltrathinkEffortAttachment } = await import(
-  `./attachments.ts?test=${Date.now()}-${Math.random()}`
-)
-
-const savedEnv = {
-  disableAttachments: process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS,
-  simple: process.env.CLAUDE_CODE_SIMPLE,
+let getUltrathinkEffortAttachment: typeof import('./attachments.js').getUltrathinkEffortAttachment
+let savedEnv: {
+  disableAttachments: string | undefined
+  simple: string | undefined
 }
 
-beforeEach(() => {
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/attachments.ultrathink.test.ts')
+  savedEnv = {
+    disableAttachments: process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS,
+    simple: process.env.CLAUDE_CODE_SIMPLE,
+  }
   delete process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS
   delete process.env.CLAUDE_CODE_SIMPLE
+  mock.module('./thinking.js', () => ({
+    ...realThinking,
+    isUltrathinkEnabled: () => true,
+  }))
+  ;({ getUltrathinkEffortAttachment } = await import(
+    `./attachments.ts?test=${Date.now()}-${Math.random()}`
+  ))
 })
 
 afterEach(() => {
-  if (savedEnv.disableAttachments === undefined) {
-    delete process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS
-  } else {
-    process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS = savedEnv.disableAttachments
-  }
-  if (savedEnv.simple === undefined) {
-    delete process.env.CLAUDE_CODE_SIMPLE
-  } else {
-    process.env.CLAUDE_CODE_SIMPLE = savedEnv.simple
+  try {
+    if (savedEnv.disableAttachments === undefined) {
+      delete process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS
+    } else {
+      process.env.CLAUDE_CODE_DISABLE_ATTACHMENTS = savedEnv.disableAttachments
+    }
+    if (savedEnv.simple === undefined) {
+      delete process.env.CLAUDE_CODE_SIMPLE
+    } else {
+      process.env.CLAUDE_CODE_SIMPLE = savedEnv.simple
+    }
+    mock.restore()
+    // Bun's mock.restore() does not unregister module mocks.
+    mock.module('./thinking.js', () => realThinking)
+  } finally {
+    releaseSharedMutationLock()
   }
 })
 


### PR DESCRIPTION
## Summary

- Fixes #2037.
- Reviewed CONTRIBUTING.md and AGENTS.md.
- Forward ultrathink high effort to the outbound request, including speculative and pipelined paths.
- Preserve explicit /effort and CLAUDE_CODE_EFFORT_LEVEL precedence; honor attachment opt-outs.

## Impact

- user-facing impact: ultrathink now changes the request reasoning effort, not only the prompt context.
- developer/maintainer impact: regression coverage for request scoping, precedence, speculation, and opt-outs.

## Testing

- [x] bun test src/query/requestOnlyMessages.test.ts src/utils/attachments.ultrathink.test.ts src/services/PromptSuggestion/speculation.test.ts
- [x] bun run typecheck
- [x] bun run build
- [x] bun run smoke
- [x] bun run scripts/pr-intent-scan.ts --base a3dc345f12d41b171cdb5cb74c1304b6cca483d8 --head HEAD

## Notes

- provider/model path tested: OpenAI-compatible reasoning-effort request-options path.
- screenshots attached: not applicable; no UI change.
- follow-up work or known limitations: none.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Ultrathink effort is now applied automatically to eligible requests, enabling higher reasoning effort when selected.
  - Explicit effort settings continue to take priority.
  - Prompt suggestions and accepted suggestions preserve Ultrathink effort settings.

- **Bug Fixes**
  - Historical or meta-generated prompts no longer incorrectly carry forward Ultrathink effort.
  - Ultrathink attachments are disabled when attachment features are opted out.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->