### PR TITLE
fix(cost): guard model-cost lookup against prototype-member model ids

### DIFF
--- a/src/bootstrap/state.modelUsageProto.test.ts
+++ b/src/bootstrap/state.modelUsageProto.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+
+import type { ModelUsage } from 'src/entrypoints/agentSdkTypes.js'
+
+import {
+  addToTotalCostState,
+  getModelUsage,
+  getUsageForModel,
+  resetStateForTests,
+  setCostStateForRestore,
+} from './state.js'
+
+// Per-model usage is keyed by the model id, an arbitrary string for
+// custom/OpenAI-compatible providers. `STATE.modelUsage` is a plain map, so an
+// id of `constructor` / `__proto__` reaches both the read (`getUsageForModel`)
+// and the write (`STATE.modelUsage[model] = ...`). On a normal object the read
+// of an absent key returns an inherited Object.prototype member and the write
+// of `__proto__` invokes the prototype setter -- the cost accumulator then
+// mutates that inherited object, polluting Object.prototype process-wide.
+
+const PROTO_NAMES = ['__proto__', 'constructor', 'toString', 'valueOf']
+
+function sampleUsage(): ModelUsage {
+  return {
+    inputTokens: 10,
+    outputTokens: 20,
+    cacheReadInputTokens: 0,
+    cacheCreationInputTokens: 0,
+    webSearchRequests: 0,
+    costUSD: 1,
+    contextWindow: 0,
+    maxOutputTokens: 0,
+  }
+}
+
+let savedNodeEnv: string | undefined
+
+beforeEach(() => {
+  savedNodeEnv = process.env.NODE_ENV
+  process.env.NODE_ENV = 'test'
+  resetStateForTests()
+})
+
+afterEach(() => {
+  resetStateForTests()
+  if (savedNodeEnv === undefined) delete process.env.NODE_ENV
+  else process.env.NODE_ENV = savedNodeEnv
+  // Undo any accidental pollution so a regression here cannot corrupt other
+  // suites sharing the process.
+  delete (Object.prototype as Record<string, unknown>).inputTokens
+})
+
+test('getUsageForModel returns undefined for prototype-member ids on an empty map', () => {
+  for (const name of PROTO_NAMES) {
+    expect(getUsageForModel(name)).toBeUndefined()
+  }
+})
+
+test('recording usage under a prototype-member id does not pollute Object.prototype', () => {
+  for (const name of PROTO_NAMES) {
+    addToTotalCostState(1, sampleUsage(), name)
+  }
+
+  // The headline hazard: a `__proto__` write must not reach Object.prototype.
+  expect((Object.prototype as Record<string, unknown>).inputTokens).toBeUndefined()
+  expect(({} as Record<string, unknown>).inputTokens).toBeUndefined()
+
+  // The ids are stored as ordinary own keys and read back verbatim.
+  for (const name of PROTO_NAMES) {
+    expect(getUsageForModel(name)?.inputTokens).toBe(10)
+  }
+  expect(Object.keys(getModelUsage()).sort()).toEqual([...PROTO_NAMES].sort())
+})
+
+test('restore re-keys a persisted breakdown into a null-prototype map', () => {
+  // A breakdown deserialized from JSON can carry an own `__proto__` key.
+  const persisted = JSON.parse(
+    '{"__proto__":{"inputTokens":7,"outputTokens":0,"cacheReadInputTokens":0,' +
+      '"cacheCreationInputTokens":0,"webSearchRequests":0,"costUSD":0,' +
+      '"contextWindow":0,"maxOutputTokens":0}}',
+  ) as { [modelName: string]: ModelUsage }
+
+  setCostStateForRestore({
+    totalCostUSD: 0,
+    totalAPIDuration: 0,
+    totalAPIDurationWithoutRetries: 0,
+    totalToolDuration: 0,
+    totalLinesAdded: 0,
+    totalLinesRemoved: 0,
+    lastDuration: undefined,
+    modelUsage: persisted,
+  })
+
+  // Restored as an own key, not the map's prototype, and safe to mutate.
+  expect(getUsageForModel('__proto__')?.inputTokens).toBe(7)
+  addToTotalCostState(1, sampleUsage(), '__proto__')
+  expect((Object.prototype as Record<string, unknown>).inputTokens).toBeUndefined()
+})

