### PR TITLE
fix(minimax): mark MiniMax-M2.7 as text-only input

### DIFF
--- a/src/integrations/models/minimax.ts
+++ b/src/integrations/models/minimax.ts
@@ -70,9 +70,13 @@ export default [
     label: 'MiniMax M2.7',
     brandId: 'minimax',
     vendorId: 'minimax',
-    classification: ['chat', 'reasoning', 'vision', 'coding'],
+    // Text-only model: accepts text input, no image/vision inputs.
+    classification: ['chat', 'reasoning', 'coding'],
     defaultModel: 'MiniMax-M2.7',
-    capabilities: minimaxM2Capabilities,
+    capabilities: {
+      ...minimaxM2Capabilities,
+      supportsVision: false,
+    },
     contextWindow: 196_608,
     maxOutputTokens: 131_072,
   }),

--- a/src/utils/visionUtils.test.ts
+++ b/src/utils/visionUtils.test.ts
@@ -111,6 +111,14 @@ describe('isVisionSupported', () => {
     ).toBe(false)
   })
 
+  test('returns false for the text-only MiniMax M2.7 model on the MiniMax route', () => {
+    expect(
+      isVisionSupported('MiniMax-M2.7', {
+        baseUrl: 'https://api.minimax.io/anthropic',
+      }),
+    ).toBe(false)
+  })
+
   test('returns true for Claude models', () => {
     expect(isVisionSupported('claude-sonnet-4-6')).toBe(true)
   })


### PR DESCRIPTION
Reason: MiniMax-M2.7 is a text-only model, but the runtime model metadata marked it as accepting image inputs.

## What changed
- Correct the `minimax-m2.7` model descriptor so it advertises text-only input: drop the `vision` classification and set `supportsVision: false`. This matches the model's actual input capability and the existing `/model` picker description, and lets the file-read vision gate refuse image reads with an actionable message instead of sending image content the model cannot accept.
- Add a regression test asserting the model resolves to a non-vision descriptor on its provider route.

## Checks
- `bunx tsc --noEmit`
- `bun test src/utils/visionUtils.test.ts`
- `bun test src/integrations/registry.test.ts src/integrations/artifactGenerator.test.ts`
- `bun run integrations:check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the MiniMax M2.7 model to correctly report that it does not support image or vision inputs.
  * Improved capability detection for MiniMax M2.7 requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->