### PR TITLE
fix(ui): keep SpinnerModeGlyph visible inside status parens

### DIFF
--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -137,6 +137,45 @@ describe('SpinnerAnimationRow', () => {
     expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
   })
 
+  it('recovers streaming tokens after suffix drop when thinkingStatus is null', async () => {
+    // Production responding + stop-hook/tool suffix often has thinkingStatus null.
+    // Suffix drop must re-gate tokens — not only the numeric-thinkingStatus path.
+    for (const columns of [30, 31, 35]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            thinkingStatus: null,
+            responseLength: 4_000,
+            spinnerSuffix: 'running stop hooks… 1/1',
+            columns,
+          })}
+        />,
+        columns,
+      )
+
+      expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
+    }
+  })
+
+  it('drops glyph to keep an untruncated suffix when bare chrome still fits', async () => {
+    // Glyph+suffix overflows cols 39 for Thinking… + production stop-hook text,
+    // but bare suffix fits — drop the glyph rather than truncating mid-suffix.
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          responseLengthRef: { current: 4_000 },
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 39,
+        })}
+      />,
+      39,
+    )
+
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (running stop hooks… 1/1)`,
+    ])
+  })
+
   it('drops an overflowing spinner suffix to keep leader thinking', async () => {
     const output = await renderToString(
       <SpinnerAnimationRow
@@ -153,6 +192,23 @@ describe('SpinnerAnimationRow', () => {
     expect(visibleRows(output)).toEqual([
       `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · thinking)`,
     ])
+  })
+
+  it('recovers teammate nested thinking after dropping an overflowing suffix', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          hasRunningTeammates: true,
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 27,
+        })}
+      />,
+      27,
+    )
+
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (thinking)`])
   })
 
   it('drops the glyph when it would hide tokens behind a visible timer', async () => {

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -1,7 +1,32 @@
 import { describe, expect, it } from 'bun:test'
+import figures from 'figures'
 import { createRef } from 'react'
 import { renderToString } from '../../utils/staticRender.js'
 import { getCurrentResponseTokenCount, SpinnerAnimationRow } from './SpinnerAnimationRow.js'
+
+function baseProps(overrides: Partial<Parameters<typeof SpinnerAnimationRow>[0]> = {}) {
+  const now = Date.now()
+  return {
+    mode: 'responding' as const,
+    reducedMotion: true,
+    hasActiveTools: false,
+    responseLengthRef: { current: 0 },
+    message: 'Thinking',
+    messageColor: 'text' as const,
+    shimmerColor: 'text' as const,
+    loadingStartTimeRef: { current: now },
+    totalPausedMsRef: { current: 0 },
+    pauseStartTimeRef: createRef<number | null>(),
+    verbose: false,
+    columns: 120,
+    hasRunningTeammates: false,
+    teammateTokens: 0,
+    foregroundedTeammate: undefined,
+    thinkingStatus: null as const,
+    effortSuffix: '',
+    ...overrides,
+  }
+}
 
 describe('SpinnerAnimationRow', () => {
   it('uses the current response length without smoothing', () => {
@@ -9,57 +34,21 @@ describe('SpinnerAnimationRow', () => {
   })
 
   it('shows the current token count immediately when streaming begins', async () => {
-    const now = Date.now()
     const output = await renderToString(
-      <SpinnerAnimationRow
-        mode="responding"
-        reducedMotion
-        hasActiveTools={false}
-        responseLengthRef={{ current: 0 }}
-        responseLength={4_000}
-        message="Thinking"
-        messageColor="text"
-        shimmerColor="text"
-        loadingStartTimeRef={{ current: now }}
-        totalPausedMsRef={{ current: 0 }}
-        pauseStartTimeRef={createRef<number | null>()}
-        verbose={false}
-        columns={120}
-        hasRunningTeammates={false}
-        teammateTokens={0}
-        foregroundedTeammate={undefined}
-        thinkingStatus={null}
-        effortSuffix=""
-      />,
+      <SpinnerAnimationRow {...baseProps({ responseLength: 4_000 })} />,
       120,
     )
 
     expect(output).toContain('1.0k tokens')
+    // Mode glyph stays inside the status parens next to the token count.
+    expect(output).toMatch(
+      new RegExp(`\\(${figures.arrowDown}[\\s\\S]*1\\.0k tokens[\\s\\S]*\\)`),
+    )
   })
 
   it('shows zero tokens as soon as the first response character arrives', async () => {
-    const now = Date.now()
     const output = await renderToString(
-      <SpinnerAnimationRow
-        mode="responding"
-        reducedMotion
-        hasActiveTools={false}
-        responseLengthRef={{ current: 0 }}
-        responseLength={1}
-        message="Thinking"
-        messageColor="text"
-        shimmerColor="text"
-        loadingStartTimeRef={{ current: now }}
-        totalPausedMsRef={{ current: 0 }}
-        pauseStartTimeRef={createRef<number | null>()}
-        verbose={false}
-        columns={120}
-        hasRunningTeammates={false}
-        teammateTokens={0}
-        foregroundedTeammate={undefined}
-        thinkingStatus={null}
-        effortSuffix=""
-      />,
+      <SpinnerAnimationRow {...baseProps({ responseLength: 1 })} />,
       120,
     )
 
@@ -67,32 +56,64 @@ describe('SpinnerAnimationRow', () => {
   })
 
   it('does not overflow a narrow row when a spinner suffix is present', async () => {
-    const now = Date.now()
     const output = await renderToString(
       <SpinnerAnimationRow
-        mode="responding"
-        reducedMotion
-        hasActiveTools={false}
-        responseLengthRef={{ current: 4_000 }}
-        message="Thinking"
-        messageColor="text"
-        shimmerColor="text"
-        loadingStartTimeRef={{ current: now }}
-        totalPausedMsRef={{ current: 0 }}
-        pauseStartTimeRef={createRef<number | null>()}
-        spinnerSuffix="running stop hooks… 1/1"
-        verbose={false}
-        columns={45}
-        hasRunningTeammates={false}
-        teammateTokens={0}
-        foregroundedTeammate={undefined}
-        thinkingStatus={null}
-        effortSuffix=""
+        {...baseProps({
+          responseLengthRef: { current: 4_000 },
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 45,
+        })}
       />,
       45,
     )
 
     expect(output).toContain('running stop hooks… 1/1')
     expect(output).not.toContain('tokens')
+  })
+
+  it('shows the requesting mode glyph inside parens before other status parts qualify', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow {...baseProps({ mode: 'requesting' })} />,
+      120,
+    )
+
+    expect(output).toContain(`(${figures.arrowUp}`)
+    expect(output).toContain(')')
+    expect(output).not.toContain('tokens')
+  })
+
+  it('shows the thinking mode glyph inside parens for thinking-only status', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+        })}
+      />,
+      120,
+    )
+
+    expect(output).toMatch(
+      new RegExp(`\\(${figures.arrowDown}[\\s\\S]*thinking[\\s\\S]*\\)`),
+    )
+    // Nested "(thinking)" is only for teammate bare status; leader uses outer parens.
+    expect(output).not.toContain('(thinking)')
+  })
+
+  it('omits the mode glyph when teammates are running', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'responding',
+          responseLength: 4_000,
+          hasRunningTeammates: true,
+        })}
+      />,
+      120,
+    )
+
+    expect(output).toContain('1.0k tokens')
+    expect(output).not.toContain(figures.arrowDown)
+    expect(output).not.toContain(figures.arrowUp)
   })
 })

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -9,6 +9,15 @@ import {
 
 /** Match Spinner.tsx production message shape: verb + ellipsis. */
 const PROD_MESSAGE = 'Thinking…'
+const PROD_MESSAGE_RE = PROD_MESSAGE.replace(/[.*+?^${}()|[\]\\]/gu, '\\$&')
+
+/**
+ * SpinnerModeGlyph wraps the arrow in a Box of width 2, so a single-width
+ * arrow always renders with one trailing pad space inside status parens.
+ */
+function paddedModeGlyph(arrow: string): string {
+  return `${arrow} `
+}
 
 function frozenElapsedRefs(elapsedMs: number): Pick<
   SpinnerAnimationRowProps,
@@ -65,7 +74,7 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowDown}  · 1.0k tokens)`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · 1.0k tokens)`,
     ])
   })
 
@@ -147,7 +156,7 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowDown}  · 0 tokens)`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · 0 tokens)`,
     ])
   })
 
@@ -164,7 +173,7 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowDown}  · running stop hooks… 1/1)`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · running stop hooks… 1/1)`,
     ])
   })
 
@@ -174,9 +183,9 @@ describe('SpinnerAnimationRow', () => {
       120,
     )
 
-    // Glyph Box width is 2, so the single-width arrow is padded inside parens.
+    // paddedModeGlyph encodes the Box(width=2) trailing space after ↑.
     expect(visibleRows(output)).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowUp} )`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowUp)})`,
     ])
   })
 
@@ -192,7 +201,7 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowDown}  · thinking)`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · thinking)`,
     ])
   })
 
@@ -212,7 +221,7 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowDown}  · thinking)`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · thinking)`,
     ])
   })
 
@@ -247,7 +256,7 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowDown} )`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)})`,
     ])
   })
 
@@ -318,7 +327,7 @@ describe('SpinnerAnimationRow', () => {
     // Spinner glyph frame varies under motion; lock nested teammate thinking.
     const rows = visibleRows(output)
     expect(rows).toHaveLength(1)
-    expect(rows[0]).toMatch(/^\S Thinking… \(thinking\)$/)
+    expect(rows[0]).toMatch(new RegExp(`^\\S ${PROD_MESSAGE_RE} \\(thinking\\)$`))
   })
 
   it('omits empty glyph chrome when post-thinking duration does not fit', async () => {
@@ -416,7 +425,7 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowDown}  · thinking with high effort)`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · thinking with high effort)`,
     ])
   })
 
@@ -435,8 +444,32 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowDown}  · thinking)`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · thinking)`,
     ])
+  })
+
+  it('prefers tokens over thinking when both unlock by dropping the glyph', async () => {
+    // Col 26 + verbose timer: glyph layout keeps timer only (leader thinking
+    // chrome does not fit); bare unlocks both tokens and thinking.
+    // preferTokensOverTimerOnly wins that tie-break.
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          responseLength: 4_000,
+          verbose: true,
+          columns: 26,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      26,
+    )
+
+    const rows = visibleRows(output)
+    expect(rows).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
+    expect(rows[0]).not.toContain('thinking')
+    expect(rows[0]).not.toContain(figures.arrowDown)
   })
 
   it('keeps zero tokens when glyph recovery would swap them for timer only', async () => {
@@ -455,7 +488,7 @@ describe('SpinnerAnimationRow', () => {
 
     const rows = visibleRows(output)
     expect(rows).toEqual([
-      `● ${PROD_MESSAGE} (${figures.arrowDown}  · 0 tokens)`,
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · 0 tokens)`,
     ])
     expect(rows[0]).not.toMatch(/\dh\b/)
   })
@@ -476,7 +509,9 @@ describe('SpinnerAnimationRow', () => {
     const rows = visibleRows(output)
     expect(rows).toHaveLength(1)
     expect(rows[0]).toMatch(
-      new RegExp(`^\\S Thinking… \\(${figures.arrowDown}  · thinking\\)$`),
+      new RegExp(
+        `^\\S ${PROD_MESSAGE_RE} \\(${figures.arrowDown}  · thinking\\)$`,
+      ),
     )
   })
 })

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -76,6 +76,25 @@ describe('SpinnerAnimationRow', () => {
     expect(rows[0]).not.toContain(figures.arrowDown)
   })
 
+  it('drops the glyph when it would hide tokens behind a visible timer', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          responseLength: 4_000,
+          verbose: true,
+          loadingStartTimeRef: { current: Date.now() - 6_000 },
+          columns: 31,
+        })}
+      />,
+      31,
+    )
+
+    const rows = visibleRows(output)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatch(/^● Thinking \(\d+s · 1\.0k tokens\)$/)
+    expect(rows[0]).not.toContain(figures.arrowDown)
+  })
+
   it('shows zero tokens as soon as the first response character arrives', async () => {
     const output = await renderToString(
       <SpinnerAnimationRow {...baseProps({ responseLength: 1 })} />,

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -194,4 +194,26 @@ describe('SpinnerAnimationRow', () => {
     expect(output).not.toContain(figures.arrowDown)
     expect(output).not.toContain(figures.arrowUp)
   })
+
+  it('nests (thinking) for teammate bare status under reduced motion', async () => {
+    // wantsTimer is true with teammates, so use a narrow width that drops the
+    // timer and leaves thinking-only bare status (no mode glyph, no outer parens).
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          hasRunningTeammates: true,
+          reducedMotion: true,
+          columns: 26,
+        })}
+      />,
+      26,
+    )
+
+    expect(output).toContain('(thinking)')
+    expect(output).not.toContain(figures.arrowDown)
+    expect(output).not.toContain(figures.arrowUp)
+    expect(output).not.toMatch(/Thinking thinking/)
+  })
 })

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -58,6 +58,24 @@ describe('SpinnerAnimationRow', () => {
     ])
   })
 
+  it('prefers token count over glyph-only status on mid-narrow terminals', async () => {
+    // Full glyph+tokens chrome fails primary gate around cols 26–30 for message
+    // "Thinking"; content recovery drops the glyph so tokens still show.
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          responseLength: 4_000,
+          columns: 28,
+        })}
+      />,
+      28,
+    )
+
+    const rows = visibleRows(output)
+    expect(rows).toEqual(['● Thinking (1.0k tokens)'])
+    expect(rows[0]).not.toContain(figures.arrowDown)
+  })
+
   it('shows zero tokens as soon as the first response character arrives', async () => {
     const output = await renderToString(
       <SpinnerAnimationRow {...baseProps({ responseLength: 1 })} />,
@@ -225,5 +243,25 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual(['● Thinking (thinking)'])
+  })
+
+  it('keeps leader thinking glyph path under reducedMotion false', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          reducedMotion: false,
+        })}
+      />,
+      120,
+    )
+
+    // Spinner glyph frame varies under motion; lock the status chrome shape.
+    const rows = visibleRows(output)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatch(
+      new RegExp(`^\\S Thinking \\(${figures.arrowDown}  · thinking\\)$`),
+    )
   })
 })

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -314,6 +314,92 @@ describe('SpinnerAnimationRow', () => {
     expect(rows[0]).toContain('6s')
   })
 
+  it('recovers tokens onto timer-only rows after preferring tokens over suffix', async () => {
+    for (const columns of [44, 46, 48]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            responseLength: 4_000,
+            spinnerSuffix: 'running stop hooks… 1/1',
+            columns,
+            ...frozenElapsedRefs(6_000),
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toContain('1.0k tokens')
+      expect(rows[0]).toContain('6s')
+      expect(rows[0]).not.toContain('running stop hooks')
+    }
+  })
+
+  it('does not wrap wide timers onto thinking and early token counts', async () => {
+    for (const columns of [34, 40]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            mode: 'thinking',
+            thinkingStatus: 'thinking',
+            responseLength: 1,
+            verbose: true,
+            columns,
+            ...frozenElapsedRefs(36_000_000),
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toContain('thinking')
+      expect(rows[0]).toContain('0 tokens')
+      expect(rows[0]).not.toMatch(/Thinkin[^g]/)
+    }
+  })
+
+  it('prefers leader thinking over a bare-fitting suffix that crowds it out', async () => {
+    for (const columns of [37, 40]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            mode: 'thinking',
+            thinkingStatus: 'thinking',
+            spinnerSuffix: 'running stop hooks… 1/1',
+            columns,
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows[0]).toContain('thinking')
+      expect(rows[0]).not.toContain('running stop hooks')
+    }
+  })
+
+  it('keeps mode glyph across the suffix-to-tokens bare-fit boundary', async () => {
+    for (const columns of [36, 37, 42]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            responseLength: 4_000,
+            spinnerSuffix: 'running stop hooks… 1/1',
+            columns,
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows).toEqual([
+        `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · 1.0k tokens)`,
+      ])
+    }
+  })
+
   it('drops an overflowing spinner suffix to keep leader thinking', async () => {
     const output = await renderToString(
       <SpinnerAnimationRow

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -264,6 +264,57 @@ describe('SpinnerAnimationRow', () => {
     expect(visibleRows(output)).toEqual(['● Thinking (thinking)'])
   })
 
+  it('omits empty glyph chrome when post-thinking duration does not fit', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'responding',
+          thinkingStatus: 3_000,
+          columns: 24,
+        })}
+      />,
+      24,
+    )
+
+    expect(visibleRows(output)).toEqual(['● Thinking'])
+    expect(visibleRows(output)[0]).not.toContain(figures.arrowDown)
+  })
+
+  it('shows post-thinking duration without glyph when bare chrome fits', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'responding',
+          thinkingStatus: 3_000,
+          columns: 27,
+        })}
+      />,
+      27,
+    )
+
+    expect(visibleRows(output)).toEqual(['● Thinking (thought for 3s)'])
+    expect(visibleRows(output)[0]).not.toContain(figures.arrowDown)
+  })
+
+  it('keeps zero tokens when glyph recovery would swap them for timer only', async () => {
+    const tenHoursMs = 10 * 60 * 60 * 1_000
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          responseLength: 1,
+          verbose: true,
+          loadingStartTimeRef: { current: Date.now() - tenHoursMs },
+          columns: 28,
+        })}
+      />,
+      28,
+    )
+
+    const rows = visibleRows(output)
+    expect(rows).toEqual([`● Thinking (${figures.arrowDown}  · 0 tokens)`])
+    expect(rows[0]).not.toMatch(/\dh\b/)
+  })
+
   it('keeps leader thinking glyph path under reducedMotion false', async () => {
     const output = await renderToString(
       <SpinnerAnimationRow

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -80,7 +80,9 @@ describe('SpinnerAnimationRow', () => {
 
   it('prefers token count over glyph-only status on mid-narrow terminals', async () => {
     // Full glyph+tokens chrome fails primary gate around cols 27–31 for
-    // production "Thinking…"; content recovery drops the glyph so tokens show.
+    // production "Thinking…" (messageWidth 11); content recovery drops the
+    // glyph so tokens show. Breakpoints are message-relative — longer verbs
+    // shift the band (see long-verb recovery test).
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
@@ -94,6 +96,63 @@ describe('SpinnerAnimationRow', () => {
     const rows = visibleRows(output)
     expect(rows).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
     expect(rows[0]).not.toContain(figures.arrowDown)
+  })
+
+  it('recovers tokens for long production verbs at their shifted column band', async () => {
+    // Spinner.tsx uses effectiveVerb + '…'; Flibbertigibbeting… is messageWidth 21,
+    // so tokens need columns >= 35 (21 + bare parens 3 + "1.0k tokens" 11).
+    const longMessage = 'Flibbertigibbeting…'
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          message: longMessage,
+          responseLength: 4_000,
+          columns: 35,
+        })}
+      />,
+      35,
+    )
+
+    const rows = visibleRows(output)
+    expect(rows).toEqual([`● ${longMessage} (1.0k tokens)`])
+    expect(rows[0]).not.toContain(figures.arrowDown)
+  })
+
+  it('drops an overflowing spinner suffix to keep streaming tokens', async () => {
+    // Stop-hook suffix (~23 cols) cannot fit under bare chrome at cols 31 with
+    // Thinking…; drop it and prefer live tokens over post-thinking duration.
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'responding',
+          thinkingStatus: 3_000,
+          responseLength: 4_000,
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 31,
+        })}
+      />,
+      31,
+    )
+
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
+  })
+
+  it('drops an overflowing spinner suffix to keep leader thinking', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 27,
+        })}
+      />,
+      27,
+    )
+
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · thinking)`,
+    ])
   })
 
   it('drops the glyph when it would hide tokens behind a visible timer', async () => {

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -400,6 +400,7 @@ describe('SpinnerAnimationRow', () => {
       )
 
       const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
       expect(rows[0]).toContain('thinking')
       expect(rows[0]).not.toContain('running stop hooks')
     }

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -141,6 +141,26 @@ describe('SpinnerAnimationRow', () => {
     expect(output).not.toContain(figures.arrowUp)
   })
 
+  it('does not enable bare thinking one column short of physical fit', async () => {
+    // bareAvailable = columns - messageWidth - 3; for "Thinking" that is
+    // columns - 13. At columns=20, bareAvailable=7 < 8, so bare must not show.
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          columns: 20,
+        })}
+      />,
+      20,
+    )
+
+    expect(output).not.toContain('(thinking)')
+    // Residual 10 >= 5 so a mode glyph alone may still appear; either way the
+    // row must not claim a bare thinking status that overflows.
+    expect(output).not.toMatch(/Thinking\(thinking\)/)
+  })
+
   it('omits the mode glyph when residual width cannot fit status chrome', async () => {
     // messageWidth("Thinking")+2 = 10; residual at columns=14 is 4 (< 5 after
     // accounting for glimmer trailing space).

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -100,6 +100,43 @@ describe('SpinnerAnimationRow', () => {
     expect(output).not.toContain('(thinking)')
   })
 
+  it('keeps thinking text with the mode glyph on moderately narrow terminals', async () => {
+    // Primary gate with full parensWidth rejects ~cols 25–27 for message
+    // "Thinking"; the leader thinking-only second chance must still fit
+    // "(↓ · thinking)" so the thinking word is not dropped.
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          columns: 26,
+        })}
+      />,
+      26,
+    )
+
+    expect(output).toContain('thinking')
+    expect(output).toMatch(
+      new RegExp(`\\(${figures.arrowDown}[\\s\\S]*thinking[\\s\\S]*\\)`),
+    )
+  })
+
+  it('omits the mode glyph when residual width cannot fit status chrome', async () => {
+    // messageWidth("Thinking")+2 = 10; residual at columns=12 is 2 (< 4).
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'requesting',
+          columns: 12,
+        })}
+      />,
+      12,
+    )
+
+    expect(output).not.toContain(figures.arrowUp)
+    expect(output).not.toContain(figures.arrowDown)
+  })
+
   it('omits the mode glyph when teammates are running', async () => {
     const output = await renderToString(
       <SpinnerAnimationRow

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -121,16 +121,37 @@ describe('SpinnerAnimationRow', () => {
     )
   })
 
+  it('falls back to bare thinking without glyph when full chrome does not fit', async () => {
+    // Cols 21–25: glyph+thinking chrome does not fit, but bare "(thinking)" does.
+    // Prefer the thinking word over glyph-only empty status.
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          columns: 23,
+        })}
+      />,
+      23,
+    )
+
+    expect(output).toContain('thinking')
+    expect(output).toContain('(thinking)')
+    expect(output).not.toContain(figures.arrowDown)
+    expect(output).not.toContain(figures.arrowUp)
+  })
+
   it('omits the mode glyph when residual width cannot fit status chrome', async () => {
-    // messageWidth("Thinking")+2 = 10; residual at columns=12 is 2 (< 4).
+    // messageWidth("Thinking")+2 = 10; residual at columns=14 is 4 (< 5 after
+    // accounting for glimmer trailing space).
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
           mode: 'requesting',
-          columns: 12,
+          columns: 14,
         })}
       />,