--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -279,7 +279,7 @@ function getInitialState(): State {
     totalLinesRemoved: 0,
     hasUnknownModelCost: false,
     cwd: resolvedCwd,
-    modelUsage: {},
+    modelUsage: emptyModelUsage(),
     mainLoopModelOverride: undefined,
     initialMainLoopModel: null,
     modelStrings: null,
@@ -870,12 +870,31 @@ export async function waitForScrollIdle(): Promise<void> {
   }
 }
 
+/**
+ * A null-prototype map for per-model usage. Model ids are arbitrary strings for
+ * custom/OpenAI-compatible providers, so `__proto__` and `constructor` can reach
+ * `STATE.modelUsage[model] = ...`. On a normal object `map['__proto__'] = obj`
+ * invokes the prototype setter (corrupting the map's chain) and a later read of
+ * an absent key returns an inherited member; with a null prototype both become
+ * ordinary own-key operations, so cost accounting stays correct and, critically,
+ * Object.prototype is never polluted.
+ */
+function emptyModelUsage(): { [modelName: string]: ModelUsage } {
+  return Object.create(null) as { [modelName: string]: ModelUsage }
+}
+
 export function getModelUsage(): { [modelName: string]: ModelUsage } {
   return STATE.modelUsage
 }
 
 export function getUsageForModel(model: string): ModelUsage | undefined {
-  return STATE.modelUsage[model]
+  // Own-property lookup: a model id of `constructor` / `__proto__` (arbitrary
+  // for custom/OpenAI-compatible providers) must not resolve to an inherited
+  // Object.prototype member, which callers would then mutate -- for `__proto__`
+  // that mutation lands on Object.prototype itself. See emptyModelUsage.
+  return Object.hasOwn(STATE.modelUsage, model)
+    ? STATE.modelUsage[model]
+    : undefined
 }
 
 /**
@@ -917,7 +936,7 @@ export function resetCostState(): void {
   STATE.totalLinesAdded = 0
   STATE.totalLinesRemoved = 0
   STATE.hasUnknownModelCost = false
-  STATE.modelUsage = {}
+  STATE.modelUsage = emptyModelUsage()
   STATE.promptId = null
 }
 
@@ -951,9 +970,16 @@ export function setCostStateForRestore({
   STATE.totalLinesAdded = totalLinesAdded
   STATE.totalLinesRemoved = totalLinesRemoved
 
-  // Restore per-model usage breakdown
+  // Restore per-model usage breakdown. Re-key into a null-prototype map: a
+  // persisted breakdown deserialized from JSON can carry an own `__proto__`
+  // key, and assigning that object wholesale would reintroduce the prototype
+  // hazard emptyModelUsage exists to avoid.
   if (modelUsage) {
-    STATE.modelUsage = modelUsage
+    const restored = emptyModelUsage()
+    for (const [name, usage] of Object.entries(modelUsage)) {
+      restored[name] = usage
+    }
+    STATE.modelUsage = restored
   }
 
   // Adjust startTime to make wall duration accumulate

--- a/src/cost-tracker.format.test.ts
+++ b/src/cost-tracker.format.test.ts
@@ -161,10 +161,25 @@ describe('formatTotalCost — token bar output (PR #1610)', () => {
   // Object.prototype member, skips initialization, and mutates it -- for
   // `__proto__` that lands on Object.prototype process-wide -- while dropping the
   // model from the breakdown. Drive the real addToTotalSessionCost -> /cost path.
-  test('aggregates prototype-member model ids without polluting Object.prototype', () => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { addToTotalSessionCost } =
-      require('./cost-tracker.js') as typeof import('./cost-tracker.js')
+  test('aggregates prototype-member model ids without polluting Object.prototype', async () => {
+    const { addToTotalSessionCost } = await import('./cost-tracker.js')
+    // Snapshot any pre-existing descriptors so cleanup restores shared
+    // Object.prototype state exactly instead of blindly deleting keys that
+    // another module may legitimately own.
+    const guardedKeys = [
+      'inputTokens',
+      'outputTokens',
+      'cacheReadInputTokens',
+      'cacheCreationInputTokens',
+      'webSearchRequests',
+      'costUSD',
+    ]
+    const savedDescriptors = new Map(
+      guardedKeys.map(k => [
+        k,
+        Object.getOwnPropertyDescriptor(Object.prototype, k),
+      ]),
+    )
     try {
       addToTotalSessionCost(1, anthropicUsage({ input: 1000, output: 500 }), '__proto__')
       addToTotalSessionCost(1, anthropicUsage({ input: 2000, output: 800 }), 'constructor')
@@ -179,17 +194,15 @@ describe('formatTotalCost — token bar output (PR #1610)', () => {
       expect(out).toContain('__proto__:')
       expect(out).toContain('constructor:')
     } finally {
-      // Belt-and-suspenders: if a regression polluted the prototype, scrub it so
-      // this suite cannot corrupt others sharing the process.
-      for (const k of [
-        'inputTokens',
-        'outputTokens',
-        'cacheReadInputTokens',
-        'cacheCreationInputTokens',
-        'webSearchRequests',
-        'costUSD',
-      ]) {
-        delete (Object.prototype as Record<string, unknown>)[k]
+      // Belt-and-suspenders: if a regression polluted the prototype, restore the
+      // saved descriptor (or delete keys that were originally absent) so this
+      // suite cannot corrupt others sharing the process.
+      for (const [k, descriptor] of savedDescriptors) {
+        if (descriptor) {
+          Object.defineProperty(Object.prototype, k, descriptor)
+        } else {
+          delete (Object.prototype as Record<string, unknown>)[k]
+        }
       }
     }
   })

--- a/src/cost-tracker.format.test.ts
+++ b/src/cost-tracker.format.test.ts
@@ -154,4 +154,43 @@ describe('formatTotalCost — token bar output (PR #1610)', () => {
     expect(out).toMatch(/Total duration \(wall\):/)
     expect(out).toMatch(/7 lines added, 3 lines removed/)
   })
+
+  // A custom-provider model id can be an arbitrary string. `formatModelUsage`
+  // accumulates into a per-short-name map; on a plain object an id that
+  // canonicalizes to `__proto__` / `constructor` reads an inherited
+  // Object.prototype member, skips initialization, and mutates it -- for
+  // `__proto__` that lands on Object.prototype process-wide -- while dropping the
+  // model from the breakdown. Drive the real addToTotalSessionCost -> /cost path.
+  test('aggregates prototype-member model ids without polluting Object.prototype', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { addToTotalSessionCost } =
+      require('./cost-tracker.js') as typeof import('./cost-tracker.js')
+    try {
+      addToTotalSessionCost(1, anthropicUsage({ input: 1000, output: 500 }), '__proto__')
+      addToTotalSessionCost(1, anthropicUsage({ input: 2000, output: 800 }), 'constructor')
+
+      const out = stripAnsi(formatTotalCost())
+
+      // No global prototype pollution from the `__proto__` accumulator write.
+      expect(
+        (Object.prototype as Record<string, unknown>).inputTokens,
+      ).toBeUndefined()
+      // Both ids appear in the per-model breakdown instead of being dropped.
+      expect(out).toContain('__proto__:')
+      expect(out).toContain('constructor:')
+    } finally {
+      // Belt-and-suspenders: if a regression polluted the prototype, scrub it so
+      // this suite cannot corrupt others sharing the process.
+      for (const k of [
+        'inputTokens',
+        'outputTokens',
+        'cacheReadInputTokens',
+        'cacheCreationInputTokens',
+        'webSearchRequests',
+        'costUSD',
+      ]) {
+        delete (Object.prototype as Record<string, unknown>)[k]
+      }
+    }
+  })
 })

--- a/src/cost-tracker.ts
+++ b/src/cost-tracker.ts
@@ -206,11 +206,18 @@ function formatModelUsage(): string {
     return 'Usage:                 0 input, 0 output'
   }
 
-  // Accumulate usage by short name
-  const usageByShortName: { [shortName: string]: ModelUsage } = {}
+  // Accumulate usage by short name. Null-prototype so an unrecognised custom
+  // provider id that canonicalizes to `__proto__` / `constructor` becomes an
+  // ordinary own key: on a plain object the truthiness check below would read an
+  // inherited Object.prototype member, skip initialization, and mutate it (for
+  // `__proto__`, polluting Object.prototype process-wide), while dropping the
+  // model from the displayed breakdown.
+  const usageByShortName: { [shortName: string]: ModelUsage } = Object.create(
+    null,
+  ) as { [shortName: string]: ModelUsage }
   for (const [model, usage] of Object.entries(modelUsageMap)) {
     const shortName = getCanonicalName(model)
-    if (!usageByShortName[shortName]) {
+    if (!Object.hasOwn(usageByShortName, shortName)) {
       usageByShortName[shortName] = {
         inputTokens: 0,
         outputTokens: 0,

--- a/src/utils/modelCost.modelGate.test.ts
+++ b/src/utils/modelCost.modelGate.test.ts
@@ -64,3 +64,38 @@ test('fast-mode Opus 4.8 is charged the elevated fast-mode tier, normal otherwis
   expect(getModelCosts('claude-opus-4-8', fast)).toEqual(COST_TIER_30_150)
   expect(getModelCosts('claude-opus-4-8', standard)).toEqual(COST_TIER_5_25)
 })
+
+// MODEL_COSTS is a plain object, so a bare `MODEL_COSTS[shortName]` lookup
+// inherits Object.prototype members. A model id of `constructor` or `__proto__`
+// (both valid arbitrary ids for custom/OpenAI-compatible providers, and already
+// lowercase so getCanonicalName returns them unchanged) resolved to a truthy
+// prototype value, bypassing the `!costs` unknown-model guard: the cost math
+// then read undefined fields and produced NaN, permanently poisoning the running
+// session total, and getModelPricingString rendered "$NaN/$NaN per Mtok".
+test('proto-member model ids fall through the unknown-model path, not NaN', async () => {
+  mock.module('./model/model.js', () => ({
+    firstPartyNameToCanonical: (model: string) => model,
+    // Mirror the real canonicalizer for these names: both are lowercase and
+    // match no Claude pattern, so they pass through verbatim.
+    getCanonicalName: (model: string) => model,
+    getDefaultMainLoopModelSetting: () => 'claude-haiku-4-5',
+  }))
+  const { getModelCosts, getModelPricingString, calculateUSDCost, COST_TIER_5_25 } =
+    await importFreshModelCost()
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const usage = {
+    input_tokens: 1_000_000,
+    output_tokens: 1_000_000,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+
+  for (const name of ['constructor', '__proto__']) {
+    // DEFAULT_UNKNOWN_MODEL_COST is COST_TIER_5_25 (see modelCost.ts).
+    expect(getModelCosts(name, usage)).toEqual(COST_TIER_5_25)
+    const cost = calculateUSDCost(name, usage)
+    expect(Number.isNaN(cost)).toBe(false)
+    expect(cost).toBeGreaterThan(0)
+    expect(getModelPricingString(name)).toBeUndefined()
+  }
+})

--- a/src/utils/modelCost.modelGate.test.ts
+++ b/src/utils/modelCost.modelGate.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import { hasUnknownModelCost, resetCostState } from '../bootstrap/state.js'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
@@ -70,8 +71,10 @@ test('fast-mode Opus 4.8 is charged the elevated fast-mode tier, normal otherwis
 // (both valid arbitrary ids for custom/OpenAI-compatible providers, and already
 // lowercase so getCanonicalName returns them unchanged) resolved to a truthy
 // prototype value, bypassing the `!costs` unknown-model guard: the cost math
-// then read undefined fields and produced NaN, permanently poisoning the running
-// session total, and getModelPricingString rendered "$NaN/$NaN per Mtok".
+// then read undefined fields and produced NaN, which flowed into the running
+// session total and stuck it at $NaN. (getModelPricingString has no production
+// callers; pre-fix it threw a TypeError from formatPrice(undefined) for these
+// ids -- the own-property guard makes it return undefined instead.)
 test('proto-member model ids fall through the unknown-model path, not NaN', async () => {
   mock.module('./model/model.js', () => ({
     firstPartyNameToCanonical: (model: string) => model,
@@ -90,12 +93,21 @@ test('proto-member model ids fall through the unknown-model path, not NaN', asyn
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any
 
-  for (const name of ['constructor', '__proto__']) {
-    // DEFAULT_UNKNOWN_MODEL_COST is COST_TIER_5_25 (see modelCost.ts).
-    expect(getModelCosts(name, usage)).toEqual(COST_TIER_5_25)
-    const cost = calculateUSDCost(name, usage)
-    expect(Number.isNaN(cost)).toBe(false)
-    expect(cost).toBeGreaterThan(0)
-    expect(getModelPricingString(name)).toBeUndefined()
+  try {
+    for (const name of ['constructor', '__proto__']) {
+      // DEFAULT_UNKNOWN_MODEL_COST is COST_TIER_5_25 (see modelCost.ts).
+      expect(getModelCosts(name, usage)).toEqual(COST_TIER_5_25)
+      const cost = calculateUSDCost(name, usage)
+      // Number.isFinite rejects Infinity too, not just NaN.
+      expect(Number.isFinite(cost)).toBe(true)
+      expect(cost).toBeGreaterThan(0)
+      expect(getModelPricingString(name)).toBeUndefined()
+    }
+    // Lock in the unknown-model detection path: dropping trackUnknownModelCost
+    // while keeping the fallback tier would otherwise still pass the checks above.
+    expect(hasUnknownModelCost()).toBe(true)
+  } finally {
+    // Clear the process-wide flag so this suite cannot leak into another.
+    resetCostState()
   }
 })

--- a/src/utils/modelCost.ts
+++ b/src/utils/modelCost.ts
@@ -162,12 +162,17 @@ export function getModelCosts(model: string, usage: Usage): ModelCosts {
     return getOpus46CostTier(isFastMode)
   }
 
-  const costs = MODEL_COSTS[shortName]
-  if (!costs) {
+  // MODEL_COSTS is a plain object, so a bare `MODEL_COSTS[shortName]` inherits
+  // Object.prototype members: a model id like `constructor` or `__proto__`
+  // (arbitrary strings for custom/OpenAI-compatible providers, and lowercase so
+  // getCanonicalName passes them through unchanged) would return a truthy
+  // prototype value, skip the unknown-model path, and yield NaN costs downstream.
+  // Match on own properties only.
+  if (!Object.hasOwn(MODEL_COSTS, shortName)) {
     trackUnknownModelCost(model, shortName)
     return DEFAULT_UNKNOWN_MODEL_COST
   }
-  return costs
+  return MODEL_COSTS[shortName]
 }
 
 function trackUnknownModelCost(model: string, shortName: ModelShortName): void {
@@ -233,7 +238,8 @@ export function formatModelPricing(costs: ModelCosts): string {
  */
 export function getModelPricingString(model: string): string | undefined {
   const shortName = getCanonicalName(model)
-  const costs = MODEL_COSTS[shortName]
-  if (!costs) return undefined
-  return formatModelPricing(costs)
+  // Own-property guard: a proto-member id (`constructor`, `__proto__`) would
+  // otherwise return an inherited value and render "$NaN/$NaN per Mtok".
+  if (!Object.hasOwn(MODEL_COSTS, shortName)) return undefined
+  return formatModelPricing(MODEL_COSTS[shortName])
 }


