### PR TITLE
docs(readme): add npm monthly downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Use OpenAI-compatible APIs, Gemini, GitHub Models, Codex OAuth, Codex, Ollama, A
 
 [![PR Checks](https://github.com/Gitlawb/openclaude/actions/workflows/pr-checks.yml/badge.svg?branch=main)](https://github.com/Gitlawb/openclaude/actions/workflows/pr-checks.yml)
 [![Release](https://img.shields.io/github/v/tag/Gitlawb/openclaude?label=release&color=0ea5e9)](https://github.com/Gitlawb/openclaude/tags)
+[![npm downloads](https://img.shields.io/npm/dm/@gitlawb/openclaude)](https://www.npmjs.com/package/@gitlawb/openclaude)
 [![Discussions](https://img.shields.io/badge/discussions-open-7c3aed)](https://github.com/Gitlawb/openclaude/discussions)
 [![Discord](https://img.shields.io/badge/Discord-join-5865F2?logo=discord&logoColor=white)](https://discord.gg/k68zFR6AcB)
 [![X](https://img.shields.io/badge/X-@gitlawb-000000?logo=x&logoColor=white)](https://x.com/gitlawb)


### PR DESCRIPTION
## Summary
- Add a shields.io npm monthly-downloads badge to the README badge row, right after the Release badge
- Badge: `https://img.shields.io/npm/dm/@gitlawb/openclaude`, linked to the package page at npmjs.com/package/@gitlawb/openclaude
- Same badge style used by other npm CLI projects (e.g. drawesome)

## Impact
- README only — no code, build, or runtime changes
- Gives visitors an at-a-glance adoption signal (currently renders as "downloads: 28k/month")

## Testing
- [x] Verified the badge URL renders for the scoped package: shields.io returns "downloads: 28k/month"
- [x] Cross-checked against the npm downloads API (28,349 downloads for the last month)

## Notes
- Skipped drawesome's second badge (npm version) since the README already has a Release tag badge covering that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an npm downloads badge to the project README alongside the existing status and project badges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->