-      12,
+      14,
     )
 
     expect(output).not.toContain(figures.arrowUp)

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -1013,4 +1013,46 @@ describe('SpinnerAnimationRow', () => {
     ])
     expect(visibleRows(output)[0]).not.toContain(figures.arrowDown)
   })
+
+  it('drops a retained glyph when bare recovery adds tokens beside thinking', async () => {
+    const numericOutput = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 3_000,
+          responseLength: 4_000,
+          columns: 42,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      42,
+    )
+
+    const numericRows = visibleRows(numericOutput)
+    expect(numericRows).toHaveLength(1)
+    expect(numericRows[0]).toContain('1.0k tokens')
+    expect(numericRows[0]).toContain('thought for 3s')
+    expect(numericRows[0]).not.toContain(figures.arrowDown)
+
+    const activeOutput = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          effortSuffix: ' with high effort',
+          responseLength: 4_000,
+          verbose: true,
+          columns: 53,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      53,
+    )
+
+    const activeRows = visibleRows(activeOutput)
+    expect(activeRows).toHaveLength(1)
+    expect(activeRows[0]).toContain('1.0k tokens')
+    expect(activeRows[0]).toContain('thinking with high effort')
+    expect(activeRows[0]).not.toContain(figures.arrowDown)
+  })
 })

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -140,7 +140,9 @@ describe('SpinnerAnimationRow', () => {
   it('recovers streaming tokens after suffix drop when thinkingStatus is null', async () => {
     // Production responding + stop-hook/tool suffix often has thinkingStatus null.
     // Suffix drop must re-gate tokens — not only the numeric-thinkingStatus path.
-    for (const columns of [30, 31, 35]) {
+    // Cols 30–31: glyph+tokens do not fit under bare recovery (same as no-suffix).
+    // Cols 35: glyph+tokens fit, so keep the mode arrow after recovery.
+    for (const columns of [30, 31]) {
       const output = await renderToString(
         <SpinnerAnimationRow
           {...baseProps({
@@ -155,15 +157,31 @@ describe('SpinnerAnimationRow', () => {
 
       expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
     }
+
+    const wide = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          thinkingStatus: null,
+          responseLength: 4_000,
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 35,
+        })}
+      />,
+      35,
+    )
+    expect(visibleRows(wide)).toEqual([
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · 1.0k tokens)`,
+    ])
   })
 
   it('drops glyph to keep an untruncated suffix when bare chrome still fits', async () => {
     // Glyph+suffix overflows cols 39 for Thinking… + production stop-hook text,
     // but bare suffix fits — drop the glyph rather than truncating mid-suffix.
+    // No streaming tokens: tokens-over-suffix preference must not fire.
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
-          responseLengthRef: { current: 4_000 },
+          responseLengthRef: { current: 0 },
           spinnerSuffix: 'running stop hooks… 1/1',
           columns: 39,
         })}
@@ -174,6 +192,126 @@ describe('SpinnerAnimationRow', () => {
     expect(visibleRows(output)).toEqual([
       `● ${PROD_MESSAGE} (running stop hooks… 1/1)`,
     ])
+  })
+
+  it('prefers streaming tokens over a bare-fitting suffix that cannot share the row', async () => {
+    // At cols 37, suffix exactly fits bare chrome but tokens+suffix do not —
+    // prefer live tokens (same priority as tokens-over-duration).
+    for (const columns of [36, 37, 39]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            responseLength: 4_000,
+            spinnerSuffix: 'running stop hooks… 1/1',
+            columns,
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows[0]).toContain('1.0k tokens')
+      expect(rows[0]).not.toContain('running stop hooks')
+    }
+  })
+
+  it('recovers teammate timer after dropping an overflowing suffix', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          hasRunningTeammates: true,
+          thinkingStatus: null,
+          responseLengthRef: { current: 0 },
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 30,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      30,
+    )
+
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (6s)`])
+  })
+
+  it('recovers timer with tokens after dropping an overflowing suffix', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          hasRunningTeammates: true,
+          thinkingStatus: null,
+          responseLength: 4_000,
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 35,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      35,
+    )
+
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (6s · 1.0k tokens)`])
+  })
+
+  it('recovers requesting timer instead of empty glyph after suffix drop', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'requesting',
+          verbose: true,
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 27,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      27,
+    )
+
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowUp)} · 6s)`,
+    ])
+  })
+
+  it('does not wrap when preferTokens would stack suffix with timer and tokens', async () => {
+    for (const columns of [49, 52, 54]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            responseLength: 4_000,
+            spinnerSuffix: 'running stop hooks… 1/1',
+            columns,
+            ...frozenElapsedRefs(6_000),
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toContain('1.0k tokens')
+      expect(rows[0]).not.toMatch(/1\.0k token$/)
+      expect(rows[0]).toContain('6s')
+    }
+  })
+
+  it('keeps already-visible thinking when tokens unlock under glyph', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          responseLength: 4_000,
+          verbose: true,
+          columns: 41,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      41,
+    )
+
+    const rows = visibleRows(output)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toContain('thinking')
+    expect(rows[0]).toContain('1.0k tokens')
+    expect(rows[0]).toContain('6s')
   })
 
   it('drops an overflowing spinner suffix to keep leader thinking', async () => {
@@ -276,10 +414,29 @@ describe('SpinnerAnimationRow', () => {
   })
 
   it('does not overflow a narrow row when a spinner suffix is present', async () => {
+    // At cols 46, suffix fits bare but cannot share with streaming tokens —
+    // tokens-over-suffix preference keeps a single-line token status.
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
           responseLengthRef: { current: 4_000 },
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 46,
+        })}
+      />,
+      46,
+    )
+
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · 1.0k tokens)`,
+    ])
+  })
+
+  it('keeps suffix with mode glyph when tokens are absent and bare chrome fits', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          responseLengthRef: { current: 0 },
           spinnerSuffix: 'running stop hooks… 1/1',
           columns: 46,
         })}

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -332,7 +332,31 @@ describe('SpinnerAnimationRow', () => {
       expect(rows).toHaveLength(1)
       expect(rows[0]).toContain('1.0k tokens')
       expect(rows[0]).toContain('6s')
+      expect(rows[0]).toContain(figures.arrowDown)
       expect(rows[0]).not.toContain('running stop hooks')
+    }
+  })
+
+  it('keeps streaming tokens when leader thinking unlocks on mid-narrow rows', async () => {
+    for (const columns of [26, 27, 30]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            mode: 'thinking',
+            thinkingStatus: 'thinking',
+            responseLength: 4_000,
+            verbose: true,
+            columns,
+            ...frozenElapsedRefs(6_000),
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toContain('1.0k tokens')
+      expect(rows[0]).not.toContain('thinking')
     }
   })
 
@@ -736,7 +760,7 @@ describe('SpinnerAnimationRow', () => {
   })
 
   it('prefers streaming tokens over post-thinking duration on mid-narrow terminals', async () => {
-    for (const columns of [30, 31, 35]) {
+    for (const columns of [30, 31]) {
       const output = await renderToString(
         <SpinnerAnimationRow
           {...baseProps({
@@ -749,10 +773,24 @@ describe('SpinnerAnimationRow', () => {
         columns,
       )
 
-      expect(visibleRows(output)).toEqual([
-        `● ${PROD_MESSAGE} (1.0k tokens)`,
-      ])
+      expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
     }
+
+    // At cols 35 glyph+tokens fit — restore the mode arrow after duration→tokens.
+    const wide = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'responding',
+          thinkingStatus: 3_000,
+          responseLength: 4_000,
+          columns: 35,
+        })}
+      />,
+      35,
+    )
+    expect(visibleRows(wide)).toEqual([
+      `● ${PROD_MESSAGE} (${paddedModeGlyph(figures.arrowDown)} · 1.0k tokens)`,
+    ])
   })
 
   it('recovers tokens at the exact-fit column boundary', async () => {

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'bun:test'
 import figures from 'figures'
-import { createRef } from 'react'
 import { renderToString } from '../../utils/staticRender.js'
 import {
   getCurrentResponseTokenCount,
@@ -8,21 +7,33 @@ import {
   type SpinnerAnimationRowProps,
 } from './SpinnerAnimationRow.js'
 
+/** Match Spinner.tsx production message shape: verb + ellipsis. */
+const PROD_MESSAGE = 'Thinking…'
+
+function frozenElapsedRefs(elapsedMs: number): Pick<
+  SpinnerAnimationRowProps,
+  'loadingStartTimeRef' | 'totalPausedMsRef' | 'pauseStartTimeRef'
+> {
+  const start = 1_000_000
+  return {
+    loadingStartTimeRef: { current: start },
+    totalPausedMsRef: { current: 0 },
+    pauseStartTimeRef: { current: start + elapsedMs },
+  }
+}
+
 function baseProps(
   overrides: Partial<SpinnerAnimationRowProps> = {},
 ): SpinnerAnimationRowProps {
-  const now = Date.now()
   return {
     mode: 'responding',
     reducedMotion: true,
     hasActiveTools: false,
     responseLengthRef: { current: 0 },
-    message: 'Thinking',
+    message: PROD_MESSAGE,
     messageColor: 'text',
     shimmerColor: 'text',
-    loadingStartTimeRef: { current: now },
-    totalPausedMsRef: { current: 0 },
-    pauseStartTimeRef: createRef<number | null>(),
+    ...frozenElapsedRefs(0),
     verbose: false,
     columns: 120,
     hasRunningTeammates: false,
@@ -34,7 +45,7 @@ function baseProps(
   }
 }
 
-/** ANSI-stripped non-empty rows from a static Ink render. */
+/** Non-empty rows from a static Ink render (`renderToString` strips ANSI). */
 function visibleRows(output: string): string[] {
   return output
     .split(/\r?\n/)
@@ -54,47 +65,79 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● Thinking (${figures.arrowDown}  · 1.0k tokens)`,
+      `● ${PROD_MESSAGE} (${figures.arrowDown}  · 1.0k tokens)`,
     ])
   })
 
   it('prefers token count over glyph-only status on mid-narrow terminals', async () => {
-    // Full glyph+tokens chrome fails primary gate around cols 26–30 for message
-    // "Thinking"; content recovery drops the glyph so tokens still show.
+    // Full glyph+tokens chrome fails primary gate around cols 27–31 for
+    // production "Thinking…"; content recovery drops the glyph so tokens show.
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
           responseLength: 4_000,
-          columns: 28,
+          columns: 29,
         })}
       />,
-      28,
+      29,
     )
 
     const rows = visibleRows(output)
-    expect(rows).toEqual(['● Thinking (1.0k tokens)'])
+    expect(rows).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
     expect(rows[0]).not.toContain(figures.arrowDown)
   })
 
   it('drops the glyph when it would hide tokens behind a visible timer', async () => {
-    for (const columns of [30, 31]) {
+    for (const columns of [31, 32]) {
       const output = await renderToString(
         <SpinnerAnimationRow
           {...baseProps({
             responseLength: 4_000,
             verbose: true,
-            loadingStartTimeRef: { current: Date.now() - 6_000 },
+            ...frozenElapsedRefs(6_000),
             columns,
           })}
         />,
         columns,
       )
 
-      const rows = visibleRows(output)
-      expect(rows).toHaveLength(1)
-      expect(rows[0]).toMatch(/^● Thinking \(\d+s · 1\.0k tokens\)$/)
-      expect(rows[0]).not.toContain(figures.arrowDown)
+      expect(visibleRows(output)).toEqual([
+        `● ${PROD_MESSAGE} (6s · 1.0k tokens)`,
+      ])
     }
+  })
+
+  it('keeps tokens when the elapsed timer becomes eligible on mid-narrow rows', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          responseLength: 4_000,
+          columns: 29,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      29,
+    )
+
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
+  })
+
+  it('keeps timer and tokens when timer text widens on mid-narrow rows', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          responseLength: 4_000,
+          verbose: true,
+          columns: 31,
+          ...frozenElapsedRefs(10_000),
+        })}
+      />,
+      31,
+    )
+
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (10s · 1.0k tokens)`,
+    ])
   })
 
   it('shows zero tokens as soon as the first response character arrives', async () => {
@@ -104,7 +147,7 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● Thinking (${figures.arrowDown}  · 0 tokens)`,
+      `● ${PROD_MESSAGE} (${figures.arrowDown}  · 0 tokens)`,
     ])
   })
 
@@ -114,14 +157,14 @@ describe('SpinnerAnimationRow', () => {
         {...baseProps({
           responseLengthRef: { current: 4_000 },
           spinnerSuffix: 'running stop hooks… 1/1',
-          columns: 45,
+          columns: 46,
         })}
       />,
-      45,
+      46,
     )
 
     expect(visibleRows(output)).toEqual([
-      `● Thinking (${figures.arrowDown}  · running stop hooks… 1/1)`,
+      `● ${PROD_MESSAGE} (${figures.arrowDown}  · running stop hooks… 1/1)`,
     ])
   })
 
@@ -133,7 +176,7 @@ describe('SpinnerAnimationRow', () => {
 
     // Glyph Box width is 2, so the single-width arrow is padded inside parens.
     expect(visibleRows(output)).toEqual([
-      `● Thinking (${figures.arrowUp} )`,
+      `● ${PROD_MESSAGE} (${figures.arrowUp} )`,
     ])
   })
 
@@ -149,81 +192,78 @@ describe('SpinnerAnimationRow', () => {
     )
 
     expect(visibleRows(output)).toEqual([
-      `● Thinking (${figures.arrowDown}  · thinking)`,
+      `● ${PROD_MESSAGE} (${figures.arrowDown}  · thinking)`,
     ])
   })
 
   it('keeps thinking text with the mode glyph on moderately narrow terminals', async () => {
-    // Primary gate with full parensWidth rejects ~cols 25–27 for message
-    // "Thinking"; the leader thinking-only second chance must still fit
+    // Primary gate with full parensWidth rejects ~cols 26–28 for production
+    // "Thinking…"; the leader thinking-only second chance must still fit
     // "(↓ · thinking)" so the thinking word is not dropped.
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
           mode: 'thinking',
           thinkingStatus: 'thinking',
-          columns: 26,
+          columns: 27,
         })}
       />,
-      26,
+      27,
     )
 
     expect(visibleRows(output)).toEqual([
-      `● Thinking (${figures.arrowDown}  · thinking)`,
+      `● ${PROD_MESSAGE} (${figures.arrowDown}  · thinking)`,
     ])
   })
 
   it('falls back to bare thinking without glyph when full chrome does not fit', async () => {
-    // Cols 21–25: glyph+thinking chrome does not fit, but bare "(thinking)" does.
-    // Prefer the thinking word over glyph-only empty status.
+    // Cols 22–26: glyph+thinking chrome does not fit, but bare "(thinking)" does.
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
           mode: 'thinking',
           thinkingStatus: 'thinking',
-          columns: 23,
+          columns: 24,
         })}
       />,
-      23,
+      24,
     )
 
-    expect(visibleRows(output)).toEqual(['● Thinking (thinking)'])
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (thinking)`])
   })
 
   it('does not enable bare thinking one column short of physical fit', async () => {
-    // bareAvailable = columns - messageWidth - 3; for "Thinking" that is
-    // columns - 13. At columns=20, bareAvailable=7 < 8, so bare must not show.
-    // Residual still allows glyph-only status chrome.
+    // bareAvailable = columns - messageWidth - 3; for "Thinking…" that is
+    // columns - 14. At columns=21, bareAvailable=7 < 8, so bare must not show.
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
           mode: 'thinking',
           thinkingStatus: 'thinking',
-          columns: 20,
+          columns: 21,
         })}
       />,
-      20,
+      21,
     )
 
     expect(visibleRows(output)).toEqual([
-      `● Thinking (${figures.arrowDown} )`,
+      `● ${PROD_MESSAGE} (${figures.arrowDown} )`,
     ])
   })
 
   it('omits the mode glyph when residual width cannot fit status chrome', async () => {
-    // messageWidth("Thinking")+2 = 10; residual at columns=14 is 4 (< 5 after
-    // accounting for glimmer trailing space).
+    // messageWidth("Thinking…")+2 = 11; residual at columns=15 is 4 (< 5).
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
           mode: 'requesting',
-          columns: 14,
+          columns: 15,
         })}
       />,
-      14,
+      15,
     )
 
-    expect(visibleRows(output)).toEqual(['● Thinking'])
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE}`])
   })
 
   it('omits the mode glyph when teammates are running', async () => {
@@ -233,23 +273,18 @@ describe('SpinnerAnimationRow', () => {
           mode: 'responding',
           responseLength: 4_000,
           hasRunningTeammates: true,
+          ...frozenElapsedRefs(0),
         })}
       />,
       120,
     )
 