### PR DESCRIPTION
## What

`MODEL_COSTS` in `src/utils/modelCost.ts` is a plain object literal, so a bare `MODEL_COSTS[shortName]` lookup inherits `Object.prototype` members. A model id of `constructor` or `__proto__` — both perfectly valid arbitrary ids for custom / OpenAI-compatible / third-party providers, and already lowercase so `getCanonicalName` returns them unchanged — resolves to a **truthy** prototype value (the `Object` constructor / `Object.prototype`), so the `!costs` unknown-model guard is skipped.

Downstream that means:

- `trackUnknownModelCost` never fires and `setHasUnknownModelCost()` is never set, so the mischarge is invisible to the very detection meant to catch it.
- `tokensToUSDCost` then reads `.inputTokens` / `.outputTokens` / … off the prototype value — all `undefined` — so every term is `number * undefined = NaN`. `calculateUSDCost` returns `NaN`, which flows into the running session total (`total + NaN` stays `NaN` forever) and surfaces as `$NaN` in the cost UI/telemetry. **This is the production failure.**

The same defect exists in the sibling per-model accounting (`getUsageForModel` / `STATE.modelUsage[model] = …`): a `__proto__` id there is worse — the read returns `Object.prototype` and the accumulator mutates it in place, polluting `Object.prototype` process-wide (every object gains `inputTokens = NaN`, etc.); the `__proto__` write also trips the prototype setter.

