### PR TITLE
refactor(openai-shim): extract response adapters

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -17,8 +17,6 @@ import {
 import {
   createOpenAIShimClient,
   hasMistralApiHost,
-  parseTextToolCalls,
-  parseXmlToolCalls,
 } from './openaiShim.ts'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -3764,17 +3764,6 @@ test('the OpenAI shim façade creates independent client instances', () => {
 })
 // openaiShim test extraction seam 112 end
 
-test('raw-text and XML fallback tool calls use one unique sequence', () => {
-  const text = parseTextToolCalls('{"name":"from_text","arguments":{}}')
-  const xml = parseXmlToolCalls('<tool_call>{"name":"from_xml","arguments":{}}</tool_call>')
-  expect(text.calls[0]?.id).toMatch(/^ollama_tc_\d+$/)
-  expect(xml.calls[0]?.id).toMatch(/^xml_tc_\d+$/)
-  const textNum = Number(text.calls[0]?.id?.replace(/^\D+/, ''))
-  const xmlNum = Number(xml.calls[0]?.id?.replace(/^\D+/, ''))
-  // Same session counter: the second mint must be exactly one greater than the first.
-  expect(xmlNum).toBe(textNum + 1)
-})
-
 // ---------------------------------------------------------------------------
 // openaiShim test extraction seam 113 start: non-streaming: reasoning_content emitted as thinking block only when content is null
 test('non-streaming: reasoning_content emitted as thinking block only when content is null', async () => {

--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -17,6 +17,8 @@ import {
 import {
   createOpenAIShimClient,
   hasMistralApiHost,
+  parseTextToolCalls,
+  parseXmlToolCalls,
 } from './openaiShim.ts'
 import * as realGithubModelsCredentials from '../../utils/githubModelsCredentials.js'
 
@@ -3761,6 +3763,19 @@ test('the OpenAI shim façade creates independent client instances', () => {
   expect(first.beta.messages).not.toBe(second.beta.messages)
 })
 // openaiShim test extraction seam 112 end
+
+test('facade parseTextToolCalls and parseXmlToolCalls share adapter sequencing', () => {
+  const text = parseTextToolCalls('{"name":"from_text","arguments":{}}')
+  const xml = parseXmlToolCalls(
+    '<tool_call>{"name":"from_xml","arguments":{}}</tool_call>',
+  )
+
+  expect(text.calls[0]?.id).toMatch(/^ollama_tc_\d+$/)
+  expect(xml.calls[0]?.id).toMatch(/^xml_tc_\d+$/)
+  const textSequence = Number(text.calls[0]?.id?.replace(/^\D+/, ''))
+  const xmlSequence = Number(xml.calls[0]?.id?.replace(/^\D+/, ''))
+  expect(xmlSequence).toBe(textSequence + 1)
+})
 
 // ---------------------------------------------------------------------------
 // openaiShim test extraction seam 113 start: non-streaming: reasoning_content emitted as thinking block only when content is null

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -93,6 +93,17 @@ import {
   openaiStreamToAnthropic as convertOpenAIStream,
 } from './openaiShim/streamConversion.js'
 import { geminiSseToAnthropic as convertGeminiStream } from './openaiShim/geminiStreamConversion.js'
+import {
+  anthropicSsePassthrough,
+  convertGeminiToAnthropicResponse,
+  convertNonStreamingResponseToAnthropicMessage,
+  geminiSseToAnthropic,
+  makeMessageId,
+  openaiStreamToAnthropic as convertOpenAIResponseStream,
+  parseTextToolCalls,
+  parseXmlToolCalls,
+} from './openaiShim/responseAdapters.js'
+export { parseTextToolCalls, parseXmlToolCalls } from './openaiShim/responseAdapters.js'
 import { compressToolHistory } from './compressToolHistory.js'
 import {
   createClassifiedTransportError,
@@ -414,142 +425,6 @@ function convertTools(
 // Streaming: OpenAI SSE → Anthropic stream events
 // ---------------------------------------------------------------------------
 
-interface OpenAIStreamChunk {
-  id: string
-  object: string
-  model: string
-  choices: Array<{
-    index: number
-    delta: {
-      role?: string
-      content?: string | null
-      reasoning_content?: string | null
-      extra_content?: Record<string, unknown>
-      tool_calls?: Array<{
-        index: number
-        id?: string
-        type?: string
-        function?: { name?: string; arguments?: string }
-        extra_content?: Record<string, unknown>
-      }>
-    }
-    finish_reason: string | null
-  }>
-  usage?: {
-    prompt_tokens?: number
-    completion_tokens?: number
-    total_tokens?: number
-    prompt_tokens_details?: {
-      cached_tokens?: number
-    }
-  }
-}
-
-function makeMessageId(): string {
-  return `msg_${crypto.randomUUID().replace(/-/g, '')}`
-}
-
-function convertChunkUsage(usage: OpenAIStreamChunk['usage'] | undefined): Partial<AnthropicUsage> | undefined {
-  return convertOpenAIStreamUsage(usage as Record<string, unknown> | undefined)
-}
-
-export function parseTextToolCalls(text: string): {
-  calls: ParsedTextToolCall[]
-  toolCallRanges: Array<[number, number]>
-} {
-  return parseTextToolCallsModule(text, nextTextToolCallSequence)
-}
-
-// Shared façade state keeps raw-text and XML fallback IDs unique per session.
-let textToolCallSequence = 0
-
-function nextTextToolCallSequence(): number {
-  return ++textToolCallSequence
-}
-
-// ---------------------------------------------------------------------------
-// XML tool parsing façade. Dialect handling lives in xmlToolCallParsing.ts.
-// ---------------------------------------------------------------------------
-
-function findXmlToolCallOpener(text: string, allowHy3: boolean): number {
-  return findXmlToolCallOpenerModule(text, allowHy3)
-}
-
-function isHy3Model(model: string): boolean {
-  return isHy3ModelModule(model)
-}
-
-export function parseXmlToolCalls(text: string, allowHy3 = false) {
-  return parseXmlToolCallsModule(text, allowHy3, nextTextToolCallSequence)
-}
-
-function trailingXmlOpenerPrefixLen(text: string, allowHy3: boolean): number {
-  return trailingXmlOpenerPrefixLenModule(text, allowHy3)
-}
-
-// The streaming finalize path buffers from this opener onward so the raw XML
-// is never surfaced as text before extraction.
-/**
- * Async generator that transforms an OpenAI SSE stream into
- * Anthropic-format BetaRawMessageStreamEvent objects.
- */
-/**
- * Passthrough for Anthropic Messages API SSE streams.
- * The response events are already in AnthropicStreamEvent format —
- * we just parse the SSE frames and yield them directly.
- */
-async function* anthropicSsePassthrough(
-  response: Response,
-  _model: string,
-  signal?: AbortSignal,
-): AsyncGenerator<AnthropicStreamEvent> {
-  yield* parseAnthropicSsePassthrough<AnthropicStreamEvent>(
-    response,
-    signal,
-    (message, options) => options?.level
-      ? logForDebugging(message, { level: options.level })
-      : logForDebugging(message),
-  )
-}
-
-/**
- * Transforms Google AI SDK SSE stream into Anthropic-format stream events.
- * Google AI SDK yields frames with { candidates: [{ content: { role, parts } }] }.
- */
-async function* geminiSseToAnthropic(
-  response: Response,
-  model: string,
-  signal?: AbortSignal,
-): AsyncGenerator<AnthropicStreamEvent> {
-  yield* convertGeminiStream(response, model, signal, {
-    createReaderCanceller,
-    createStreamAbortError,
-    getStreamIdleTimeoutMs,
-    makeMessageId,
-    readWithIdleTimeout,
-    throwIfStreamAborted,
-  })
-}
-// Extraction seam: Gemini streaming | completed response conversion.
-
-function convertNonStreamingResponseToAnthropicMessage(
-  data: NonStreamingOpenAIResponse,
-  model: string,
-) {
-  return convertResponseToAnthropicMessage(data, model, {
-    makeMessageId,
-    buildUsage: usage => buildAnthropicUsageFromRawUsage(usage),
-    stripThinkTags,
-    parseXmlToolCalls,
-    isHy3Model,
-    stripRanges,
-    parseRawToolCalls: parseRawToolCallsRequestedText,
-    normalizeToolArguments,
-    getGeminiThoughtSignature: geminiThoughtSignatureFromExtraContent,
-    mergeGeminiThoughtSignature,
-  })
-}
-
 import { headersWithRequestUrl as buildHeadersWithRequestUrl } from './openaiShim/clientDispatch.js'
 
 function headersWithRequestUrl(headers: Headers, requestUrl?: string): Headers {
@@ -565,31 +440,14 @@ async function* openaiStreamToAnthropic(
   isOllama = false,
   requestUrl?: string,
 ): AsyncGenerator<AnthropicStreamEvent> {
-  yield* convertOpenAIStream(response, model, signal, isOllama, requestUrl, {
-    convertNonStreamingResponseToAnthropicMessage: (data, streamModel) =>
-      convertNonStreamingResponseToAnthropicMessage(
-        data as NonStreamingOpenAIResponse,
-        streamModel,
-      ),
-    couldBeRawToolCallsRequestedPrefix,
-    createReaderCanceller,
-    createStreamAbortError,
-    findXmlToolCallOpener,
-    geminiThoughtSignatureFromExtraContent,
-    getStreamIdleTimeoutMs,
+  yield* convertOpenAIResponseStream(
+    response,
+    model,
+    signal,
+    isOllama,
+    requestUrl,
     headersWithRequestUrl,
-    isHy3Model,
-    makeMessageId,
-    mergeGeminiThoughtSignature,
-    parseRawToolCallsRequestedText,
-    parseTextToolCalls,
-    parseXmlToolCalls,
-    readWithIdleTimeout,
-    repairPossiblyTruncatedObjectJson,
-    stripRanges,
-    throwIfStreamAborted,
-    trailingXmlOpenerPrefixLen,
-  })
+  )
 }
 
 
@@ -1113,54 +971,7 @@ class OpenAIShimMessages {
     data: Record<string, unknown>,
     model: string,
   ) {
-    const content: Array<Record<string, unknown>> = []
-    let hasToolUse = false
-    const candidates = data.candidates as Array<Record<string, unknown>> | undefined
-    const candidate = candidates?.[0]
-    const candidateContent = candidate?.content as { parts?: Array<Record<string, unknown>> } | undefined
-
-    if (candidateContent?.parts) {
-      for (const part of candidateContent.parts) {
-        const text = part.text as string | undefined
-        if (text) {
-          content.push({ type: 'text', text })
-        }
-        const fc = part.functionCall as { name?: string; args?: unknown } | undefined
-        if (fc?.name) {
-          hasToolUse = true
-          content.push({
-            type: 'tool_use',
-            id: `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
-            name: fc.name,
-            input: fc.args ?? {},
-          })
-        }
-      }
-    }
-
-    const stopReason =
-      hasToolUse
-        ? 'tool_use'
-        : candidate?.finishReason === 'MAX_TOKENS'
-          ? 'max_tokens'
-          : 'end_turn'
-
-    const usageMetadata = data.usageMetadata as Record<string, number> | undefined
-    const usage = buildAnthropicUsageFromRawUsage({
-      input_tokens: usageMetadata?.promptTokenCount ?? 0,
-      output_tokens: (usageMetadata?.candidatesTokenCount ?? 0) + (usageMetadata?.thoughtsTokenCount ?? 0),
-    } as unknown as Record<string, unknown>)
-
-    return {
-      id: makeMessageId(),
-      type: 'message',
-      role: 'assistant',
-      content,
-      model,
-      stop_reason: stopReason,
-      stop_sequence: null,
-      usage,
-    }
+    return convertGeminiToAnthropicResponse(data, model)
   }
 }
 

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -42,7 +42,7 @@ import {
   refreshCodexAccessTokenIfNeeded,
 } from '../../utils/codexCredentials.js'
 import { logForDebugging } from '../../utils/debug.js'
-import { anthropicSsePassthrough as parseAnthropicSsePassthrough, createReaderCanceller, createStreamAbortError, getStreamIdleTimeoutMs, readWithIdleTimeout, StreamIdleTimeoutError, throwIfStreamAborted } from './openaiShim/streamControl.js'
+import { createStreamAbortError, getStreamIdleTimeoutMs, readWithIdleTimeout, StreamIdleTimeoutError } from './openaiShim/streamControl.js'
 export { getStreamIdleTimeoutMs } from './openaiShim/streamControl.js'
 import { isBareMode, isEnvTruthy } from '../../utils/envUtils.js'
 import {
@@ -69,10 +69,6 @@ import {
 } from '../../integrations/routeMetadata.js'
 import { getSessionId } from '../../bootstrap/state.js'
 import {
-  createThinkTagFilter,
-  stripThinkTags,
-} from './thinkTagSanitizer.js'
-import {
   codexStreamToAnthropic,
   collectCodexCompletedResponse,
   convertAnthropicMessagesToResponsesInput,
@@ -80,19 +76,12 @@ import {
   convertToolsToResponsesTools,
   performCodexRequest,
   type AnthropicStreamEvent,
-  type AnthropicUsage,
   type ShimCreateParams,
 } from './codexShim.js'
 import {
   createRequestBodyPlanner,
   hydrateOpenAIShimCompatibilityEnv as hydrateRequestPlanningEnv,
 } from './openaiShim/requestPlanner.js'
-import { buildAnthropicUsageFromRawUsage } from './cacheMetrics.js'
-import {
-  convertOpenAIStreamUsage,
-  openaiStreamToAnthropic as convertOpenAIStream,
-} from './openaiShim/streamConversion.js'
-import { geminiSseToAnthropic as convertGeminiStream } from './openaiShim/geminiStreamConversion.js'
 import {
   anthropicSsePassthrough,
   convertGeminiToAnthropicResponse,
@@ -100,8 +89,6 @@ import {
   geminiSseToAnthropic,
   makeMessageId,
   openaiStreamToAnthropic as convertOpenAIResponseStream,
-  parseTextToolCalls,
-  parseXmlToolCalls,
 } from './openaiShim/responseAdapters.js'
 export { parseTextToolCalls, parseXmlToolCalls } from './openaiShim/responseAdapters.js'
 import { compressToolHistory } from './compressToolHistory.js'
@@ -138,10 +125,6 @@ import {
   markOpenAIRequestNonReplayable,
 } from './openaiErrorClassification.js'
 import { redactSecretValueForDisplay, type SecretValueSource } from '../../utils/providerProfile.js'
-import {
-  normalizeToolArguments,
-  hasToolFieldMapping,
-} from './toolArgumentNormalization.js'
 import { logApiCallStart, logApiCallEnd } from '../../utils/requestLogging.js'
 import {
   createStreamState,
@@ -150,13 +133,6 @@ import {
 } from '../../utils/streamingOptimizer.js'
 import { stableStringifyJson } from '../../utils/stableStringify.js'
 import {
-  findXmlToolCallOpener as findXmlToolCallOpenerModule,
-  isHy3Model as isHy3ModelModule,
-  parseXmlToolCalls as parseXmlToolCallsModule,
-  trailingXmlOpenerPrefixLen as trailingXmlOpenerPrefixLenModule,
-} from './openaiShim/xmlToolCallParsing.js'
-import {
-  convertNonStreamingResponseToAnthropicMessage as convertResponseToAnthropicMessage,
   type NonStreamingOpenAIResponse,
 } from './openaiShim/responseConversion.js'
 import {
@@ -190,17 +166,6 @@ import {
   convertMessages as convertAnthropicMessages,
   convertSystemPrompt as convertSystemPromptImpl,
 } from './openaiShim/messageConversion.js'
-import {
-  JSON_REPAIR_SUFFIXES,
-  couldBeRawToolCallsRequestedPrefix,
-  extractBalancedJson,
-  parseRawToolCallsRequestedText,
-  parseTextToolCalls as parseTextToolCallsModule,
-  repairPossiblyTruncatedObjectJson,
-  stripRanges,
-  type ParsedRawToolCall,
-  type ParsedTextToolCall,
-} from './openaiShim/rawToolCallParsing.js'
 import {
   convertTools as convertToolsModule,
   normalizeSchemaForOpenAI as normalizeSchemaForOpenAIModule,

--- a/src/services/api/openaiShim/responseAdapters.test.ts
+++ b/src/services/api/openaiShim/responseAdapters.test.ts
@@ -1,0 +1,62 @@
+import { expect, test } from 'bun:test'
+import {
+  convertGeminiToAnthropicResponse,
+  parseTextToolCalls,
+  parseXmlToolCalls,
+} from './responseAdapters.js'
+
+test('raw-text and XML fallback tool calls use one unique sequence', () => {
+  const text = parseTextToolCalls('{"name":"from_text","arguments":{}}')
+  const xml = parseXmlToolCalls(
+    '<tool_call>{"name":"from_xml","arguments":{}}</tool_call>',
+  )
+
+  expect(text.calls[0]?.id).toMatch(/^ollama_tc_\d+$/)
+  expect(xml.calls[0]?.id).toMatch(/^xml_tc_\d+$/)
+  const textSequence = Number(text.calls[0]?.id?.replace(/^\D+/, ''))
+  const xmlSequence = Number(xml.calls[0]?.id?.replace(/^\D+/, ''))
+  expect(xmlSequence).toBe(textSequence + 1)
+})
+
+test('converts Gemini text and function calls into an Anthropic message', () => {
+  const message = convertGeminiToAnthropicResponse({
+    candidates: [{
+      content: {
+        parts: [
+          { text: 'Checking the workspace.' },
+          { functionCall: { name: 'Read', args: { file_path: 'a.ts' } } },
+        ],
+      },
+      finishReason: 'STOP',
+    }],
+    usageMetadata: {
+      promptTokenCount: 5,
+      candidatesTokenCount: 3,
+      thoughtsTokenCount: 2,
+    },
+  }, 'gemini-test')
+
+  expect(message).toMatchObject({
+    type: 'message',
+    role: 'assistant',
+    model: 'gemini-test',
+    stop_reason: 'tool_use',
+    content: [
+      { type: 'text', text: 'Checking the workspace.' },
+      { type: 'tool_use', name: 'Read', input: { file_path: 'a.ts' } },
+    ],
+    usage: { input_tokens: 5, output_tokens: 5 },
+  })
+})
+
+test('maps Gemini max-token completion without tool calls', () => {
+  const message = convertGeminiToAnthropicResponse({
+    candidates: [{
+      content: { parts: [{ text: 'partial' }] },
+      finishReason: 'MAX_TOKENS',
+    }],
+  }, 'gemini-test')
+
+  expect(message.stop_reason).toBe('max_tokens')
+  expect(message.content).toEqual([{ type: 'text', text: 'partial' }])
+})

--- a/src/services/api/openaiShim/responseAdapters.test.ts
+++ b/src/services/api/openaiShim/responseAdapters.test.ts
@@ -120,6 +120,25 @@ test('geminiSseToAnthropic wrapper emits content, usage, and terminal stop', asy
     event.type === 'content_block_delta' &&
     (event.delta as { text?: string })?.text === 'Inspecting.',
   )).toBe(true)
+
+  const toolStartIndex = events.findIndex(event =>
+    event.type === 'content_block_start' &&
+    (event.content_block as { type?: string; name?: string })?.type === 'tool_use' &&
+    (event.content_block as { name?: string })?.name === 'Read',
+  )
+  expect(toolStartIndex).toBeGreaterThan(-1)
+  expect(events[toolStartIndex + 1]).toMatchObject({
+    type: 'content_block_delta',
+    delta: {
+      type: 'input_json_delta',
+      partial_json: '{"file_path":"a.ts"}',
+    },
+  })
+  expect(events[toolStartIndex + 2]).toEqual({
+    type: 'content_block_stop',
+    index: (events[toolStartIndex] as { index: number }).index,
+  })
+
   expect(events.at(-2)).toMatchObject({
     type: 'message_delta',
     delta: { stop_reason: 'tool_use' },

--- a/src/services/api/openaiShim/responseAdapters.test.ts
+++ b/src/services/api/openaiShim/responseAdapters.test.ts
@@ -1,9 +1,36 @@
 import { expect, test } from 'bun:test'
+import type { AnthropicStreamEvent } from '../codexShim.js'
 import {
   convertGeminiToAnthropicResponse,
+  geminiSseToAnthropic,
+  openaiStreamToAnthropic,
   parseTextToolCalls,
   parseXmlToolCalls,
 } from './responseAdapters.js'
+
+function makeSseResponse(frames: unknown[]): Response {
+  const encoder = new TextEncoder()
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const frame of frames) {
+          const data = frame === '[DONE]' ? frame : JSON.stringify(frame)
+          controller.enqueue(encoder.encode(`data: ${data}\n\n`))
+        }
+        controller.close()
+      },
+    }),
+    { headers: { 'content-type': 'text/event-stream' } },
+  )
+}
+
+async function collectStreamEvents(
+  generator: AsyncGenerator<AnthropicStreamEvent>,
+): Promise<AnthropicStreamEvent[]> {
+  const events: AnthropicStreamEvent[] = []
+  for await (const event of generator) events.push(event)
+  return events
+}
 
 test('raw-text and XML fallback tool calls use one unique sequence', () => {
   const text = parseTextToolCalls('{"name":"from_text","arguments":{}}')
@@ -59,4 +86,91 @@ test('maps Gemini max-token completion without tool calls', () => {
 
   expect(message.stop_reason).toBe('max_tokens')
   expect(message.content).toEqual([{ type: 'text', text: 'partial' }])
+})
+
+test('geminiSseToAnthropic wrapper emits content, usage, and terminal stop', async () => {
+  const events = await collectStreamEvents(geminiSseToAnthropic(
+    makeSseResponse([
+      {
+        usageMetadata: {
+          promptTokenCount: 4,
+          candidatesTokenCount: 2,
+          thoughtsTokenCount: 1,
+        },
+        candidates: [{
+          content: {
+            parts: [
+              { text: 'Inspecting.' },
+              { functionCall: { name: 'Read', args: { file_path: 'a.ts' } } },
+            ],
+          },
+          finishReason: 'STOP',
+        }],
+      },
+      '[DONE]',
+    ]),
+    'gemini-test',
+  ))
+
+  expect(events[0]).toMatchObject({
+    type: 'message_start',
+    message: { model: 'gemini-test' },
+  })
+  expect(events.some(event =>
+    event.type === 'content_block_delta' &&
+    (event.delta as { text?: string })?.text === 'Inspecting.',
+  )).toBe(true)
+  expect(events.at(-2)).toMatchObject({
+    type: 'message_delta',
+    delta: { stop_reason: 'tool_use' },
+    usage: {
+      input_tokens: 4,
+      output_tokens: 3,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+  })
+  expect(events.at(-1)).toEqual({ type: 'message_stop' })
+})
+
+test('openaiStreamToAnthropic wrapper emits text, usage, and terminal stop', async () => {
+  const events = await collectStreamEvents(openaiStreamToAnthropic(
+    makeSseResponse([
+      {
+        choices: [{
+          index: 0,
+          delta: { content: 'hello' },
+          finish_reason: null,
+        }],
+      },
+      {
+        choices: [{
+          index: 0,
+          delta: {},
+          finish_reason: 'stop',
+        }],
+        usage: { prompt_tokens: 7, completion_tokens: 2 },
+      },
+      '[DONE]',
+    ]),
+    'test-model',
+  ))
+
+  expect(events.map(event => event.type)).toContain('message_start')
+  expect(events).toContainEqual({
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'text_delta', text: 'hello' },
+  })
+  expect(events.at(-2)).toMatchObject({
+    type: 'message_delta',
+    delta: { stop_reason: 'end_turn', stop_sequence: null },
+    usage: {
+      input_tokens: 7,
+      output_tokens: 2,
+      cache_creation_input_tokens: 0,
+      cache_read_input_tokens: 0,
+    },
+  })
+  expect(events.at(-1)).toEqual({ type: 'message_stop' })
 })

--- a/src/services/api/openaiShim/responseAdapters.ts
+++ b/src/services/api/openaiShim/responseAdapters.ts
@@ -1,0 +1,208 @@
+import { logForDebugging } from '../../../utils/debug.js'
+import { buildAnthropicUsageFromRawUsage } from '../cacheMetrics.js'
+import {
+  type AnthropicStreamEvent,
+} from '../codexShim.js'
+import { normalizeToolArguments } from '../toolArgumentNormalization.js'
+import { stripThinkTags } from '../thinkTagSanitizer.js'
+import {
+  geminiThoughtSignatureFromExtraContent,
+  mergeGeminiThoughtSignature,
+} from './providerCompatibility.js'
+import {
+  couldBeRawToolCallsRequestedPrefix,
+  parseRawToolCallsRequestedText,
+  parseTextToolCalls as parseTextToolCallsModule,
+  repairPossiblyTruncatedObjectJson,
+  stripRanges,
+  type ParsedTextToolCall,
+} from './rawToolCallParsing.js'
+import {
+  convertNonStreamingResponseToAnthropicMessage as convertResponseToAnthropicMessage,
+  type NonStreamingOpenAIResponse,
+} from './responseConversion.js'
+import { openaiStreamToAnthropic as convertOpenAIStream } from './streamConversion.js'
+import { geminiSseToAnthropic as convertGeminiStream } from './geminiStreamConversion.js'
+import {
+  anthropicSsePassthrough as parseAnthropicSsePassthrough,
+  createReaderCanceller,
+  createStreamAbortError,
+  getStreamIdleTimeoutMs,
+  readWithIdleTimeout,
+  throwIfStreamAborted,
+} from './streamControl.js'
+import {
+  findXmlToolCallOpener as findXmlToolCallOpenerModule,
+  isHy3Model as isHy3ModelModule,
+  parseXmlToolCalls as parseXmlToolCallsModule,
+  trailingXmlOpenerPrefixLen as trailingXmlOpenerPrefixLenModule,
+} from './xmlToolCallParsing.js'
+
+export function makeMessageId(): string {
+  return `msg_${crypto.randomUUID().replace(/-/g, '')}`
+}
+
+// Raw-text and XML fallbacks share one sequence so their generated IDs cannot
+// collide when both syntaxes occur during the same process lifetime.
+let textToolCallSequence = 0
+
+function nextTextToolCallSequence(): number {
+  return ++textToolCallSequence
+}
+
+export function parseTextToolCalls(text: string): {
+  calls: ParsedTextToolCall[]
+  toolCallRanges: Array<[number, number]>
+} {
+  return parseTextToolCallsModule(text, nextTextToolCallSequence)
+}
+
+function findXmlToolCallOpener(text: string, allowHy3: boolean): number {
+  return findXmlToolCallOpenerModule(text, allowHy3)
+}
+
+function isHy3Model(model: string): boolean {
+  return isHy3ModelModule(model)
+}
+
+export function parseXmlToolCalls(text: string, allowHy3 = false) {
+  return parseXmlToolCallsModule(text, allowHy3, nextTextToolCallSequence)
+}
+
+function trailingXmlOpenerPrefixLen(text: string, allowHy3: boolean): number {
+  return trailingXmlOpenerPrefixLenModule(text, allowHy3)
+}
+
+export async function* anthropicSsePassthrough(
+  response: Response,
+  _model: string,
+  signal?: AbortSignal,
+): AsyncGenerator<AnthropicStreamEvent> {
+  yield* parseAnthropicSsePassthrough<AnthropicStreamEvent>(
+    response,
+    signal,
+    (message, options) => options?.level
+      ? logForDebugging(message, { level: options.level })
+      : logForDebugging(message),
+  )
+}
+
+export async function* geminiSseToAnthropic(
+  response: Response,
+  model: string,
+  signal?: AbortSignal,
+): AsyncGenerator<AnthropicStreamEvent> {
+  yield* convertGeminiStream(response, model, signal, {
+    createReaderCanceller,
+    createStreamAbortError,
+    getStreamIdleTimeoutMs,
+    makeMessageId,
+    readWithIdleTimeout,
+    throwIfStreamAborted,
+  })
+}
+
+export function convertNonStreamingResponseToAnthropicMessage(
+  data: NonStreamingOpenAIResponse,
+  model: string,
+) {
+  return convertResponseToAnthropicMessage(data, model, {
+    makeMessageId,
+    buildUsage: usage => buildAnthropicUsageFromRawUsage(usage),
+    stripThinkTags,
+    parseXmlToolCalls,
+    isHy3Model,
+    stripRanges,
+    parseRawToolCalls: parseRawToolCallsRequestedText,
+    normalizeToolArguments,
+    getGeminiThoughtSignature: geminiThoughtSignatureFromExtraContent,
+    mergeGeminiThoughtSignature,
+  })
+}
+
+export async function* openaiStreamToAnthropic(
+  response: Response,
+  model: string,
+  signal?: AbortSignal,
+  isOllama = false,
+  requestUrl?: string,
+  headersWithRequestUrl?: (headers: Headers, requestUrl?: string) => Headers,
+): AsyncGenerator<AnthropicStreamEvent> {
+  yield* convertOpenAIStream(response, model, signal, isOllama, requestUrl, {
+    convertNonStreamingResponseToAnthropicMessage: (data, streamModel) =>
+      convertNonStreamingResponseToAnthropicMessage(
+        data as NonStreamingOpenAIResponse,
+        streamModel,
+      ),
+    couldBeRawToolCallsRequestedPrefix,
+    createReaderCanceller,
+    createStreamAbortError,
+    findXmlToolCallOpener,
+    geminiThoughtSignatureFromExtraContent,
+    getStreamIdleTimeoutMs,
+    headersWithRequestUrl: headersWithRequestUrl ?? ((headers) => headers),
+    isHy3Model,
+    makeMessageId,
+    mergeGeminiThoughtSignature,
+    parseRawToolCallsRequestedText,
+    parseTextToolCalls,
+    parseXmlToolCalls,
+    readWithIdleTimeout,
+    repairPossiblyTruncatedObjectJson,
+    stripRanges,
+    throwIfStreamAborted,
+    trailingXmlOpenerPrefixLen,
+  })
+}
+
+export function convertGeminiToAnthropicResponse(
+  data: Record<string, unknown>,
+  model: string,
+) {
+  const content: Array<Record<string, unknown>> = []
+  let hasToolUse = false
+  const candidates = data.candidates as Array<Record<string, unknown>> | undefined
+  const candidate = candidates?.[0]
+  const candidateContent = candidate?.content as {
+    parts?: Array<Record<string, unknown>>
+  } | undefined
+
+  for (const part of candidateContent?.parts ?? []) {
+    const text = part.text as string | undefined
+    if (text) content.push({ type: 'text', text })
+    const functionCall = part.functionCall as {
+      name?: string
+      args?: unknown
+    } | undefined
+    if (functionCall?.name) {
+      hasToolUse = true
+      content.push({
+        type: 'tool_use',
+        id: `toolu_${crypto.randomUUID().replace(/-/g, '').slice(0, 24)}`,
+        name: functionCall.name,
+        input: functionCall.args ?? {},
+      })
+    }
+  }
+
+  const usageMetadata = data.usageMetadata as Record<string, number> | undefined
+  return {
+    id: makeMessageId(),
+    type: 'message',
+    role: 'assistant',
+    content,
+    model,
+    stop_reason: hasToolUse
+      ? 'tool_use'
+      : candidate?.finishReason === 'MAX_TOKENS'
+        ? 'max_tokens'
+        : 'end_turn',
+    stop_sequence: null,
+    usage: buildAnthropicUsageFromRawUsage({
+      input_tokens: usageMetadata?.promptTokenCount ?? 0,
+      output_tokens:
+        (usageMetadata?.candidatesTokenCount ?? 0) +
+        (usageMetadata?.thoughtsTokenCount ?? 0),
+    } as unknown as Record<string, unknown>),
+  }
+}


### PR DESCRIPTION
## Summary

- move raw/XML fallback sequencing, stream-adapter dependency wiring, completed response conversion, and Gemini response conversion into `openaiShim/responseAdapters.ts`
- preserve the public `parseTextToolCalls` and `parseXmlToolCalls` exports through the facade
- move the raw/XML tool-call sequence test into paired `responseAdapters.test.ts`
- reduce `openaiShim.ts` from 1,208 to 1,019 lines (19 additions, 208 deletions)

## Why

The facade still owned response-adapter assembly after the earlier transport and Gemini-stream extractions landed on `main`. This gives that responsibility an explicit source/test owner without depending on any other follow-up extraction.

Rebased onto upstream `main` at `c327805e`. The architecture guard and `geminiStreamConversion.test.ts` pairing already exist on `main`; this PR only adds the `responseAdapters` module and wires the facade to it.

## Impact

No intended user-facing or provider behavior change. The facade delegates through the same converters and retains its public parser API.

## Validation

- `bun test src/services/api/openaiShim/responseAdapters.test.ts` — 5 pass
- `bun test src/services/api/openaiShim.architecture.test.ts` — 2 pass
- `bun test src/services/api/openaiShim.test.ts --test-name-pattern "facade parseTextToolCalls"` — 1 pass
- `bun run typecheck` — pass
- `bun run typecheck:type-tests` — pass (10 files checked)

## Contributor checklist

- Reviewed `CONTRIBUTING.md` and `AGENTS.md`.
- No linked issue; this is focused post-extraction architecture housekeeping.
- OpenAI-compatible and Gemini conversion paths were tested.
- No UI changes or screenshots required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when converting OpenAI and Gemini responses into the app’s standard message format.
  * Preserved text, tool-call, stop-reason, and usage details across streaming and non-streaming responses.
  * Improved sequencing for tool calls parsed from text and XML formats.

* **Tests**
  * Added coverage for response conversion, streaming events, usage metadata, stop reasons, and tool-call sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->