-    // wantsTimer is true for teammates, so the elapsed timer appears with tokens.
-    // Timer text depends on wall clock (0s vs 0.0s), so match the full row shape.
-    const rows = visibleRows(output)
-    expect(rows).toHaveLength(1)
-    expect(rows[0]).toMatch(/^● Thinking \(\d+(?:\.\d+)?s · 1\.0k tokens\)$/)
-    expect(rows[0]).not.toContain(figures.arrowDown)
-    expect(rows[0]).not.toContain(figures.arrowUp)
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (0s · 1.0k tokens)`,
+    ])
   })
 
   it('nests (thinking) for teammate bare status under reduced motion', async () => {
-    // wantsTimer is true with teammates, so use a narrow width that drops the
-    // timer and leaves thinking-only bare status (no mode glyph, no outer parens).
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
@@ -257,13 +292,33 @@ describe('SpinnerAnimationRow', () => {
           thinkingStatus: 'thinking',
           hasRunningTeammates: true,
           reducedMotion: true,
-          columns: 26,
+          columns: 27,
         })}
       />,
-      26,
+      27,
     )
 
-    expect(visibleRows(output)).toEqual(['● Thinking (thinking)'])
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (thinking)`])
+  })
+
+  it('nests (thinking) for teammate bare status under shimmer', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          hasRunningTeammates: true,
+          reducedMotion: false,
+          columns: 27,
+        })}
+      />,
+      27,
+    )
+
+    // Spinner glyph frame varies under motion; lock nested teammate thinking.
+    const rows = visibleRows(output)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatch(/^\S Thinking… \(thinking\)$/)
   })
 
   it('omits empty glyph chrome when post-thinking duration does not fit', async () => {
@@ -272,14 +327,13 @@ describe('SpinnerAnimationRow', () => {
         {...baseProps({
           mode: 'responding',
           thinkingStatus: 3_000,
-          columns: 24,
+          columns: 25,
         })}
       />,
-      24,
+      25,
     )
 
-    expect(visibleRows(output)).toEqual(['● Thinking'])
-    expect(visibleRows(output)[0]).not.toContain(figures.arrowDown)
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE}`])
   })
 
   it('omits empty glyph chrome for requesting spins with numeric thinkingStatus', async () => {
@@ -288,14 +342,13 @@ describe('SpinnerAnimationRow', () => {
         {...baseProps({
           mode: 'requesting',
           thinkingStatus: 3_000,
-          columns: 16,
+          columns: 17,
         })}
       />,
-      16,
+      17,
     )
 
-    expect(visibleRows(output)).toEqual(['● Thinking'])
-    expect(visibleRows(output)[0]).not.toContain(figures.arrowUp)
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE}`])
   })
 
   it('shows post-thinking duration without glyph when bare chrome fits', async () => {
@@ -304,18 +357,19 @@ describe('SpinnerAnimationRow', () => {
         {...baseProps({
           mode: 'responding',
           thinkingStatus: 3_000,
-          columns: 27,
+          columns: 28,
         })}
       />,
-      27,
+      28,
     )
 
-    expect(visibleRows(output)).toEqual(['● Thinking (thought for 3s)'])
-    expect(visibleRows(output)[0]).not.toContain(figures.arrowDown)
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (thought for 3s)`,
+    ])
   })
 
   it('prefers streaming tokens over post-thinking duration on mid-narrow terminals', async () => {
-    for (const columns of [29, 30]) {
+    for (const columns of [30, 31, 35]) {
       const output = await renderToString(
         <SpinnerAnimationRow
           {...baseProps({
@@ -328,9 +382,61 @@ describe('SpinnerAnimationRow', () => {
         columns,
       )
 
-      expect(visibleRows(output)).toEqual(['● Thinking (1.0k tokens)'])
-      expect(visibleRows(output)[0]).not.toContain('thought for')
+      expect(visibleRows(output)).toEqual([
+        `● ${PROD_MESSAGE} (1.0k tokens)`,
+      ])
     }
+  })
+
+  it('recovers tokens at the exact-fit column boundary', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          responseLength: 4_000,
+          columns: 25,
+        })}
+      />,
+      25,
+    )
+
+    expect(visibleRows(output)).toEqual([`● ${PROD_MESSAGE} (1.0k tokens)`])
+  })
+
+  it('keeps full effort text when it fits with the mode glyph', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          effortSuffix: ' with high effort',
+          columns: 44,
+        })}
+      />,
+      44,
+    )
+
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (${figures.arrowDown}  · thinking with high effort)`,
+    ])
+  })
+
+  it('prefers active thinking over timer-only status on mid-narrow rows', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          verbose: true,
+          columns: 27,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      27,
+    )
+
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (${figures.arrowDown}  · thinking)`,
+    ])
   })
 
   it('keeps zero tokens when glyph recovery would swap them for timer only', async () => {
@@ -340,15 +446,17 @@ describe('SpinnerAnimationRow', () => {
         {...baseProps({
           responseLength: 1,
           verbose: true,
-          loadingStartTimeRef: { current: Date.now() - tenHoursMs },
-          columns: 28,
+          ...frozenElapsedRefs(tenHoursMs),
+          columns: 29,
         })}
       />,
-      28,
+      29,
     )
 
     const rows = visibleRows(output)
-    expect(rows).toEqual([`● Thinking (${figures.arrowDown}  · 0 tokens)`])
+    expect(rows).toEqual([
+      `● ${PROD_MESSAGE} (${figures.arrowDown}  · 0 tokens)`,
+    ])
     expect(rows[0]).not.toMatch(/\dh\b/)
   })
 
@@ -368,7 +476,7 @@ describe('SpinnerAnimationRow', () => {
     const rows = visibleRows(output)
     expect(rows).toHaveLength(1)
     expect(rows[0]).toMatch(
-      new RegExp(`^\\S Thinking \\(${figures.arrowDown}  · thinking\\)$`),
+      new RegExp(`^\\S Thinking… \\(${figures.arrowDown}  · thinking\\)$`),
     )
   })
 })

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -77,22 +77,24 @@ describe('SpinnerAnimationRow', () => {
   })
 
   it('drops the glyph when it would hide tokens behind a visible timer', async () => {
-    const output = await renderToString(
-      <SpinnerAnimationRow
-        {...baseProps({
-          responseLength: 4_000,
-          verbose: true,
-          loadingStartTimeRef: { current: Date.now() - 6_000 },
-          columns: 31,
-        })}
-      />,
-      31,
-    )
+    for (const columns of [30, 31]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            responseLength: 4_000,
+            verbose: true,
+            loadingStartTimeRef: { current: Date.now() - 6_000 },
+            columns,
+          })}
+        />,
+        columns,
+      )
 
-    const rows = visibleRows(output)
-    expect(rows).toHaveLength(1)
-    expect(rows[0]).toMatch(/^● Thinking \(\d+s · 1\.0k tokens\)$/)
-    expect(rows[0]).not.toContain(figures.arrowDown)
+      const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toMatch(/^● Thinking \(\d+s · 1\.0k tokens\)$/)
+      expect(rows[0]).not.toContain(figures.arrowDown)
+    }
   })
 
   it('shows zero tokens as soon as the first response character arrives', async () => {
@@ -280,6 +282,22 @@ describe('SpinnerAnimationRow', () => {
     expect(visibleRows(output)[0]).not.toContain(figures.arrowDown)
   })
 
+  it('omits empty glyph chrome for requesting spins with numeric thinkingStatus', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'requesting',
+          thinkingStatus: 3_000,
+          columns: 16,
+        })}
+      />,
+      16,
+    )
+
+    expect(visibleRows(output)).toEqual(['● Thinking'])
+    expect(visibleRows(output)[0]).not.toContain(figures.arrowUp)
+  })
+
   it('shows post-thinking duration without glyph when bare chrome fits', async () => {
     const output = await renderToString(
       <SpinnerAnimationRow
@@ -294,6 +312,25 @@ describe('SpinnerAnimationRow', () => {
 
     expect(visibleRows(output)).toEqual(['● Thinking (thought for 3s)'])
     expect(visibleRows(output)[0]).not.toContain(figures.arrowDown)
+  })
+
+  it('prefers streaming tokens over post-thinking duration on mid-narrow terminals', async () => {
+    for (const columns of [29, 30]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            mode: 'responding',
+            thinkingStatus: 3_000,
+            responseLength: 4_000,
+            columns,
+          })}
+        />,
+        columns,
+      )
+
+      expect(visibleRows(output)).toEqual(['● Thinking (1.0k tokens)'])
+      expect(visibleRows(output)[0]).not.toContain('thought for')
+    }
   })
 
   it('keeps zero tokens when glyph recovery would swap them for timer only', async () => {

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -210,6 +210,7 @@ describe('SpinnerAnimationRow', () => {
       )
 
       const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
       expect(rows[0]).toContain('1.0k tokens')
       expect(rows[0]).not.toContain('running stop hooks')
     }
@@ -909,5 +910,107 @@ describe('SpinnerAnimationRow', () => {
         `^\\S ${PROD_MESSAGE_RE} \\(${figures.arrowDown}  · thinking\\)$`,
       ),
     )
+  })
+
+  it('keeps elapsed timer monotonic when suffix starts fitting beside thinking', async () => {
+    const suffix = 'running stop hooks… 1/1'
+    for (const columns of [48, 49, 50, 51, 52, 53, 54]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            mode: 'thinking',
+            thinkingStatus: 'thinking',
+            verbose: true,
+            spinnerSuffix: suffix,
+            columns,
+            ...frozenElapsedRefs(6_000),
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toContain('6s')
+      expect(rows[0]).toContain('thinking')
+      if (columns < 54) {
+        expect(rows[0]).not.toContain('running stop hooks')
+      } else {
+        expect(rows[0]).toContain('running stop hooks')
+      }
+    }
+  })
+
+  it('keeps teammate streaming tokens monotonic across the mid-width band', async () => {
+    for (const columns of [35, 36, 37, 38, 39, 40, 41]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            mode: 'thinking',
+            thinkingStatus: 'thinking',
+            hasRunningTeammates: true,
+            responseLength: 4_000,
+            columns,
+            ...frozenElapsedRefs(0),
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toContain('1.0k tokens')
+    }
+  })
+
+  it('keeps streaming tokens when effort suffix and spinner suffix widen', async () => {
+    const suffix = 'running stop hooks… 1/1'
+    for (const columns of [55, 60, 65, 70, 75]) {
+      const output = await renderToString(
+        <SpinnerAnimationRow
+          {...baseProps({
+            mode: 'thinking',
+            thinkingStatus: 'thinking',
+            effortSuffix: ' with high effort',
+            responseLength: 4_000,
+            spinnerSuffix: suffix,
+            verbose: true,
+            columns,
+            ...frozenElapsedRefs(6_000),
+          })}
+        />,
+        columns,
+      )
+
+      const rows = visibleRows(output)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]).toContain('1.0k tokens')
+      expect(rows[0]).toContain('6s')
+      if (columns >= 75) {
+        expect(rows[0]).toContain('thinking with high effort')
+      }
+    }
+  })
+
+  it('recovers thinking plus tokens without glyph overflow after suffix drop', async () => {
+    const output = await renderToString(
+      <SpinnerAnimationRow
+        {...baseProps({
+          mode: 'thinking',
+          thinkingStatus: 'thinking',
+          responseLength: 4_000,
+          spinnerSuffix: 'running stop hooks… 1/1',
+          columns: 36,
+          verbose: true,
+          ...frozenElapsedRefs(6_000),
+        })}
+      />,
+      36,
+    )
+
+    expect(visibleRows(output)).toEqual([
+      `● ${PROD_MESSAGE} (6s · 1.0k tokens)`,
+    ])
+    expect(visibleRows(output)[0]).not.toContain(figures.arrowDown)
   })
 })

--- a/src/components/Spinner/SpinnerAnimationRow.test.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.test.tsx
@@ -2,18 +2,24 @@ import { describe, expect, it } from 'bun:test'
 import figures from 'figures'
 import { createRef } from 'react'
 import { renderToString } from '../../utils/staticRender.js'
-import { getCurrentResponseTokenCount, SpinnerAnimationRow } from './SpinnerAnimationRow.js'
+import {
+  getCurrentResponseTokenCount,
+  SpinnerAnimationRow,
+  type SpinnerAnimationRowProps,
+} from './SpinnerAnimationRow.js'
 
-function baseProps(overrides: Partial<Parameters<typeof SpinnerAnimationRow>[0]> = {}) {
+function baseProps(
+  overrides: Partial<SpinnerAnimationRowProps> = {},
+): SpinnerAnimationRowProps {
   const now = Date.now()
   return {
-    mode: 'responding' as const,
+    mode: 'responding',
     reducedMotion: true,
     hasActiveTools: false,
     responseLengthRef: { current: 0 },
     message: 'Thinking',
-    messageColor: 'text' as const,
-    shimmerColor: 'text' as const,
+    messageColor: 'text',
+    shimmerColor: 'text',
     loadingStartTimeRef: { current: now },
     totalPausedMsRef: { current: 0 },
     pauseStartTimeRef: createRef<number | null>(),
@@ -22,10 +28,18 @@ function baseProps(overrides: Partial<Parameters<typeof SpinnerAnimationRow>[0]>
     hasRunningTeammates: false,
     teammateTokens: 0,
     foregroundedTeammate: undefined,
-    thinkingStatus: null as const,
+    thinkingStatus: null,
     effortSuffix: '',
     ...overrides,
   }
+}
+
+/** ANSI-stripped non-empty rows from a static Ink render. */
+function visibleRows(output: string): string[] {
+  return output
+    .split(/\r?\n/)
+    .map(line => line.replace(/\s+$/u, ''))
+    .filter(line => line.trim().length > 0)
 }
 
 describe('SpinnerAnimationRow', () => {
@@ -39,11 +53,9 @@ describe('SpinnerAnimationRow', () => {
       120,
     )
 
-    expect(output).toContain('1.0k tokens')
-    // Mode glyph stays inside the status parens next to the token count.
-    expect(output).toMatch(
-      new RegExp(`\\(${figures.arrowDown}[\\s\\S]*1\\.0k tokens[\\s\\S]*\\)`),
-    )
+    expect(visibleRows(output)).toEqual([
+      `● Thinking (${figures.arrowDown}  · 1.0k tokens)`,
+    ])
   })
 
   it('shows zero tokens as soon as the first response character arrives', async () => {
@@ -52,7 +64,9 @@ describe('SpinnerAnimationRow', () => {
       120,
     )
 
-    expect(output).toContain('0 tokens')
+    expect(visibleRows(output)).toEqual([
+      `● Thinking (${figures.arrowDown}  · 0 tokens)`,
+    ])
   })
 
   it('does not overflow a narrow row when a spinner suffix is present', async () => {
@@ -67,8 +81,9 @@ describe('SpinnerAnimationRow', () => {
       45,
     )
 
-    expect(output).toContain('running stop hooks… 1/1')
-    expect(output).not.toContain('tokens')
+    expect(visibleRows(output)).toEqual([
+      `● Thinking (${figures.arrowDown}  · running stop hooks… 1/1)`,
+    ])
   })
 
   it('shows the requesting mode glyph inside parens before other status parts qualify', async () => {
@@ -77,9 +92,10 @@ describe('SpinnerAnimationRow', () => {
       120,
     )
 
-    expect(output).toContain(`(${figures.arrowUp}`)
-    expect(output).toContain(')')
-    expect(output).not.toContain('tokens')
+    // Glyph Box width is 2, so the single-width arrow is padded inside parens.
+    expect(visibleRows(output)).toEqual([
+      `● Thinking (${figures.arrowUp} )`,
+    ])
   })
 
   it('shows the thinking mode glyph inside parens for thinking-only status', async () => {
@@ -93,11 +109,9 @@ describe('SpinnerAnimationRow', () => {
       120,
     )
 
-    expect(output).toMatch(
-      new RegExp(`\\(${figures.arrowDown}[\\s\\S]*thinking[\\s\\S]*\\)`),
-    )
-    // Nested "(thinking)" is only for teammate bare status; leader uses outer parens.
-    expect(output).not.toContain('(thinking)')
+    expect(visibleRows(output)).toEqual([
+      `● Thinking (${figures.arrowDown}  · thinking)`,
+    ])
   })
 
   it('keeps thinking text with the mode glyph on moderately narrow terminals', async () => {
@@ -115,10 +129,9 @@ describe('SpinnerAnimationRow', () => {
       26,
     )
 
-    expect(output).toContain('thinking')
-    expect(output).toMatch(
-      new RegExp(`\\(${figures.arrowDown}[\\s\\S]*thinking[\\s\\S]*\\)`),
-    )
+    expect(visibleRows(output)).toEqual([
+      `● Thinking (${figures.arrowDown}  · thinking)`,
+    ])
   })
 
   it('falls back to bare thinking without glyph when full chrome does not fit', async () => {
@@ -135,15 +148,13 @@ describe('SpinnerAnimationRow', () => {
       23,
     )
 
-    expect(output).toContain('thinking')
-    expect(output).toContain('(thinking)')
-    expect(output).not.toContain(figures.arrowDown)
-    expect(output).not.toContain(figures.arrowUp)
+    expect(visibleRows(output)).toEqual(['● Thinking (thinking)'])
   })
 
   it('does not enable bare thinking one column short of physical fit', async () => {
     // bareAvailable = columns - messageWidth - 3; for "Thinking" that is
     // columns - 13. At columns=20, bareAvailable=7 < 8, so bare must not show.
+    // Residual still allows glyph-only status chrome.
     const output = await renderToString(
       <SpinnerAnimationRow
         {...baseProps({
@@ -155,10 +166,9 @@ describe('SpinnerAnimationRow', () => {
       20,
     )
 
-    expect(output).not.toContain('(thinking)')
-    // Residual 10 >= 5 so a mode glyph alone may still appear; either way the
-    // row must not claim a bare thinking status that overflows.
-    expect(output).not.toMatch(/Thinking\(thinking\)/)
+    expect(visibleRows(output)).toEqual([
+      `● Thinking (${figures.arrowDown} )`,
+    ])
   })
 
   it('omits the mode glyph when residual width cannot fit status chrome', async () => {
@@ -174,8 +184,7 @@ describe('SpinnerAnimationRow', () => {
       14,
     )
 
-    expect(output).not.toContain(figures.arrowUp)
-    expect(output).not.toContain(figures.arrowDown)
+    expect(visibleRows(output)).toEqual(['● Thinking'])
   })
 
   it('omits the mode glyph when teammates are running', async () => {
@@ -190,9 +199,13 @@ describe('SpinnerAnimationRow', () => {
       120,
     )
 
-    expect(output).toContain('1.0k tokens')
-    expect(output).not.toContain(figures.arrowDown)
-    expect(output).not.toContain(figures.arrowUp)
+    // wantsTimer is true for teammates, so the elapsed timer appears with tokens.
+    // Timer text depends on wall clock (0s vs 0.0s), so match the full row shape.
+    const rows = visibleRows(output)
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatch(/^● Thinking \(\d+(?:\.\d+)?s · 1\.0k tokens\)$/)
+    expect(rows[0]).not.toContain(figures.arrowDown)
+    expect(rows[0]).not.toContain(figures.arrowUp)
   })
 
   it('nests (thinking) for teammate bare status under reduced motion', async () => {
@@ -211,9 +224,6 @@ describe('SpinnerAnimationRow', () => {
       26,
     )
 
-    expect(output).toContain('(thinking)')
-    expect(output).not.toContain(figures.arrowDown)
-    expect(output).not.toContain(figures.arrowUp)
-    expect(output).not.toMatch(/Thinking thinking/)
+    expect(visibleRows(output)).toEqual(['● Thinking (thinking)'])
   })
 })

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -242,9 +242,11 @@ export function SpinnerAnimationRow({
     const glyphHidesThinking = bareShowThinking && !showThinking;
     const glyphHidesTimer = bareShowTimer && !showTimer;
     const glyphHidesTokens = bareShowTokens && !showTokens;
-    // Timer under glyph with no tokens: prefer tokens alone (or timer+tokens)
-    // over timer-only / glyph+timer chrome.
-    const preferTokensOverTimerOnly = Boolean(showTimer && !showTokens && tokensFitBareAlone);
+    // Timer under glyph with no tokens and thinking not already visible: prefer
+    // tokens alone (or timer+tokens) over timer-only / glyph+timer chrome.
+    // Do not enter this shortcut when thinking is already on-screen — the else
+    // bare layout can keep thinking+timer+tokens together when they fit.
+    const preferTokensOverTimerOnly = Boolean(showTimer && !showTokens && !showThinking && tokensFitBareAlone);
     // Active thinking hidden behind glyph+timer: prefer thinking (drop timer if needed).
     const preferThinkingOverTimerOnly = Boolean(showTimer && !showThinking && bareShowThinking && thinkingStatus === 'thinking');
     // Do not swap already-visible tokens for a timer that only fits without the glyph,
@@ -258,8 +260,15 @@ export function SpinnerAnimationRow({
         // Tie-break: when tokens and thinking both unlock by dropping the glyph
         // (preferTokensOverTimerOnly && preferThinkingOverTimerOnly), tokens win.
         // Keep tokens; include timer only when both fit without the glyph.
+        // If a suffix is still reserved and cannot share the row with tokens
+        // (and timer when both fit), drop it — otherwise Ink wraps/truncates.
+        const timerTokensWidth = timerAndTokensFitBare ? timerWidth + sep + tokensWidth : tokensWidth;
+        if (showSuffix && bareAvailableSpace < effectiveSuffixWidth + timerTokensWidth) {
+          showSuffix = false;
+          effectiveSuffixWidth = 0;
+        }
         showThinking = false;
-        showTimer = Boolean(wantsTimer && timerAndTokensFitBare);
+        showTimer = Boolean(wantsTimer && (showSuffix ? bareAvailableSpace >= effectiveSuffixWidth + timerWidth + sep + tokensWidth : timerAndTokensFitBare));
         showTokens = true;
         thinkingText = fullThinkingText;
         thinkingWidthValue = fullThinkingWidth;
@@ -305,14 +314,52 @@ export function SpinnerAnimationRow({
       }
     }
   }
-  // After dropping a crowding suffix, recover tokens that primary gating hid
-  // while suffix width was reserved — including thinkingStatus === null (the
-  // common responding + stop-hook/tool suffix path from REPL).
-  if (!showSuffix && !showTokens && !showTimer && !showThinking && wantsTokens && hasTokenContent && physicalBareBudget >= tokensWidth) {
-    showTokens = true;
-    reserveModeGlyph = false;
-    usedAfterThinking = 0;
-    usedAfterTimer = 0;
+  // Prefer live streaming tokens over a bare-fitting suffix when both cannot
+  // share the row (same priority as tokens-over-duration). Avoids the
+  // non-monotonic cliff where widening from overflow-drop to exact suffix-fit
+  // swaps tokens for suffix-only chrome.
+  if (showSuffix && hasTokenContent && physicalBareBudget >= tokensWidth) {
+    const tokensWithSuffixFit = physicalBareBudget >= suffixTextWidth + sep + tokensWidth;
+    if (!tokensWithSuffixFit) {
+      showSuffix = false;
+      effectiveSuffixWidth = 0;
+    }
+  }
+  // After dropping a crowding suffix (or preferring tokens over it), recover
+  // status primary gating hid while suffix width was reserved — including
+  // thinkingStatus === null (common responding + stop-hook/tool suffix path).
+  // Restore timer symmetrically with tokens when the freed budget allows.
+  // Leave empty rows that still want thinking for the thinking second-chance
+  // block below (do not steal with a timer-only recovery first).
+  if (!showSuffix) {
+    const tokensFitBareAlone = wantsTokens && hasTokenContent && physicalBareBudget >= tokensWidth;
+    const timerFitBareAlone = wantsTimer && physicalBareBudget > timerWidth;
+    const timerAndTokensFitBare = wantsTimer && hasTokenContent && physicalBareBudget >= timerWidth + sep + tokensWidth;
+    const withGlyphSpace = columns - messageWidth - BASE_PARENS_WIDTH - MODE_GLYPH_RESERVE;
+    if (!showTokens && !showTimer && !showThinking) {
+      if (tokensFitBareAlone) {
+        showTokens = true;
+        showTimer = Boolean(timerAndTokensFitBare);
+        usedAfterThinking = 0;
+        usedAfterTimer = showTimer ? timerWidth + sep : 0;
+        // Keep the mode glyph only when primary glyph chrome would also fit
+        // the recovered content (strict `>` matches the initial gate).
+        const recoveredWidth = usedAfterTimer + tokensWidth;
+        if (reserveModeGlyph && !(withGlyphSpace > recoveredWidth)) {
+          reserveModeGlyph = false;
+        }
+      } else if (!wantsThinking && timerFitBareAlone) {
+        showTimer = true;
+        usedAfterThinking = 0;
+        usedAfterTimer = timerWidth + sep;
+        if (reserveModeGlyph && !(withGlyphSpace > timerWidth)) {
+          reserveModeGlyph = false;
+        }
+      }
+    } else if (showTokens && !showTimer && timerAndTokensFitBare) {
+      showTimer = true;
+      usedAfterTimer = timerWidth + sep + tokensWidth;
+    }
   }
   // Prefer live streaming tokens over numeric post-thinking duration when both
   // cannot fit (including when primary already chose duration under the glyph,
@@ -378,6 +425,28 @@ export function SpinnerAnimationRow({
         showThinking = true;
         suppressModeGlyphForBareThinking = true;
         reserveModeGlyph = false;
+      }
+    }
+  }
+  // After thinking recovery from a dropped suffix, co-restore a fitting timer
+  // so recovered thinking matches the no-suffix layout at the same width.
+  if (!showSuffix && showThinking && !showTimer && wantsTimer) {
+    const thinkingWidth = thinkingWidthValue + sep;
+    if (physicalBareBudget > thinkingWidth + timerWidth) {
+      // Timer fits with thinking under bare chrome. Drop glyph if glyph+both
+      // would not fit, matching the earlier bare-glyph recovery trade-off.
+      const glyphThinkingTimerWidth = MODE_GLYPH_RESERVE + thinkingWidth + timerWidth;
+      if (reserveModeGlyph && physicalBareBudget < glyphThinkingTimerWidth) {
+        if (physicalBareBudget > thinkingWidth + timerWidth) {
+          reserveModeGlyph = false;
+          showTimer = true;
+          usedAfterThinking = thinkingWidth;
+          usedAfterTimer = usedAfterThinking + timerWidth + sep;
+        }
+      } else {
+        showTimer = true;
+        usedAfterThinking = thinkingWidth;
+        usedAfterTimer = usedAfterThinking + timerWidth + sep;
       }
     }
   }

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -332,10 +332,7 @@ export function SpinnerAnimationRow({
           : thinkingWidthValue;
       }
     }
-    const timerWantedVisible =
-      showTimer ||
-      (wantsTimer &&
-        (verbose || hasRunningTeammates || effectiveElapsedMs > SHOW_TIMER_AFTER_MS));
+    const timerWantedVisible = showTimer || wantsTimer;
     let suffixWithAllVisibleFit = suffixTextWidth;
     if (timerWantedVisible) suffixWithAllVisibleFit += sep + timerWidth;
     if (hasTokenContent) suffixWithAllVisibleFit += sep + tokensWidth;

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -193,13 +193,16 @@ export function SpinnerAnimationRow({
   const showTimer = wantsTimer && availableSpace > usedAfterThinking + timerWidth;
   const usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
   const showTokens = wantsTokens && hasTokenContent && availableSpace > usedAfterTimer + tokensWidth;
-  // Leader thinking-only now keeps the mode glyph inside outer parens
+  // Leader thinking-only prefers the mode glyph inside outer parens
   // ("(↓ · thinking)"). The primary gate above still uses a conservative
   // parensWidth that can reject widths where that physical layout still fits.
-  // Retry with the real leader chrome budget so the thinking word is not lost
-  // on moderately narrow terminals.
-  // Physical: "(" + glyph(2) + " · " + thinking + ")" (+ 1 safety).
+  // Retry in two steps so the thinking word is not lost on narrow terminals:
+  // 1) full leader chrome with glyph when it fits
+  // 2) bare "(thinking)" without the glyph (same band as pre-glyph layout)
+  //    rather than rendering glyph-only empty status
+  // Physical full chrome: "(" + glyph(2) + " · " + thinking + ")" (+ 1 safety).
   const leaderThinkingOnlyChrome = 2 + 2 + SEP_WIDTH + 1;
+  let suppressModeGlyphForBareThinking = false;
   if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && !hasRunningTeammates && !spinnerSuffix && !showTimer && !showTokens) {
     const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
     if (leaderThinkingAvailable >= thinkingWidthValue) {
@@ -208,17 +211,31 @@ export function SpinnerAnimationRow({
       thinkingText = 'thinking';
       thinkingWidthValue = THINKING_BARE_WIDTH;
       showThinking = true;
+    } else {
+      const bareAvailable = columns - messageWidth - 2;
+      if (bareAvailable >= thinkingWidthValue) {
+        showThinking = true;
+        suppressModeGlyphForBareThinking = true;
+      } else if (effortSuffix && bareAvailable >= THINKING_BARE_WIDTH) {
+        thinkingText = 'thinking';
+        thinkingWidthValue = THINKING_BARE_WIDTH;
+        showThinking = true;
+        suppressModeGlyphForBareThinking = true;
+      }
     }
   }
-  // thinkingOnly: only the thinking word (plus the mode glyph on leader spins).
-  // Nested "(thinking)" is reserved for teammate spins that skip the mode glyph
-  // and therefore have no outer status parens.
+  // thinkingOnly: only the thinking word (plus the mode glyph on leader spins
+  // when space allows). Nested "(thinking)" is reserved for teammate spins that
+  // skip the mode glyph and therefore have no outer status parens. Leader bare
+  // fallback still uses outer parens with just the thinking word: "(thinking)".
   const thinkingOnly = showThinking && thinkingStatus === 'thinking' && !spinnerSuffix && !showTimer && !showTokens;
   const bareThinkingOnly = thinkingOnly && hasRunningTeammates;
-  // Minimum residual for leader status chrome: "(" + glyph Box(width=2) + ")".
-  // Below this, omit the glyph entirely rather than overflow the row.
+  // Minimum residual for leader status chrome after the glimmer trailing space:
+  // " " + "(" + glyph Box(width=2) + ")". Below this, omit the glyph rather
+  // than overflow the row. Also omit when the bare-thinking fallback chose to
+  // keep the thinking word without glyph chrome.
   const residualForStatus = columns - messageWidth;
-  const canShowModeGlyph = !hasRunningTeammates && residualForStatus >= 4;
+  const canShowModeGlyph = !hasRunningTeammates && !suppressModeGlyphForBareThinking && residualForStatus >= 5;
 
   // === Thinking shimmer color (formerly ThinkingShimmerText's own timer) ===
   // Same sine-wave opacity, but derived from our shared `time` instead of a

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -211,12 +211,15 @@ export function SpinnerAnimationRow({
     const bareShowTimer = wantsTimer && bareAvailableSpace > bareUsedAfterThinking + timerWidth;
     const bareUsedAfterTimer = bareUsedAfterThinking + (bareShowTimer ? timerWidth + sep : 0);
     const bareShowTokens = wantsTokens && hasTokenContent && bareAvailableSpace > bareUsedAfterTimer + tokensWidth;
+    const bareShowTokensWithTimer = wantsTokens && hasTokenContent && bareAvailableSpace >= bareUsedAfterTimer + tokensWidth;
     // Thinking-only recovery stays in the dedicated second-chance block below
     // so full "(↓ · thinking)" chrome still wins when it fits.
     const glyphHidesContent = bareShowTimer && !showTimer || bareShowTokens && !showTokens;
     // Do not swap already-visible tokens for a timer that only fits without the glyph.
     const glyphRecoveryLosesTokens = showTokens && !bareShowTokens;
-    if (glyphHidesContent && !glyphRecoveryLosesTokens) {
+    // Timer may already show with the glyph while tokens only fit after dropping it.
+    const glyphRecoveryAddsTokens = showTimer && !showTokens && bareShowTokensWithTimer;
+    if ((glyphHidesContent || glyphRecoveryAddsTokens) && !glyphRecoveryLosesTokens) {
       reserveModeGlyph = false;
       parensWidth = BASE_PARENS_WIDTH;
       availableSpace = bareAvailableSpace;
@@ -224,7 +227,7 @@ export function SpinnerAnimationRow({
       usedAfterThinking = bareUsedAfterThinking;
       showTimer = bareShowTimer;
       usedAfterTimer = bareUsedAfterTimer;
-      showTokens = bareShowTokens;
+      showTokens = glyphRecoveryAddsTokens ? bareShowTokensWithTimer : bareShowTokens;
     }
   }
   // Leader thinking-only prefers the mode glyph inside outer parens
@@ -248,7 +251,13 @@ export function SpinnerAnimationRow({
     if (!showThinking) {
       // Bare chrome: glimmer trailing space + "(" + ")" (matches physical row).
       const bareAvailable = columns - messageWidth - 3;
-      if (bareAvailable >= thinkingWidthValue) {
+      const tokensFitBareAlone = wantsTokens && hasTokenContent && bareAvailable > tokensWidth;
+      const thinkingAndTokensFitBare = bareAvailable > thinkingWidthValue + sep + tokensWidth;
+      if (typeof thinkingStatus === 'number' && tokensFitBareAlone && !thinkingAndTokensFitBare && !showTokens) {
+        showTokens = true;
+        suppressModeGlyphForBareThinking = true;
+        reserveModeGlyph = false;
+      } else if (bareAvailable >= thinkingWidthValue) {
         showThinking = true;
         suppressModeGlyphForBareThinking = true;
         reserveModeGlyph = false;
@@ -274,7 +283,7 @@ export function SpinnerAnimationRow({
   const hasVisibleStatusContent = Boolean(spinnerSuffix) || showTimer || showTokens || showThinking;
   // Requesting and active "thinking" may show glyph-only chrome; completed-thought
   // duration and other states must not render an empty "(↓ )" row.
-  const allowGlyphOnlyStatus = mode === 'requesting' || thinkingStatus === 'thinking';
+  const allowGlyphOnlyStatus = (mode === 'requesting' || thinkingStatus === 'thinking') && typeof thinkingStatus !== 'number';
   const canShowModeGlyph = reserveModeGlyph && !suppressModeGlyphForBareThinking && residualForStatus >= 5 && (hasVisibleStatusContent || allowGlyphOnlyStatus);
 
   // === Thinking shimmer color (formerly ThinkingShimmerText's own timer) ===

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -171,19 +171,34 @@ export function SpinnerAnimationRow({
   // messageWidth = glimmer text + spinner glyph (width: 2).
   // Base parens chrome is 4: glimmer trailing space + "(" + ")" + safety.
   // Leader spins may also reserve mode glyph (width 2) + separator.
+  // Physical bare chrome (no safety) is 3 — used for exact-fit recovery so
+  // higher-value status (tokens/thinking) appears as soon as it actually fits.
   const messageWidth = glimmerMessageWidth + 2;
   const sep = SEP_WIDTH;
   const MODE_GLYPH_RESERVE = 2 + SEP_WIDTH;
   const BASE_PARENS_WIDTH = 4;
+  const PHYSICAL_BARE_PARENS = 3;
+  // Full glyph+thinking chrome budget includes +1 safety vs physical Ink width.
+  const leaderThinkingOnlyChrome = 2 + 2 + SEP_WIDTH + 1;
   const suffixWidth = spinnerSuffix ? stringWidth(spinnerSuffix) + sep : 0;
   const wantsThinking = thinkingStatus !== null;
   const wantsTimer = verbose || hasRunningTeammates || effectiveElapsedMs > SHOW_TIMER_AFTER_MS;
   const wantsTokens = true;
+  const fullThinkingText = thinkingText;
+  const fullThinkingWidth = thinkingWidthValue;
   // Prefer layout with the mode glyph when it fits alongside other status.
   let reserveModeGlyph = !hasRunningTeammates;
   let parensWidth = BASE_PARENS_WIDTH + (reserveModeGlyph ? MODE_GLYPH_RESERVE : 0);
   let availableSpace = columns - messageWidth - parensWidth;
+  // Try full effort text against the looser leader glyph chrome before shrinking,
+  // so "(↓ · thinking with high effort)" wins when it physically fits.
   let showThinking = wantsThinking && availableSpace > suffixWidth + thinkingWidthValue;
+  if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && !hasRunningTeammates && !spinnerSuffix && reserveModeGlyph) {
+    const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
+    if (leaderThinkingAvailable >= fullThinkingWidth) {
+      showThinking = true;
+    }
+  }
   if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
     if (availableSpace > suffixWidth + THINKING_BARE_WIDTH) {
       thinkingText = 'thinking';
@@ -196,51 +211,100 @@ export function SpinnerAnimationRow({
   let usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
   let showTokens = wantsTokens && hasTokenContent && availableSpace > usedAfterTimer + tokensWidth;
   // Re-check without the glyph. Keep it when it fits alongside the same
-  // content, but prefer timer/token status when reserving the glyph hides it.
+  // content, but prefer higher-value status when reserving the glyph hides it.
+  // Use physical bare chrome for recovery so exact-fit columns are not rejected
+  // by the +1 safety margin that primary gating already applied.
   if (reserveModeGlyph) {
-    const bareAvailableSpace = columns - messageWidth - BASE_PARENS_WIDTH;
-    let bareShowThinking = wantsThinking && bareAvailableSpace > suffixWidth + thinkingWidthValue;
+    const bareAvailableSpace = columns - messageWidth - PHYSICAL_BARE_PARENS;
+    let bareThinkingText = fullThinkingText;
+    let bareThinkingWidth = fullThinkingWidth;
+    let bareShowThinking = wantsThinking && bareAvailableSpace > suffixWidth + bareThinkingWidth;
     if (!bareShowThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
       if (bareAvailableSpace > suffixWidth + THINKING_BARE_WIDTH) {
-        thinkingText = 'thinking';
-        thinkingWidthValue = THINKING_BARE_WIDTH;
+        bareThinkingText = 'thinking';
+        bareThinkingWidth = THINKING_BARE_WIDTH;
         bareShowThinking = true;
       }
     }
-    const bareUsedAfterThinking = suffixWidth + (bareShowThinking ? thinkingWidthValue + sep : 0);
+    const bareUsedAfterThinking = suffixWidth + (bareShowThinking ? bareThinkingWidth + sep : 0);
     const bareShowTimer = wantsTimer && bareAvailableSpace > bareUsedAfterThinking + timerWidth;
     const bareUsedAfterTimer = bareUsedAfterThinking + (bareShowTimer ? timerWidth + sep : 0);
-    const bareShowTokens = wantsTokens && hasTokenContent && bareAvailableSpace > bareUsedAfterTimer + tokensWidth;
-    const bareShowTokensWithTimer = wantsTokens && hasTokenContent && bareAvailableSpace >= bareUsedAfterTimer + tokensWidth;
+    const bareShowTokens = wantsTokens && hasTokenContent && bareAvailableSpace >= bareUsedAfterTimer + tokensWidth;
+    const tokensFitBareAlone = wantsTokens && hasTokenContent && bareAvailableSpace >= tokensWidth;
+    const timerAndTokensFitBare = wantsTimer && hasTokenContent && bareAvailableSpace >= timerWidth + sep + tokensWidth;
     // Thinking-only recovery stays in the dedicated second-chance block below
     // so full "(↓ · thinking)" chrome still wins when it fits.
-    const glyphHidesContent = bareShowTimer && !showTimer || bareShowTokens && !showTokens;
-    // Do not swap already-visible tokens for a timer that only fits without the glyph.
-    const glyphRecoveryLosesTokens = showTokens && !bareShowTokens;
-    // Timer may already show with the glyph while tokens only fit after dropping it.
-    const glyphRecoveryAddsTokens = showTimer && !showTokens && bareShowTokensWithTimer;
-    if ((glyphHidesContent || glyphRecoveryAddsTokens) && !glyphRecoveryLosesTokens) {
+    const glyphHidesThinking = bareShowThinking && !showThinking;
+    const glyphHidesTimer = bareShowTimer && !showTimer;
+    const glyphHidesTokens = bareShowTokens && !showTokens;
+    // Timer under glyph with no tokens: prefer tokens alone (or timer+tokens)
+    // over timer-only / glyph+timer chrome.
+    const preferTokensOverTimerOnly = Boolean(showTimer && !showTokens && tokensFitBareAlone);
+    // Active thinking hidden behind glyph+timer: prefer thinking (drop timer if needed).
+    const preferThinkingOverTimerOnly = Boolean(showTimer && !showThinking && bareShowThinking && thinkingStatus === 'thinking');
+    // Do not swap already-visible tokens for a timer that only fits without the glyph,
+    // unless we are explicitly choosing tokens-over-timer-only below.
+    const glyphRecoveryLosesTokens = showTokens && !bareShowTokens && !preferTokensOverTimerOnly;
+    if ((glyphHidesThinking || glyphHidesTimer || glyphHidesTokens || preferTokensOverTimerOnly || preferThinkingOverTimerOnly) && !glyphRecoveryLosesTokens) {
       reserveModeGlyph = false;
       parensWidth = BASE_PARENS_WIDTH;
-      availableSpace = bareAvailableSpace;
-      showThinking = bareShowThinking;
-      usedAfterThinking = bareUsedAfterThinking;
-      showTimer = bareShowTimer;
-      usedAfterTimer = bareUsedAfterTimer;
-      showTokens = glyphRecoveryAddsTokens ? bareShowTokensWithTimer : bareShowTokens;
+      availableSpace = columns - messageWidth - BASE_PARENS_WIDTH;
+      if (preferTokensOverTimerOnly) {
+        // Keep tokens; include timer only when both fit without the glyph.
+        showThinking = false;
+        showTimer = Boolean(wantsTimer && timerAndTokensFitBare);
+        showTokens = true;
+        thinkingText = fullThinkingText;
+        thinkingWidthValue = fullThinkingWidth;
+        usedAfterThinking = suffixWidth;
+        usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
+      } else if (preferThinkingOverTimerOnly && !bareShowTimer) {
+        // Thinking fits bare; timer does not fit alongside — drop timer.
+        thinkingText = bareThinkingText ?? fullThinkingText;
+        thinkingWidthValue = bareThinkingWidth;
+        showThinking = true;
+        showTimer = false;
+        showTokens = false;
+        usedAfterThinking = suffixWidth + thinkingWidthValue + sep;
+        usedAfterTimer = usedAfterThinking;
+      } else {
+        thinkingText = bareThinkingText ?? fullThinkingText;
+        thinkingWidthValue = bareThinkingWidth;
+        showThinking = bareShowThinking;
+        usedAfterThinking = bareUsedAfterThinking;
+        showTimer = bareShowTimer;
+        usedAfterTimer = bareUsedAfterTimer;
+        showTokens = bareShowTokens;
+      }
+    }
+  }
+  // Prefer live streaming tokens over numeric post-thinking duration when both
+  // cannot fit (including when primary already chose duration under the glyph).
+  let suppressModeGlyphForBareThinking = false;
+  if (typeof thinkingStatus === 'number' && hasTokenContent && showThinking && !showTokens && !spinnerSuffix) {
+    const physicalBare = columns - messageWidth - PHYSICAL_BARE_PARENS;
+    const tokensFitBareAlone = physicalBare >= tokensWidth;
+    const thinkingAndTokensFit = physicalBare >= thinkingWidthValue + sep + tokensWidth;
+    if (tokensFitBareAlone && !thinkingAndTokensFit) {
+      showThinking = false;
+      showTokens = true;
+      showTimer = false;
+      reserveModeGlyph = false;
+      suppressModeGlyphForBareThinking = true;
+      usedAfterThinking = suffixWidth;
+      usedAfterTimer = usedAfterThinking;
     }
   }
   // Leader thinking-only prefers the mode glyph inside outer parens
   // ("(↓ · thinking)") when both fit. When full chrome does not fit, fall
   // back to bare "(thinking)" without the glyph (same band as pre-glyph
   // layout) rather than empty glyph-only status.
-  // Full chrome budget includes +1 safety vs physical Ink width.
-  const leaderThinkingOnlyChrome = 2 + 2 + SEP_WIDTH + 1;
-  let suppressModeGlyphForBareThinking = false;
   if (!showThinking && wantsThinking && !hasRunningTeammates && !spinnerSuffix && !showTimer && !showTokens) {
     if (reserveModeGlyph) {
       const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
-      if (leaderThinkingAvailable >= thinkingWidthValue) {
+      if (leaderThinkingAvailable >= fullThinkingWidth) {
+        thinkingText = fullThinkingText;
+        thinkingWidthValue = fullThinkingWidth;
         showThinking = true;
       } else if (thinkingStatus === 'thinking' && effortSuffix && leaderThinkingAvailable >= THINKING_BARE_WIDTH) {
         thinkingText = 'thinking';
@@ -250,14 +314,16 @@ export function SpinnerAnimationRow({
     }
     if (!showThinking) {
       // Bare chrome: glimmer trailing space + "(" + ")" (matches physical row).
-      const bareAvailable = columns - messageWidth - 3;
-      const tokensFitBareAlone = wantsTokens && hasTokenContent && bareAvailable > tokensWidth;
-      const thinkingAndTokensFitBare = bareAvailable > thinkingWidthValue + sep + tokensWidth;
+      const bareAvailable = columns - messageWidth - PHYSICAL_BARE_PARENS;
+      const tokensFitBareAlone = wantsTokens && hasTokenContent && bareAvailable >= tokensWidth;
+      const thinkingAndTokensFitBare = bareAvailable >= fullThinkingWidth + sep + tokensWidth;
       if (typeof thinkingStatus === 'number' && tokensFitBareAlone && !thinkingAndTokensFitBare && !showTokens) {
         showTokens = true;
         suppressModeGlyphForBareThinking = true;
         reserveModeGlyph = false;
-      } else if (bareAvailable >= thinkingWidthValue) {
+      } else if (bareAvailable >= fullThinkingWidth) {
+        thinkingText = fullThinkingText;
+        thinkingWidthValue = fullThinkingWidth;
         showThinking = true;
         suppressModeGlyphForBareThinking = true;
         reserveModeGlyph = false;

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -571,15 +571,21 @@ export function SpinnerAnimationRow({
       reserveModeGlyph = false;
     }
   }
+  // Token recovery can restore content using bare chrome, so a glyph reserved
+  // earlier may no longer fit once tokens are visible. Thinking-only layouts
+  // have their own looser dedicated chrome budget above.
+  const modeGlyphAvailableSpace = columns - messageWidth - BASE_PARENS_WIDTH - MODE_GLYPH_RESERVE;
+  let modeGlyphContentWidth = 0;
+  if (showTimer) modeGlyphContentWidth += timerWidth;
+  if (showTokens) modeGlyphContentWidth += (modeGlyphContentWidth > 0 ? sep : 0) + tokensWidth;
+  if (showThinking) modeGlyphContentWidth += (modeGlyphContentWidth > 0 ? sep : 0) + thinkingWidthValue;
+  if (reserveModeGlyph && showTokens && !(modeGlyphAvailableSpace > modeGlyphContentWidth)) {
+    reserveModeGlyph = false;
+  }
   // Restore mode glyph whenever leader content fits under glyph chrome —
   // covers suffix-keep cascades and bare recovery that cleared the glyph.
   if (!showSuffix && !hasRunningTeammates && !suppressModeGlyphForBareThinking && !reserveModeGlyph && (showTokens || showTimer || showThinking)) {
-    const withGlyphSpace = columns - messageWidth - BASE_PARENS_WIDTH - MODE_GLYPH_RESERVE;
-    let contentW = 0;
-    if (showTimer) contentW += timerWidth;
-    if (showTokens) contentW += (contentW > 0 ? sep : 0) + tokensWidth;
-    if (showThinking) contentW += (contentW > 0 ? sep : 0) + thinkingWidthValue;
-    if (withGlyphSpace > contentW) {
+    if (modeGlyphAvailableSpace > modeGlyphContentWidth) {
       reserveModeGlyph = true;
     }
   }

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -212,7 +212,8 @@ export function SpinnerAnimationRow({
       thinkingWidthValue = THINKING_BARE_WIDTH;
       showThinking = true;
     } else {
-      const bareAvailable = columns - messageWidth - 2;
+      // Bare chrome: glimmer trailing space + "(" + ")" (matches physical row).
+      const bareAvailable = columns - messageWidth - 3;
       if (bareAvailable >= thinkingWidthValue) {
         showThinking = true;
         suppressModeGlyphForBareThinking = true;

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -218,6 +218,8 @@ export function SpinnerAnimationRow({
     const bareAvailableSpace = columns - messageWidth - PHYSICAL_BARE_PARENS;
     let bareThinkingText = fullThinkingText;
     let bareThinkingWidth = fullThinkingWidth;
+    // Thinking/timer keep `>` so they leave one safety column; token checks use
+    // `>=` so live token counts may consume the exact physical bare budget.
     let bareShowThinking = wantsThinking && bareAvailableSpace > suffixWidth + bareThinkingWidth;
     if (!bareShowThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
       if (bareAvailableSpace > suffixWidth + THINKING_BARE_WIDTH) {
@@ -250,6 +252,8 @@ export function SpinnerAnimationRow({
       parensWidth = BASE_PARENS_WIDTH;
       availableSpace = columns - messageWidth - BASE_PARENS_WIDTH;
       if (preferTokensOverTimerOnly) {
+        // Tie-break: when tokens and thinking both unlock by dropping the glyph
+        // (preferTokensOverTimerOnly && preferThinkingOverTimerOnly), tokens win.
         // Keep tokens; include timer only when both fit without the glyph.
         showThinking = false;
         showTimer = Boolean(wantsTimer && timerAndTokensFitBare);
@@ -289,8 +293,8 @@ export function SpinnerAnimationRow({
       showThinking = false;
       showTokens = true;
       showTimer = false;
+      // reserveModeGlyph=false is enough to keep canShowModeGlyph false.
       reserveModeGlyph = false;
-      suppressModeGlyphForBareThinking = true;
       usedAfterThinking = suffixWidth;
       usedAfterTimer = usedAfterThinking;
     }
@@ -319,7 +323,6 @@ export function SpinnerAnimationRow({
       const thinkingAndTokensFitBare = bareAvailable >= fullThinkingWidth + sep + tokensWidth;
       if (typeof thinkingStatus === 'number' && tokensFitBareAlone && !thinkingAndTokensFitBare && !showTokens) {
         showTokens = true;
-        suppressModeGlyphForBareThinking = true;
         reserveModeGlyph = false;
       } else if (bareAvailable >= fullThinkingWidth) {
         thinkingText = fullThinkingText;

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -319,20 +319,77 @@ export function SpinnerAnimationRow({
   // widening from overflow-drop to exact suffix-fit swaps higher-value status
   // for suffix-only chrome.
   if (showSuffix) {
-    const thinkingWidthForSuffix = thinkingStatus === 'thinking' ? THINKING_BARE_WIDTH : fullThinkingWidth;
-    const tokensWithSuffixFit = !hasTokenContent || physicalBareBudget >= suffixTextWidth + sep + tokensWidth;
+    // Budget companions at the widths actually rendered (or about to be).
+    let thinkingWidthForSuffix = 0;
+    if (showThinking || wantsThinking) {
+      if (typeof thinkingStatus === 'number') {
+        thinkingWidthForSuffix = fullThinkingWidth;
+      } else if (thinkingStatus === 'thinking') {
+        // Effort text may be restored after this pass — budget full width so
+        // suffix is not kept when only bare "thinking" fit in the estimate.
+        thinkingWidthForSuffix = effortSuffix
+          ? Math.max(thinkingWidthValue, fullThinkingWidth)
+          : thinkingWidthValue;
+      }
+    }
+    const timerWantedVisible =
+      showTimer ||
+      (wantsTimer &&
+        (verbose || hasRunningTeammates || effectiveElapsedMs > SHOW_TIMER_AFTER_MS));
+    const tokensWithSuffixFit =
+      !hasTokenContent || physicalBareBudget >= suffixTextWidth + sep + tokensWidth;
     // Use `>` (not `>=`) so exact-fit suffix+thinking does not keep the suffix
     // while glyph chrome still cannot show thinking — avoids a one-column cliff.
-    const thinkingWithSuffixFit = !wantsThinking || physicalBareBudget > suffixTextWidth + sep + thinkingWidthForSuffix;
-    const tokensWithSuffixAndThinkingFit = !hasTokenContent || !wantsThinking || physicalBareBudget >= suffixTextWidth + sep + thinkingWidthForSuffix + sep + tokensWidth;
-    if (hasTokenContent && physicalBareBudget >= tokensWidth && !tokensWithSuffixFit) {
+    const thinkingWithSuffixFit =
+      !wantsThinking ||
+      physicalBareBudget > suffixTextWidth + sep + thinkingWidthForSuffix;
+    const tokensWithSuffixAndThinkingFit =
+      !hasTokenContent ||
+      !wantsThinking ||
+      physicalBareBudget >=
+        suffixTextWidth + sep + thinkingWidthForSuffix + sep + tokensWidth;
+    const suffixWithTimerAndThinkingFit =
+      !(timerWantedVisible && wantsThinking) ||
+      physicalBareBudget >
+        suffixTextWidth + sep + timerWidth + sep + thinkingWidthForSuffix;
+    let suffixWithAllVisibleFit = suffixTextWidth;
+    if (timerWantedVisible) suffixWithAllVisibleFit += sep + timerWidth;
+    if (hasTokenContent) suffixWithAllVisibleFit += sep + tokensWidth;
+    if (wantsThinking && (showThinking || thinkingWidthForSuffix > 0)) {
+      suffixWithAllVisibleFit += sep + thinkingWidthForSuffix;
+    }
+    const allVisibleFitWithSuffix = physicalBareBudget >= suffixWithAllVisibleFit;
+    if (hasTokenContent && physicalBareBudget >= tokensWidth && !allVisibleFitWithSuffix) {
       showSuffix = false;
       effectiveSuffixWidth = 0;
-    } else if (hasTokenContent && wantsThinking && physicalBareBudget >= tokensWidth && tokensWithSuffixFit && !tokensWithSuffixAndThinkingFit) {
+    } else if (hasTokenContent && physicalBareBudget >= tokensWidth && !tokensWithSuffixFit) {
+      showSuffix = false;
+      effectiveSuffixWidth = 0;
+    } else if (
+      hasTokenContent &&
+      wantsThinking &&
+      physicalBareBudget >= tokensWidth &&
+      tokensWithSuffixFit &&
+      !tokensWithSuffixAndThinkingFit
+    ) {
       // Suffix+thinking would fit without tokens; prefer live tokens over that pair.
       showSuffix = false;
       effectiveSuffixWidth = 0;
-    } else if (!hasTokenContent && wantsThinking && physicalBareBudget >= thinkingWidthForSuffix && !thinkingWithSuffixFit) {
+    } else if (
+      timerWantedVisible &&
+      wantsThinking &&
+      physicalBareBudget >= timerWidth + sep + thinkingWidthForSuffix &&
+      !suffixWithTimerAndThinkingFit
+    ) {
+      // Timer+thinking fit without suffix; keep them and drop suffix until all three fit.
+      showSuffix = false;
+      effectiveSuffixWidth = 0;
+    } else if (
+      !hasTokenContent &&
+      wantsThinking &&
+      physicalBareBudget >= thinkingWidthForSuffix &&
+      !thinkingWithSuffixFit
+    ) {
       showSuffix = false;
       effectiveSuffixWidth = 0;
     }
@@ -367,7 +424,24 @@ export function SpinnerAnimationRow({
       }
     } else if (showTimer && !showTokens && tokensFitBareAlone) {
       // Suffix drop freed budget that primary spent on suffix+timer only.
-      if (timerAndTokensFitBare && physicalBareBudget >= timerWidth + sep + tokensWidth + (showThinking ? sep + thinkingWidthValue : 0)) {
+      const thinkingAndTokensFit =
+        showThinking && physicalBareBudget >= thinkingWidthValue + sep + tokensWidth;
+      const timerThinkingTokensFit =
+        showThinking &&
+        physicalBareBudget >= timerWidth + sep + thinkingWidthValue + sep + tokensWidth;
+      if (showThinking && timerThinkingTokensFit) {
+        showTokens = true;
+        usedAfterTimer = timerWidth + sep + tokensWidth;
+      } else if (thinkingAndTokensFit) {
+        // Prefer tokens + thinking over timer + thinking when timer crowds tokens.
+        showTimer = false;
+        showTokens = true;
+        usedAfterThinking = thinkingWidthValue + sep;
+        usedAfterTimer = 0;
+      } else if (
+        timerAndTokensFitBare &&
+        physicalBareBudget >= timerWidth + sep + tokensWidth + (showThinking ? sep + thinkingWidthValue : 0)
+      ) {
         showTokens = true;
         usedAfterTimer = timerWidth + sep + tokensWidth;
       } else if (!showThinking) {
@@ -383,6 +457,9 @@ export function SpinnerAnimationRow({
       if (showTimer) total += timerWidth + sep;
       if (physicalBareBudget >= total) {
         showTokens = true;
+        if (reserveModeGlyph && !(withGlyphSpace > total)) {
+          reserveModeGlyph = false;
+        }
       }
     } else if (showTokens && !showTimer && wantsTimer) {
       let total = timerWidth + sep + tokensWidth;

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -287,10 +287,32 @@ export function SpinnerAnimationRow({
   }
   // Drop an overflowing spinner suffix before other recovery so mid-narrow rows
   // can keep tokens/thinking instead of wrapping glyph+suffix-only chrome.
+  // Budget must include mode-glyph chrome when reserved — comparing suffix text
+  // alone against bare parens leaves glyph+suffix rows that Ink truncates mid-string.
+  // Prefer dropping the glyph to keep a suffix that still fits under bare parens.
   const physicalBareBudget = columns - messageWidth - PHYSICAL_BARE_PARENS;
-  if (showSuffix && physicalBareBudget < suffixTextWidth) {
-    showSuffix = false;
-    effectiveSuffixWidth = 0;
+  if (showSuffix) {
+    const suffixFitsBare = physicalBareBudget >= suffixTextWidth;
+    const suffixFitsWithGlyph = reserveModeGlyph ? physicalBareBudget - MODE_GLYPH_RESERVE >= suffixTextWidth : suffixFitsBare;
+    if (!suffixFitsWithGlyph) {
+      if (reserveModeGlyph && suffixFitsBare) {
+        reserveModeGlyph = false;
+        parensWidth = BASE_PARENS_WIDTH;
+        availableSpace = columns - messageWidth - BASE_PARENS_WIDTH;
+      } else {
+        showSuffix = false;
+        effectiveSuffixWidth = 0;
+      }
+    }
+  }
+  // After dropping a crowding suffix, recover tokens that primary gating hid
+  // while suffix width was reserved — including thinkingStatus === null (the
+  // common responding + stop-hook/tool suffix path from REPL).
+  if (!showSuffix && !showTokens && !showTimer && !showThinking && wantsTokens && hasTokenContent && physicalBareBudget >= tokensWidth) {
+    showTokens = true;
+    reserveModeGlyph = false;
+    usedAfterThinking = 0;
+    usedAfterTimer = 0;
   }
   // Prefer live streaming tokens over numeric post-thinking duration when both
   // cannot fit (including when primary already chose duration under the glyph,
@@ -316,13 +338,14 @@ export function SpinnerAnimationRow({
       usedAfterTimer = usedAfterThinking;
     }
   }
-  // Leader thinking-only prefers the mode glyph inside outer parens
+  // Thinking-only prefers the mode glyph inside outer parens for leaders
   // ("(↓ · thinking)") when both fit. When full chrome does not fit, fall
   // back to bare "(thinking)" without the glyph (same band as pre-glyph
-  // layout) rather than empty glyph-only status. Runs after suffix overflow
-  // drop so stop-hook/tool suffixes do not permanently hide thinking.
-  if (!showThinking && wantsThinking && !hasRunningTeammates && !showSuffix && !showTimer && !showTokens) {
-    if (reserveModeGlyph) {
+  // layout) rather than empty glyph-only status. Teammates skip glyph chrome
+  // and recover nested "(thinking)" here after suffix overflow drop so
+  // stop-hook/tool suffixes do not permanently hide thinking.
+  if (!showThinking && wantsThinking && !showSuffix && !showTimer && !showTokens) {
+    if (reserveModeGlyph && !hasRunningTeammates) {
       const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
       if (leaderThinkingAvailable >= fullThinkingWidth) {
         thinkingText = fullThinkingText;
@@ -336,6 +359,7 @@ export function SpinnerAnimationRow({
     }
     if (!showThinking) {
       // Bare chrome: glimmer trailing space + "(" + ")" (matches physical row).
+      // Teammates nest these parens on the thinking word via bareThinkingOnly.
       const bareAvailable = physicalBareBudget;
       const tokensFitBareAlone = wantsTokens && hasTokenContent && bareAvailable >= tokensWidth;
       const thinkingAndTokensFitBare = bareAvailable >= fullThinkingWidth + sep + tokensWidth;

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -336,43 +336,22 @@ export function SpinnerAnimationRow({
       showTimer ||
       (wantsTimer &&
         (verbose || hasRunningTeammates || effectiveElapsedMs > SHOW_TIMER_AFTER_MS));
-    const tokensWithSuffixFit =
-      !hasTokenContent || physicalBareBudget >= suffixTextWidth + sep + tokensWidth;
-    // Use `>` (not `>=`) so exact-fit suffix+thinking does not keep the suffix
-    // while glyph chrome still cannot show thinking — avoids a one-column cliff.
-    const thinkingWithSuffixFit =
-      !wantsThinking ||
-      physicalBareBudget > suffixTextWidth + sep + thinkingWidthForSuffix;
-    const tokensWithSuffixAndThinkingFit =
-      !hasTokenContent ||
-      !wantsThinking ||
-      physicalBareBudget >=
-        suffixTextWidth + sep + thinkingWidthForSuffix + sep + tokensWidth;
-    const suffixWithTimerAndThinkingFit =
-      !(timerWantedVisible && wantsThinking) ||
-      physicalBareBudget >
-        suffixTextWidth + sep + timerWidth + sep + thinkingWidthForSuffix;
     let suffixWithAllVisibleFit = suffixTextWidth;
     if (timerWantedVisible) suffixWithAllVisibleFit += sep + timerWidth;
     if (hasTokenContent) suffixWithAllVisibleFit += sep + tokensWidth;
     if (wantsThinking && (showThinking || thinkingWidthForSuffix > 0)) {
       suffixWithAllVisibleFit += sep + thinkingWidthForSuffix;
     }
-    const allVisibleFitWithSuffix = physicalBareBudget >= suffixWithAllVisibleFit;
-    if (hasTokenContent && physicalBareBudget >= tokensWidth && !allVisibleFitWithSuffix) {
-      showSuffix = false;
-      effectiveSuffixWidth = 0;
-    } else if (hasTokenContent && physicalBareBudget >= tokensWidth && !tokensWithSuffixFit) {
-      showSuffix = false;
-      effectiveSuffixWidth = 0;
-    } else if (
-      hasTokenContent &&
-      wantsThinking &&
-      physicalBareBudget >= tokensWidth &&
-      tokensWithSuffixFit &&
-      !tokensWithSuffixAndThinkingFit
-    ) {
-      // Suffix+thinking would fit without tokens; prefer live tokens over that pair.
+    // Use `>` (not `>=`) so exact-fit suffix+thinking does not keep the suffix
+    // while glyph chrome still cannot show thinking — avoids a one-column cliff.
+    const thinkingWithSuffixFit =
+      !wantsThinking ||
+      physicalBareBudget > suffixTextWidth + sep + thinkingWidthForSuffix;
+    const suffixWithTimerAndThinkingFit =
+      !(timerWantedVisible && wantsThinking) ||
+      physicalBareBudget >
+        suffixTextWidth + sep + timerWidth + sep + thinkingWidthForSuffix;
+    if (hasTokenContent && physicalBareBudget >= tokensWidth && physicalBareBudget < suffixWithAllVisibleFit) {
       showSuffix = false;
       effectiveSuffixWidth = 0;
     } else if (

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -169,18 +169,20 @@ export function SpinnerAnimationRow({
 
   // === Progressive width gating ===
   // messageWidth = glimmer text + spinner glyph (width: 2).
-  // parensWidth = 3 accounts for " (" and ")" wrapping the status parts.
-  // The extra 1 is a safety margin so content never touches the right edge.
+  // Base parens chrome is 4: glimmer trailing space + "(" + ")" + safety.
+  // Leader spins may also reserve mode glyph (width 2) + separator.
   const messageWidth = glimmerMessageWidth + 2;
   const sep = SEP_WIDTH;
-  // Non-teammate spins prepend the ↑/↓ mode glyph (width 2) + separator to
-  // the status parts, so reserve that space in the gating math too.
-  const parensWidth = hasRunningTeammates ? 4 : 4 + 2 + SEP_WIDTH;
+  const MODE_GLYPH_RESERVE = 2 + SEP_WIDTH;
+  const BASE_PARENS_WIDTH = 4;
   const suffixWidth = spinnerSuffix ? stringWidth(spinnerSuffix) + sep : 0;
   const wantsThinking = thinkingStatus !== null;
   const wantsTimer = verbose || hasRunningTeammates || effectiveElapsedMs > SHOW_TIMER_AFTER_MS;
   const wantsTokens = true;
-  const availableSpace = columns - messageWidth - parensWidth;
+  // Prefer layout with the mode glyph when it fits alongside other status.
+  let reserveModeGlyph = !hasRunningTeammates;
+  let parensWidth = BASE_PARENS_WIDTH + (reserveModeGlyph ? MODE_GLYPH_RESERVE : 0);
+  let availableSpace = columns - messageWidth - parensWidth;
   let showThinking = wantsThinking && availableSpace > suffixWidth + thinkingWidthValue;
   if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
     if (availableSpace > suffixWidth + THINKING_BARE_WIDTH) {
@@ -189,54 +191,86 @@ export function SpinnerAnimationRow({
       showThinking = true;
     }
   }
-  const usedAfterThinking = suffixWidth + (showThinking ? thinkingWidthValue + sep : 0);
-  const showTimer = wantsTimer && availableSpace > usedAfterThinking + timerWidth;
-  const usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
-  const showTokens = wantsTokens && hasTokenContent && availableSpace > usedAfterTimer + tokensWidth;
+  let usedAfterThinking = suffixWidth + (showThinking ? thinkingWidthValue + sep : 0);
+  let showTimer = wantsTimer && availableSpace > usedAfterThinking + timerWidth;
+  let usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
+  let showTokens = wantsTokens && hasTokenContent && availableSpace > usedAfterTimer + tokensWidth;
+  // If glyph reservation dropped every content part, retry without the glyph so
+  // tokens/timer/thinking win over empty "(↓ )" chrome on mid-narrow rows.
+  const hasContentStatus = Boolean(spinnerSuffix) || showTimer || showTokens || showThinking;
+  if (reserveModeGlyph && !hasContentStatus) {
+    const bareAvailableSpace = columns - messageWidth - BASE_PARENS_WIDTH;
+    let bareShowThinking = wantsThinking && bareAvailableSpace > suffixWidth + thinkingWidthValue;
+    if (!bareShowThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
+      if (bareAvailableSpace > suffixWidth + THINKING_BARE_WIDTH) {
+        thinkingText = 'thinking';
+        thinkingWidthValue = THINKING_BARE_WIDTH;
+        bareShowThinking = true;
+      }
+    }
+    const bareUsedAfterThinking = suffixWidth + (bareShowThinking ? thinkingWidthValue + sep : 0);
+    const bareShowTimer = wantsTimer && bareAvailableSpace > bareUsedAfterThinking + timerWidth;
+    const bareUsedAfterTimer = bareUsedAfterThinking + (bareShowTimer ? timerWidth + sep : 0);
+    const bareShowTokens = wantsTokens && hasTokenContent && bareAvailableSpace > bareUsedAfterTimer + tokensWidth;
+    // Prefer tokens/timer/suffix without glyph over empty glyph-only status.
+    // Thinking-only recovery stays in the dedicated second-chance block below
+    // so full "(↓ · thinking)" chrome still wins when it fits.
+    if (bareShowTimer || bareShowTokens || Boolean(spinnerSuffix)) {
+      reserveModeGlyph = false;
+      parensWidth = BASE_PARENS_WIDTH;
+      availableSpace = bareAvailableSpace;
+      showThinking = bareShowThinking;
+      usedAfterThinking = bareUsedAfterThinking;
+      showTimer = bareShowTimer;
+      usedAfterTimer = bareUsedAfterTimer;
+      showTokens = bareShowTokens;
+    }
+  }
   // Leader thinking-only prefers the mode glyph inside outer parens
-  // ("(↓ · thinking)"). The primary gate above still uses a conservative
-  // parensWidth that can reject widths where that physical layout still fits.
-  // Retry in two steps so the thinking word is not lost on narrow terminals:
-  // 1) full leader chrome with glyph when it fits
-  // 2) bare "(thinking)" without the glyph (same band as pre-glyph layout)
-  //    rather than rendering glyph-only empty status
-  // Physical full chrome: "(" + glyph(2) + " · " + thinking + ")" (+ 1 safety).
+  // ("(↓ · thinking)") when both fit. When full chrome does not fit, fall
+  // back to bare "(thinking)" without the glyph (same band as pre-glyph
+  // layout) rather than empty glyph-only status.
+  // Full chrome budget includes +1 safety vs physical Ink width.
   const leaderThinkingOnlyChrome = 2 + 2 + SEP_WIDTH + 1;
   let suppressModeGlyphForBareThinking = false;
-  if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && !hasRunningTeammates && !spinnerSuffix && !showTimer && !showTokens) {
-    const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
-    if (leaderThinkingAvailable >= thinkingWidthValue) {
-      showThinking = true;
-    } else if (effortSuffix && leaderThinkingAvailable >= THINKING_BARE_WIDTH) {
-      thinkingText = 'thinking';
-      thinkingWidthValue = THINKING_BARE_WIDTH;
-      showThinking = true;
-    } else {
+  if (!showThinking && wantsThinking && !hasRunningTeammates && !spinnerSuffix && !showTimer && !showTokens) {
+    if (reserveModeGlyph) {
+      const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
+      if (leaderThinkingAvailable >= thinkingWidthValue) {
+        showThinking = true;
+      } else if (thinkingStatus === 'thinking' && effortSuffix && leaderThinkingAvailable >= THINKING_BARE_WIDTH) {
+        thinkingText = 'thinking';
+        thinkingWidthValue = THINKING_BARE_WIDTH;
+        showThinking = true;
+      }
+    }
+    if (!showThinking) {
       // Bare chrome: glimmer trailing space + "(" + ")" (matches physical row).
       const bareAvailable = columns - messageWidth - 3;
       if (bareAvailable >= thinkingWidthValue) {
         showThinking = true;
         suppressModeGlyphForBareThinking = true;
-      } else if (effortSuffix && bareAvailable >= THINKING_BARE_WIDTH) {
+        reserveModeGlyph = false;
+      } else if (thinkingStatus === 'thinking' && effortSuffix && bareAvailable >= THINKING_BARE_WIDTH) {
         thinkingText = 'thinking';
         thinkingWidthValue = THINKING_BARE_WIDTH;
         showThinking = true;
         suppressModeGlyphForBareThinking = true;
+        reserveModeGlyph = false;
       }
     }
   }
-  // thinkingOnly: only the thinking word (plus the mode glyph on leader spins
-  // when space allows). Nested "(thinking)" is reserved for teammate spins that
-  // skip the mode glyph and therefore have no outer status parens. Leader bare
-  // fallback still uses outer parens with just the thinking word: "(thinking)".
-  const thinkingOnly = showThinking && thinkingStatus === 'thinking' && !spinnerSuffix && !showTimer && !showTokens;
-  const bareThinkingOnly = thinkingOnly && hasRunningTeammates;
+  // Nested "(thinking)" is reserved for teammate spins that skip the mode glyph
+  // and therefore have no outer status parens. Leader bare fallback still uses
+  // outer parens with just the thinking word: "(thinking)".
+  const isThinkingOnlyStatus = showThinking && thinkingStatus === 'thinking' && !spinnerSuffix && !showTimer && !showTokens;
+  const bareThinkingOnly = isThinkingOnlyStatus && hasRunningTeammates;
   // Minimum residual for leader status chrome after the glimmer trailing space:
   // " " + "(" + glyph Box(width=2) + ")". Below this, omit the glyph rather
-  // than overflow the row. Also omit when the bare-thinking fallback chose to
-  // keep the thinking word without glyph chrome.
+  // than overflow. Also omit when content recovery or bare-thinking fallback
+  // dropped the glyph so higher-value status can show.
   const residualForStatus = columns - messageWidth;
-  const canShowModeGlyph = !hasRunningTeammates && !suppressModeGlyphForBareThinking && residualForStatus >= 5;
+  const canShowModeGlyph = reserveModeGlyph && !suppressModeGlyphForBareThinking && residualForStatus >= 5;
 
   // === Thinking shimmer color (formerly ThinkingShimmerText's own timer) ===
   // Same sine-wave opacity, but derived from our shared `time` instead of a
@@ -262,11 +296,9 @@ export function SpinnerAnimationRow({
               {thinkingDisplay}
             </Text>] : [])];
   // Lead the status with the request-direction glyph (↑ requesting /
-  // ↓ streaming) inside the status parens so the mode is always visible while
-  // the spinner is active — including the early requesting window before any
-  // other status part qualifies, and thinking-only spins. Teammate spins skip
-  // it (the teammate tree carries its own activity cue). Very narrow rows that
-  // cannot fit "(" + glyph + ")" omit the glyph instead of overflowing.
+  // ↓ streaming) inside the status parens when residual width allows and the
+  // glyph did not force higher-value status (tokens/timer/thinking) off the
+  // row. Teammate spins skip it (the teammate tree carries its own cue).
   if (canShowModeGlyph) {
     parts.unshift(<Box flexDirection="row" key="mode">
             <SpinnerModeGlyph mode={mode} />
@@ -297,20 +329,6 @@ function SpinnerModeGlyph(t0) {
     mode
   } = t0;
   switch (mode) {
-    case "tool-input":
-    case "tool-use":
-    case "responding":
-    case "thinking":
-      {
-        let t1;
-        if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-          t1 = <Box width={2}><Text dimColor={true}>{figures.arrowDown}</Text></Box>;
-          $[0] = t1;
-        } else {
-          t1 = $[0];
-        }
-        return t1;
-      }
     case "requesting":
       {
         let t1;
@@ -319,6 +337,23 @@ function SpinnerModeGlyph(t0) {
           $[1] = t1;
         } else {
           t1 = $[1];
+        }
+        return t1;
+      }
+    case "tool-input":
+    case "tool-use":
+    case "responding":
+    case "thinking":
+    default:
+      {
+        // Default to down-arrow for known streaming modes and any open-union
+        // SpinnerMode string so unmapped modes never unshift an empty child.
+        let t1;
+        if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+          t1 = <Box width={2}><Text dimColor={true}>{figures.arrowDown}</Text></Box>;
+          $[0] = t1;
+        } else {
+          t1 = $[0];
         }
         return t1;
       }

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -193,11 +193,32 @@ export function SpinnerAnimationRow({
   const showTimer = wantsTimer && availableSpace > usedAfterThinking + timerWidth;
   const usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
   const showTokens = wantsTokens && hasTokenContent && availableSpace > usedAfterTimer + tokensWidth;
+  // Leader thinking-only now keeps the mode glyph inside outer parens
+  // ("(↓ · thinking)"). The primary gate above still uses a conservative
+  // parensWidth that can reject widths where that physical layout still fits.
+  // Retry with the real leader chrome budget so the thinking word is not lost
+  // on moderately narrow terminals.
+  // Physical: "(" + glyph(2) + " · " + thinking + ")" (+ 1 safety).
+  const leaderThinkingOnlyChrome = 2 + 2 + SEP_WIDTH + 1;
+  if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && !hasRunningTeammates && !spinnerSuffix && !showTimer && !showTokens) {
+    const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
+    if (leaderThinkingAvailable >= thinkingWidthValue) {
+      showThinking = true;
+    } else if (effortSuffix && leaderThinkingAvailable >= THINKING_BARE_WIDTH) {
+      thinkingText = 'thinking';
+      thinkingWidthValue = THINKING_BARE_WIDTH;
+      showThinking = true;
+    }
+  }
   // thinkingOnly: only the thinking word (plus the mode glyph on leader spins).
   // Nested "(thinking)" is reserved for teammate spins that skip the mode glyph
   // and therefore have no outer status parens.
   const thinkingOnly = showThinking && thinkingStatus === 'thinking' && !spinnerSuffix && !showTimer && !showTokens;
   const bareThinkingOnly = thinkingOnly && hasRunningTeammates;
+  // Minimum residual for leader status chrome: "(" + glyph Box(width=2) + ")".
+  // Below this, omit the glyph entirely rather than overflow the row.
+  const residualForStatus = columns - messageWidth;
+  const canShowModeGlyph = !hasRunningTeammates && residualForStatus >= 4;
 
   // === Thinking shimmer color (formerly ThinkingShimmerText's own timer) ===
   // Same sine-wave opacity, but derived from our shared `time` instead of a
@@ -222,8 +243,9 @@ export function SpinnerAnimationRow({
   // ↓ streaming) inside the status parens so the mode is always visible while
   // the spinner is active — including the early requesting window before any
   // other status part qualifies, and thinking-only spins. Teammate spins skip
-  // it (the teammate tree carries its own activity cue).
-  if (!hasRunningTeammates) {
+  // it (the teammate tree carries its own activity cue). Very narrow rows that
+  // cannot fit "(" + glyph + ")" omit the glyph instead of overflowing.
+  if (canShowModeGlyph) {
     parts.unshift(<Box flexDirection="row" key="mode">
             <SpinnerModeGlyph mode={mode} />
           </Box>);

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -300,14 +300,12 @@ export function SpinnerAnimationRow({
   // alone against bare parens leaves glyph+suffix rows that Ink truncates mid-string.
   // Prefer dropping the glyph to keep a suffix that still fits under bare parens.
   const physicalBareBudget = columns - messageWidth - PHYSICAL_BARE_PARENS;
-  let glyphDroppedToKeepSuffix = false;
   if (showSuffix) {
     const suffixFitsBare = physicalBareBudget >= suffixTextWidth;
     const suffixFitsWithGlyph = reserveModeGlyph ? physicalBareBudget - MODE_GLYPH_RESERVE >= suffixTextWidth : suffixFitsBare;
     if (!suffixFitsWithGlyph) {
       if (reserveModeGlyph && suffixFitsBare) {
         reserveModeGlyph = false;
-        glyphDroppedToKeepSuffix = true;
         parensWidth = BASE_PARENS_WIDTH;
         availableSpace = columns - messageWidth - BASE_PARENS_WIDTH;
       } else {
@@ -321,9 +319,11 @@ export function SpinnerAnimationRow({
   // widening from overflow-drop to exact suffix-fit swaps higher-value status
   // for suffix-only chrome.
   if (showSuffix) {
-    const tokensWithSuffixFit = !hasTokenContent || physicalBareBudget >= suffixTextWidth + sep + tokensWidth;
     const thinkingWidthForSuffix = thinkingStatus === 'thinking' ? THINKING_BARE_WIDTH : fullThinkingWidth;
-    const thinkingWithSuffixFit = !wantsThinking || physicalBareBudget >= suffixTextWidth + sep + thinkingWidthForSuffix;
+    const tokensWithSuffixFit = !hasTokenContent || physicalBareBudget >= suffixTextWidth + sep + tokensWidth;
+    // Use `>` (not `>=`) so exact-fit suffix+thinking does not keep the suffix
+    // while glyph chrome still cannot show thinking — avoids a one-column cliff.
+    const thinkingWithSuffixFit = !wantsThinking || physicalBareBudget > suffixTextWidth + sep + thinkingWidthForSuffix;
     if (hasTokenContent && physicalBareBudget >= tokensWidth && !tokensWithSuffixFit) {
       showSuffix = false;
       effectiveSuffixWidth = 0;
@@ -479,6 +479,21 @@ export function SpinnerAnimationRow({
       usedAfterTimer = timerWidth + sep + (showTokens ? tokensWidth : 0);
     }
   }
+  // Prefer live tokens over active thinking when both cannot share bare chrome
+  // (same tie-break as preferTokensOverTimerOnly). Prevents a widen cliff where
+  // tokens visible at cols 25–26 disappear once leader thinking unlocks at 27.
+  if (showThinking && !showTokens && thinkingStatus === 'thinking' && hasTokenContent && physicalBareBudget >= tokensWidth) {
+    const thinkingAndTokensFit = physicalBareBudget >= thinkingWidthValue + sep + tokensWidth;
+    if (!thinkingAndTokensFit) {
+      showThinking = false;
+      showTokens = true;
+      showTimer = Boolean(wantsTimer && physicalBareBudget >= timerWidth + sep + tokensWidth);
+      suppressModeGlyphForBareThinking = false;
+      reserveModeGlyph = false;
+      usedAfterThinking = 0;
+      usedAfterTimer = showTimer ? timerWidth + sep : 0;
+    }
+  }
   // If thinking could not claim an empty post-suffix row, recover timer-only
   // rather than leaving blank / empty glyph-only chrome.
   if (!showSuffix && !showThinking && !showTimer && !showTokens && wantsTimer && physicalBareBudget > timerWidth) {
@@ -488,9 +503,9 @@ export function SpinnerAnimationRow({
       reserveModeGlyph = false;
     }
   }
-  // Restore mode glyph only after a suffix-keep cascade that later dropped the
-  // suffix for tokens/thinking — not after intentional content-over-glyph drops.
-  if (glyphDroppedToKeepSuffix && !showSuffix && !hasRunningTeammates && !suppressModeGlyphForBareThinking && !reserveModeGlyph && (showTokens || showTimer || showThinking)) {
+  // Restore mode glyph whenever leader content fits under glyph chrome —
+  // covers suffix-keep cascades and bare recovery that cleared the glyph.
+  if (!showSuffix && !hasRunningTeammates && !suppressModeGlyphForBareThinking && !reserveModeGlyph && (showTokens || showTimer || showThinking)) {
     const withGlyphSpace = columns - messageWidth - BASE_PARENS_WIDTH - MODE_GLYPH_RESERVE;
     let contentW = 0;
     if (showTimer) contentW += timerWidth;

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -180,7 +180,8 @@ export function SpinnerAnimationRow({
   const PHYSICAL_BARE_PARENS = 3;
   // Full glyph+thinking chrome budget includes +1 safety vs physical Ink width.
   const leaderThinkingOnlyChrome = 2 + 2 + SEP_WIDTH + 1;
-  const suffixWidth = spinnerSuffix ? stringWidth(spinnerSuffix) + sep : 0;
+  const suffixTextWidth = spinnerSuffix ? stringWidth(spinnerSuffix) : 0;
+  const suffixWidth = spinnerSuffix ? suffixTextWidth + sep : 0;
   const wantsThinking = thinkingStatus !== null;
   const wantsTimer = verbose || hasRunningTeammates || effectiveElapsedMs > SHOW_TIMER_AFTER_MS;
   const wantsTokens = true;
@@ -188,25 +189,27 @@ export function SpinnerAnimationRow({
   const fullThinkingWidth = thinkingWidthValue;
   // Prefer layout with the mode glyph when it fits alongside other status.
   let reserveModeGlyph = !hasRunningTeammates;
+  let showSuffix = Boolean(spinnerSuffix);
+  let effectiveSuffixWidth = showSuffix ? suffixWidth : 0;
   let parensWidth = BASE_PARENS_WIDTH + (reserveModeGlyph ? MODE_GLYPH_RESERVE : 0);
   let availableSpace = columns - messageWidth - parensWidth;
   // Try full effort text against the looser leader glyph chrome before shrinking,
   // so "(↓ · thinking with high effort)" wins when it physically fits.
-  let showThinking = wantsThinking && availableSpace > suffixWidth + thinkingWidthValue;
-  if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && !hasRunningTeammates && !spinnerSuffix && reserveModeGlyph) {
+  let showThinking = wantsThinking && availableSpace > effectiveSuffixWidth + thinkingWidthValue;
+  if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && !hasRunningTeammates && !showSuffix && reserveModeGlyph) {
     const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
     if (leaderThinkingAvailable >= fullThinkingWidth) {
       showThinking = true;
     }
   }
   if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
-    if (availableSpace > suffixWidth + THINKING_BARE_WIDTH) {
+    if (availableSpace > effectiveSuffixWidth + THINKING_BARE_WIDTH) {
       thinkingText = 'thinking';
       thinkingWidthValue = THINKING_BARE_WIDTH;
       showThinking = true;
     }
   }
-  let usedAfterThinking = suffixWidth + (showThinking ? thinkingWidthValue + sep : 0);
+  let usedAfterThinking = effectiveSuffixWidth + (showThinking ? thinkingWidthValue + sep : 0);
   let showTimer = wantsTimer && availableSpace > usedAfterThinking + timerWidth;
   let usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
   let showTokens = wantsTokens && hasTokenContent && availableSpace > usedAfterTimer + tokensWidth;
@@ -220,15 +223,15 @@ export function SpinnerAnimationRow({
     let bareThinkingWidth = fullThinkingWidth;
     // Thinking/timer keep `>` so they leave one safety column; token checks use
     // `>=` so live token counts may consume the exact physical bare budget.
-    let bareShowThinking = wantsThinking && bareAvailableSpace > suffixWidth + bareThinkingWidth;
+    let bareShowThinking = wantsThinking && bareAvailableSpace > effectiveSuffixWidth + bareThinkingWidth;
     if (!bareShowThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
-      if (bareAvailableSpace > suffixWidth + THINKING_BARE_WIDTH) {
+      if (bareAvailableSpace > effectiveSuffixWidth + THINKING_BARE_WIDTH) {
         bareThinkingText = 'thinking';
         bareThinkingWidth = THINKING_BARE_WIDTH;
         bareShowThinking = true;
       }
     }
-    const bareUsedAfterThinking = suffixWidth + (bareShowThinking ? bareThinkingWidth + sep : 0);
+    const bareUsedAfterThinking = effectiveSuffixWidth + (bareShowThinking ? bareThinkingWidth + sep : 0);
     const bareShowTimer = wantsTimer && bareAvailableSpace > bareUsedAfterThinking + timerWidth;
     const bareUsedAfterTimer = bareUsedAfterThinking + (bareShowTimer ? timerWidth + sep : 0);
     const bareShowTokens = wantsTokens && hasTokenContent && bareAvailableSpace >= bareUsedAfterTimer + tokensWidth;
@@ -260,7 +263,7 @@ export function SpinnerAnimationRow({
         showTokens = true;
         thinkingText = fullThinkingText;
         thinkingWidthValue = fullThinkingWidth;
-        usedAfterThinking = suffixWidth;
+        usedAfterThinking = effectiveSuffixWidth;
         usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
       } else if (preferThinkingOverTimerOnly && !bareShowTimer) {
         // Thinking fits bare; timer does not fit alongside — drop timer.
@@ -269,7 +272,7 @@ export function SpinnerAnimationRow({
         showThinking = true;
         showTimer = false;
         showTokens = false;
-        usedAfterThinking = suffixWidth + thinkingWidthValue + sep;
+        usedAfterThinking = effectiveSuffixWidth + thinkingWidthValue + sep;
         usedAfterTimer = usedAfterThinking;
       } else {
         thinkingText = bareThinkingText ?? fullThinkingText;
@@ -282,28 +285,43 @@ export function SpinnerAnimationRow({
       }
     }
   }
+  // Drop an overflowing spinner suffix before other recovery so mid-narrow rows
+  // can keep tokens/thinking instead of wrapping glyph+suffix-only chrome.
+  const physicalBareBudget = columns - messageWidth - PHYSICAL_BARE_PARENS;
+  if (showSuffix && physicalBareBudget < suffixTextWidth) {
+    showSuffix = false;
+    effectiveSuffixWidth = 0;
+  }
   // Prefer live streaming tokens over numeric post-thinking duration when both
-  // cannot fit (including when primary already chose duration under the glyph).
+  // cannot fit (including when primary already chose duration under the glyph,
+  // or when a dropped/crowding suffix hid both). Keep suffix only when it still
+  // fits beside tokens.
   let suppressModeGlyphForBareThinking = false;
-  if (typeof thinkingStatus === 'number' && hasTokenContent && showThinking && !showTokens && !spinnerSuffix) {
-    const physicalBare = columns - messageWidth - PHYSICAL_BARE_PARENS;
-    const tokensFitBareAlone = physicalBare >= tokensWidth;
-    const thinkingAndTokensFit = physicalBare >= thinkingWidthValue + sep + tokensWidth;
-    if (tokensFitBareAlone && !thinkingAndTokensFit) {
+  if (typeof thinkingStatus === 'number' && hasTokenContent && !showTokens) {
+    const tokensFitBareAlone = physicalBareBudget >= tokensWidth;
+    const thinkingAndTokensFit = physicalBareBudget >= fullThinkingWidth + sep + tokensWidth;
+    const durationShowingWithoutTokens = showThinking && !thinkingAndTokensFit;
+    const nothingVisibleYet = !showThinking && !showTimer;
+    if (tokensFitBareAlone && !thinkingAndTokensFit && (durationShowingWithoutTokens || nothingVisibleYet)) {
       showThinking = false;
       showTokens = true;
       showTimer = false;
       // reserveModeGlyph=false is enough to keep canShowModeGlyph false.
       reserveModeGlyph = false;
-      usedAfterThinking = suffixWidth;
+      if (showSuffix && physicalBareBudget < suffixWidth + tokensWidth) {
+        showSuffix = false;
+        effectiveSuffixWidth = 0;
+      }
+      usedAfterThinking = effectiveSuffixWidth;
       usedAfterTimer = usedAfterThinking;
     }
   }
   // Leader thinking-only prefers the mode glyph inside outer parens
   // ("(↓ · thinking)") when both fit. When full chrome does not fit, fall
   // back to bare "(thinking)" without the glyph (same band as pre-glyph
-  // layout) rather than empty glyph-only status.
-  if (!showThinking && wantsThinking && !hasRunningTeammates && !spinnerSuffix && !showTimer && !showTokens) {
+  // layout) rather than empty glyph-only status. Runs after suffix overflow
+  // drop so stop-hook/tool suffixes do not permanently hide thinking.
+  if (!showThinking && wantsThinking && !hasRunningTeammates && !showSuffix && !showTimer && !showTokens) {
     if (reserveModeGlyph) {
       const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
       if (leaderThinkingAvailable >= fullThinkingWidth) {
@@ -318,7 +336,7 @@ export function SpinnerAnimationRow({
     }
     if (!showThinking) {
       // Bare chrome: glimmer trailing space + "(" + ")" (matches physical row).
-      const bareAvailable = columns - messageWidth - PHYSICAL_BARE_PARENS;
+      const bareAvailable = physicalBareBudget;
       const tokensFitBareAlone = wantsTokens && hasTokenContent && bareAvailable >= tokensWidth;
       const thinkingAndTokensFitBare = bareAvailable >= fullThinkingWidth + sep + tokensWidth;
       if (typeof thinkingStatus === 'number' && tokensFitBareAlone && !thinkingAndTokensFitBare && !showTokens) {
@@ -342,14 +360,14 @@ export function SpinnerAnimationRow({
   // Nested "(thinking)" is reserved for teammate spins that skip the mode glyph
   // and therefore have no outer status parens. Leader bare fallback still uses
   // outer parens with just the thinking word: "(thinking)".
-  const isThinkingOnlyStatus = showThinking && thinkingStatus === 'thinking' && !spinnerSuffix && !showTimer && !showTokens;
+  const isThinkingOnlyStatus = showThinking && thinkingStatus === 'thinking' && !showSuffix && !showTimer && !showTokens;
   const bareThinkingOnly = isThinkingOnlyStatus && hasRunningTeammates;
   // Minimum residual for leader status chrome after the glimmer trailing space:
   // " " + "(" + glyph Box(width=2) + ")". Below this, omit the glyph rather
   // than overflow. Also omit when content recovery or bare-thinking fallback
   // dropped the glyph so higher-value status can show.
   const residualForStatus = columns - messageWidth;
-  const hasVisibleStatusContent = Boolean(spinnerSuffix) || showTimer || showTokens || showThinking;
+  const hasVisibleStatusContent = Boolean(showSuffix) || showTimer || showTokens || showThinking;
   // Requesting and active "thinking" may show glyph-only chrome; completed-thought
   // duration and other states must not render an empty "(↓ )" row.
   const allowGlyphOnlyStatus = (mode === 'requesting' || thinkingStatus === 'thinking') && typeof thinkingStatus !== 'number';
@@ -367,7 +385,7 @@ export function SpinnerAnimationRow({
   // Apply in both shimmer and reduced-motion arms so teammate bare status is
   // always "(thinking)", not a bare word jammed after the verb.
   const thinkingDisplay = thinkingText ? bareThinkingOnly ? `(${thinkingText})` : thinkingText : null;
-  const parts = [...(spinnerSuffix ? [<Text dimColor key="suffix">
+  const parts = [...(showSuffix && spinnerSuffix ? [<Text dimColor key="suffix">
             {spinnerSuffix}
           </Text>] : []), ...(showTimer ? [<Text dimColor key="elapsedTime">
             {timerText}

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -195,10 +195,9 @@ export function SpinnerAnimationRow({
   let showTimer = wantsTimer && availableSpace > usedAfterThinking + timerWidth;
   let usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
   let showTokens = wantsTokens && hasTokenContent && availableSpace > usedAfterTimer + tokensWidth;
-  // If glyph reservation dropped every content part, retry without the glyph so
-  // tokens/timer/thinking win over empty "(↓ )" chrome on mid-narrow rows.
-  const hasContentStatus = Boolean(spinnerSuffix) || showTimer || showTokens || showThinking;
-  if (reserveModeGlyph && !hasContentStatus) {
+  // Re-check without the glyph. Keep it when it fits alongside the same
+  // content, but prefer timer/token status when reserving the glyph hides it.
+  if (reserveModeGlyph) {
     const bareAvailableSpace = columns - messageWidth - BASE_PARENS_WIDTH;
     let bareShowThinking = wantsThinking && bareAvailableSpace > suffixWidth + thinkingWidthValue;
     if (!bareShowThinking && wantsThinking && thinkingStatus === 'thinking' && effortSuffix) {
@@ -212,10 +211,10 @@ export function SpinnerAnimationRow({
     const bareShowTimer = wantsTimer && bareAvailableSpace > bareUsedAfterThinking + timerWidth;
     const bareUsedAfterTimer = bareUsedAfterThinking + (bareShowTimer ? timerWidth + sep : 0);
     const bareShowTokens = wantsTokens && hasTokenContent && bareAvailableSpace > bareUsedAfterTimer + tokensWidth;
-    // Prefer tokens/timer/suffix without glyph over empty glyph-only status.
     // Thinking-only recovery stays in the dedicated second-chance block below
     // so full "(↓ · thinking)" chrome still wins when it fits.
-    if (bareShowTimer || bareShowTokens || Boolean(spinnerSuffix)) {
+    const glyphHidesContent = bareShowTimer && !showTimer || bareShowTokens && !showTokens;
+    if (glyphHidesContent) {
       reserveModeGlyph = false;
       parensWidth = BASE_PARENS_WIDTH;
       availableSpace = bareAvailableSpace;

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -300,12 +300,14 @@ export function SpinnerAnimationRow({
   // alone against bare parens leaves glyph+suffix rows that Ink truncates mid-string.
   // Prefer dropping the glyph to keep a suffix that still fits under bare parens.
   const physicalBareBudget = columns - messageWidth - PHYSICAL_BARE_PARENS;
+  let glyphDroppedToKeepSuffix = false;
   if (showSuffix) {
     const suffixFitsBare = physicalBareBudget >= suffixTextWidth;
     const suffixFitsWithGlyph = reserveModeGlyph ? physicalBareBudget - MODE_GLYPH_RESERVE >= suffixTextWidth : suffixFitsBare;
     if (!suffixFitsWithGlyph) {
       if (reserveModeGlyph && suffixFitsBare) {
         reserveModeGlyph = false;
+        glyphDroppedToKeepSuffix = true;
         parensWidth = BASE_PARENS_WIDTH;
         availableSpace = columns - messageWidth - BASE_PARENS_WIDTH;
       } else {
@@ -314,36 +316,38 @@ export function SpinnerAnimationRow({
       }
     }
   }
-  // Prefer live streaming tokens over a bare-fitting suffix when both cannot
-  // share the row (same priority as tokens-over-duration). Avoids the
-  // non-monotonic cliff where widening from overflow-drop to exact suffix-fit
-  // swaps tokens for suffix-only chrome.
-  if (showSuffix && hasTokenContent && physicalBareBudget >= tokensWidth) {
-    const tokensWithSuffixFit = physicalBareBudget >= suffixTextWidth + sep + tokensWidth;
-    if (!tokensWithSuffixFit) {
+  // Prefer live streaming tokens (and active thinking) over a bare-fitting
+  // suffix when both cannot share the row. Avoids non-monotonic cliffs where
+  // widening from overflow-drop to exact suffix-fit swaps higher-value status
+  // for suffix-only chrome.
+  if (showSuffix) {
+    const tokensWithSuffixFit = !hasTokenContent || physicalBareBudget >= suffixTextWidth + sep + tokensWidth;
+    const thinkingWidthForSuffix = thinkingStatus === 'thinking' ? THINKING_BARE_WIDTH : fullThinkingWidth;
+    const thinkingWithSuffixFit = !wantsThinking || physicalBareBudget >= suffixTextWidth + sep + thinkingWidthForSuffix;
+    if (hasTokenContent && physicalBareBudget >= tokensWidth && !tokensWithSuffixFit) {
+      showSuffix = false;
+      effectiveSuffixWidth = 0;
+    } else if (!hasTokenContent && wantsThinking && physicalBareBudget >= thinkingWidthForSuffix && !thinkingWithSuffixFit) {
       showSuffix = false;
       effectiveSuffixWidth = 0;
     }
   }
-  // After dropping a crowding suffix (or preferring tokens over it), recover
-  // status primary gating hid while suffix width was reserved — including
-  // thinkingStatus === null (common responding + stop-hook/tool suffix path).
-  // Restore timer symmetrically with tokens when the freed budget allows.
-  // Leave empty rows that still want thinking for the thinking second-chance
-  // block below (do not steal with a timer-only recovery first).
+  // After dropping a crowding suffix (or preferring tokens/thinking over it),
+  // recover status primary gating hid while suffix width was reserved.
+  // Parts order is timer · tokens · thinking — any co-restore must budget all
+  // already-visible parts or Ink wraps on wide timers / early token counts.
   if (!showSuffix) {
     const tokensFitBareAlone = wantsTokens && hasTokenContent && physicalBareBudget >= tokensWidth;
     const timerFitBareAlone = wantsTimer && physicalBareBudget > timerWidth;
     const timerAndTokensFitBare = wantsTimer && hasTokenContent && physicalBareBudget >= timerWidth + sep + tokensWidth;
     const withGlyphSpace = columns - messageWidth - BASE_PARENS_WIDTH - MODE_GLYPH_RESERVE;
+
     if (!showTokens && !showTimer && !showThinking) {
       if (tokensFitBareAlone) {
         showTokens = true;
         showTimer = Boolean(timerAndTokensFitBare);
         usedAfterThinking = 0;
         usedAfterTimer = showTimer ? timerWidth + sep : 0;
-        // Keep the mode glyph only when primary glyph chrome would also fit
-        // the recovered content (strict `>` matches the initial gate).
         const recoveredWidth = usedAfterTimer + tokensWidth;
         if (reserveModeGlyph && !(withGlyphSpace > recoveredWidth)) {
           reserveModeGlyph = false;
@@ -356,9 +360,29 @@ export function SpinnerAnimationRow({
           reserveModeGlyph = false;
         }
       }
-    } else if (showTokens && !showTimer && timerAndTokensFitBare) {
-      showTimer = true;
-      usedAfterTimer = timerWidth + sep + tokensWidth;
+    } else if (showTimer && !showTokens && tokensFitBareAlone) {
+      // Suffix drop freed budget that primary spent on suffix+timer only.
+      if (timerAndTokensFitBare && physicalBareBudget >= timerWidth + sep + tokensWidth + (showThinking ? sep + thinkingWidthValue : 0)) {
+        showTokens = true;
+        usedAfterTimer = timerWidth + sep + tokensWidth;
+      } else if (!showThinking) {
+        // Prefer tokens over timer-only when both cannot share the row.
+        showTimer = false;
+        showTokens = true;
+        usedAfterThinking = 0;
+        usedAfterTimer = 0;
+      }
+    } else if (showTokens && !showTimer && wantsTimer) {
+      let total = timerWidth + sep + tokensWidth;
+      if (showThinking) total += sep + thinkingWidthValue;
+      if (physicalBareBudget >= total) {
+        if (reserveModeGlyph && !(withGlyphSpace > total)) {
+          reserveModeGlyph = false;
+        }
+        showTimer = true;
+        usedAfterThinking = showThinking ? thinkingWidthValue + sep : 0;
+        usedAfterTimer = timerWidth + sep + tokensWidth;
+      }
     }
   }
   // Prefer live streaming tokens over numeric post-thinking duration when both
@@ -391,17 +415,21 @@ export function SpinnerAnimationRow({
   // layout) rather than empty glyph-only status. Teammates skip glyph chrome
   // and recover nested "(thinking)" here after suffix overflow drop so
   // stop-hook/tool suffixes do not permanently hide thinking.
-  if (!showThinking && wantsThinking && !showSuffix && !showTimer && !showTokens) {
+  // Allow replacing timer-only chrome when thinking fits (alone or with timer).
+  if (!showThinking && wantsThinking && !showSuffix && !showTokens) {
+    let recoveredThinking = false;
     if (reserveModeGlyph && !hasRunningTeammates) {
       const leaderThinkingAvailable = columns - messageWidth - leaderThinkingOnlyChrome;
       if (leaderThinkingAvailable >= fullThinkingWidth) {
         thinkingText = fullThinkingText;
         thinkingWidthValue = fullThinkingWidth;
         showThinking = true;
+        recoveredThinking = true;
       } else if (thinkingStatus === 'thinking' && effortSuffix && leaderThinkingAvailable >= THINKING_BARE_WIDTH) {
         thinkingText = 'thinking';
         thinkingWidthValue = THINKING_BARE_WIDTH;
         showThinking = true;
+        recoveredThinking = true;
       }
     }
     if (!showThinking) {
@@ -412,6 +440,7 @@ export function SpinnerAnimationRow({
       const thinkingAndTokensFitBare = bareAvailable >= fullThinkingWidth + sep + tokensWidth;
       if (typeof thinkingStatus === 'number' && tokensFitBareAlone && !thinkingAndTokensFitBare && !showTokens) {
         showTokens = true;
+        showTimer = false;
         reserveModeGlyph = false;
       } else if (bareAvailable >= fullThinkingWidth) {
         thinkingText = fullThinkingText;
@@ -419,35 +448,56 @@ export function SpinnerAnimationRow({
         showThinking = true;
         suppressModeGlyphForBareThinking = true;
         reserveModeGlyph = false;
+        recoveredThinking = true;
       } else if (thinkingStatus === 'thinking' && effortSuffix && bareAvailable >= THINKING_BARE_WIDTH) {
         thinkingText = 'thinking';
         thinkingWidthValue = THINKING_BARE_WIDTH;
         showThinking = true;
         suppressModeGlyphForBareThinking = true;
         reserveModeGlyph = false;
+        recoveredThinking = true;
+      }
+    }
+    // If thinking recovered onto a timer-only row, keep timer only when both fit.
+    if (recoveredThinking && showTimer) {
+      const need = timerWidth + sep + thinkingWidthValue;
+      if (physicalBareBudget < need) {
+        showTimer = false;
       }
     }
   }
   // After thinking recovery from a dropped suffix, co-restore a fitting timer
-  // so recovered thinking matches the no-suffix layout at the same width.
+  // only when current glyph chrome (or bare, if glyph already dropped) has room —
+  // matching the primary `availableSpace > … + timerWidth` gate so we do not
+  // strip an already-correct glyph+thinking row or wrap wide timers onto tokens.
   if (!showSuffix && showThinking && !showTimer && wantsTimer) {
-    const thinkingWidth = thinkingWidthValue + sep;
-    if (physicalBareBudget > thinkingWidth + timerWidth) {
-      // Timer fits with thinking under bare chrome. Drop glyph if glyph+both
-      // would not fit, matching the earlier bare-glyph recovery trade-off.
-      const glyphThinkingTimerWidth = MODE_GLYPH_RESERVE + thinkingWidth + timerWidth;
-      if (reserveModeGlyph && physicalBareBudget < glyphThinkingTimerWidth) {
-        if (physicalBareBudget > thinkingWidth + timerWidth) {
-          reserveModeGlyph = false;
-          showTimer = true;
-          usedAfterThinking = thinkingWidth;
-          usedAfterTimer = usedAfterThinking + timerWidth + sep;
-        }
-      } else {
-        showTimer = true;
-        usedAfterThinking = thinkingWidth;
-        usedAfterTimer = usedAfterThinking + timerWidth + sep;
-      }
+    const space = columns - messageWidth - BASE_PARENS_WIDTH - (reserveModeGlyph ? MODE_GLYPH_RESERVE : 0);
+    const usedBeforeTimer = (showTokens ? tokensWidth + sep : 0) + thinkingWidthValue + sep;
+    if (space > usedBeforeTimer + timerWidth) {
+      showTimer = true;
+      usedAfterThinking = thinkingWidthValue + sep;
+      usedAfterTimer = timerWidth + sep + (showTokens ? tokensWidth : 0);
+    }
+  }
+  // If thinking could not claim an empty post-suffix row, recover timer-only
+  // rather than leaving blank / empty glyph-only chrome.
+  if (!showSuffix && !showThinking && !showTimer && !showTokens && wantsTimer && physicalBareBudget > timerWidth) {
+    showTimer = true;
+    const withGlyphSpace = columns - messageWidth - BASE_PARENS_WIDTH - MODE_GLYPH_RESERVE;
+    if (reserveModeGlyph && !(withGlyphSpace > timerWidth)) {
+      reserveModeGlyph = false;
+    }
+  }
+  // Restore mode glyph only after a suffix-keep cascade that later dropped the
+  // suffix for tokens/thinking — not after intentional content-over-glyph drops.
+  if (glyphDroppedToKeepSuffix && !showSuffix && !hasRunningTeammates && !suppressModeGlyphForBareThinking && !reserveModeGlyph && (showTokens || showTimer || showThinking)) {
+    const withGlyphSpace = columns - messageWidth - BASE_PARENS_WIDTH - MODE_GLYPH_RESERVE;
+    let contentW = 0;
+    if (showTimer) contentW += timerWidth;
+    if (showTokens) contentW += (contentW > 0 ? sep : 0) + tokensWidth;
+    if (showThinking) contentW += (contentW > 0 ? sep : 0) + thinkingWidthValue;
+    if (withGlyphSpace > contentW) {
+      reserveModeGlyph = true;
     }
   }
   // Nested "(thinking)" is reserved for teammate spins that skip the mode glyph

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -193,22 +193,11 @@ export function SpinnerAnimationRow({
   const showTimer = wantsTimer && availableSpace > usedAfterThinking + timerWidth;
   const usedAfterTimer = usedAfterThinking + (showTimer ? timerWidth + sep : 0);
   const showTokens = wantsTokens && hasTokenContent && availableSpace > usedAfterTimer + tokensWidth;
-  // Second chance for narrow terminals: the gating above reserves space for
-  // the mode glyph + separator, but a would-be thinking-only spin renders
-  // neither the glyph nor the wrapping parens beyond "( )". When nothing
-  // else will show, re-try the thinking gate with that space returned so
-  // "(thinking)" appears instead of nothing.
-  if (!showThinking && wantsThinking && thinkingStatus === 'thinking' && !hasRunningTeammates && !spinnerSuffix && !showTimer && !showTokens) {
-    const bareAvailable = columns - messageWidth - 2;
-    if (bareAvailable > thinkingWidthValue) {
-      showThinking = true;
-    } else if (effortSuffix && bareAvailable > THINKING_BARE_WIDTH) {
-      thinkingText = 'thinking';
-      thinkingWidthValue = THINKING_BARE_WIDTH;
-      showThinking = true;
-    }
-  }
-  const thinkingOnly = showThinking && thinkingStatus === 'thinking' && !spinnerSuffix && !showTimer && !showTokens && true;
+  // thinkingOnly: only the thinking word (plus the mode glyph on leader spins).
+  // Nested "(thinking)" is reserved for teammate spins that skip the mode glyph
+  // and therefore have no outer status parens.
+  const thinkingOnly = showThinking && thinkingStatus === 'thinking' && !spinnerSuffix && !showTimer && !showTokens;
+  const bareThinkingOnly = thinkingOnly && hasRunningTeammates;
 
   // === Thinking shimmer color (formerly ThinkingShimmerText's own timer) ===
   // Same sine-wave opacity, but derived from our shared `time` instead of a
@@ -225,15 +214,16 @@ export function SpinnerAnimationRow({
           </Text>] : []), ...(showTokens ? [<Text dimColor key="tokens">
             {tokensText}
           </Text>] : []), ...(showThinking && thinkingText ? [thinkingStatus === 'thinking' && !reducedMotion ? <Text key="thinking" color={thinkingShimmerColor}>
-              {thinkingOnly ? `(${thinkingText})` : thinkingText}
+              {bareThinkingOnly ? `(${thinkingText})` : thinkingText}
             </Text> : <Text dimColor key="thinking">
               {thinkingText}
             </Text>] : [])];
   // Lead the status with the request-direction glyph (↑ requesting /
-  // ↓ responding) so the mode is visible whenever any status shows — it was
-  // previously buried inside the tokens part, which only appears after 30s.
-  // Skipped for thinkingOnly (kept minimal) and teammate spins (tree has it).
-  if (!hasRunningTeammates && !thinkingOnly && parts.length > 0) {
+  // ↓ streaming) inside the status parens so the mode is always visible while
+  // the spinner is active — including the early requesting window before any
+  // other status part qualifies, and thinking-only spins. Teammate spins skip
+  // it (the teammate tree carries its own activity cue).
+  if (!hasRunningTeammates) {
     parts.unshift(<Box flexDirection="row" key="mode">
             <SpinnerModeGlyph mode={mode} />
           </Box>);
@@ -244,7 +234,7 @@ export function SpinnerAnimationRow({
           {foregroundedTeammate.identity.agentName}
         </Text>
         <Text dimColor>)</Text>
-      </> : !foregroundedTeammate && parts.length > 0 ? thinkingOnly ? <Byline>{parts}</Byline> : <>
+      </> : !foregroundedTeammate && parts.length > 0 ? bareThinkingOnly ? <Byline>{parts}</Byline> : <>
           <Text dimColor>(</Text>
           <Byline>{parts}</Byline>
           <Text dimColor>)</Text>

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -246,16 +246,20 @@ export function SpinnerAnimationRow({
   const thinkingShimmerColor = toRGBColor(interpolateColor(THINKING_INACTIVE, THINKING_INACTIVE_SHIMMER, thinkingOpacity));
 
   // === Build status parts ===
+  // bareThinkingOnly nests parens on the thinking word (no outer status parens).
+  // Apply in both shimmer and reduced-motion arms so teammate bare status is
+  // always "(thinking)", not a bare word jammed after the verb.
+  const thinkingDisplay = thinkingText ? bareThinkingOnly ? `(${thinkingText})` : thinkingText : null;
   const parts = [...(spinnerSuffix ? [<Text dimColor key="suffix">
             {spinnerSuffix}
           </Text>] : []), ...(showTimer ? [<Text dimColor key="elapsedTime">
             {timerText}
           </Text>] : []), ...(showTokens ? [<Text dimColor key="tokens">
             {tokensText}
-          </Text>] : []), ...(showThinking && thinkingText ? [thinkingStatus === 'thinking' && !reducedMotion ? <Text key="thinking" color={thinkingShimmerColor}>
-              {bareThinkingOnly ? `(${thinkingText})` : thinkingText}
+          </Text>] : []), ...(showThinking && thinkingDisplay ? [thinkingStatus === 'thinking' && !reducedMotion ? <Text key="thinking" color={thinkingShimmerColor}>
+              {thinkingDisplay}
             </Text> : <Text dimColor key="thinking">
-              {thinkingText}
+              {thinkingDisplay}
             </Text>] : [])];
   // Lead the status with the request-direction glyph (↑ requesting /
   // ↓ streaming) inside the status parens so the mode is always visible while

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -214,7 +214,9 @@ export function SpinnerAnimationRow({
     // Thinking-only recovery stays in the dedicated second-chance block below
     // so full "(↓ · thinking)" chrome still wins when it fits.
     const glyphHidesContent = bareShowTimer && !showTimer || bareShowTokens && !showTokens;
-    if (glyphHidesContent) {
+    // Do not swap already-visible tokens for a timer that only fits without the glyph.
+    const glyphRecoveryLosesTokens = showTokens && !bareShowTokens;
+    if (glyphHidesContent && !glyphRecoveryLosesTokens) {
       reserveModeGlyph = false;
       parensWidth = BASE_PARENS_WIDTH;
       availableSpace = bareAvailableSpace;
@@ -269,7 +271,11 @@ export function SpinnerAnimationRow({
   // than overflow. Also omit when content recovery or bare-thinking fallback
   // dropped the glyph so higher-value status can show.
   const residualForStatus = columns - messageWidth;
-  const canShowModeGlyph = reserveModeGlyph && !suppressModeGlyphForBareThinking && residualForStatus >= 5;
+  const hasVisibleStatusContent = Boolean(spinnerSuffix) || showTimer || showTokens || showThinking;
+  // Requesting and active "thinking" may show glyph-only chrome; completed-thought
+  // duration and other states must not render an empty "(↓ )" row.
+  const allowGlyphOnlyStatus = mode === 'requesting' || thinkingStatus === 'thinking';
+  const canShowModeGlyph = reserveModeGlyph && !suppressModeGlyphForBareThinking && residualForStatus >= 5 && (hasVisibleStatusContent || allowGlyphOnlyStatus);
 
   // === Thinking shimmer color (formerly ThinkingShimmerText's own timer) ===
   // Same sine-wave opacity, but derived from our shared `time` instead of a

--- a/src/components/Spinner/SpinnerAnimationRow.tsx
+++ b/src/components/Spinner/SpinnerAnimationRow.tsx
@@ -324,7 +324,12 @@ export function SpinnerAnimationRow({
     // Use `>` (not `>=`) so exact-fit suffix+thinking does not keep the suffix
     // while glyph chrome still cannot show thinking — avoids a one-column cliff.
     const thinkingWithSuffixFit = !wantsThinking || physicalBareBudget > suffixTextWidth + sep + thinkingWidthForSuffix;
+    const tokensWithSuffixAndThinkingFit = !hasTokenContent || !wantsThinking || physicalBareBudget >= suffixTextWidth + sep + thinkingWidthForSuffix + sep + tokensWidth;
     if (hasTokenContent && physicalBareBudget >= tokensWidth && !tokensWithSuffixFit) {
+      showSuffix = false;
+      effectiveSuffixWidth = 0;
+    } else if (hasTokenContent && wantsThinking && physicalBareBudget >= tokensWidth && tokensWithSuffixFit && !tokensWithSuffixAndThinkingFit) {
+      // Suffix+thinking would fit without tokens; prefer live tokens over that pair.
       showSuffix = false;
       effectiveSuffixWidth = 0;
     } else if (!hasTokenContent && wantsThinking && physicalBareBudget >= thinkingWidthForSuffix && !thinkingWithSuffixFit) {
@@ -371,6 +376,13 @@ export function SpinnerAnimationRow({
         showTokens = true;
         usedAfterThinking = 0;
         usedAfterTimer = 0;
+      }
+    } else if (showThinking && !showTokens && tokensFitBareAlone) {
+      // Thinking recovered after suffix drop — co-restore tokens when they fit.
+      let total = thinkingWidthValue + sep + tokensWidth;
+      if (showTimer) total += timerWidth + sep;
+      if (physicalBareBudget >= total) {
+        showTokens = true;
       }
     } else if (showTokens && !showTimer && wantsTimer) {
       let total = timerWidth + sep + tokensWidth;


### PR DESCRIPTION
## Summary

Fixes SpinnerModeGlyph visibility and placement bugs from #2033.

### Acceptance
- **Early requesting:** ↑ mode glyph renders inside status parens even when no other status parts qualify yet.
- **Placement:** glyph is the first child of `parts` inside `( … )`, not floating left of the opening paren.
- **Thinking-only:** ↓ glyph shows for leader thinking-only status when width allows; narrow rows fall back to bare `(thinking)` rather than empty glyph-only chrome.
- **Tokens on mid-narrow rows:** when glyph reservation would drop the token count, drop the glyph and keep tokens.
- **Teammates:** mode glyph remains omitted (tree has its own cue); bare teammate thinking nests `(thinking)` under reduced motion as well as shimmer.
- **Suffix recovery:** overflowing or crowding stop-hook/tool suffixes drop so timer/tokens/thinking can recover without blank rows, wraps, or non-monotonic cliffs.

### Root cause
`SpinnerModeGlyph` was unshifted only when `!thinkingOnly && parts.length > 0`, so early requesting and thinking-only phases dropped the arrow. Later width-recovery passes also left timer/token/thinking re-gating incomplete after suffix overflow.

### Implementation
- Unshift mode glyph for leader spins when residual width allows and the glyph does not steal higher-value status.
- Keep glyph inside outer status parens as the first Byline child.
- Content recovery: if glyph reservation empties the status of tokens/timer, retry without glyph.
- Thinking-only second chance: full `(↓ · thinking)` then bare `(thinking)`.
- Shared `thinkingDisplay` for teammate bare nesting in both motion arms.
- Suffix-drop / tokens-over-suffix recovery restores timer and tokens symmetrically, budgets co-restores against all visible parts, and restores the mode glyph when content fits.

Stretch item (token-trend semantics) left out of this minimum viable fix.

## Test plan
- [x] `bun test --feature=UNATTENDED_RETRY --max-concurrency=1 ./src/components/Spinner/SpinnerAnimationRow.test.tsx` (45 pass)
- [x] Isolation with `./src/utils/context.test.ts` (pass)
- [ ] Manual: send a message and confirm ↑ inside parens in the first ~500ms, then ↓ inside parens once streaming/thinking status appears

Closes #2033

Final reviewed SHA: 84af7110511f15badd5a678f7f881aa786408828


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spinner/status layout with progressive space budgeting so thinking, timers, token counts, suffix indicators, and the mode glyph display consistently (or degrade cleanly) across more terminal widths and streaming states.
  * Refined prioritization and recovery logic to avoid empty glyph-only rows and to preserve higher-priority content when space is tight.
  * Standardized “requesting” mode glyph rendering while keeping existing nested “(thinking)” behavior.
* **Tests**
  * Reworked spinner layout tests to be deterministic and expanded coverage across many width/state combinations and edge-case recoveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->