## Repro

```js
// model id "constructor" (or "__proto__") from a custom provider config
MODEL_COSTS['constructor']            // → Object (truthy) — guard bypassed
tokensToUSDCost(that, usage)          // → NaN → $NaN session total
```

`getCanonicalName('constructor')` → `resolveOverriddenModel` (returns it unchanged, no matching override) → `firstPartyNameToCanonical` (lowercases, matches no `claude-*` pattern, returns verbatim) → `'constructor'`. `toString`/`valueOf`/etc. are neutralized by the lowercasing (they become non-prototype strings); `constructor` and `__proto__` are already lowercase, so they slip through.

## Fix

Match on own properties via `Object.hasOwn`, mirroring the existing `resolveOutputStyle` guard in `src/constants/outputStyles.ts`:

- `getModelCosts` and `getModelPricingString` in `modelCost.ts`.
- `getUsageForModel` in `bootstrap/state.ts`, and — because a read guard alone does not stop the `__proto__` *write* from tripping the prototype setter — back `STATE.modelUsage` with a null-prototype map at init/reset/restore so both read and write are ordinary own-key operations. Restore re-keys a persisted breakdown (which can carry an own `__proto__` from JSON) into the null-proto map.

## Notes / scope

- The real production symptom is `calculateUSDCost → NaN → $NaN` session totals. `getModelPricingString` has **no production callers**; pre-fix it threw a `TypeError` from `formatPrice(undefined)` for these ids — the guard makes it return `undefined` instead. Included for consistency, not because a live model-picker path is affected.

## Tests

- `modelCost.modelGate.test.ts`: `constructor`/`__proto__` ids take the unknown-model path, yield a finite (`Number.isFinite`) positive cost, set `hasUnknownModelCost()`, and `getModelPricingString` returns `undefined`. Cost state reset afterward to avoid suite bleed.
- `state.modelUsageProto.test.ts`: recording usage under proto-name ids does not pollute `Object.prototype`, stores/reads them as own keys, and restore re-keys a persisted own-`__proto__` breakdown safely.

Both fail on the pre-fix code and pass after. `tsc --noEmit` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cost calculations for unrecognized model IDs that could produce invalid or `NaN` values.
  * Unknown models now correctly use the configured fallback pricing tier.
  * Prevented invalid pricing details from appearing for unsupported model IDs.
  * Preserved cost and usage tracking for unusual model IDs, including `__proto__` and `constructor`.
  * Prevented unusual model IDs from affecting application state, usage totals, or other object properties.
  * Added regression coverage to ensure reliable tracking and reporting for these edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->