### PR TITLE
fix(query): do not trip tool-failure guard on parallel same-turn failures

### DIFF
--- a/src/query/toolFailureLoopGuard.test.ts
+++ b/src/query/toolFailureLoopGuard.test.ts
@@ -352,7 +352,7 @@ test('trip messages do not echo unsafe tool names, error categories, or paths', 
 test('multiple identical failures in the same batch count once toward the threshold', () => {
   const state = createToolFailureLoopGuardState()
 
-  const decision = update(
+  const first = update(
     state,
     [
       toolUse('a', 'Edit'),
@@ -365,14 +365,34 @@ test('multiple identical failures in the same batch count once toward the thresh
       toolResult('c', 'Error writing file: failed to replace text'),
     ],
   )
+  expect(first.tripped).toBe(false)
 
-  expect(decision.tripped).toBe(false)
+  // Once-per-key counting must land at 1, not a partial double-count: the next
+  // turn stays below threshold, and only the turn after that trips.
+  const second = update(state, [toolUse('d', 'Edit')], [
+    toolResult('d', 'Error writing file: failed to replace text'),
+  ])
+  expect(second.tripped).toBe(false)
+  if (second.tripped || !second.advisories) {
+    throw new Error('Expected penultimate advisory after a once-counted parallel batch')
+  }
+  expect(second.advisories).toHaveLength(1)
+  expect(second.advisories[0]?.message).toContain('2/3 times')
+
+  const third = update(state, [toolUse('e', 'Edit')], [
+    toolResult('e', 'Error writing file: failed to replace text'),
+  ])
+  if (!third.tripped) {
+    throw new Error('Expected Edit FileWriteError failures to trip on the third turn')
+  }
+  expect(third.message).toContain('`Edit` failed 3 times')
+  expect(third.message).toContain('`FileWriteError`')
 })
 
 test('same-batch parallel failures still accumulate across later turns', () => {
   const state = createToolFailureLoopGuardState()
 
-  update(
+  const first = update(
     state,
     [toolUse('a', 'Bash'), toolUse('b', 'Bash'), toolUse('c', 'Bash')],
     [
@@ -381,9 +401,17 @@ test('same-batch parallel failures still accumulate across later turns', () => {
       toolResult('c', '<tool_use_error>ENOENT: no such file or directory: /z</tool_use_error>'),
     ],
   )
-  update(state, [toolUse('d', 'Bash')], [
+  expect(first.tripped).toBe(false)
+
+  const second = update(state, [toolUse('d', 'Bash')], [
     toolResult('d', '<tool_use_error>ENOENT: no such file or directory: /w</tool_use_error>'),
   ])
+  expect(second.tripped).toBe(false)
+  if (second.tripped || !second.advisories) {
+    throw new Error('Expected penultimate advisory on the second Bash NotFound turn')
+  }
+  expect(second.advisories).toHaveLength(1)
+
   const decision = update(state, [toolUse('e', 'Bash')], [
     toolResult('e', '<tool_use_error>ENOENT: no such file or directory: /v</tool_use_error>'),
   ])
@@ -431,6 +459,25 @@ test('parallel different-tool failures of the same category in one turn do not t
       toolResult('a', '<tool_use_error>Error writing file: one</tool_use_error>'),
       toolResult('b', 'Error writing file: two'),
       toolResult('c', 'Error writing file: three'),
+    ],
+  )
+  expect(decision.tripped).toBe(false)
+})
+
+test('parallel same-path failures in a single turn do not trip the guard', () => {
+  const state = createToolFailureLoopGuardState()
+  const decision = update(
+    state,
+    [
+      toolUse('a', 'Edit', { file_path: 'src/a.ts' }),
+      toolUse('b', 'Write', { file_path: 'src/a.ts' }),
+      toolUse('c', 'NotebookEdit', { notebook_path: 'src/a.ts' }),
+    ],
+    [
+      // Distinct categories so signature/category counters cannot hide a path trip.
+      toolResult('a', 'Error writing file: one'),
+      toolResult('b', 'ENOENT: no such file or directory'),
+      toolResult('c', 'No such tool available: NotebookEdit'),
     ],
   )
   expect(decision.tripped).toBe(false)

--- a/src/query/toolFailureLoopGuard.test.ts
+++ b/src/query/toolFailureLoopGuard.test.ts
@@ -349,7 +349,7 @@ test('trip messages do not echo unsafe tool names, error categories, or paths', 
   expect(pathTrip.message).not.toContain(unsafePath)
 })
 
-test('multiple failures in the same batch each increment the counters', () => {
+test('multiple identical failures in the same batch count once toward the threshold', () => {
   const state = createToolFailureLoopGuardState()
 
   const decision = update(
@@ -366,7 +366,74 @@ test('multiple failures in the same batch each increment the counters', () => {
     ],
   )
 
-  expect(decision.tripped).toBe(true)
+  expect(decision.tripped).toBe(false)
+})
+
+test('same-batch parallel failures still accumulate across later turns', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(
+    state,
+    [toolUse('a', 'Bash'), toolUse('b', 'Bash'), toolUse('c', 'Bash')],
+    [
+      toolResult('a', '<tool_use_error>ENOENT: no such file or directory: /x</tool_use_error>'),
+      toolResult('b', '<tool_use_error>ENOENT: no such file or directory: /y</tool_use_error>'),
+      toolResult('c', '<tool_use_error>ENOENT: no such file or directory: /z</tool_use_error>'),
+    ],
+  )
+  update(state, [toolUse('d', 'Bash')], [
+    toolResult('d', '<tool_use_error>ENOENT: no such file or directory: /w</tool_use_error>'),
+  ])
+  const decision = update(state, [toolUse('e', 'Bash')], [
+    toolResult('e', '<tool_use_error>ENOENT: no such file or directory: /v</tool_use_error>'),
+  ])
+
+  if (!decision.tripped) {
+    throw new Error('Expected cross-turn Bash NotFound failures to trip')
+  }
+  expect(decision.message).toContain('`Bash` failed 3 times')
+  expect(decision.message).toContain('`NotFound`')
+})
+
+test('parallel tool failures in a single turn do not trip the guard', () => {
+  const state = createToolFailureLoopGuardState()
+  const decision = update(
+    state,
+    [toolUse('a', 'Bash'), toolUse('b', 'Bash'), toolUse('c', 'Bash')],
+    [
+      toolResult(
+        'a',
+        '<tool_use_error>ENOENT: no such file or directory: /x</tool_use_error>',
+      ),
+      toolResult(
+        'b',
+        '<tool_use_error>ENOENT: no such file or directory: /y</tool_use_error>',
+      ),
+      toolResult(
+        'c',
+        '<tool_use_error>ENOENT: no such file or directory: /z</tool_use_error>',
+      ),
+    ],
+  )
+  expect(decision.tripped).toBe(false)
+})
+
+test('parallel different-tool failures of the same category in one turn do not trip', () => {
+  const state = createToolFailureLoopGuardState()
+  const decision = update(
+    state,
+    [
+      toolUse('a', 'Edit'),
+      toolUse('b', 'Write'),
+      toolUse('c', 'NotebookEdit'),
+    ],
+    [
+      toolResult('a', '<tool_use_error>Error writing file: one</tool_use_error>'),
+      toolResult('b', 'Error writing file: two'),
+      toolResult('c', 'Error writing file: three'),
+    ],
+  )
+  expect(decision.tripped).toBe(false)
 })
 
 test('different tools with different error categories do not trip early', () => {

--- a/src/query/toolFailureLoopGuard.test.ts
+++ b/src/query/toolFailureLoopGuard.test.ts
@@ -436,6 +436,31 @@ test('parallel different-tool failures of the same category in one turn do not t
   expect(decision.tripped).toBe(false)
 })
 
+test('parallel penultimate failures emit a single advisory per signature', () => {
+  const state = createToolFailureLoopGuardState()
+
+  update(state, [toolUse('a', 'Bash')], [
+    toolResult('a', 'ENOENT: no such file or directory: /a'),
+  ])
+  const decision = update(
+    state,
+    [toolUse('b', 'Bash'), toolUse('c', 'Bash'), toolUse('d', 'Bash')],
+    [
+      toolResult('b', 'ENOENT: no such file or directory: /b'),
+      toolResult('c', 'ENOENT: no such file or directory: /c'),
+      toolResult('d', 'ENOENT: no such file or directory: /d'),
+    ],
+  )
+
+  if (decision.tripped || !decision.advisories) {
+    throw new Error('Expected one advisory for the parallel penultimate batch')
+  }
+  expect(decision.advisories).toHaveLength(1)
+  expect(decision.advisories[0]?.toolName).toBe('Bash')
+  expect(decision.advisories[0]?.errorCategory).toBe('NotFound')
+  expect(decision.advisories[0]?.message).toContain('2/3 times')
+})
+
 test('different tools with different error categories do not trip early', () => {
   const state = createToolFailureLoopGuardState()
 

--- a/src/query/toolFailureLoopGuard.ts
+++ b/src/query/toolFailureLoopGuard.ts
@@ -143,6 +143,9 @@ export function updateToolFailureLoopGuard(params: {
   const advisories: ToolFailureLoopGuardAdvisory[] = []
   for (const failure of failures) {
     const persistentSignature = `${failure.toolName}\0${failure.errorCategory}`
+    const isNewPersistentSignature = !seenPersistentSignatures.has(
+      persistentSignature,
+    )
     const persistentSignatureCount = incrementCounterOnce(
       params.state.persistentSignatureCounts,
       persistentSignature,
@@ -165,7 +168,11 @@ export function updateToolFailureLoopGuard(params: {
       }
     }
 
-    if (threshold > 1 && persistentSignatureCount === threshold - 1) {
+    if (
+      isNewPersistentSignature &&
+      threshold > 1 &&
+      persistentSignatureCount === threshold - 1
+    ) {
       advisories.push({
         threshold,
         toolName: failure.toolName,

--- a/src/query/toolFailureLoopGuard.ts
+++ b/src/query/toolFailureLoopGuard.ts
@@ -133,11 +133,20 @@ export function updateToolFailureLoopGuard(params: {
     resetPersistentToolSignatures(params.state, toolName)
   }
 
+  // Parallel failures in one model turn must only count once per key so the
+  // model can observe the batch and adapt. Cross-turn accumulation still trips.
+  const seenPersistentSignatures = new Set<string>()
+  const seenPaths = new Set<string>()
+  const seenSignatures = new Set<string>()
+  const seenCategories = new Set<string>()
+
   const advisories: ToolFailureLoopGuardAdvisory[] = []
   for (const failure of failures) {
-    const persistentSignatureCount = incrementCounter(
+    const persistentSignature = `${failure.toolName}\0${failure.errorCategory}`
+    const persistentSignatureCount = incrementCounterOnce(
       params.state.persistentSignatureCounts,
-      `${failure.toolName}\0${failure.errorCategory}`,
+      persistentSignature,
+      seenPersistentSignatures,
     )
 
     if (persistentSignatureCount >= threshold) {
@@ -175,7 +184,11 @@ export function updateToolFailureLoopGuard(params: {
       continue
     }
 
-    const pathCount = incrementCounter(params.state.pathCounts, failure.path)
+    const pathCount = incrementCounterOnce(
+      params.state.pathCounts,
+      failure.path,
+      seenPaths,
+    )
     if (pathCount >= threshold) {
       return {
         tripped: true,
@@ -199,13 +212,16 @@ export function updateToolFailureLoopGuard(params: {
   }
 
   for (const failure of failures) {
-    const signatureCount = incrementCounter(
+    const signature = `${failure.toolName}\0${failure.errorCategory}`
+    const signatureCount = incrementCounterOnce(
       params.state.signatureCounts,
-      `${failure.toolName}\0${failure.errorCategory}`,
+      signature,
+      seenSignatures,
     )
-    const categoryCount = incrementCounter(
+    const categoryCount = incrementCounterOnce(
       params.state.categoryCounts,
       failure.errorCategory,
+      seenCategories,
     )
     if (signatureCount >= threshold) {
       return {
@@ -451,6 +467,18 @@ function incrementCounter(counts: Map<string, number>, key: string): number {
   const next = (counts.get(key) ?? 0) + 1
   counts.set(key, next)
   return next
+}
+
+function incrementCounterOnce(
+  counts: Map<string, number>,
+  key: string,
+  seenThisTurn: Set<string>,
+): number {
+  if (seenThisTurn.has(key)) {
+    return counts.get(key) ?? 0
+  }
+  seenThisTurn.add(key)
+  return incrementCounter(counts, key)
 }
 
 function createTripMessage(


### PR DESCRIPTION
## Summary

- Count each tool-failure loop-guard key at most once per model turn so a parallel fan-out of same-category / same-signature / same-path errors cannot stop the response before the model sees the results.
- Keep cross-turn accumulation (and the existing category / persistent-signature / path trips) intact; emit at most one advisory per signature when a parallel batch reaches the penultimate count.
- Fixes #2035

## Impact

- user-facing impact: parallel tool batches (common under `--permission-mode bypassPermissions`) no longer end the turn with "Stopped: repeated tool failures detected" after a single fan-out of matching errors.
- developer/maintainer impact: `updateToolFailureLoopGuard` now uses per-turn dedupe via `incrementCounterOnce`; regression coverage lives in `src/query/toolFailureLoopGuard.test.ts`.

## Testing

- [ ] `bun run build`
- [ ] `bun run smoke`
- [ ] `bun run check`
- [x] focused tests: `bun test ./src/query/toolFailureLoopGuard.test.ts`
- [x] adjacent isolation: `bun test ./src/query/` (111 pass)

## Notes

- provider/model path tested: N/A (unit-level guard / query-loop fixtures)
- screenshots attached (if UI changed): N/A
- follow-up work or known limitations: category normalization for bare "No such file or directory" (without `ENOENT` / "not found") is unchanged and pre-existing; final reviewed head `f4a191afe784812ca2987d107758d8f6922d48d6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated parallel tool failures within the same turn are now counted once, avoiding premature query termination.
  * Failure-loop protection now accumulates correctly across separate turns.
  * Warnings and termination advisories are emitted only at the correct thresholds, with improved accuracy for matching tool/error patterns.
* **Tests**
  * Updated and expanded coverage for parallel and repeated tool-failure scenarios, including precise advisory messaging at expected thresholds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->