### PR TITLE
feat(integrations): add Ling 3.0 Flash free to the Opengateway catalog

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -1447,6 +1447,7 @@ test('/model applies auto provider surface for single-model static descriptor pr
       'qwen/qwen3.7-max',
       'z-ai/glm-5.2',
       'nvidia/nemotron-3-ultra-550b-a55b:free',
+      'inclusionai/ling-3.0-flash:free',
       'tencent/hy3',
     ])
   } finally {

--- a/src/integrations/brands/ling.ts
+++ b/src/integrations/brands/ling.ts
@@ -1,0 +1,16 @@
+import { defineBrand } from '../define.js'
+
+export default defineBrand({
+  id: 'ling',
+  label: 'Ling',
+  canonicalVendorId: 'openai',
+  defaultCapabilities: {
+    supportsVision: false,
+    supportsStreaming: true,
+    supportsFunctionCalling: true,
+    supportsJsonMode: false,
+    supportsReasoning: true,
+    supportsPreciseTokenCount: false,
+  },
+  modelIds: ['inclusionai/ling-3.0-flash:free'],
+})

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -136,6 +136,14 @@ export default defineGateway({
         modelDescriptorId: 'nvidia/nemotron-3-ultra-550b-a55b:free',
         notes: 'Free',
       },
+      // Time-boxed free window on the gateway (delists itself 2026-08-03).
+      {
+        id: 'opengateway-ling-3.0-flash-free',
+        apiName: 'inclusionai/ling-3.0-flash:free',
+        label: 'Ling 3.0 Flash Free (via Opengateway)',
+        modelDescriptorId: 'inclusionai/ling-3.0-flash:free',
+        notes: 'Free',
+      },
       {
         id: 'opengateway-tencent-hy3',
         apiName: 'tencent/hy3',

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -53,6 +53,7 @@ import brandGemini from '../brands/gemini.js'
 import brandGlm from '../brands/glm.js'
 import brandGpt from '../brands/gpt.js'
 import brandKimi from '../brands/kimi.js'
+import brandLing from '../brands/ling.js'
 import brandLlama from '../brands/llama.js'
 import brandLongcat from '../brands/longcat.js'
 import brandMinimax from '../brands/minimax.js'
@@ -71,6 +72,7 @@ import modelGemini from '../models/gemini.js'
 import modelGlm from '../models/glm.js'
 import modelGpt from '../models/gpt.js'
 import modelKimi from '../models/kimi.js'
+import modelLing from '../models/ling.js'
 import modelLlama from '../models/llama.js'
 import modelLongcat from '../models/longcat.js'
 import modelMinimax from '../models/minimax.js'
@@ -87,8 +89,8 @@ import modelXiaomiMimo from '../models/xiaomi-mimo.js'
 export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorBankr, vendorDeepseek, vendorFireworks, vendorGemini, vendorLongcat, vendorMinimax, vendorMoonshot, vendorNearai, vendorOpenai, vendorVenice, vendorXai, vendorXiaomiMimo, vendorZai] as const satisfies readonly VendorDescriptor[]
 export const GATEWAY_DESCRIPTORS = [gatewayAimlapi, gatewayAtlasCloud, gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayClinepass, gatewayCloudflare, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithubEnterprise, gatewayGithub, gatewayGitlawbOpengateway, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpencodeGo, gatewayOpencode, gatewayOpenrouter, gatewayTogether, gatewayVertex, gatewayXiaomiMimoToken] as const satisfies readonly GatewayDescriptor[]
 export const ANTHROPIC_PROXY_DESCRIPTORS = [anthropicproxyCustom] as const satisfies readonly AnthropicProxyDescriptor[]
-export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandFireworks, brandGemini, brandGlm, brandGpt, brandKimi, brandLlama, brandLongcat, brandMinimax, brandMistral, brandNearai, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandTencent, brandXai, brandXiaomiMimo] as const satisfies readonly BrandDescriptor[]
-export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelFireworksMerged, modelGemini, modelGlm, modelGpt, modelKimi, modelLlama, modelLongcat, modelMinimax, modelMistral, modelNearai, modelNemotron, modelOpenaiCompatibleAlias, modelOpencode, modelQwen, modelTencent, modelXai, modelXiaomiMimo] as const satisfies readonly (readonly ModelDescriptor[])[]
+export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandFireworks, brandGemini, brandGlm, brandGpt, brandKimi, brandLing, brandLlama, brandLongcat, brandMinimax, brandMistral, brandNearai, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandTencent, brandXai, brandXiaomiMimo] as const satisfies readonly BrandDescriptor[]
+export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelFireworksMerged, modelGemini, modelGlm, modelGpt, modelKimi, modelLing, modelLlama, modelLongcat, modelMinimax, modelMistral, modelNearai, modelNemotron, modelOpenaiCompatibleAlias, modelOpencode, modelQwen, modelTencent, modelXai, modelXiaomiMimo] as const satisfies readonly (readonly ModelDescriptor[])[]
 export const MODEL_DESCRIPTORS = MODEL_DESCRIPTOR_GROUPS.flat() satisfies readonly ModelDescriptor[]
 
 export { PROVIDER_PRESET_MANIFEST, ORDERED_PROVIDER_PRESETS } from './integrationManifest.generated.js'

