### PR TITLE
fix(openai-shim): stop tool-result filler stall on local OpenAI backends

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -235,8 +235,9 @@ export OPENAI_MODEL=/models/your-model.gguf
 
 OpenClaude never inserts the Mistral/Devstral tool-boundary placeholder
 (`[Tool results received]`) for local OpenAI-compatible hosts (loopback,
-RFC1918, `.local`, Ollama). That filler is reserved for Mistral cloud routes
-and `CLAUDE_CODE_USE_MISTRAL=1` on non-local endpoints so quantized local
+RFC1918, `.local`) or Ollama endpoints. That filler is reserved for Mistral
+cloud routes, `CLAUDE_CODE_USE_MISTRAL=1` on non-local endpoints, and
+non-local model ids that clearly look Mistral-class, so quantized local
 models do not imitate it and end the turn early.
 
 If a local model still echoes short repeated phrases, enable server-side

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -235,10 +235,11 @@ export OPENAI_MODEL=/models/your-model.gguf
 
 OpenClaude never inserts the Mistral/Devstral tool-boundary placeholder
 (`[Tool results received]`) for local OpenAI-compatible hosts (loopback,
-RFC1918, `.local`) or Ollama endpoints. That filler is reserved for Mistral
-cloud routes, `CLAUDE_CODE_USE_MISTRAL=1` on non-local endpoints, and
-non-local model ids that clearly look Mistral-class, so quantized local
-models do not imitate it and end the turn early.
+RFC1918, CGNAT/`100.64/10`, `host.docker.internal`, `.local`) or Ollama
+endpoints. That filler is reserved for Mistral cloud routes,
+`CLAUDE_CODE_USE_MISTRAL=1` on non-local endpoints, and non-local model ids
+that clearly look Mistral-class, so quantized local models do not imitate it
+and end the turn early.
 
 If a local model still echoes short repeated phrases, enable server-side
 `repeat_penalty` / DRY sampling (llama.cpp defaults often leave

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -233,11 +233,11 @@ export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
 export OPENAI_MODEL=/models/your-model.gguf
 ```
 
-OpenClaude only inserts the Mistral/Devstral tool-boundary placeholder
-(`[Tool results received]`) when the active route is Mistral-class. Local
-servers such as llama.cpp, Ollama, and vLLM keep a plain `tool` → `user`
-history so quantized models do not imitate that placeholder and end the turn
-early.
+OpenClaude never inserts the Mistral/Devstral tool-boundary placeholder
+(`[Tool results received]`) for local OpenAI-compatible hosts (loopback,
+RFC1918, `.local`, Ollama). That filler is reserved for Mistral cloud routes
+and `CLAUDE_CODE_USE_MISTRAL=1` on non-local endpoints so quantized local
+models do not imitate it and end the turn early.
 
 If a local model still echoes short repeated phrases, enable server-side
 `repeat_penalty` / DRY sampling (llama.cpp defaults often leave

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -225,6 +225,24 @@ export OPENAI_BASE_URL=http://localhost:1234/v1
 export OPENAI_MODEL=your-model-name
 ```
 
+### llama.cpp / vLLM / other local OpenAI-compatible servers
+
+```bash
+export CLAUDE_CODE_USE_OPENAI=1
+export OPENAI_BASE_URL=http://127.0.0.1:8080/v1
+export OPENAI_MODEL=/models/your-model.gguf
+```
+
+OpenClaude only inserts the Mistral/Devstral tool-boundary placeholder
+(`[Tool results received]`) when the active route is Mistral-class. Local
+servers such as llama.cpp, Ollama, and vLLM keep a plain `tool` → `user`
+history so quantized models do not imitate that placeholder and end the turn
+early.
+
+If a local model still echoes short repeated phrases, enable server-side
+`repeat_penalty` / DRY sampling (llama.cpp defaults often leave
+`--repeat-penalty` at `1.0` and `dry_multiplier` at `0.0`).
+
 ### Together AI
 
 ```bash

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -235,11 +235,11 @@ export OPENAI_MODEL=/models/your-model.gguf
 
 OpenClaude never inserts the Mistral/Devstral tool-boundary placeholder
 (`[Tool results received]`) for local OpenAI-compatible hosts (loopback,
-RFC1918, CGNAT/`100.64/10`, `host.docker.internal`, `.local`) or Ollama
-endpoints. That filler is reserved for Mistral cloud routes,
-`CLAUDE_CODE_USE_MISTRAL=1` on non-local endpoints, and non-local model ids
-that clearly look Mistral-class, so quantized local models do not imitate it
-and end the turn early.
+RFC1918, CGNAT/`100.64/10`, `host.docker.internal`, reserved TLDs such as
+`.local` / `.localhost` / `.home.arpa` / `.lan`) or Ollama endpoints. That
+filler is reserved for Mistral cloud routes, `CLAUDE_CODE_USE_MISTRAL=1` on
+non-local endpoints, and non-local model ids that clearly look Mistral-class,
+so quantized local models do not imitate it and end the turn early.
 
 If a local model still echoes short repeated phrases, enable server-side
 `repeat_penalty` / DRY sampling (llama.cpp defaults often leave

--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -118,6 +118,8 @@ describe('Agent loop continuation nudge', () => {
       reason: 'tool_result_placeholder_echo',
     })
     expect(analyzeContinuationIntent('  [Tool results received]  ').shouldNudge).toBe(true)
+    expect(analyzeContinuationIntent('[Tool results received].').shouldNudge).toBe(true)
+    expect(analyzeContinuationIntent('"[Tool results received]"').shouldNudge).toBe(true)
     expect(
       analyzeContinuationIntent('Done. [Tool results received] and more text').shouldNudge,
     ).toBe(false)

--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -120,6 +120,7 @@ describe('Agent loop continuation nudge', () => {
     expect(analyzeContinuationIntent('  [Tool results received]  ').shouldNudge).toBe(true)
     expect(analyzeContinuationIntent('[Tool results received].').shouldNudge).toBe(true)
     expect(analyzeContinuationIntent('"[Tool results received]"').shouldNudge).toBe(true)
+    expect(analyzeContinuationIntent('[Tool results received],').shouldNudge).toBe(true)
     expect(
       analyzeContinuationIntent('Done. [Tool results received] and more text').shouldNudge,
     ).toBe(false)

--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -111,6 +111,16 @@ describe('Agent loop continuation nudge', () => {
     // Transition intent detected (requires explicit action verb or transition phrase)
     expect(analyzeContinuationIntent("So now I will start task 2").shouldNudge).toBe(true)
     expect(analyzeContinuationIntent("I will now do the following").shouldNudge).toBe(true)
+
+    // Model echoed the OpenAI-shim transport placeholder as its entire reply
+    expect(analyzeContinuationIntent('[Tool results received]')).toEqual({
+      shouldNudge: true,
+      reason: 'tool_result_placeholder_echo',
+    })
+    expect(analyzeContinuationIntent('  [Tool results received]  ').shouldNudge).toBe(true)
+    expect(
+      analyzeContinuationIntent('Done. [Tool results received] and more text').shouldNudge,
+    ).toBe(false)
     
     // Completion marker suppresses nudge
     expect(analyzeContinuationIntent("Task finished").shouldNudge).toBe(false)

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -8560,13 +8560,13 @@ test('providerOverride does not inherit parent CLAUDE_CODE_USE_MISTRAL for seman
   }) as unknown as FetchType
 
   process.env.CLAUDE_CODE_USE_MISTRAL = '1'
-  process.env.OPENAI_API_KEY = 'local'
+  process.env.OPENAI_API_KEY = 'remote-key'
 
   const client = createOpenAIShimClient({
     providerOverride: {
       model: 'Qwen3.6-35B-A3B',
-      baseURL: 'http://127.0.0.1:8080/v1',
-      apiKey: 'override-local',
+      baseURL: 'https://api.example.com/v1',
+      apiKey: 'override-remote',
     },
   }) as OpenAIShimClient
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -43,6 +43,7 @@ const originalEnv = {
   GH_TOKEN: process.env.GH_TOKEN,
   CLAUDE_CODE_USE_OPENAI: process.env.CLAUDE_CODE_USE_OPENAI,
   CLAUDE_CODE_USE_GEMINI: process.env.CLAUDE_CODE_USE_GEMINI,
+  CLAUDE_CODE_USE_MISTRAL: process.env.CLAUDE_CODE_USE_MISTRAL,
   GEMINI_API_KEY: process.env.GEMINI_API_KEY,
   GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
   GEMINI_ACCESS_TOKEN: process.env.GEMINI_ACCESS_TOKEN,
@@ -553,6 +554,7 @@ afterEach(() => {
     restoreEnv('GH_TOKEN', originalEnv.GH_TOKEN)
     restoreEnv('CLAUDE_CODE_USE_OPENAI', originalEnv.CLAUDE_CODE_USE_OPENAI)
     restoreEnv('CLAUDE_CODE_USE_GEMINI', originalEnv.CLAUDE_CODE_USE_GEMINI)
+    restoreEnv('CLAUDE_CODE_USE_MISTRAL', originalEnv.CLAUDE_CODE_USE_MISTRAL)
     restoreEnv('GEMINI_API_KEY', originalEnv.GEMINI_API_KEY)
     restoreEnv('GOOGLE_API_KEY', originalEnv.GOOGLE_API_KEY)
     restoreEnv('GEMINI_ACCESS_TOKEN', originalEnv.GEMINI_ACCESS_TOKEN)
@@ -8359,11 +8361,10 @@ test('preserves valid tool_result and drops orphan tool_result', async () => {
   const orphanMessage = toolMessages.find(m => m.tool_call_id === 'orphan_call_2')
   expect(orphanMessage).toBeUndefined()
   
-  // Actually, the semantic message IS injected here because the user block with orphan 
-  // tool result is converted to:
+  // Mistral model name triggers the Mistral-only tool→user semantic boundary.
   // 1. Tool result (valid_call_1) -> role 'tool'
   // 2. User content ("What happened?") -> role 'user'
-  // This triggers the tool -> assistant injection.
+  // This triggers the tool -> assistant injection for Mistral.
   const assistantMessages = messages.filter(m => m.role === 'assistant')
   expect(assistantMessages.some(m => m.content === '[Tool results received]')).toBe(true)
 })
@@ -8497,6 +8498,50 @@ test('injects semantic assistant message when tool result is followed by user me
   expect(semanticMsg.content).toBe('[Tool results received]')
   expect(semanticMsg.content).not.toContain('interrupted')
   expect(semanticMsg.content).not.toContain('user')
+})
+
+test('does not inject semantic assistant message for non-Mistral OpenAI-compatible models', async () => {
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(JSON.stringify({
+      id: 'chatcmpl-3',
+      object: 'chat.completion',
+      created: 123456789,
+      model: 'Qwen3.6-35B-A3B',
+      choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }), { headers: { 'Content-Type': 'application/json' } })
+  }) as unknown as FetchType
+
+  process.env.OPENAI_BASE_URL = 'http://127.0.0.1:8080/v1'
+  process.env.OPENAI_API_KEY = 'local'
+  process.env.OPENAI_MODEL = 'Qwen3.6-35B-A3B'
+  delete process.env.CLAUDE_CODE_USE_MISTRAL
+
+  const client = createOpenAIShimClient({}) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'Qwen3.6-35B-A3B',
+    messages: [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'call_1', name: 'search', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'Result' }],
+      },
+      { role: 'user', content: 'Next user query' },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  expect(messages.map(m => m.role)).toEqual(['assistant', 'tool', 'user'])
+  expect(messages.some(m => m.content === '[Tool results received]')).toBe(false)
 })
 // openaiShim test extraction seam 136 end
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -8543,6 +8543,54 @@ test('does not inject semantic assistant message for non-Mistral OpenAI-compatib
   expect(messages.map(m => m.role)).toEqual(['assistant', 'tool', 'user'])
   expect(messages.some(m => m.content === '[Tool results received]')).toBe(false)
 })
+
+test('providerOverride does not inherit parent CLAUDE_CODE_USE_MISTRAL for semantic boundary', async () => {
+  let requestBody: Record<string, unknown> | undefined
+
+  globalThis.fetch = (async (_input, init) => {
+    requestBody = JSON.parse(String(init?.body))
+    return new Response(JSON.stringify({
+      id: 'chatcmpl-4',
+      object: 'chat.completion',
+      created: 123456789,
+      model: 'Qwen3.6-35B-A3B',
+      choices: [{ message: { role: 'assistant', content: 'hi' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 }
+    }), { headers: { 'Content-Type': 'application/json' } })
+  }) as unknown as FetchType
+
+  process.env.CLAUDE_CODE_USE_MISTRAL = '1'
+  process.env.OPENAI_API_KEY = 'local'
+
+  const client = createOpenAIShimClient({
+    providerOverride: {
+      model: 'Qwen3.6-35B-A3B',
+      baseURL: 'http://127.0.0.1:8080/v1',
+      apiKey: 'override-local',
+    },
+  }) as OpenAIShimClient
+
+  await client.beta.messages.create({
+    model: 'mistral-large-latest',
+    messages: [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'call_1', name: 'search', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'Result' }],
+      },
+      { role: 'user', content: 'Next user query' },
+    ],
+    max_tokens: 64,
+    stream: false,
+  })
+
+  const messages = requestBody?.messages as Array<Record<string, unknown>>
+  expect(messages.map(m => m.role)).toEqual(['assistant', 'tool', 'user'])
+  expect(messages.some(m => m.content === '[Tool results received]')).toBe(false)
+})
 // openaiShim test extraction seam 136 end
 
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -1046,8 +1046,16 @@ class OpenAIShimMessages {
     params: ShimCreateParams,
     options?: { signal?: AbortSignal; headers?: Record<string, string> },
   ) {
+    // A provider override is a complete route, so it must not inherit an
+    // Azure-style escape hatch or Mistral selector intended for the parent.
+    // Otherwise a Mistral parent still injects [Tool results received] into a
+    // Qwen/llama override and reintroduces the post-tool stall (#2039/#2059).
     const requestProcessEnv = this.providerOverride
-      ? { ...process.env, OPENAI_AZURE_STYLE: undefined }
+      ? {
+          ...process.env,
+          OPENAI_AZURE_STYLE: undefined,
+          CLAUDE_CODE_USE_MISTRAL: undefined,
+        }
       : process.env
     return createShimRequest(params, options, {
       providerOverride: this.providerOverride,

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -107,6 +107,8 @@ import {
   resolveRuntimeCodexCredentials,
   resolveProviderRequest,
   shouldAttemptLocalToollessRetry,
+  shouldInjectToolResultSemanticBoundary,
+  TOOL_RESULT_SEMANTIC_PLACEHOLDER,
   type LocalFastPathConfig,
 } from './providerConfig.js'
 import {
@@ -765,6 +767,8 @@ function convertMessages(
     reasoningContentFallback?: '' | 'omit'
     preserveGeminiThoughtSignature?: boolean
     supportsImageInputs?: boolean
+    injectToolResultSemanticBoundary?: boolean
+    toolResultSemanticPlaceholder?: string
   },
 ): OpenAIMessage[] {
   return convertAnthropicMessages(messages, system, {
@@ -1281,6 +1285,12 @@ class OpenAIShimMessages {
           request.baseUrl,
         ),
         supportsImageInputs: shimConfig.supportsImageInputs,
+        injectToolResultSemanticBoundary: shouldInjectToolResultSemanticBoundary({
+          baseUrl: request.baseUrl,
+          model: request.resolvedModel,
+          processEnv: requestProcessEnv,
+        }),
+        toolResultSemanticPlaceholder: TOOL_RESULT_SEMANTIC_PLACEHOLDER,
       }),
     )
 

--- a/src/services/api/openaiShim/messageConversion.test.ts
+++ b/src/services/api/openaiShim/messageConversion.test.ts
@@ -234,6 +234,22 @@ test('strips prior placeholder-only assistant echoes from converted history', ()
   expect(messages.some(message => message.content === '[Tool results received]')).toBe(false)
 })
 
+test('strips punctuated and quoted placeholder-only assistant echoes from converted history', () => {
+  for (const echo of [
+    '[Tool results received].',
+    '"[Tool results received]"',
+    '[tool results received]',
+  ]) {
+    const messages = convert([
+      { role: 'user', content: 'Start' },
+      { role: 'assistant', content: echo },
+      { role: 'user', content: 'Continue the task' },
+    ])
+    expect(messages.map(message => message.role)).toEqual(['user'])
+    expect(messages.some(message => String(message.content ?? '').includes('Tool results'))).toBe(false)
+  }
+})
+
 test('collapses multiple text blocks in tool_result to string for DeepSeek compatibility (issue #774)', () => {
   const messages = convert(toolExchange([
     { type: 'text', text: 'line one' },

--- a/src/services/api/openaiShim/messageConversion.test.ts
+++ b/src/services/api/openaiShim/messageConversion.test.ts
@@ -200,7 +200,7 @@ test('injects semantic assistant message when tool result is followed by user me
   expect(messages[2]?.content).not.toContain('interrupted')
 })
 
-test('does not inject placeholder after tool result when next user message is snip-only reminder', () => {
+test('default conversion keeps tool then snip reminder without placeholder', () => {
   const messages = convert([
     {
       role: 'assistant',

--- a/src/services/api/openaiShim/messageConversion.test.ts
+++ b/src/services/api/openaiShim/messageConversion.test.ts
@@ -200,6 +200,40 @@ test('injects semantic assistant message when tool result is followed by user me
   expect(messages[2]?.content).not.toContain('interrupted')
 })
 
+test('does not inject placeholder after tool result when next user message is snip-only reminder', () => {
+  const messages = convert([
+    {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 'call_1', name: 'Bash', input: { command: 'pwd' } }],
+    },
+    {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'call_1', content: '/tmp' }],
+    },
+    {
+      role: 'user',
+      content: '<system-reminder>snip_id=abc123</system-reminder>',
+    },
+  ])
+
+  expect(messages.map(message => message.role)).toEqual(['assistant', 'tool', 'user'])
+  expect(messages.some(message => message.content === '[Tool results received]')).toBe(false)
+  expect(String(messages[2]?.content)).toContain('snip_id=abc123')
+})
+
+test('strips prior placeholder-only assistant echoes from converted history', () => {
+  const messages = convert([
+    { role: 'user', content: 'Start' },
+    { role: 'assistant', content: '[Tool results received]' },
+    { role: 'user', content: 'Continue the task' },
+  ])
+
+  expect(messages.map(message => message.role)).toEqual(['user'])
+  expect(String(messages[0]?.content)).toContain('Start')
+  expect(String(messages[0]?.content)).toContain('Continue the task')
+  expect(messages.some(message => message.content === '[Tool results received]')).toBe(false)
+})
+
 test('collapses multiple text blocks in tool_result to string for DeepSeek compatibility (issue #774)', () => {
   const messages = convert(toolExchange([
     { type: 'text', text: 'line one' },

--- a/src/services/api/openaiShim/messageConversion.test.ts
+++ b/src/services/api/openaiShim/messageConversion.test.ts
@@ -136,7 +136,8 @@ test('preserves valid tool_result and drops orphan tool_result', () => {
 
   expect(tools).toHaveLength(1)
   expect(tools[0]?.tool_call_id).toBe('valid_call_1')
-  expect(messages.some(message => message.content === '[Tool results received]')).toBe(true)
+  // Default conversion must not inject the Mistral-only semantic placeholder.
+  expect(messages.some(message => message.content === '[Tool results received]')).toBe(false)
   expect(logs).toContain('Dropping orphan tool_result for ID: orphan_call_2 to prevent API error')
 })
 
@@ -160,7 +161,7 @@ test('drops empty assistant message when only redacted_thinking block was presen
   expect(messages).toEqual([{ role: 'user', content: 'Initial\nInterrupting query' }])
 })
 
-test('injects semantic assistant message when tool result is followed by user message', () => {
+test('does not inject semantic assistant message between tool and user by default', () => {
   const messages = convert([
     {
       role: 'assistant',
@@ -172,6 +173,27 @@ test('injects semantic assistant message when tool result is followed by user me
     },
     { role: 'user', content: 'Next user query' },
   ])
+
+  expect(messages.map(message => message.role)).toEqual(['assistant', 'tool', 'user'])
+  expect(messages.some(message => message.content === '[Tool results received]')).toBe(false)
+})
+
+test('injects semantic assistant message when tool result is followed by user message and opted in', () => {
+  const messages = convertMessages(
+    [
+      {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 'call_1', name: 'search', input: {} }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'Result' }],
+      },
+      { role: 'user', content: 'Next user query' },
+    ],
+    '',
+    { injectToolResultSemanticBoundary: true },
+  )
 
   expect(messages.map(message => message.role)).toEqual(['assistant', 'tool', 'assistant', 'user'])
   expect(messages[2]?.content).toBe('[Tool results received]')

--- a/src/services/api/openaiShim/messageConversion.ts
+++ b/src/services/api/openaiShim/messageConversion.ts
@@ -1,4 +1,7 @@
-import { TOOL_RESULT_SEMANTIC_PLACEHOLDER } from '../providerConfig.js'
+import {
+  isToolResultSemanticPlaceholderEcho,
+  TOOL_RESULT_SEMANTIC_PLACEHOLDER,
+} from '../providerConfig.js'
 
 export type OpenAIContentPart =
   | { type: 'text'; text: string }
@@ -22,7 +25,7 @@ function isPlaceholderOnlyAssistantContent(
   content: ConvertedOpenAIMessage['content'],
 ): boolean {
   if (typeof content !== 'string') return false
-  return content.trim() === TOOL_RESULT_SEMANTIC_PLACEHOLDER
+  return isToolResultSemanticPlaceholderEcho(content)
 }
 
 export function convertSystemPrompt(system: unknown): string {

--- a/src/services/api/openaiShim/messageConversion.ts
+++ b/src/services/api/openaiShim/messageConversion.ts
@@ -146,6 +146,15 @@ export function convertMessages(
     reasoningContentFallback?: '' | 'omit'
     preserveGeminiThoughtSignature?: boolean
     supportsImageInputs?: boolean
+    /**
+     * When true, insert a synthetic assistant message between `tool` and
+     * `user` roles (Mistral/Devstral Jinja only). Default false — injecting
+     * a static placeholder for other backends causes models to echo it as a
+     * terminal reply (issues #2039, #2059).
+     */
+    injectToolResultSemanticBoundary?: boolean
+    /** Placeholder text used when injectToolResultSemanticBoundary is true. */
+    toolResultSemanticPlaceholder?: string
     getGeminiThoughtSignature?: (extraContent: unknown) => string | undefined
     mergeGeminiThoughtSignature?: (
       extraContent: Record<string, unknown> | undefined,
@@ -259,10 +268,24 @@ export function convertMessages(
   }
 
   const coalesced: ConvertedOpenAIMessage[] = []
+  const injectToolResultSemanticBoundary =
+    options.injectToolResultSemanticBoundary === true
+  const toolResultSemanticPlaceholder =
+    options.toolResultSemanticPlaceholder ?? '[Tool results received]'
   for (const msg of result) {
     const prev = coalesced[coalesced.length - 1]
-    if (prev?.role === 'tool' && msg.role === 'user') {
-      coalesced.push({ role: 'assistant', content: '[Tool results received]' })
+    // Mistral/Devstral only (opt-in): 'tool' must be followed by 'assistant'
+    // before 'user'. Other OpenAI-compatible backends must keep tool→user so
+    // the placeholder is not echoed as a real end_turn reply.
+    if (
+      injectToolResultSemanticBoundary &&
+      prev?.role === 'tool' &&
+      msg.role === 'user'
+    ) {
+      coalesced.push({
+        role: 'assistant',
+        content: toolResultSemanticPlaceholder,
+      })
     }
     const last = coalesced[coalesced.length - 1]
     if (!last || last.role !== msg.role || msg.role === 'tool' || msg.role === 'system') {

--- a/src/services/api/openaiShim/messageConversion.ts
+++ b/src/services/api/openaiShim/messageConversion.ts
@@ -1,3 +1,5 @@
+import { TOOL_RESULT_SEMANTIC_PLACEHOLDER } from '../providerConfig.js'
+
 export type OpenAIContentPart =
   | { type: 'text'; text: string }
   | { type: 'image_url'; image_url: { url: string } }
@@ -14,6 +16,13 @@ export type ConvertedOpenAIMessage = {
   tool_call_id?: string
   name?: string
   reasoning_content?: string
+}
+
+function isPlaceholderOnlyAssistantContent(
+  content: ConvertedOpenAIMessage['content'],
+): boolean {
+  if (typeof content !== 'string') return false
+  return content.trim() === TOOL_RESULT_SEMANTIC_PLACEHOLDER
 }
 
 export function convertSystemPrompt(system: unknown): string {
@@ -213,7 +222,11 @@ export function convertMessages(
     if (!Array.isArray(content)) {
       const converted = convertContentBlocks(content, options)
       const text = typeof converted === 'string' ? converted : joinTextContentParts(converted)
-      if (text) result.push({ role: 'assistant', content: text })
+      // Drop prior model echoes of the transport-only placeholder so resumed
+      // sessions do not keep teaching the model to imitate it.
+      if (text && !isPlaceholderOnlyAssistantContent(text)) {
+        result.push({ role: 'assistant', content: text })
+      }
       continue
     }
     const toolUses: Array<{
@@ -264,14 +277,19 @@ export function convertMessages(
       mappedToolCalls.push(toolCall)
     }
     if (mappedToolCalls.length) assistantMsg.tool_calls = mappedToolCalls
-    if (assistantMsg.content || assistantMsg.tool_calls?.length) result.push(assistantMsg)
+    const placeholderOnly =
+      !assistantMsg.tool_calls?.length &&
+      isPlaceholderOnlyAssistantContent(assistantMsg.content)
+    if ((assistantMsg.content || assistantMsg.tool_calls?.length) && !placeholderOnly) {
+      result.push(assistantMsg)
+    }
   }
 
   const coalesced: ConvertedOpenAIMessage[] = []
   const injectToolResultSemanticBoundary =
     options.injectToolResultSemanticBoundary === true
   const toolResultSemanticPlaceholder =
-    options.toolResultSemanticPlaceholder ?? '[Tool results received]'
+    options.toolResultSemanticPlaceholder ?? TOOL_RESULT_SEMANTIC_PLACEHOLDER
   for (const msg of result) {
     const prev = coalesced[coalesced.length - 1]
     // Mistral/Devstral only (opt-in): 'tool' must be followed by 'assistant'

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -168,6 +168,15 @@ test('semantic tool-result boundary is Mistral-only and never local', () => {
       processEnv: { CLAUDE_CODE_USE_MISTRAL: '1' },
     }),
   ).toBe(true)
+
+  // Ollama endpoints are excluded even when the hostname is not loopback.
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'http://ollama:11434/v1',
+      model: 'mistral:latest',
+      processEnv: {},
+    }),
+  ).toBe(false)
 })
 
 test('creates a cache scope for local openai-compatible providers', () => {

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -92,7 +92,7 @@ test('treats public hosts as remote', () => {
   expect(isLocalProviderUrl('http://[2001:4860:4860::8888]:11434/v1')).toBe(false)
 })
 
-test('semantic tool-result boundary is Mistral-only', () => {
+test('semantic tool-result boundary is Mistral-only and never local', () => {
   expect(TOOL_RESULT_SEMANTIC_PLACEHOLDER).toBe('[Tool results received]')
 
   expect(
@@ -128,13 +128,14 @@ test('semantic tool-result boundary is Mistral-only', () => {
     }),
   ).toBe(false)
 
+  // Local hosts never inject, even for Mistral-class model names.
   expect(
     shouldInjectToolResultSemanticBoundary({
       baseUrl: 'http://127.0.0.1:8080/v1',
       model: 'devstral-small',
       processEnv: {},
     }),
-  ).toBe(true)
+  ).toBe(false)
 
   expect(
     shouldInjectToolResultSemanticBoundary({
@@ -142,13 +143,29 @@ test('semantic tool-result boundary is Mistral-only', () => {
       model: 'qwen',
       processEnv: { CLAUDE_CODE_USE_MISTRAL: '1' },
     }),
-  ).toBe(true)
+  ).toBe(false)
 
   expect(
     shouldInjectToolResultSemanticBoundary({
       baseUrl: 'https://api.mistral.ai/v1',
       model: 'qwen',
       processEnv: {},
+    }),
+  ).toBe(true)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'https://api.example.com/v1',
+      model: 'devstral-small',
+      processEnv: {},
+    }),
+  ).toBe(true)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'https://api.example.com/v1',
+      model: 'qwen',
+      processEnv: { CLAUDE_CODE_USE_MISTRAL: '1' },
     }),
   ).toBe(true)
 })

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -185,6 +185,22 @@ test('semantic tool-result boundary is Mistral-only and never local', () => {
       processEnv: {},
     }),
   ).toBe(false)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'http://host.docker.internal:8080/v1',
+      model: 'mistral-7b-instruct',
+      processEnv: {},
+    }),
+  ).toBe(false)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'http://100.64.1.5:8080/v1',
+      model: 'devstral-small',
+      processEnv: {},
+    }),
+  ).toBe(false)
 })
 
 test('creates a cache scope for local openai-compatible providers', () => {

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -84,6 +84,9 @@ test('treats private IPv6 endpoints as local', () => {
   expect(isLocalProviderUrl('http://[fd00::1]:11434/v1')).toBe(true)
   expect(isLocalProviderUrl('http://[fe80::1]:11434/v1')).toBe(true)
   expect(isLocalProviderUrl('http://[::1]:11434/v1')).toBe(true)
+  expect(isLocalProviderUrl('http://[::ffff:127.0.0.1]:11434/v1')).toBe(true)
+  expect(isLocalProviderUrl('http://[::ffff:10.0.0.5]:11434/v1')).toBe(true)
+  expect(isLocalProviderUrl('http://[::ffff:100.64.1.5]:11434/v1')).toBe(true)
 })
 
 test('treats public hosts as remote', () => {

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -81,7 +81,10 @@ test('treats .local hostnames as local', () => {
   expect(isLocalProviderUrl('http://llm.localhost:8080/v1')).toBe(true)
   expect(isLocalProviderUrl('http://vllm.home.arpa:8080/v1')).toBe(true)
   expect(isLocalProviderUrl('http://gpu.lan:8080/v1')).toBe(true)
-  expect(isLocalProviderUrl('http://proxy.internal:8080/v1')).toBe(true)
+  // Corporate/custom proxy suffixes must remain non-local.
+  expect(isLocalProviderUrl('http://proxy.internal:8080/v1')).toBe(false)
+  expect(isLocalProviderUrl('http://proxy.intranet:8080/v1')).toBe(false)
+  expect(isLocalProviderUrl('https://my-proxy.internal/v1')).toBe(false)
 })
 
 test('treats private IPv6 endpoints as local', () => {

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -164,6 +164,14 @@ test('semantic tool-result boundary is Mistral-only and never local', () => {
   expect(
     shouldInjectToolResultSemanticBoundary({
       baseUrl: 'https://api.example.com/v1',
+      model: 'mixtral-8x7b-instruct',
+      processEnv: {},
+    }),
+  ).toBe(true)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'https://api.example.com/v1',
       model: 'qwen',
       processEnv: { CLAUDE_CODE_USE_MISTRAL: '1' },
     }),

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -9,6 +9,8 @@ import {
   modelRequiresResponsesApi,
   resolveProviderRequest,
   shouldAttemptLocalToollessRetry,
+  shouldInjectToolResultSemanticBoundary,
+  TOOL_RESULT_SEMANTIC_PLACEHOLDER,
 } from './providerConfig.js'
 
 const originalEnv = {
@@ -88,6 +90,67 @@ test('treats public hosts as remote', () => {
   expect(isLocalProviderUrl('http://203.0.113.1:11434/v1')).toBe(false)
   expect(isLocalProviderUrl('https://example.com/v1')).toBe(false)
   expect(isLocalProviderUrl('http://[2001:4860:4860::8888]:11434/v1')).toBe(false)
+})
+
+test('semantic tool-result boundary is Mistral-only', () => {
+  expect(TOOL_RESULT_SEMANTIC_PLACEHOLDER).toBe('[Tool results received]')
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'http://localhost:8080/v1',
+      model: 'qwen3.6:35b',
+      processEnv: {},
+    }),
+  ).toBe(false)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'https://api.openai.com/v1',
+      model: 'gpt-4o',
+      processEnv: {},
+    }),
+  ).toBe(false)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'https://api.mistral.ai/v1',
+      model: 'mistral-large-latest',
+      processEnv: {},
+    }),
+  ).toBe(true)
+
+  // Substring must not match — only hostname mistral.ai / *.mistral.ai
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'https://mistral.ai-proxy.example/v1',
+      model: 'qwen3.6:35b',
+      processEnv: {},
+    }),
+  ).toBe(false)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'http://127.0.0.1:8080/v1',
+      model: 'devstral-small',
+      processEnv: {},
+    }),
+  ).toBe(true)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'http://127.0.0.1:8080/v1',
+      model: 'qwen',
+      processEnv: { CLAUDE_CODE_USE_MISTRAL: '1' },
+    }),
+  ).toBe(true)
+
+  expect(
+    shouldInjectToolResultSemanticBoundary({
+      baseUrl: 'https://api.mistral.ai/v1',
+      model: 'qwen',
+      processEnv: {},
+    }),
+  ).toBe(true)
 })
 
 test('creates a cache scope for local openai-compatible providers', () => {

--- a/src/services/api/providerConfig.local.test.ts
+++ b/src/services/api/providerConfig.local.test.ts
@@ -78,6 +78,10 @@ test('treats private IPv4 endpoints as local', () => {
 
 test('treats .local hostnames as local', () => {
   expect(isLocalProviderUrl('http://ollama.local:11434/v1')).toBe(true)
+  expect(isLocalProviderUrl('http://llm.localhost:8080/v1')).toBe(true)
+  expect(isLocalProviderUrl('http://vllm.home.arpa:8080/v1')).toBe(true)
+  expect(isLocalProviderUrl('http://gpu.lan:8080/v1')).toBe(true)
+  expect(isLocalProviderUrl('http://proxy.internal:8080/v1')).toBe(true)
 })
 
 test('treats private IPv6 endpoints as local', () => {

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -640,13 +640,13 @@ export function isLocalProviderUrl(baseUrl: string | undefined): boolean {
     if (LOCALHOST_HOSTNAMES.has(hostname)) {
       return true
     }
-    // Align with cacheMetrics self-hosted host classification (RFC 6761/6762/8375).
+    // RFC reserved / home-network TLDs. Do not include de-facto corporate
+    // suffixes like `.internal` / `.intranet` here — those are common custom
+    // proxy hostnames and must stay non-local for provider detection.
     if (
       hostname.endsWith('.localhost') ||
       hostname.endsWith('.local') ||
       hostname.endsWith('.lan') ||
-      hostname.endsWith('.internal') ||
-      hostname.endsWith('.intranet') ||
       hostname.endsWith('.home.arpa')
     ) {
       return true
@@ -659,17 +659,8 @@ export function isLocalProviderUrl(baseUrl: string | undefined): boolean {
       return firstOctet === 127 || isPrivateIpv4Address(hostname)
     }
     if (ipVersion === 6) {
-      // Unwrap IPv4-mapped IPv6 so dual-stack URLs keep the same local
-      // classification as their IPv4 form. URL parsers may keep dotted
-      // decimal (::ffff:127.0.0.1) or expand to hextets (::ffff:7f00:1).
-      const mappedDotted = hostname
-        .toLowerCase()
-        .match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/)
-      if (mappedDotted?.[1]) {
-        const v4 = mappedDotted[1]
-        const firstOctet = Number.parseInt(v4.split('.', 1)[0] ?? '', 10)
-        return firstOctet === 127 || isPrivateIpv4Address(v4)
-      }
+      // Unwrap IPv4-mapped IPv6. `new URL(...).hostname` normalizes dotted
+      // forms like ::ffff:127.0.0.1 to hextets (::ffff:7f00:1).
       const mappedHex = hostname.toLowerCase().match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
       if (mappedHex?.[1] && mappedHex[2]) {
         const hi = Number.parseInt(mappedHex[1], 16)

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -44,9 +44,10 @@ export const DEFAULT_GITHUB_MODELS_API_MODEL = 'gpt-4o'
 /**
  * Synthetic assistant content used only for Mistral/Devstral Jinja role
  * sequencing when a `tool` message must be followed by `assistant` before
- * `user`. Never inject this for llama.cpp / Ollama / vLLM / OpenAI — those
- * backends treat it as real assistant text and often echo it, ending the
- * agent turn early (issues #2039, #2059).
+ * `user`. Never inject this for local-classified OpenAI-compatible hosts
+ * (loopback, RFC1918, `.local`) or Ollama — those backends often treat it as
+ * real assistant text and echo it, ending the agent turn early
+ * (issues #2039, #2059).
  */
 export const TOOL_RESULT_SEMANTIC_PLACEHOLDER = '[Tool results received]'
 
@@ -100,7 +101,9 @@ export function shouldInjectToolResultSemanticBoundary(options?: {
     processEnv.OPENAI_MODEL ??
     ''
   ).toLowerCase()
-  return /\b(devstral|mistral|ministral|codestral)\b/.test(model)
+  return /\b(devstral|mistral|mixtral|ministral|magistral|mathstral|codestral)\b/.test(
+    model,
+  )
 }
 
 /** True when assistant text is only the transport tool-result placeholder. */

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -113,7 +113,7 @@ export function isToolResultSemanticPlaceholderEcho(text: string): boolean {
     .toLowerCase()
     // Local models often append terminal punctuation to short echoes.
     .replace(/^["'`]+|["'`]+$/g, '')
-    .replace(/[.!?…]+$/g, '')
+    .replace(/[.!?…,;:]+$/g, '')
     .trim()
   return normalized === TOOL_RESULT_SEMANTIC_PLACEHOLDER.toLowerCase()
 }
