### PR TITLE
feat(opengateway): add Macaron V1 Tall to the gateway catalog

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -1448,6 +1448,7 @@ test('/model applies auto provider surface for single-model static descriptor pr
       'z-ai/glm-5.2',
       'nvidia/nemotron-3-ultra-550b-a55b:free',
       'inclusionai/ling-3.0-flash:free',
+      'mindai/macaron-v1-tall',
       'tencent/hy3',
     ])
   } finally {

--- a/src/integrations/brands/macaron.ts
+++ b/src/integrations/brands/macaron.ts
@@ -1,0 +1,16 @@
+import { defineBrand } from '../define.js'
+
+export default defineBrand({
+  id: 'macaron',
+  label: 'Macaron',
+  canonicalVendorId: 'openai',
+  defaultCapabilities: {
+    supportsVision: false,
+    supportsStreaming: true,
+    supportsFunctionCalling: true,
+    supportsJsonMode: false,
+    supportsReasoning: true,
+    supportsPreciseTokenCount: false,
+  },
+  modelIds: ['mindai/macaron-v1-tall'],
+})

--- a/src/integrations/gateways/gitlawb-opengateway.ts
+++ b/src/integrations/gateways/gitlawb-opengateway.ts
@@ -144,6 +144,15 @@ export default defineGateway({
         modelDescriptorId: 'inclusionai/ling-3.0-flash:free',
         notes: 'Free',
       },
+      // Macaron V1 Tall — served by the gateway via direct Novita (not on
+      // OpenRouter). Free launch window; the gateway delists it 2026-08-10.
+      {
+        id: 'opengateway-macaron-v1-tall',
+        apiName: 'mindai/macaron-v1-tall',
+        label: 'Macaron V1 Tall (via Opengateway)',
+        modelDescriptorId: 'mindai/macaron-v1-tall',
+        notes: 'Free',
+      },
       {
         id: 'opengateway-tencent-hy3',
         apiName: 'tencent/hy3',

--- a/src/integrations/generated/integrationArtifacts.generated.ts
+++ b/src/integrations/generated/integrationArtifacts.generated.ts
@@ -56,6 +56,7 @@ import brandKimi from '../brands/kimi.js'
 import brandLing from '../brands/ling.js'
 import brandLlama from '../brands/llama.js'
 import brandLongcat from '../brands/longcat.js'
+import brandMacaron from '../brands/macaron.js'
 import brandMinimax from '../brands/minimax.js'
 import brandMistral from '../brands/mistral.js'
 import brandNearai from '../brands/nearai.js'
@@ -75,6 +76,7 @@ import modelKimi from '../models/kimi.js'
 import modelLing from '../models/ling.js'
 import modelLlama from '../models/llama.js'
 import modelLongcat from '../models/longcat.js'
+import modelMacaron from '../models/macaron.js'
 import modelMinimax from '../models/minimax.js'
 import modelMistral from '../models/mistral.js'
 import modelNearai from '../models/nearai.js'
@@ -89,8 +91,8 @@ import modelXiaomiMimo from '../models/xiaomi-mimo.js'
 export const VENDOR_DESCRIPTORS = [vendorAnthropic, vendorBankr, vendorDeepseek, vendorFireworks, vendorGemini, vendorLongcat, vendorMinimax, vendorMoonshot, vendorNearai, vendorOpenai, vendorVenice, vendorXai, vendorXiaomiMimo, vendorZai] as const satisfies readonly VendorDescriptor[]
 export const GATEWAY_DESCRIPTORS = [gatewayAimlapi, gatewayAtlasCloud, gatewayAtomicChat, gatewayAzureOpenai, gatewayBedrock, gatewayClinepass, gatewayCloudflare, gatewayCustom, gatewayDashscopeCn, gatewayDashscopeIntl, gatewayGithubEnterprise, gatewayGithub, gatewayGitlawbOpengateway, gatewayGroq, gatewayHicap, gatewayKimiCode, gatewayLmstudio, gatewayMistral, gatewayNvidiaNim, gatewayOllama, gatewayOpencodeGo, gatewayOpencode, gatewayOpenrouter, gatewayTogether, gatewayVertex, gatewayXiaomiMimoToken] as const satisfies readonly GatewayDescriptor[]
 export const ANTHROPIC_PROXY_DESCRIPTORS = [anthropicproxyCustom] as const satisfies readonly AnthropicProxyDescriptor[]
-export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandFireworks, brandGemini, brandGlm, brandGpt, brandKimi, brandLing, brandLlama, brandLongcat, brandMinimax, brandMistral, brandNearai, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandTencent, brandXai, brandXiaomiMimo] as const satisfies readonly BrandDescriptor[]
-export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelFireworksMerged, modelGemini, modelGlm, modelGpt, modelKimi, modelLing, modelLlama, modelLongcat, modelMinimax, modelMistral, modelNearai, modelNemotron, modelOpenaiCompatibleAlias, modelOpencode, modelQwen, modelTencent, modelXai, modelXiaomiMimo] as const satisfies readonly (readonly ModelDescriptor[])[]
+export const BRAND_DESCRIPTORS = [brandClaude, brandDeepseek, brandFireworks, brandGemini, brandGlm, brandGpt, brandKimi, brandLing, brandLlama, brandLongcat, brandMacaron, brandMinimax, brandMistral, brandNearai, brandNemotron, brandOpenaiCompatibleAlias, brandQwen, brandTencent, brandXai, brandXiaomiMimo] as const satisfies readonly BrandDescriptor[]
+export const MODEL_DESCRIPTOR_GROUPS = [modelClaude, modelDeepseek, modelFireworksMerged, modelGemini, modelGlm, modelGpt, modelKimi, modelLing, modelLlama, modelLongcat, modelMacaron, modelMinimax, modelMistral, modelNearai, modelNemotron, modelOpenaiCompatibleAlias, modelOpencode, modelQwen, modelTencent, modelXai, modelXiaomiMimo] as const satisfies readonly (readonly ModelDescriptor[])[]
 export const MODEL_DESCRIPTORS = MODEL_DESCRIPTOR_GROUPS.flat() satisfies readonly ModelDescriptor[]
 
 export { PROVIDER_PRESET_MANIFEST, ORDERED_PROVIDER_PRESETS } from './integrationManifest.generated.js'

--- a/src/integrations/macaron.test.ts
+++ b/src/integrations/macaron.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  getCatalogEntriesForRoute,
+  getModel,
+  getModelsForBrand,
+} from './index.js'
+import { resolveModelRuntimeLimits } from './runtimeMetadata.js'
+
+describe('Macaron V1 Tall descriptor', () => {
+  test('exposes the verified Macaron capabilities and limits to gateway catalogs', () => {
+    const model = getModel('mindai/macaron-v1-tall')
+
+    expect(model).toBeDefined()
+    expect(model).toMatchObject({
+      id: 'mindai/macaron-v1-tall',
+      brandId: 'macaron',
+      classification: ['chat', 'reasoning', 'coding'],
+      contextWindow: 262_144,
+      maxOutputTokens: 32_768,
+      capabilities: {
+        supportsVision: false,
+        supportsStreaming: true,
+        supportsFunctionCalling: true,
+        supportsJsonMode: false,
+        supportsReasoning: true,
+      },
+    })
+    expect(getModelsForBrand('macaron').map(m => m.id)).toContain(
+      'mindai/macaron-v1-tall',
+    )
+
+    const catalogEntry = getCatalogEntriesForRoute('gitlawb-opengateway').find(
+      entry => entry.apiName === 'mindai/macaron-v1-tall',
+    )
+    expect(catalogEntry?.id).toBe('opengateway-macaron-v1-tall')
+    expect(catalogEntry?.modelDescriptorId).toBe(model?.id)
+
+    expect(
+      resolveModelRuntimeLimits({
+        model: 'mindai/macaron-v1-tall',
+        baseUrl: 'https://opengateway.gitlawb.com/v1',
+        processEnv: {},
+      }),
+    ).toEqual({ contextWindow: 262_144, maxOutputTokens: 32_768 })
+  })
+})