--- a/src/integrations/models/ling.ts
+++ b/src/integrations/models/ling.ts
@@ -1,0 +1,22 @@
+import { defineModel } from '../define.js'
+
+export default [
+  defineModel({
+    id: 'inclusionai/ling-3.0-flash:free',
+    label: 'Ling 3.0 Flash (free)',
+    brandId: 'ling',
+    vendorId: 'openai',
+    classification: ['chat', 'reasoning', 'coding'],
+    defaultModel: 'inclusionai/ling-3.0-flash:free',
+    capabilities: {
+      supportsVision: false,
+      supportsStreaming: true,
+      supportsFunctionCalling: true,
+      supportsJsonMode: false,
+      supportsReasoning: true,
+      supportsPreciseTokenCount: false,
+    },
+    contextWindow: 262_144,
+    maxOutputTokens: 32_768,
+  }),
+]


### PR DESCRIPTION
## Summary

Adds **Ling 3.0 Flash (free)** — `inclusionai/ling-3.0-flash:free` — to the Opengateway model catalog. 124B-parameter MoE (~5.1B active per token) by InclusionAI, tuned for token-efficient agentic inference.

## Changes

- **New brand** `src/integrations/brands/ling.ts` — Ling family, OpenAI-compatible transport.
- **New model descriptor** `src/integrations/models/ling.ts` — 262K context, 32K max output, reasoning + function calling enabled, vision off. `supportsJsonMode` is off because the serving endpoint does not list `response_format` in its supported parameters.
- **Gateway catalog entry** in `src/integrations/gateways/gitlawb-opengateway.ts` — `Ling 3.0 Flash Free (via Opengateway)`, tagged `Free`, listed next to Nemotron 3 Ultra Free.
- Regenerated `integrationArtifacts.generated.ts` via `bun run integrations:generate`.

## Notes

- The model is free for everyone on the gateway — `$0` billing, no credits needed, works with an empty balance (same credit-gate bypass as Nemotron).
- **Time-boxed**: the gateway's free window runs until **2026-08-03 10:00 UTC**, after which the gateway delists the id automatically. This catalog entry should be removed in a follow-up after that date.
- Tool calling and streaming were live-verified through the gateway before this change (`finish_reason: tool_calls`, streamed chunks OK).
- Reasoning model: very small `max_tokens` values get consumed by reasoning tokens — clients should send ≥300.

## Testing

- `bun test src/integrations` — 306 pass, 0 fail (includes the registry test cross-checking every catalog entry against its descriptor).
- `bun run integrations:check` clean after regeneration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for the Ling 3.0 Flash free model.
  - Added Ling model availability through the OpenGateway integration.
  - Enabled streaming, function calling, and reasoning capabilities for the model.
  - Model availability is scheduled to end on August 3, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->