### PR TITLE
fix(web): make web/ build standalone — stop importing the repo-root p…

### DIFF
--- a/web/scripts/verify-dist.test.ts
+++ b/web/scripts/verify-dist.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { verifyDist } from './verify-dist'
+import { verifyDist, npmFreshnessFailure } from './verify-dist'
 import { SITE } from '../src/data/site'
 import { docsPages } from '../src/data/docsNav'
 import { releases, releaseUrl } from '../src/data/releases'
@@ -122,5 +122,37 @@ describe('verifyDist', () => {
       writeFileSync(join(dist, 'changelog', 'index.html'), html)
     })
     expect(failures.some(f => f.startsWith('changelog release URL'))).toBe(true)
+  })
+})
+
+describe('npmFreshnessFailure', () => {
+  function fetchReturning(body: unknown, ok = true): typeof fetch {
+    return (() =>
+      Promise.resolve({ ok, json: () => Promise.resolve(body) } as Response)) as typeof fetch
+  }
+
+  test('passes when npm matches the site version', async () => {
+    expect(await npmFreshnessFailure(fetchReturning({ version: SITE.version }))).toBeNull()
+  })
+
+  test('passes when the site is ahead of npm (release PR before publish)', async () => {
+    expect(await npmFreshnessFailure(fetchReturning({ version: '0.1.0' }))).toBeNull()
+  })
+
+  test('fails when npm has a newer release than releases.ts', async () => {
+    const failure = await npmFreshnessFailure(fetchReturning({ version: '999.0.0' }))
+    expect(failure).toContain('999.0.0')
+    expect(failure).toContain('src/data/releases.ts')
+  })
+
+  test('skips on network failure instead of breaking the build', async () => {
+    const offline = (() => Promise.reject(new Error('offline'))) as typeof fetch
+    expect(await npmFreshnessFailure(offline)).toBeNull()
+  })
+
+  test('skips on a malformed registry response', async () => {
+    expect(await npmFreshnessFailure(fetchReturning({}))).toBeNull()
+    expect(await npmFreshnessFailure(fetchReturning({ version: 'not-semver' }))).toBeNull()
+    expect(await npmFreshnessFailure(fetchReturning({}, false))).toBeNull()
   })
 })

--- a/web/scripts/verify-dist.test.ts
+++ b/web/scripts/verify-dist.test.ts
@@ -153,6 +153,8 @@ describe('npmFreshnessFailure', () => {
   test('skips on a malformed registry response', async () => {
     expect(await npmFreshnessFailure(fetchReturning({}))).toBeNull()
     expect(await npmFreshnessFailure(fetchReturning({ version: 'not-semver' }))).toBeNull()
+    expect(await npmFreshnessFailure(fetchReturning({ version: '01.2.3' }))).toBeNull()
+    expect(await npmFreshnessFailure(fetchReturning({ version: '999.00.0' }))).toBeNull()
     expect(await npmFreshnessFailure(fetchReturning({}, false))).toBeNull()
   })
 })

--- a/web/scripts/verify-dist.ts
+++ b/web/scripts/verify-dist.ts
@@ -34,15 +34,9 @@ export function verifyDist(dist: string): string[] {
     if (html !== '' && !html.includes(needle)) failures.push(`${why}: missing ${JSON.stringify(needle)}`)
   }
 
-  // ── version propagation (site.ts imports the root package.json) ──────────
-  const rootPkg = JSON.parse(
-    readFileSync(join(import.meta.dir, '..', '..', 'package.json'), 'utf8'),
-  ) as { version: string }
-  if (SITE.version !== rootPkg.version)
-    failures.push(`SITE.version ${SITE.version} != root package.json ${rootPkg.version}`)
-
+  // ── version propagation (site.ts derives from the newest releases entry) ─
   const index = page('/')
-  expect(index, `v${rootPkg.version}`, 'landing version')
+  expect(index, `v${SITE.version}`, 'landing version')
 
   // ── navigation exposes every docsNav route, in data AND rendered output ──
   const docsIndex = page('/docs/')
@@ -61,7 +55,7 @@ export function verifyDist(dist: string): string[] {
     expect(changelog, `v${r.version}`, `changelog release ${r.version}`)
     expect(changelog, releaseUrl(r.version), `changelog release URL ${r.version}`)
   }
-  expect(changelog, `v${rootPkg.version}`, 'changelog current-version pill')
+  expect(changelog, `v${SITE.version}`, 'changelog current-version pill')
 
   // ── /buddy/: every hero renders with its sprite ──────────────────────────
   const buddy = page('/buddy/')
@@ -92,8 +86,41 @@ export function verifyDist(dist: string): string[] {
   return [...new Set(failures)]
 }
 
