### PR TITLE
feat(auth): opt-in loopback proxy hosts that keep subscription (OAuth) auth

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -429,6 +429,28 @@ directly configured endpoint that instead requires Anthropic's native
 `x-api-key` authentication, set `ANTHROPIC_API_KEY` in place of the Bearer
 token; do not set both credentials.
 
+#### Keeping a subscription (OAuth) session through a local proxy
+
+Pointing `ANTHROPIC_BASE_URL` at any host other than `api.anthropic.com`
+normally switches the client to API-key mode, so a signed-in subscription
+session is dropped. To route traffic through a **local, transparent** proxy
+(compression, request inspection, caching) that forwards the `Authorization`
+and `anthropic-beta` headers to Anthropic unchanged, opt in with
+`ANTHROPIC_FIRST_PARTY_PROXY_HOSTS` — a comma-separated `host[:port]` allowlist
+that extends first-party detection:
+
+```bash
+export ANTHROPIC_BASE_URL=http://127.0.0.1:47821
+export ANTHROPIC_FIRST_PARTY_PROXY_HOSTS=127.0.0.1:47821
+openclaude   # OAuth session persists; traffic rides the local proxy
+```
+
+Only loopback hosts (`127.0.0.1`, `[::1]`, `localhost`) are ever honored, so
+the setting can never route OAuth tokens off the machine — a non-loopback entry
+is ignored. Write IPv6 in bracket form (`[::1]` or `[::1]:8080`). An entry with
+a port matches that port only; an entry without a port matches any port on the
+host. Without this variable the behavior is unchanged.
+
 | Variable | Required | Description |
 |----------|----------|-------------|
 | `CLAUDE_CODE_USE_OPENAI` | OpenAI-compatible only | Set to `1` to enable the OpenAI-compatible provider path |

--- a/src/utils/anthropicBaseUrl.test.ts
+++ b/src/utils/anthropicBaseUrl.test.ts
@@ -135,6 +135,53 @@ describe('ANTHROPIC_FIRST_PARTY_PROXY_HOSTS loopback allowlist', () => {
     ).toBe(false)
   })
 
+  test('matches a default-port entry against a scheme-default base URL', () => {
+    // Node leaves url.port empty for the scheme default; an explicit :80/:443
+    // entry must still match.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '127.0.0.1:80',
+      }),
+    ).toBe(true)
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'https://[::1]',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '[::1]:443',
+      }),
+    ).toBe(true)
+    // A default-port entry that does not match the scheme default is rejected.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '127.0.0.1:443',
+      }),
+    ).toBe(false)
+  })
+
+  test('rejects embedded credentials and non-http(s) schemes', () => {
+    // Userinfo on an otherwise-canonical URL is never first-party.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'https://user:pass@api.anthropic.com',
+      }),
+    ).toBe(false)
+    // Userinfo on a loopback proxy is likewise rejected.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://user@127.0.0.1:47821',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '127.0.0.1:47821',
+      }),
+    ).toBe(false)
+    // A non-http(s) loopback scheme does not match the proxy allowlist.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'ftp://127.0.0.1:47821',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '127.0.0.1:47821',
+      }),
+    ).toBe(false)
+  })
+
   test('does nothing without the opt-in variable', () => {
     // Default behavior is unchanged: a loopback base URL is still a custom
     // provider unless the allowlist explicitly opts in.

--- a/src/utils/anthropicBaseUrl.test.ts
+++ b/src/utils/anthropicBaseUrl.test.ts
@@ -55,3 +55,99 @@ describe('isFirstPartyAnthropicBaseUrlForEnv', () => {
     ).toBe(false)
   })
 })