@@ -273,7 +273,13 @@ type ModelDescriptor = {
   }
 }
 
-const LOCALHOST_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1'])
+const LOCALHOST_HOSTNAMES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  'host.docker.internal',
+  'gateway.docker.internal',
+])
 
 function hashCacheScopePartition(value: unknown): string {
   return createHash('sha256')
@@ -295,7 +301,9 @@ function isPrivateIpv4Address(hostname: string): boolean {
   return (
     octets[0] === 10 ||
     (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) ||
-    (octets[0] === 192 && octets[1] === 168)
+    (octets[0] === 192 && octets[1] === 168) ||
+    // CGNAT / Tailscale (100.64.0.0/10)
+    (octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127)
   )
 }
 

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -70,9 +70,9 @@ export function shouldInjectToolResultSemanticBoundary(options?: {
     processEnv.OPENAI_BASE_URL ??
     ''
 
-  // Local servers must never receive the synthetic assistant filler, even when
-  // the model id looks Mistral-class or CLAUDE_CODE_USE_MISTRAL is stale.
-  if (isLocalProviderUrl(baseUrl)) {
+  // Local / Ollama servers must never receive the synthetic assistant filler,
+  // even when the model id looks Mistral-class or CLAUDE_CODE_USE_MISTRAL is stale.
+  if (isLocalProviderUrl(baseUrl) || isLikelyOllamaEndpoint(baseUrl)) {
     return false
   }
 

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -651,13 +651,26 @@ export function isLocalProviderUrl(baseUrl: string | undefined): boolean {
       return firstOctet === 127 || isPrivateIpv4Address(hostname)
     }
     if (ipVersion === 6) {
-      // Unwrap IPv4-mapped IPv6 (::ffff:127.0.0.1) so dual-stack URLs keep
-      // the same local classification as their IPv4 form.
-      const mapped = hostname.toLowerCase().match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
-      if (mapped?.[1]) {
-        const v4 = mapped[1]
+      // Unwrap IPv4-mapped IPv6 so dual-stack URLs keep the same local
+      // classification as their IPv4 form. URL parsers may keep dotted
+      // decimal (::ffff:127.0.0.1) or expand to hextets (::ffff:7f00:1).
+      const mappedDotted = hostname
+        .toLowerCase()
+        .match(/^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/)
+      if (mappedDotted?.[1]) {
+        const v4 = mappedDotted[1]
         const firstOctet = Number.parseInt(v4.split('.', 1)[0] ?? '', 10)
         return firstOctet === 127 || isPrivateIpv4Address(v4)
+      }
+      const mappedHex = hostname.toLowerCase().match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/)
+      if (mappedHex?.[1] && mappedHex[2]) {
+        const hi = Number.parseInt(mappedHex[1], 16)
+        const lo = Number.parseInt(mappedHex[2], 16)
+        if (!Number.isNaN(hi) && !Number.isNaN(lo)) {
+          const v4 = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`
+          const firstOctet = Number.parseInt(v4.split('.', 1)[0] ?? '', 10)
+          return firstOctet === 127 || isPrivateIpv4Address(v4)
+        }
       }
       return isPrivateIpv6Address(hostname)
     }

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -53,6 +53,10 @@ export const TOOL_RESULT_SEMANTIC_PLACEHOLDER = '[Tool results received]'
 /**
  * Whether to inject {@link TOOL_RESULT_SEMANTIC_PLACEHOLDER} between `tool`
  * and `user` roles in OpenAI chat conversion. Default is off.
+ *
+ * Local OpenAI-compatible backends (llama.cpp, Ollama, vLLM, loopback) never
+ * inject — quantized models echo the placeholder and stall (#2039, #2059).
+ * Mistral cloud / CLAUDE_CODE_USE_MISTRAL still inject for Jinja sequencing.
  */
 export function shouldInjectToolResultSemanticBoundary(options?: {
   baseUrl?: string
@@ -60,15 +64,22 @@ export function shouldInjectToolResultSemanticBoundary(options?: {
   processEnv?: NodeJS.ProcessEnv
 }): boolean {
   const processEnv = options?.processEnv ?? process.env
-  if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_MISTRAL)) {
-    return true
-  }
-
   const baseUrl =
     options?.baseUrl ??
     processEnv.MISTRAL_BASE_URL ??
     processEnv.OPENAI_BASE_URL ??
     ''
+
+  // Local servers must never receive the synthetic assistant filler, even when
+  // the model id looks Mistral-class or CLAUDE_CODE_USE_MISTRAL is stale.
+  if (isLocalProviderUrl(baseUrl)) {
+    return false
+  }
+
+  if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_MISTRAL)) {
+    return true
+  }
+
   // Hostname only — avoid false positives like https://mistral.ai-proxy.example/v1
   try {
     const host = new URL(baseUrl).hostname.toLowerCase()
@@ -90,6 +101,18 @@ export function shouldInjectToolResultSemanticBoundary(options?: {
     ''
   ).toLowerCase()
   return /\b(devstral|mistral|ministral|codestral)\b/.test(model)
+}
+
+/** True when assistant text is only the transport tool-result placeholder. */
+export function isToolResultSemanticPlaceholderEcho(text: string): boolean {
+  const normalized = text
+    .trim()
+    .toLowerCase()
+    // Local models often append terminal punctuation to short echoes.
+    .replace(/^["'`]+|["'`]+$/g, '')
+    .replace(/[.!?…]+$/g, '')
+    .trim()
+  return normalized === TOOL_RESULT_SEMANTIC_PLACEHOLDER.toLowerCase()
 }
 
 const warnedUndefinedEnvNames = new Set<string>()

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -640,7 +640,15 @@ export function isLocalProviderUrl(baseUrl: string | undefined): boolean {
     if (LOCALHOST_HOSTNAMES.has(hostname)) {
       return true
     }
-    if (hostname.endsWith('.local')) {
+    // Align with cacheMetrics self-hosted host classification (RFC 6761/6762/8375).
+    if (
+      hostname.endsWith('.localhost') ||
+      hostname.endsWith('.local') ||
+      hostname.endsWith('.lan') ||
+      hostname.endsWith('.internal') ||
+      hostname.endsWith('.intranet') ||
+      hostname.endsWith('.home.arpa')
+    ) {
       return true
     }
 

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -651,6 +651,14 @@ export function isLocalProviderUrl(baseUrl: string | undefined): boolean {
       return firstOctet === 127 || isPrivateIpv4Address(hostname)
     }
     if (ipVersion === 6) {
+      // Unwrap IPv4-mapped IPv6 (::ffff:127.0.0.1) so dual-stack URLs keep
+      // the same local classification as their IPv4 form.
+      const mapped = hostname.toLowerCase().match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/)
+      if (mapped?.[1]) {
+        const v4 = mapped[1]
+        const firstOctet = Number.parseInt(v4.split('.', 1)[0] ?? '', 10)
+        return firstOctet === 127 || isPrivateIpv4Address(v4)
+      }
       return isPrivateIpv6Address(hostname)
     }
 

--- a/src/services/api/providerConfig.ts
+++ b/src/services/api/providerConfig.ts
@@ -40,6 +40,58 @@ export const DEFAULT_OPENCODE_GO_BASE_URL = 'https://opencode.ai/zen/go/v1'
 export const DEFAULT_CLINEPASS_API_BASE_URL = `${DEFAULT_CLINEPASS_BASE_URL}/api/v1`
 /** Default GitHub Copilot API model when user selects copilot / github:copilot */
 export const DEFAULT_GITHUB_MODELS_API_MODEL = 'gpt-4o'
+
+/**
+ * Synthetic assistant content used only for Mistral/Devstral Jinja role
+ * sequencing when a `tool` message must be followed by `assistant` before
+ * `user`. Never inject this for llama.cpp / Ollama / vLLM / OpenAI — those
+ * backends treat it as real assistant text and often echo it, ending the
+ * agent turn early (issues #2039, #2059).
+ */
+export const TOOL_RESULT_SEMANTIC_PLACEHOLDER = '[Tool results received]'
+
+/**
+ * Whether to inject {@link TOOL_RESULT_SEMANTIC_PLACEHOLDER} between `tool`
+ * and `user` roles in OpenAI chat conversion. Default is off.
+ */
+export function shouldInjectToolResultSemanticBoundary(options?: {
+  baseUrl?: string
+  model?: string
+  processEnv?: NodeJS.ProcessEnv
+}): boolean {
+  const processEnv = options?.processEnv ?? process.env
+  if (isEnvTruthy(processEnv.CLAUDE_CODE_USE_MISTRAL)) {
+    return true
+  }
+
+  const baseUrl =
+    options?.baseUrl ??
+    processEnv.MISTRAL_BASE_URL ??
+    processEnv.OPENAI_BASE_URL ??
+    ''
+  // Hostname only — avoid false positives like https://mistral.ai-proxy.example/v1
+  try {
+    const host = new URL(baseUrl).hostname.toLowerCase()
+    if (
+      host === 'mistral.ai' ||
+      host === 'api.mistral.ai' ||
+      host.endsWith('.mistral.ai')
+    ) {
+      return true
+    }
+  } catch {
+    // Invalid URL — fall through to model-name detection.
+  }
+
+  const model = (
+    options?.model ??
+    processEnv.MISTRAL_MODEL ??
+    processEnv.OPENAI_MODEL ??
+    ''
+  ).toLowerCase()
+  return /\b(devstral|mistral|ministral|codestral)\b/.test(model)
+}
+
 const warnedUndefinedEnvNames = new Set<string>()
 
 function asGithubEnterpriseEnvUrl(value: string | undefined): string | undefined {

--- a/src/utils/continuation.ts
+++ b/src/utils/continuation.ts
@@ -104,8 +104,18 @@ export const COMPLETION_MARKERS = /\b(done|finished|completed|complete|summary|t
 
 export type ContinuationResult = {
   shouldNudge: boolean
-  reason?: 'possible_truncation' | 'continuation_signal'
+  reason?:
+    | 'possible_truncation'
+    | 'continuation_signal'
+    | 'tool_result_placeholder_echo'
 }
+
+/**
+ * Exact match for the OpenAI-shim Mistral tool→user boundary placeholder when
+ * a model echoes it as a real assistant reply (issues #2039, #2059). Keep in
+ * sync with TOOL_RESULT_SEMANTIC_PLACEHOLDER in providerConfig.ts.
+ */
+const TOOL_RESULT_SEMANTIC_PLACEHOLDER_ECHO = '[tool results received]'
 
 export const UNFINISHED_SENTIMENT_SIGNALS = [
   // English trailing connectors
@@ -128,6 +138,12 @@ export function analyzeContinuationIntent(
   if (lastText.length === 0) return { shouldNudge: false }
   
   const lowerText = lastText.toLowerCase()
+
+  // 0. Model echoed the transport-only tool-result placeholder as its entire
+  // reply (finish_reason=stop). Treat as a stall and nudge continuation.
+  if (lowerText === TOOL_RESULT_SEMANTIC_PLACEHOLDER_ECHO) {
+    return { shouldNudge: true, reason: 'tool_result_placeholder_echo' }
+  }
 
   // 1. High-Confidence Structural Truncation signals (Strongest - Ignore completion markers)
   

--- a/src/utils/continuation.ts
+++ b/src/utils/continuation.ts
@@ -1,4 +1,5 @@
 import { tokenCountWithEstimation } from './tokens.js'
+import { isToolResultSemanticPlaceholderEcho } from '../services/api/providerConfig.js'
 
 /**
  * Heuristics to detect if the agent intends to continue its task
@@ -112,10 +113,8 @@ export type ContinuationResult = {
 
 /**
  * Exact match for the OpenAI-shim Mistral tool→user boundary placeholder when
- * a model echoes it as a real assistant reply (issues #2039, #2059). Keep in
- * sync with TOOL_RESULT_SEMANTIC_PLACEHOLDER in providerConfig.ts.
+ * a model echoes it as a real assistant reply (issues #2039, #2059).
  */
-const TOOL_RESULT_SEMANTIC_PLACEHOLDER_ECHO = '[tool results received]'
 
 export const UNFINISHED_SENTIMENT_SIGNALS = [
   // English trailing connectors
@@ -141,7 +140,7 @@ export function analyzeContinuationIntent(
 
   // 0. Model echoed the transport-only tool-result placeholder as its entire
   // reply (finish_reason=stop). Treat as a stall and nudge continuation.
-  if (lowerText === TOOL_RESULT_SEMANTIC_PLACEHOLDER_ECHO) {
+  if (isToolResultSemanticPlaceholderEcho(lastText)) {
     return { shouldNudge: true, reason: 'tool_result_placeholder_echo' }
   }
 


### PR DESCRIPTION
## Summary

- Gate the synthetic `[Tool results received]` assistant boundary so it is no longer inserted on every `tool` → `user` conversion. Local OpenAI-compatible hosts (loopback, RFC1918, CGNAT, Docker internal, reserved TLDs) and Ollama never get it; Mistral cloud / `CLAUDE_CODE_USE_MISTRAL` / Mistral-class model ids on non-local routes still can for Jinja sequencing.
- Strip prior placeholder-only assistant echoes from outbound history, clear inherited `CLAUDE_CODE_USE_MISTRAL` on `providerOverride`, and treat placeholder-only model replies as a continuation nudge.
- Document llama.cpp / vLLM mitigation notes in `docs/advanced-setup.md`.

Fixes #2059
Fixes #2039

Related incomplete work: #1977 (still conflicting / changes-requested; this PR is a focused root-cause fix on current `main`).

## Impact

- user-facing impact: Local / self-hosted OpenAI-compatible sessions (llama.cpp, Ollama, vLLM on local-classified hosts) no longer silently end a turn after echoing `[Tool results received]`.
- developer/maintainer impact: `shouldInjectToolResultSemanticBoundary` is the single decision point; `isLocalProviderUrl` now matches cacheMetrics reserved-TLD / CGNAT classification more closely.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [ ] `bun run check`
- [x] focused tests: `bun test ./src/services/api/openaiShim/messageConversion.test.ts ./src/services/api/providerConfig.local.test.ts ./src/__tests__/bugfixes.test.ts ./src/services/api/openaiShim.test.ts` (371 pass)

## Notes

- provider/model path tested: unit/integration coverage for Mistral inject-on, local/Qwen inject-off, snip reminder history, placeholder echo nudge/scrub, providerOverride env isolation. No live llama.cpp server in this environment.
- screenshots attached (if UI changed): n/a
- follow-up work or known limitations:
  - Remote public hosts with Mistral-class model ids still inject (intentional for Jinja).
  - Stale `CLAUDE_CODE_USE_MISTRAL=1` on a remote non-Mistral primary route still injects (product flag semantics); overrides clear the flag.
  - `--print` may briefly stream an echoed placeholder before the continuation nudge recovers.
  - Final reviewed head: will match PR head after push verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded guidance and configuration for local OpenAI-compatible providers (e.g., llama.cpp, vLLM, and other local servers).
  - Added smarter handling for synthetic tool-result “boundary” injection, including configurable placeholder behavior.

- **Bug Fixes**
  - Prevented repeated tool-result placeholder echoes from being treated as meaningful continuation signals.
  - Improved continuation nudging logic when the tool-result placeholder appears mid-session.

- **Documentation**
  - Updated advanced setup notes with new provider examples and troubleshooting tips for repeated short phrases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->