--- a/src/integrations/models/macaron.ts
+++ b/src/integrations/models/macaron.ts
@@ -1,0 +1,22 @@
+import { defineModel } from '../define.js'
+
+export default [
+  defineModel({
+    id: 'mindai/macaron-v1-tall',
+    label: 'Macaron V1 Tall',
+    brandId: 'macaron',
+    vendorId: 'openai',
+    classification: ['chat', 'reasoning', 'coding'],
+    defaultModel: 'mindai/macaron-v1-tall',
+    capabilities: {
+      supportsVision: false,
+      supportsStreaming: true,
+      supportsFunctionCalling: true,
+      supportsJsonMode: false,
+      supportsReasoning: true,
+      supportsPreciseTokenCount: false,
+    },
+    contextWindow: 262_144,
+    maxOutputTokens: 32_768,
+  }),
+]


### PR DESCRIPTION
## Summary

Adds `mindai/macaron-v1-tall` (Macaron V1 Tall) to the Gitlawb Opengateway
provider catalog. The model is served by the gateway via a direct Novita
integration — it is not available on OpenRouter — so the gateway URL and
transport are unchanged; only the `apiName` the client sends determines the
upstream.

Free launch window on the gateway: bills $0 and bypasses the credit gate, so
it works with an empty credit balance. The gateway delists it automatically on
2026-08-10.

## Changes

- `gateways/gitlawb-opengateway.ts` — new catalog entry
  `opengateway-macaron-v1-tall` (`apiName: mindai/macaron-v1-tall`, notes:
  Free), following the Ling free-window pattern.
- `models/macaron.ts` (new) — model descriptor: routed Mixture-of-LoRA on
  Qwen3.6-35B-A3B, 262k context window, 32,768 max output tokens, streaming +
  function calling + reasoning.
- `brands/macaron.ts` (new) — Macaron brand descriptor.
- `generated/integrationArtifacts.generated.ts` — regenerated via
  `bun scripts/generate-integrations-artifacts.ts` (registry validation
  requires a registered model descriptor for every `modelDescriptorId`).

## Model notes

- Reasoning model: small `max_tokens` values can be consumed entirely by
  reasoning and return empty content (same behavior as Kimi K3) — the gateway
  clamps oversized asks to the model's 32,768 output cap.
- Verified end-to-end through the live gateway: plain completion, streaming,
  and a tool-call round trip (`finish_reason: tool_calls`), plus the
  `max_completion_tokens` shim path openclaude uses.

## Test plan

- `bun test src/integrations` — 306 pass (includes registry validation:
  gateway `modelDescriptorId` references resolve, loaded registry valid)
- `bun run typecheck` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the **Macaron V1 Tall** model (Macaron brand integration).
  * Supports **chat**, **reasoning**, and **coding**.
  * Enables **streaming** and **function calling**; **vision**, **JSON mode**, and **precise token counting** are not available.
  * Added availability via **Opengateway** with a **free launch window** (scheduled through **2026-08-10**).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->