+
+describe('ANTHROPIC_FIRST_PARTY_PROXY_HOSTS loopback allowlist', () => {
+  test('keeps first-party status for an allowlisted loopback proxy', () => {
+    // The whole point: a local transparent proxy (http, non-default port) that
+    // forwards auth to Anthropic must not drop the OAuth session.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:47821',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '127.0.0.1:47821',
+      }),
+    ).toBe(true)
+  })
+
+  test('honors localhost and bracketed IPv6 loopback entries', () => {
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://localhost:8080',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: 'localhost:8080',
+      }),
+    ).toBe(true)
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://[::1]:8080',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '[::1]:8080',
+      }),
+    ).toBe(true)
+    // A case-different localhost still matches.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://LocalHost:8080',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: 'localhost:8080',
+      }),
+    ).toBe(true)
+  })
+
+  test('an entry with no port matches any port on that loopback host', () => {
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:59999',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '127.0.0.1',
+      }),
+    ).toBe(true)
+  })
+
+  test('picks the matching host out of a comma-separated list', () => {
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://[::1]:8080',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '127.0.0.1:47821, [::1]:8080',
+      }),
+    ).toBe(true)
+  })
+
+  test('a port on the entry must match the base URL port exactly', () => {
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:47821',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '127.0.0.1:47822',
+      }),
+    ).toBe(false)
+  })
+
+  test('never widens first-party status to an off-machine host', () => {
+    // A non-loopback base URL is rejected even if the operator lists it -- the
+    // token can only ever ride a proxy on the local machine.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://proxy.internal.example:47821',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: 'proxy.internal.example:47821',
+      }),
+    ).toBe(false)
+    // A loopback base URL with a non-loopback allowlist entry does not match.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:47821',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: 'evil.example:47821',
+      }),
+    ).toBe(false)
+  })
+
+  test('does nothing without the opt-in variable', () => {
+    // Default behavior is unchanged: a loopback base URL is still a custom
+    // provider unless the allowlist explicitly opts in.
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:47821',
+      }),
+    ).toBe(false)
+    expect(
+      isFirstPartyAnthropicBaseUrlForEnv({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:47821',
+        ANTHROPIC_FIRST_PARTY_PROXY_HOSTS: '',
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/utils/anthropicBaseUrl.ts
+++ b/src/utils/anthropicBaseUrl.ts
@@ -61,12 +61,16 @@ function matchesLoopbackProxyAllowlist(
   if (!rawAllowlist || !isLoopbackHost(url.hostname)) return false
 
   const urlHost = normalizeHost(url.hostname)
+  // Compare against the effective port: Node leaves `url.port` empty for the
+  // scheme default, so an explicit `127.0.0.1:80` entry must still match
+  // `http://127.0.0.1`.
+  const urlPort = url.port || (url.protocol === 'https:' ? '443' : '80')
   for (const raw of rawAllowlist.split(',')) {
     const entry = raw.trim()
     if (!entry) continue
     const { host, port } = parseAllowlistEntry(entry)
     if (!LOOPBACK_HOSTNAMES.has(host) || host !== urlHost) continue
-    if (port !== undefined && port !== url.port) continue
+    if (port !== undefined && port !== urlPort) continue
     return true
   }
   return false
@@ -96,6 +100,12 @@ export function isFirstPartyAnthropicBaseUrlForEnv(
 
   try {
     const url = new URL(baseUrl)
+
+    // A first-party endpoint is always a bare http(s) origin. Embedded
+    // credentials (`https://user:pass@host`) or any other scheme are never
+    // treated as first-party, so an OAuth session can't be attached to them.
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
+    if (url.username || url.password) return false
 
     const allowedHosts = ['api.anthropic.com']
     if (processEnv.USER_TYPE === 'ant') {

--- a/src/utils/anthropicBaseUrl.ts
+++ b/src/utils/anthropicBaseUrl.ts
@@ -1,3 +1,93 @@
+/**
+ * Loopback hostnames a first-party proxy may bind to. Restricting the allowlist
+ * to these is what guarantees an OAuth session can never be forwarded off the
+ * machine: a non-loopback base URL is never treated as first-party no matter
+ * what the allowlist says.
+ */
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', '::1', 'localhost'])
+
+/**
+ * Strip the brackets Node's URL parser keeps around an IPv6 hostname
+ * (`http://[::1]` -> `[::1]`) and lower-case it, so `[::1]` and `localhost`
+ * compare against the allowlist consistently.
+ */
+function normalizeHost(hostname: string): string {
+  return hostname.replace(/^\[|\]$/g, '').toLowerCase()
+}
+
+function isLoopbackHost(hostname: string): boolean {
+  return LOOPBACK_HOSTNAMES.has(normalizeHost(hostname))
+}
+
+/**
+ * Split one `host[:port]` allowlist entry into its parts. IPv6 must be written
+ * in bracket form (`[::1]` or `[::1]:8080`) to be unambiguous; a bare `::1`
+ * (which carries no port) is accepted too, but `::1:8080` cannot be told apart
+ * from an address and is treated as a host with no port.
+ */
+function parseAllowlistEntry(entry: string): { host: string; port?: string } {
+  const bracketed = entry.match(/^\[([^\]]+)\](?::(\d+))?$/)
+  if (bracketed) {
+    return { host: normalizeHost(bracketed[1]), port: bracketed[2] }
+  }
+  // More than one colon and no brackets: an unbracketed IPv6 address, no port.
+  if ((entry.match(/:/g)?.length ?? 0) > 1) {
+    return { host: normalizeHost(entry) }
+  }
+  const colon = entry.indexOf(':')
+  if (colon >= 0) {
+    return {
+      host: normalizeHost(entry.slice(0, colon)),
+      port: entry.slice(colon + 1),
+    }
+  }
+  return { host: normalizeHost(entry) }
+}
+
+/**
+ * Whether `url` matches an opt-in loopback proxy allowlist.
+ *
+ * The allowlist is a comma-separated list of `host[:port]` entries. It is
+ * honored only when the base URL itself points at a loopback host, and only
+ * loopback entries within it are considered -- both checks are redundant on
+ * purpose, so a misconfigured non-loopback entry can never widen first-party
+ * status to an off-machine host. A port on an entry must match exactly; an
+ * entry with no port matches any port on that host.
+ */
+function matchesLoopbackProxyAllowlist(
+  url: URL,
+  rawAllowlist: string | undefined,
+): boolean {
+  if (!rawAllowlist || !isLoopbackHost(url.hostname)) return false
+
+  const urlHost = normalizeHost(url.hostname)
+  for (const raw of rawAllowlist.split(',')) {
+    const entry = raw.trim()
+    if (!entry) continue
+    const { host, port } = parseAllowlistEntry(entry)
+    if (!LOOPBACK_HOSTNAMES.has(host) || host !== urlHost) continue
+    if (port !== undefined && port !== url.port) continue
+    return true
+  }
+  return false
+}
+
+/**
+ * Whether the configured `ANTHROPIC_BASE_URL` should be treated as first-party
+ * Anthropic (subscription/OAuth) rather than a custom API-key provider.
+ *
+ * Returns true if unset (default API) or a canonical `https://api.anthropic.com`
+ * endpoint on its default port. It can also be extended with an opt-in,
+ * loopback-only allowlist so a signed-in session survives running the CLI
+ * through a local transparent proxy (compression, inspection, caching) that
+ * forwards auth headers to Anthropic unchanged:
+ *
+ *   ANTHROPIC_BASE_URL=http://127.0.0.1:47821
+ *   ANTHROPIC_FIRST_PARTY_PROXY_HOSTS=127.0.0.1:47821
+ *
+ * Only loopback hosts are ever honored, so the token cannot leave the machine.
+ * Without the allowlist the behavior is unchanged.
+ */
 export function isFirstPartyAnthropicBaseUrlForEnv(
   processEnv: NodeJS.ProcessEnv,
 ): boolean {
@@ -5,15 +95,23 @@ export function isFirstPartyAnthropicBaseUrlForEnv(
   if (!baseUrl) return true
 
   try {
+    const url = new URL(baseUrl)
+
     const allowedHosts = ['api.anthropic.com']
     if (processEnv.USER_TYPE === 'ant') {
       allowedHosts.push('api-staging.anthropic.com')
     }
-    const url = new URL(baseUrl)
-    return (
+    if (
       url.protocol === 'https:' &&
       allowedHosts.includes(url.hostname) &&
       (url.port === '' || url.port === '443')
+    ) {
+      return true
+    }
+
+    return matchesLoopbackProxyAllowlist(
+      url,
+      processEnv.ANTHROPIC_FIRST_PARTY_PROXY_HOSTS,
     )
   } catch {
     return false


### PR DESCRIPTION
## Problem

Pointing `ANTHROPIC_BASE_URL` at a local proxy (compression, request inspection, caching) silently drops a signed-in subscription session: `isFirstPartyAnthropicBaseUrlForEnv` treats only `api.anthropic.com` as first-party, so any other base URL switches auth to API-key mode. `ANTHROPIC_AUTH_TOKEN` is not an escape either — it selects the custom-provider path and drops subscriber detection.

## Change

Add an opt-in `ANTHROPIC_FIRST_PARTY_PROXY_HOSTS`: a comma-separated `host[:port]` allowlist that extends first-party detection.

```bash
export ANTHROPIC_BASE_URL=http://127.0.0.1:47821
export ANTHROPIC_FIRST_PARTY_PROXY_HOSTS=127.0.0.1:47821
openclaude   # OAuth session persists; traffic rides the local proxy
```

All first-party checks funnel through `isFirstPartyAnthropicBaseUrlForEnv`, so the change is contained to that one function.

## Security posture

- **Loopback-only.** Entries are honored only for `127.0.0.1`, `[::1]`, and `localhost`. The base URL host is checked for loopback *and* each allowlist entry is checked for loopback — both redundantly — so a misconfigured non-loopback entry can never widen first-party status to an off-machine host. OAuth tokens cannot leave the machine.
- **Default unchanged.** Without the variable, a non-`api.anthropic.com` base URL is still a custom API-key provider exactly as before.
- **Explicit ports.** An entry with a port matches that port only; an entry without a port matches any port on the host. IPv6 uses bracket form (`[::1]` / `[::1]:8080`).

## Tests

`src/utils/anthropicBaseUrl.test.ts` — 13 cases: the existing first-party checks plus the allowlist (loopback host/localhost/IPv6, case-insensitive host, portless-matches-any-port, comma lists, exact port match, and the two off-machine-rejection guarantees), and that the feature is inert without the opt-in.

Closes #2016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional support for preserving authenticated subscription sessions when routing requests through a local transparent proxy.
  - Introduced a new allowlist configuration for loopback proxy hosts (`host[:port]`), supporting IPv4, IPv6 (including bracketed forms), and strict port matching.
  - Non-loopback hosts are still excluded; default behavior remains unchanged unless configured.

- **Documentation**
  - Updated advanced setup guidance with a local proxy example and explanation of the new allowlist option.

- **Tests**
  - Added coverage for allowlist parsing and loopback matching edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->