+function newerThan(a: string, b: string): boolean {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) !== (pb[i] ?? 0)) return (pa[i] ?? 0) > (pb[i] ?? 0)
+  }
+  return false
+}
+
+// With web/ standalone, releases.ts is the only version source — this is the
+// guard against it silently going stale. Best-effort by design: an unreachable
+// registry (offline CI, npm outage) skips the check rather than failing the
+// build; only a *confirmed newer* npm release fails. A site version ahead of
+// npm is allowed so a release PR can land before the publish completes.
+export async function npmFreshnessFailure(fetchImpl: typeof fetch = fetch): Promise<string | null> {
+  let published: string
+  try {
+    const res = await fetchImpl('https://registry.npmjs.org/@gitlawb/openclaude/latest', {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return null
+    published = ((await res.json()) as { version?: string }).version ?? ''
+  } catch {
+    return null
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(published)) return null
+  if (newerThan(published, SITE.version))
+    return `npm latest ${published} is newer than site version ${SITE.version} — add it to src/data/releases.ts`
+  return null
+}
+
 if (import.meta.main) {
   const failures = verifyDist(join(import.meta.dir, '..', 'dist'))
+  const stale = await npmFreshnessFailure()
+  if (stale) failures.push(stale)
   if (failures.length > 0) {
     console.error(`verify-dist: ${failures.length} failure(s)`)
     for (const f of failures) console.error(`  ✗ ${f}`)

--- a/web/scripts/verify-dist.ts
+++ b/web/scripts/verify-dist.ts
@@ -111,7 +111,7 @@ export async function npmFreshnessFailure(fetchImpl: typeof fetch = fetch): Prom
   } catch {
     return null
   }
-  if (!/^\d+\.\d+\.\d+$/.test(published)) return null
+  if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(published)) return null
   if (newerThan(published, SITE.version))
     return `npm latest ${published} is newer than site version ${SITE.version} — add it to src/data/releases.ts`
   return null

--- a/web/src/data/releases.ts
+++ b/web/src/data/releases.ts
@@ -122,3 +122,8 @@ export const releases: Release[] = [
     ],
   },
 ]
+
+// web/ builds standalone (no access to the repo root), so the newest changelog
+// entry doubles as the site's displayed version. verify-dist cross-checks it
+// against the published npm version so this list can't silently go stale.
+export const latestVersion = releases[0].version

--- a/web/src/data/site.ts
+++ b/web/src/data/site.ts
@@ -1,4 +1,4 @@
-import pkg from '../../../package.json'
+import { latestVersion } from './releases'
 
 export const SITE = {
   url: 'https://openclaude.gitlawb.com',
@@ -11,7 +11,7 @@ export const SITE = {
   github: 'https://github.com/Gitlawb/openclaude',
   gitlawb: 'https://gitlawb.com',
   gitlawbRepo: 'https://gitlawb.com/node/repos/z6MkqDnb/openclaude',
-  version: pkg.version,
+  version: latestVersion,
   ogDefault: '/og/default.png',
   ogDocs: '/og/docs.png',
 } as const


### PR DESCRIPTION
## Summary

`vercel --prod` (run from `web/`) uploads only the `web/` directory, but `src/data/site.ts` imported `../../../package.json` and `scripts/verify-dist.ts` read the same file — so every Vercel build died in `astro check` with `ts(2307): Cannot find module '../../../package.json'` while local `bun run build` passed. This makes `web/` fully standalone:

- `SITE.version` now derives from `latestVersion`, a new export of `src/data/releases.ts` that reads the newest changelog entry — committed data inside `web/`, so builds are deterministic and need nothing outside the directory. Updating the changelog for a release *is* the version bump.
- `verify-dist` replaces the root-package.json comparison with a best-effort npm freshness guard: after the build it queries `registry.npmjs.org/@gitlawb/openclaude/latest` and fails only when npm reports a **newer** version than `releases.ts`. Unreachable registry or malformed responses skip the check (offline CI / npm outages can't break deploys), and site-ahead-of-npm is allowed so a release PR can land before the publish completes.

## Impact

- Vercel deploys from `web/` work again (production was failing since the v0.26 refresh landed; last good deploy was 47 days old).
- The version-staleness protection the old check provided is preserved, now against the actually published npm version instead of the local repo state.
- No rendered-output changes: the site still shows v0.26.0 everywhere.

## Testing

- [x] `bun run build` in `web/` — astro check 0 errors, `verify-dist: ok`
- [x] `bun test web/scripts/verify-dist.test.ts` from the repo root — 14 pass (5 new tests cover the freshness guard via injected fetch: match, site-ahead, npm-newer, offline, malformed response)
- [x] Vercel preview deploy → `Ready`
- [x] `vercel --prod` → `Ready`; https://openclaude.gitlawb.com serves the new build showing v0.26.0

## Notes

- The npm check runs only under `import.meta.main`, so importing `verify-dist.ts` in tests never touches the network.
- Alternative considered: fetching the version from npm at build time — rejected because it makes builds non-reproducible and could render a version the changelog doesn't list; npm is used only as a cross-check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version consistency across the website, landing page, and changelog using the latest published site version.
  * Added a stricter npm freshness check to detect when the registry version is confirmed newer than the site version.
  * Prevented version checks from incorrectly failing on network issues or malformed/invalid registry responses.
* **Tests**
  * Expanded verification coverage for matching versions, newer npm releases, fetch/network failures, and invalid registry payloads (e.g., missing or non-semver version fields).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->