### PR TITLE
refactor(openai-shim): extract request preparation

### DIFF
--- a/src/__tests__/bugfixes.test.ts
+++ b/src/__tests__/bugfixes.test.ts
@@ -41,14 +41,6 @@ describe('Gemini store field fix', () => {
     expect(mistralDescriptor).toContain("removeBodyFields: ['store']")
   })
 
-  test('store: false is still set by default and only removed via shim config', async () => {
-    const content = await file('services/api/openaiShim.ts').text()
-
-    expect(content).toMatch(/store:\s*false/)
-    expect(content).toContain('shimConfig.removeBodyFields')
-    expect(content).toContain('delete body[field]')
-  })
-
   test('openaiShim does not keep a hardcoded descriptor route fallback list', async () => {
     const content = await file('services/api/openaiShim.ts').text()
 
@@ -451,14 +443,6 @@ describe('Regression checks', () => {
     }
   })
 
-  test('store field remains opt-out by per-route config rather than unconditional deletion', async () => {
-    const openaiShim = await file('services/api/openaiShim.ts').text()
-    const runtimeMetadata = await file('integrations/runtimeMetadata.ts').text()
-
-    expect(openaiShim).toMatch(/store:\s*false/)
-    expect(openaiShim).toContain('for (const field of shimConfig.removeBodyFields ?? [])')
-    expect(runtimeMetadata).toContain('mergeRemoveBodyFields')
-  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -45,11 +45,7 @@ import { logForDebugging } from '../../utils/debug.js'
 import { createStreamAbortError, getStreamIdleTimeoutMs, readWithIdleTimeout, StreamIdleTimeoutError } from './openaiShim/streamControl.js'
 export { getStreamIdleTimeoutMs } from './openaiShim/streamControl.js'
 import { isBareMode, isEnvTruthy } from '../../utils/envUtils.js'
-import {
-  resolveModelReasoningControl,
-  resolveOpenAIShimReasoningRequestPlan,
-  type OpenAIShimEffortLevel,
-} from '../../utils/effort.js'
+import { type OpenAIShimEffortLevel } from '../../utils/effort.js'
 import { resolveGeminiCredential } from '../../utils/geminiAuth.js'
 import { hydrateGeminiAccessTokenFromSecureStorage } from '../../utils/geminiCredentials.js'
 import {
@@ -57,10 +53,6 @@ import {
   refreshCopilotTokenOn401,
 } from '../../utils/githubModelsCredentials.js'
 import { resolveXaiAccessToken } from '../../utils/xaiCredentials.js'
-import {
-  resolveModelRuntimeLimits,
-  resolveOpenAIShimRuntimeContext,
-} from '../../integrations/runtimeMetadata.js'
 import {
   getRouteDescriptor,
   isLongcatBaseUrl,
@@ -71,17 +63,12 @@ import { getSessionId } from '../../bootstrap/state.js'
 import {
   codexStreamToAnthropic,
   collectCodexCompletedResponse,
-  convertAnthropicMessagesToResponsesInput,
   convertCodexResponseToAnthropicMessage,
-  convertToolsToResponsesTools,
   performCodexRequest,
   type AnthropicStreamEvent,
   type ShimCreateParams,
 } from './codexShim.js'
-import {
-  createRequestBodyPlanner,
-  hydrateOpenAIShimCompatibilityEnv as hydrateRequestPlanningEnv,
-} from './openaiShim/requestPlanner.js'
+import { hydrateOpenAIShimCompatibilityEnv as hydrateRequestPlanningEnv } from './openaiShim/requestPlanner.js'
 import { prepareOpenAIRequest } from './openaiShim/requestPreparation.js'
 import {
   anthropicSsePassthrough,
@@ -92,7 +79,6 @@ import {
   openaiStreamToAnthropic as convertOpenAIResponseStream,
 } from './openaiShim/responseAdapters.js'
 export { parseTextToolCalls, parseXmlToolCalls } from './openaiShim/responseAdapters.js'
-import { compressToolHistory } from './compressToolHistory.js'
 import {
   createClassifiedTransportError,
   fetchWithHeadersDeadline,
@@ -105,19 +91,13 @@ import {
 export { getApiTimeoutMs } from './openaiShim/transport.js'
 import { executeOpenAIRequest } from './openaiShim/requestExecutor.js'
 import {
-  getLocalFastPathConfig,
   getLocalProviderRetryBaseUrls,
   getGithubEndpointType,
-  baseUrlSupportsResponsesAutoRoute,
   isAzureStyleBaseUrl,
-  isDirectLocalOllamaEndpoint,
-  isLikelyOllamaEndpoint,
   isLocalProviderUrl,
-  modelRequiresResponsesApi,
   resolveRuntimeCodexCredentials,
   resolveProviderRequest,
   shouldAttemptLocalToollessRetry,
-  type LocalFastPathConfig,
 } from './providerConfig.js'
 import {
   buildOpenAICompatibilityErrorMessage,
@@ -145,13 +125,11 @@ import {
 import {
   filterAnthropicHeaders,
   geminiThoughtSignatureFromExtraContent,
-  hasCerebrasApiHost,
   hasGeminiApiHost as matchesGeminiApiHost,
   hasMistralApiHost,
   isGithubModelsMode,
   isGeminiModelName,
   mergeGeminiThoughtSignature,
-  maybeSetNvidiaNimChatTemplateThinking,
   shouldPreserveGeminiThoughtSignature as shouldPreserveGeminiThoughtSignatureForRoute,
 } from './openaiShim/providerCompatibility.js'
 
@@ -160,8 +138,6 @@ import {
   buildOllamaChatUrl,
   convertOllamaNonStreamingResponse,
   convertOllamaStreamingResponse,
-  getOllamaNumCtx,
-  normalizeOllamaNativeMessages,
 } from './openaiShim/ollamaAdapter.js'
 import {
   convertMessages as convertAnthropicMessages,

--- a/src/services/api/openaiShim.ts
+++ b/src/services/api/openaiShim.ts
@@ -82,6 +82,7 @@ import {
   createRequestBodyPlanner,
   hydrateOpenAIShimCompatibilityEnv as hydrateRequestPlanningEnv,
 } from './openaiShim/requestPlanner.js'
+import { prepareOpenAIRequest } from './openaiShim/requestPreparation.js'
 import {
   anthropicSsePassthrough,
   convertGeminiToAnthropicResponse,
@@ -632,283 +633,35 @@ class OpenAIShimMessages {
     requestProcessEnv: NodeJS.ProcessEnv = process.env,
   ): Promise<Response> {
     const apiTimeoutMs = getApiTimeoutMs()
-    // Local backends (llama.cpp, vLLM, Ollama, LM Studio, …) do not implement
-    // the cloud-side caching/strict-validation behaviours that several of our
-    // pre-send transforms target. Computing the fast-path config once here
-    // lets us skip those transforms uniformly. See providerConfig.ts.
-    const fastPath: LocalFastPathConfig = getLocalFastPathConfig(request.baseUrl)
-
-    const rawMessages = params.messages as Array<{
-      role: string
-      message?: { role?: string; content?: unknown }
-      content?: unknown
-    }>
-    const runtimeModel = request.requestedModel
-    const runtimeShimContext = resolveOpenAIShimRuntimeContext({
-      processEnv: requestProcessEnv,
-      baseUrl: request.baseUrl,
-      model: runtimeModel,
-      treatAsLocal: isLocalProviderUrl(request.baseUrl),
-      preferBaseUrlRoute: Boolean(this.providerOverride),
+    const prepared = prepareOpenAIRequest({
+      request,
+      params,
+      requestProcessEnv,
+      providerOverride: this.providerOverride,
+      dependencies: {
+        convertMessages,
+        convertSystemPrompt,
+        convertTools,
+        hasGeminiApiHost,
+        isGeminiMode,
+        shouldPreserveGeminiThoughtSignature,
+      },
     })
-    const runtimeLimits = resolveModelRuntimeLimits({
-      model: runtimeModel,
-      baseUrl: request.baseUrl,
-      processEnv: requestProcessEnv,
-      activeProfileProvider: runtimeShimContext.routeId ?? undefined,
-    })
-    const shimConfig = runtimeShimContext.openaiShimConfig
-    // When endpointPath is overridden, the body format must match the target
-    // API contract rather than request.transport from providerConfig.
-    // - /responses         → OpenAI Responses API (input, max_output_tokens, instructions)
-    // - /messages          → Anthropic Messages API (system, max_tokens, content blocks)
-    // - /models/gemini-*   → Google AI SDK (contents, systemInstruction, generationConfig)
-    const effectiveTransport = shimConfig.endpointPath === '/responses'
-      ? 'responses'
-      : shimConfig.endpointPath === '/messages'
-        ? 'anthropic_messages'
-        : shimConfig.endpointPath?.startsWith('/models/gemini-')
-          ? 'gemini'
-          : request.transport
-    const compressedMessages = getCompressedMessagesForTransport(
+    const {
+      fastPath,
+      runtimeShimContext,
+      shimConfig,
+      body,
       effectiveTransport,
-      rawMessages,
-      () => fastPath.skipToolHistoryCompression
-        ? rawMessages
-        : compressToolHistory(rawMessages, runtimeModel, {
-          textBlockSeparator:
-            effectiveTransport === 'chat_completions' ? '\n\n' : '\n',
-          runtimeLimits,
-        }),
-    )
-    const useNativeOllamaChat =
-      effectiveTransport === 'chat_completions' &&
-      !shimConfig.endpointPath &&
-      isDirectLocalOllamaEndpoint(request.baseUrl) &&
-      isLikelyOllamaEndpoint(request.baseUrl)
-    const openaiMessages = getChatMessagesForTransport(
-      effectiveTransport,
-      () => convertMessages(compressedMessages, params.system, {
-        preserveReasoningContent: shimConfig.preserveReasoningContent,
-        reasoningContentFallback: shimConfig.reasoningContentFallback,
-        preserveGeminiThoughtSignature: shouldPreserveGeminiThoughtSignature(
-          request.resolvedModel,
-          request.baseUrl,
-        ),
-        supportsImageInputs: shimConfig.supportsImageInputs,
-      }),
-    )
-
-    const reasoningControl = resolveModelReasoningControl(runtimeModel, {
-      routeId: runtimeShimContext.routeId,
-      useRuntimeFallback: false,
-      openaiShimConfig: shimConfig,
-      baseUrl: request.baseUrl,
-      processEnv: requestProcessEnv,
-    })
-    // The explicit chat-completions escape hatch for GPT-5.4/5.5/5.6 must
-    // also omit reasoning effort: these models reject the tools + effort
-    // combination on that API surface.
-    const suppressReasoningForForcedChat =
-      effectiveTransport === 'chat_completions' &&
-      Array.isArray(params.tools) &&
-      params.tools.length > 0 &&
-      modelRequiresResponsesApi(request.resolvedModel) &&
-      baseUrlSupportsResponsesAutoRoute(request.baseUrl, requestProcessEnv)
-    const reasoningRequestPlan = resolveOpenAIShimReasoningRequestPlan({
-      model: runtimeModel,
-      requestedEffort: suppressReasoningForForcedChat ? undefined : request.reasoning?.effort,
-      requestThinkingType: (params.thinking as { type?: string } | undefined)?.type,
-      defaultThinkingType: request.thinking?.type,
-      thinkingRequestFormat: shimConfig.thinkingRequestFormat,
-      routeId: runtimeShimContext.routeId ?? 'custom',
-      useRuntimeFallback: false,
-      reasoningControl,
-    })
-
-    const body: Record<string, unknown> = {
-      model: request.resolvedModel,
-      ...(openaiMessages ? { messages: openaiMessages } : {}),
-      stream: params.stream ?? false,
-      store: false,
-    }
-    // Emit reasoning_effort for chat_completions when the resolved provider
-     // request carries a reasoning effort (set via /effort, model alias default,
-     // or `?reasoning=<level>` query on the model string). OpenAI, Codex, and
-     // most OpenAI-compatible endpoints read it from this top-level field.
-    if (reasoningRequestPlan.wireFormat === 'reasoning_effort' && reasoningRequestPlan.reasoningEffort) {
-      body.reasoning_effort = reasoningRequestPlan.reasoningEffort
-    }
-    if (
-      reasoningRequestPlan.wireFormat === 'reasoning_effort' &&
-      reasoningRequestPlan.thinkingType === 'disabled'
-    ) {
-      body.thinking = { type: 'disabled' }
-      delete body.reasoning_effort
-    }
-    // Convert max_tokens to max_completion_tokens for OpenAI API compatibility.
-    // Azure OpenAI requires max_completion_tokens and does not accept max_tokens.
-    // Ensure max_tokens is a valid positive number before using it.
-    const maxTokensValue = typeof params.max_tokens === 'number' && params.max_tokens > 0
-      ? params.max_tokens
-      : undefined
-    const maxCompletionTokensValue = typeof (params as Record<string, unknown>).max_completion_tokens === 'number'
-      ? (params as Record<string, unknown>).max_completion_tokens as number
-      : undefined
-
-    if (maxTokensValue !== undefined) {
-      body.max_completion_tokens = maxTokensValue
-    } else if (maxCompletionTokensValue !== undefined) {
-      body.max_completion_tokens = maxCompletionTokensValue
-    }
-
-    if (params.stream && !isLocalProviderUrl(request.baseUrl)) {
-      body.stream_options = { include_usage: true }
-    }
-
-    const isGithub = isGithubModelsMode()
-    const isLocal = isLocalProviderUrl(request.baseUrl)
-
-    const githubEndpointType = getGithubEndpointType(request.baseUrl)
-    const isGithubCopilot = isGithub && (githubEndpointType === 'copilot' || githubEndpointType === 'ghe')
-    const isGithubModels = isGithub && (githubEndpointType === 'models' || githubEndpointType === 'custom')
-    const shouldStripResponsesStore =
-      (shimConfig.removeBodyFields ?? []).includes('store') ||
-      isGeminiMode() ||
-      hasGeminiApiHost(request.baseUrl) ||
-      hasCerebrasApiHost(request.baseUrl) ||
-      hasMistralApiHost(request.baseUrl) ||
-      isLocal
-
-    // Mistral's chat completions reject `max_completion_tokens` (and `store`).
-    // When the route resolves to the Mistral descriptor the config already maps
-    // to `max_tokens`; on the host-detected fallback (`hasMistralApiHost`) the
-    // generic default leaves `max_completion_tokens`, so map it here too.
-    if (
-      (shimConfig.maxTokensField === 'max_tokens' ||
-        hasMistralApiHost(request.baseUrl)) &&
-      body.max_completion_tokens !== undefined
-    ) {
-      body.max_tokens = body.max_completion_tokens
-      delete body.max_completion_tokens
-    }
-
-    for (const field of shimConfig.removeBodyFields ?? []) {
-      delete body[field]
-    }
-
-    if (shouldStripResponsesStore) {
-      delete body.store
-    }
-
-    if (params.temperature !== undefined) body.temperature = params.temperature
-    if (params.top_p !== undefined) body.top_p = params.top_p
-
-    if (reasoningRequestPlan.wireFormat === 'deepseek_compatible') {
-      if (reasoningRequestPlan.thinkingType) {
-        body.thinking = { type: reasoningRequestPlan.thinkingType }
-      }
-      if (reasoningRequestPlan.reasoningEffort) {
-        body.reasoning_effort = reasoningRequestPlan.reasoningEffort
-      }
-      maybeSetNvidiaNimChatTemplateThinking(body, request.baseUrl, reasoningRequestPlan)
-    }
-
-    if (reasoningRequestPlan.wireFormat === 'zai_compatible') {
-      if (reasoningRequestPlan.thinkingType) {
-        body.thinking = { type: reasoningRequestPlan.thinkingType }
-      }
-      if (reasoningRequestPlan.thinkingType === 'disabled') {
-        delete body.reasoning_effort
-      } else if (reasoningRequestPlan.reasoningEffort) {
-        body.reasoning_effort = reasoningRequestPlan.reasoningEffort
-      } else {
-        delete body.reasoning_effort
-      }
-      maybeSetNvidiaNimChatTemplateThinking(body, request.baseUrl, reasoningRequestPlan)
-    }
-
-    // Route/model strip rules are authoritative even when compatibility
-    // serializers add provider-specific reasoning fields later in the pipeline.
-    for (const field of shimConfig.removeBodyFields ?? []) {
-      delete body[field]
-    }
-
-    if (
-      !(shimConfig.removeBodyFields ?? []).includes('tools') &&
-      params.tools &&
-      params.tools.length > 0
-    ) {
-      const converted = convertTools(
-        params.tools as Array<{
-          name: string
-          description?: string
-          input_schema?: Record<string, unknown>
-        }>,
-        { skipStrict: fastPath.skipStrictTools },
-      )
-      if (converted.length > 0) {
-        body.tools = converted
-        if (
-          effectiveTransport === 'chat_completions' &&
-          params.stream &&
-          shimConfig.enableToolStreaming === true
-        ) {
-          body.tool_stream = true
-        }
-        if (params.tool_choice) {
-          const tc = params.tool_choice as { type?: string; name?: string }
-          if (tc.type === 'auto') {
-            body.tool_choice = 'auto'
-          } else if (tc.type === 'tool' && tc.name) {
-            body.tool_choice = {
-              type: 'function',
-              function: { name: tc.name },
-            }
-          } else if (tc.type === 'any') {
-            body.tool_choice = 'required'
-          } else if (tc.type === 'none') {
-            body.tool_choice = 'none'
-          }
-        }
-      }
-    }
-
-    let responsesInput: ReturnType<
-      typeof convertAnthropicMessagesToResponsesInput
-    > | undefined
-    let responsesMessages: typeof compressedMessages | undefined
-    const getResponsesInput = () => {
-      // GitHub can reject a Chat request and retry it through Responses. That
-      // retry must budget structured text with the Responses separator rather
-      // than reusing the Chat-compressed form (which uses a double newline).
-      responsesMessages ??= effectiveTransport === 'chat_completions'
-        ? fastPath.skipToolHistoryCompression
-          ? rawMessages
-          : compressToolHistory(rawMessages, request.resolvedModel, {
-            textBlockSeparator: '\n',
-          })
-        : compressedMessages
-      responsesInput ??= convertAnthropicMessagesToResponsesInput(
-        responsesMessages,
-        effectiveTransport === 'responses_compat',
-      )
-      return responsesInput
-    }
-
-    const omitTools = {
-      responses: false,
-      anthropic: false,
-      gemini: false,
-    }
-    const planner = createRequestBodyPlanner({
-      request, params, effectiveTransport, shouldStripResponsesStore, body,
-      reasoningRequestPlan, shimConfig, getResponsesInput, convertSystemPrompt,
-      convertToolsToResponsesTools, maxTokensValue, maxCompletionTokensValue,
-      getOllamaNumCtx, normalizeOllamaNativeMessages, useNativeOllamaChat,
-      fastPath, stableStringifyJson, omitTools,
-    })
-    const { buildResponsesBody, serializeBody } = planner
+      useNativeOllamaChat,
+      buildResponsesBody,
+      serializeBody,
+      isLocal,
+      isGithub,
+      isGithubCopilot,
+      isGithubModels,
+      omitTools,
+    } = prepared
 
     // Extraction boundary: request planning | request execution.
     // The prepared body builders above are executor inputs, not executor-owned logic.

--- a/src/services/api/openaiShim/requestPreparation.test.ts
+++ b/src/services/api/openaiShim/requestPreparation.test.ts
@@ -1,0 +1,90 @@
+import { expect, test } from 'bun:test'
+import { ensureIntegrationsLoaded } from '../../../integrations/index.js'
+import { resolveProviderRequest } from '../providerConfig.js'
+import { prepareOpenAIRequest } from './requestPreparation.js'
+
+const dependencies = {
+  convertMessages: (
+    messages: Array<{ role: string; content?: unknown }>,
+    system: unknown,
+  ) => [
+    ...(system ? [{ role: 'system', content: String(system) }] : []),
+    ...messages,
+  ],
+  convertSystemPrompt: (system: unknown) => String(system ?? ''),
+  convertTools: (tools: unknown[]) => tools,
+  hasGeminiApiHost: () => false,
+  isGeminiMode: () => false,
+  shouldPreserveGeminiThoughtSignature: () => false,
+}
+
+test('prepares a chat-completions request without executing transport', async () => {
+  await ensureIntegrationsLoaded()
+  const processEnv = {
+    OPENAI_BASE_URL: 'https://gateway.example.test/v1',
+    OPENAI_API_KEY: 'test-key',
+  }
+  const request = resolveProviderRequest({
+    model: 'gpt-4o',
+    processEnv,
+  })
+  const prepared = prepareOpenAIRequest({
+    request,
+    requestProcessEnv: processEnv,
+    params: {
+      model: 'gpt-4o',
+      system: 'system prompt',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 64,
+      temperature: 0.2,
+      stream: false,
+    },
+    dependencies,
+  })
+
+  expect(prepared.effectiveTransport).toBe('chat_completions')
+  expect(prepared.body).toMatchObject({
+    model: 'gpt-4o',
+    messages: [
+      { role: 'system', content: 'system prompt' },
+      { role: 'user', content: 'hello' },
+    ],
+    max_completion_tokens: 64,
+    temperature: 0.2,
+    stream: false,
+  })
+  expect(prepared.body).not.toHaveProperty('stream_options')
+})
+
+test('prepares tools and streaming options for a remote chat route', async () => {
+  await ensureIntegrationsLoaded()
+  const processEnv = {
+    OPENAI_BASE_URL: 'https://gateway.example.test/v1',
+    OPENAI_API_KEY: 'test-key',
+  }
+  const request = resolveProviderRequest({ model: 'gpt-4o', processEnv })
+  const prepared = prepareOpenAIRequest({
+    request,
+    requestProcessEnv: processEnv,
+    params: {
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'hello' }],
+      tools: [{
+        name: 'Read',
+        description: 'Read a file',
+        input_schema: { type: 'object', properties: {} },
+      }],
+      tool_choice: { type: 'tool', name: 'Read' },
+      max_tokens: 64,
+      stream: true,
+    },
+    dependencies,
+  })
+
+  expect(prepared.body.stream_options).toEqual({ include_usage: true })
+  expect(prepared.body.tools).toHaveLength(1)
+  expect(prepared.body.tool_choice).toEqual({
+    type: 'function',
+    function: { name: 'Read' },
+  })
+})

--- a/src/services/api/openaiShim/requestPreparation.test.ts
+++ b/src/services/api/openaiShim/requestPreparation.test.ts
@@ -18,29 +18,32 @@ const dependencies = {
   shouldPreserveGeminiThoughtSignature: () => false,
 }
 
-test('store: false is still set by default and only removed via shim config', async () => {
-  const requestPreparation = await Bun.file(
-    new URL('./requestPreparation.ts', import.meta.url),
-  ).text()
+test('keeps store: false by default and removes it only for configured routes', async () => {
+  await ensureIntegrationsLoaded()
+  const prepare = (model: string, processEnv: NodeJS.ProcessEnv) =>
+    prepareOpenAIRequest({
+      request: resolveProviderRequest({ model, processEnv }),
+      requestProcessEnv: processEnv,
+      params: {
+        model,
+        messages: [{ role: 'user', content: 'hello' }],
+        max_tokens: 64,
+      },
+      dependencies,
+    })
 
-  expect(requestPreparation).toMatch(/store:\s*false/)
-  expect(requestPreparation).toContain('shimConfig.removeBodyFields')
-  expect(requestPreparation).toContain('delete body[field]')
-})
+  const generic = prepare('gpt-4o', {
+    OPENAI_BASE_URL: 'https://gateway.example.test/v1',
+    OPENAI_API_KEY: 'test-key',
+  })
+  expect(generic.body.store).toBe(false)
 
-test('store field remains opt-out by per-route config rather than unconditional deletion', async () => {
-  const requestPreparation = await Bun.file(
-    new URL('./requestPreparation.ts', import.meta.url),
-  ).text()
-  const runtimeMetadata = await Bun.file(
-    new URL('../../../integrations/runtimeMetadata.ts', import.meta.url),
-  ).text()
-
-  expect(requestPreparation).toMatch(/store:\s*false/)
-  expect(requestPreparation).toContain(
-    'for (const field of shimConfig.removeBodyFields ?? [])',
-  )
-  expect(runtimeMetadata).toContain('mergeRemoveBodyFields')
+  const mistral = prepare('codestral-2508', {
+    OPENAI_BASE_URL: 'https://api.mistral.ai/v1',
+    OPENAI_API_KEY: 'test-key',
+  })
+  expect(mistral.shimConfig.removeBodyFields).toContain('store')
+  expect(mistral.body).not.toHaveProperty('store')
 })
 
 test('prepares a chat-completions request without executing transport', async () => {

--- a/src/services/api/openaiShim/requestPreparation.test.ts
+++ b/src/services/api/openaiShim/requestPreparation.test.ts
@@ -18,6 +18,31 @@ const dependencies = {
   shouldPreserveGeminiThoughtSignature: () => false,
 }
 
+test('store: false is still set by default and only removed via shim config', async () => {
+  const requestPreparation = await Bun.file(
+    new URL('./requestPreparation.ts', import.meta.url),
+  ).text()
+
+  expect(requestPreparation).toMatch(/store:\s*false/)
+  expect(requestPreparation).toContain('shimConfig.removeBodyFields')
+  expect(requestPreparation).toContain('delete body[field]')
+})
+
+test('store field remains opt-out by per-route config rather than unconditional deletion', async () => {
+  const requestPreparation = await Bun.file(
+    new URL('./requestPreparation.ts', import.meta.url),
+  ).text()
+  const runtimeMetadata = await Bun.file(
+    new URL('../../../integrations/runtimeMetadata.ts', import.meta.url),
+  ).text()
+
+  expect(requestPreparation).toMatch(/store:\s*false/)
+  expect(requestPreparation).toContain(
+    'for (const field of shimConfig.removeBodyFields ?? [])',
+  )
+  expect(runtimeMetadata).toContain('mergeRemoveBodyFields')
+})
+
 test('prepares a chat-completions request without executing transport', async () => {
   await ensureIntegrationsLoaded()
   const processEnv = {
@@ -52,6 +77,7 @@ test('prepares a chat-completions request without executing transport', async ()
     max_completion_tokens: 64,
     temperature: 0.2,
     stream: false,
+    store: false,
   })
   expect(prepared.body).not.toHaveProperty('stream_options')
 })

--- a/src/services/api/openaiShim/requestPreparation.test.ts
+++ b/src/services/api/openaiShim/requestPreparation.test.ts
@@ -3,6 +3,15 @@ import { ensureIntegrationsLoaded } from '../../../integrations/index.js'
 import { resolveProviderRequest } from '../providerConfig.js'
 import { prepareOpenAIRequest } from './requestPreparation.js'
 
+const convertedTools = [{
+  type: 'function',
+  function: {
+    name: 'Read',
+    description: 'Read a file',
+    parameters: { type: 'object', properties: {} },
+  },
+}]
+
 const dependencies = {
   convertMessages: (
     messages: Array<{ role: string; content?: unknown }>,
@@ -12,7 +21,7 @@ const dependencies = {
     ...messages,
   ],
   convertSystemPrompt: (system: unknown) => String(system ?? ''),
-  convertTools: (tools: unknown[]) => tools,
+  convertTools: () => convertedTools,
   hasGeminiApiHost: () => false,
   isGeminiMode: () => false,
   shouldPreserveGeminiThoughtSignature: () => false,
@@ -111,7 +120,7 @@ test('prepares tools and streaming options for a remote chat route', async () =>
   })
 
   expect(prepared.body.stream_options).toEqual({ include_usage: true })
-  expect(prepared.body.tools).toHaveLength(1)
+  expect(prepared.body.tools).toEqual(convertedTools)
   expect(prepared.body.tool_choice).toEqual({
     type: 'function',
     function: { name: 'Read' },

--- a/src/services/api/openaiShim/requestPreparation.ts
+++ b/src/services/api/openaiShim/requestPreparation.ts
@@ -1,0 +1,353 @@
+import {
+  resolveModelReasoningControl,
+  resolveOpenAIShimReasoningRequestPlan,
+} from '../../../utils/effort.js'
+import {
+  resolveModelRuntimeLimits,
+  resolveOpenAIShimRuntimeContext,
+} from '../../../integrations/runtimeMetadata.js'
+import { compressToolHistory } from '../compressToolHistory.js'
+import {
+  convertAnthropicMessagesToResponsesInput,
+  convertToolsToResponsesTools,
+  type ShimCreateParams,
+} from '../codexShim.js'
+import {
+  baseUrlSupportsResponsesAutoRoute,
+  getGithubEndpointType,
+  getLocalFastPathConfig,
+  isDirectLocalOllamaEndpoint,
+  isLikelyOllamaEndpoint,
+  isLocalProviderUrl,
+  modelRequiresResponsesApi,
+  resolveProviderRequest,
+} from '../providerConfig.js'
+import { stableStringifyJson } from '../../../utils/stableStringify.js'
+import {
+  hasCerebrasApiHost,
+  hasMistralApiHost,
+  isGithubModelsMode,
+  maybeSetNvidiaNimChatTemplateThinking,
+} from './providerCompatibility.js'
+import {
+  getOllamaNumCtx,
+  normalizeOllamaNativeMessages,
+} from './ollamaAdapter.js'
+import { createRequestBodyPlanner } from './requestPlanner.js'
+
+type RawMessage = {
+  role: string
+  message?: { role?: string; content?: unknown }
+  content?: unknown
+}
+
+type Dependencies = {
+  convertMessages(
+    messages: RawMessage[],
+    system: unknown,
+    options: {
+      preserveReasoningContent?: boolean
+      reasoningContentFallback?: '' | 'omit'
+      preserveGeminiThoughtSignature?: boolean
+      supportsImageInputs?: boolean
+    },
+  ): unknown
+  convertSystemPrompt(system: unknown): string
+  convertTools(
+    tools: Array<{
+      name: string
+      description?: string
+      input_schema?: Record<string, unknown>
+    }>,
+    options?: { skipStrict?: boolean },
+  ): unknown[]
+  hasGeminiApiHost(baseUrl: string | undefined): boolean
+  isGeminiMode(): boolean
+  shouldPreserveGeminiThoughtSignature(
+    model: string | undefined,
+    baseUrl?: string,
+  ): boolean
+}
+
+export function prepareOpenAIRequest({
+  request,
+  params,
+  requestProcessEnv,
+  providerOverride,
+  dependencies,
+}: {
+  request: ReturnType<typeof resolveProviderRequest>
+  params: ShimCreateParams
+  requestProcessEnv: NodeJS.ProcessEnv
+  providerOverride?: { model: string; baseURL: string; apiKey: string }
+  dependencies: Dependencies
+}) {
+  const {
+    convertMessages,
+    convertSystemPrompt,
+    convertTools,
+    hasGeminiApiHost,
+    isGeminiMode,
+    shouldPreserveGeminiThoughtSignature,
+  } = dependencies
+  const fastPath = getLocalFastPathConfig(request.baseUrl)
+  const rawMessages = params.messages as RawMessage[]
+  const runtimeModel = request.requestedModel
+  const runtimeShimContext = resolveOpenAIShimRuntimeContext({
+    processEnv: requestProcessEnv,
+    baseUrl: request.baseUrl,
+    model: runtimeModel,
+    treatAsLocal: isLocalProviderUrl(request.baseUrl),
+    preferBaseUrlRoute: Boolean(providerOverride),
+  })
+  const runtimeLimits = resolveModelRuntimeLimits({
+    model: runtimeModel,
+    baseUrl: request.baseUrl,
+    processEnv: requestProcessEnv,
+    activeProfileProvider: runtimeShimContext.routeId ?? undefined,
+  })
+  const shimConfig = runtimeShimContext.openaiShimConfig
+  const effectiveTransport = shimConfig.endpointPath === '/responses'
+    ? 'responses'
+    : shimConfig.endpointPath === '/messages'
+      ? 'anthropic_messages'
+      : shimConfig.endpointPath?.startsWith('/models/gemini-')
+        ? 'gemini'
+        : request.transport
+  const compressedMessages =
+    effectiveTransport === 'chat_completions' ||
+    effectiveTransport === 'responses' ||
+    effectiveTransport === 'responses_compat'
+      ? fastPath.skipToolHistoryCompression
+        ? rawMessages
+        : compressToolHistory(rawMessages, runtimeModel, {
+          textBlockSeparator:
+            effectiveTransport === 'chat_completions' ? '\n\n' : '\n',
+          runtimeLimits,
+        })
+      : rawMessages
+  const useNativeOllamaChat =
+    effectiveTransport === 'chat_completions' &&
+    !shimConfig.endpointPath &&
+    isDirectLocalOllamaEndpoint(request.baseUrl) &&
+    isLikelyOllamaEndpoint(request.baseUrl)
+  const openaiMessages = effectiveTransport === 'chat_completions'
+    ? convertMessages(compressedMessages, params.system, {
+      preserveReasoningContent: shimConfig.preserveReasoningContent,
+      reasoningContentFallback: shimConfig.reasoningContentFallback,
+      preserveGeminiThoughtSignature: shouldPreserveGeminiThoughtSignature(
+        request.resolvedModel,
+        request.baseUrl,
+      ),
+      supportsImageInputs: shimConfig.supportsImageInputs,
+    })
+    : undefined
+
+  const reasoningControl = resolveModelReasoningControl(runtimeModel, {
+    routeId: runtimeShimContext.routeId,
+    useRuntimeFallback: false,
+    openaiShimConfig: shimConfig,
+    baseUrl: request.baseUrl,
+    processEnv: requestProcessEnv,
+  })
+  const suppressReasoningForForcedChat =
+    effectiveTransport === 'chat_completions' &&
+    Array.isArray(params.tools) &&
+    params.tools.length > 0 &&
+    modelRequiresResponsesApi(request.resolvedModel) &&
+    baseUrlSupportsResponsesAutoRoute(request.baseUrl, requestProcessEnv)
+  const reasoningRequestPlan = resolveOpenAIShimReasoningRequestPlan({
+    model: runtimeModel,
+    requestedEffort: suppressReasoningForForcedChat
+      ? undefined
+      : request.reasoning?.effort,
+    requestThinkingType:
+      (params.thinking as { type?: string } | undefined)?.type,
+    defaultThinkingType: request.thinking?.type,
+    thinkingRequestFormat: shimConfig.thinkingRequestFormat,
+    routeId: runtimeShimContext.routeId ?? 'custom',
+    useRuntimeFallback: false,
+    reasoningControl,
+  })
+
+  const body: Record<string, unknown> = {
+    model: request.resolvedModel,
+    ...(openaiMessages ? { messages: openaiMessages } : {}),
+    stream: params.stream ?? false,
+    store: false,
+  }
+  if (
+    reasoningRequestPlan.wireFormat === 'reasoning_effort' &&
+    reasoningRequestPlan.reasoningEffort
+  ) body.reasoning_effort = reasoningRequestPlan.reasoningEffort
+  if (
+    reasoningRequestPlan.wireFormat === 'reasoning_effort' &&
+    reasoningRequestPlan.thinkingType === 'disabled'
+  ) {
+    body.thinking = { type: 'disabled' }
+    delete body.reasoning_effort
+  }
+
+  const maxTokensValue =
+    typeof params.max_tokens === 'number' && params.max_tokens > 0
+      ? params.max_tokens
+      : undefined
+  const maxCompletionTokensValue =
+    typeof (params as Record<string, unknown>).max_completion_tokens === 'number'
+      ? (params as Record<string, unknown>).max_completion_tokens as number
+      : undefined
+  if (maxTokensValue !== undefined) body.max_completion_tokens = maxTokensValue
+  else if (maxCompletionTokensValue !== undefined) {
+    body.max_completion_tokens = maxCompletionTokensValue
+  }
+  if (params.stream && !isLocalProviderUrl(request.baseUrl)) {
+    body.stream_options = { include_usage: true }
+  }
+
+  const isGithub = isGithubModelsMode()
+  const isLocal = isLocalProviderUrl(request.baseUrl)
+  const githubEndpointType = getGithubEndpointType(request.baseUrl)
+  const isGithubCopilot =
+    isGithub && (githubEndpointType === 'copilot' || githubEndpointType === 'ghe')
+  const isGithubModels =
+    isGithub && (githubEndpointType === 'models' || githubEndpointType === 'custom')
+  const shouldStripResponsesStore =
+    (shimConfig.removeBodyFields ?? []).includes('store') ||
+    isGeminiMode() ||
+    hasGeminiApiHost(request.baseUrl) ||
+    hasCerebrasApiHost(request.baseUrl) ||
+    hasMistralApiHost(request.baseUrl) ||
+    isLocal
+
+  if (
+    (shimConfig.maxTokensField === 'max_tokens' ||
+      hasMistralApiHost(request.baseUrl)) &&
+    body.max_completion_tokens !== undefined
+  ) {
+    body.max_tokens = body.max_completion_tokens
+    delete body.max_completion_tokens
+  }
+  for (const field of shimConfig.removeBodyFields ?? []) delete body[field]
+  if (shouldStripResponsesStore) delete body.store
+  if (params.temperature !== undefined) body.temperature = params.temperature
+  if (params.top_p !== undefined) body.top_p = params.top_p
+
+  if (reasoningRequestPlan.wireFormat === 'deepseek_compatible') {
+    if (reasoningRequestPlan.thinkingType) {
+      body.thinking = { type: reasoningRequestPlan.thinkingType }
+    }
+    if (reasoningRequestPlan.reasoningEffort) {
+      body.reasoning_effort = reasoningRequestPlan.reasoningEffort
+    }
+    maybeSetNvidiaNimChatTemplateThinking(
+      body,
+      request.baseUrl,
+      reasoningRequestPlan,
+    )
+  }
+  if (reasoningRequestPlan.wireFormat === 'zai_compatible') {
+    if (reasoningRequestPlan.thinkingType) {
+      body.thinking = { type: reasoningRequestPlan.thinkingType }
+    }
+    if (reasoningRequestPlan.thinkingType === 'disabled') {
+      delete body.reasoning_effort
+    } else if (reasoningRequestPlan.reasoningEffort) {
+      body.reasoning_effort = reasoningRequestPlan.reasoningEffort
+    } else {
+      delete body.reasoning_effort
+    }
+    maybeSetNvidiaNimChatTemplateThinking(
+      body,
+      request.baseUrl,
+      reasoningRequestPlan,
+    )
+  }
+  for (const field of shimConfig.removeBodyFields ?? []) delete body[field]
+
+  if (
+    !(shimConfig.removeBodyFields ?? []).includes('tools') &&
+    params.tools?.length
+  ) {
+    const converted = convertTools(params.tools as Array<{
+      name: string
+      description?: string
+      input_schema?: Record<string, unknown>
+    }>, { skipStrict: fastPath.skipStrictTools })
+    if (converted.length > 0) {
+      body.tools = converted
+      if (
+        effectiveTransport === 'chat_completions' &&
+        params.stream &&
+        shimConfig.enableToolStreaming === true
+      ) body.tool_stream = true
+      const toolChoice = params.tool_choice as {
+        type?: string
+        name?: string
+      } | undefined
+      if (toolChoice?.type === 'auto') body.tool_choice = 'auto'
+      else if (toolChoice?.type === 'tool' && toolChoice.name) {
+        body.tool_choice = {
+          type: 'function',
+          function: { name: toolChoice.name },
+        }
+      } else if (toolChoice?.type === 'any') body.tool_choice = 'required'
+      else if (toolChoice?.type === 'none') body.tool_choice = 'none'
+    }
+  }
+
+  let responsesInput: ReturnType<
+    typeof convertAnthropicMessagesToResponsesInput
+  > | undefined
+  let responsesMessages: typeof compressedMessages | undefined
+  const getResponsesInput = () => {
+    responsesMessages ??= effectiveTransport === 'chat_completions'
+      ? fastPath.skipToolHistoryCompression
+        ? rawMessages
+        : compressToolHistory(rawMessages, request.resolvedModel, {
+          textBlockSeparator: '\n',
+        })
+      : compressedMessages
+    responsesInput ??= convertAnthropicMessagesToResponsesInput(
+      responsesMessages,
+      effectiveTransport === 'responses_compat',
+    )
+    return responsesInput
+  }
+  const omitTools = { responses: false, anthropic: false, gemini: false }
+  const planner = createRequestBodyPlanner({
+    request,
+    params,
+    effectiveTransport,
+    shouldStripResponsesStore,
+    body,
+    reasoningRequestPlan,
+    shimConfig,
+    getResponsesInput,
+    convertSystemPrompt,
+    convertToolsToResponsesTools,
+    maxTokensValue,
+    maxCompletionTokensValue,
+    getOllamaNumCtx,
+    normalizeOllamaNativeMessages,
+    useNativeOllamaChat,
+    fastPath,
+    stableStringifyJson,
+    omitTools,
+  })
+
+  return {
+    fastPath,
+    runtimeShimContext,
+    shimConfig,
+    body,
+    effectiveTransport,
+    useNativeOllamaChat,
+    buildResponsesBody: planner.buildResponsesBody,
+    serializeBody: planner.serializeBody,
+    isLocal,
+    isGithub,
+    isGithubCopilot,
+    isGithubModels,
+    omitTools,
+  }
+}


### PR DESCRIPTION
## Summary

- move runtime-context resolution, message compression, reasoning shaping, token fields, tool selection, and request-body planner assembly into `openaiShim/requestPreparation.ts`
- keep request execution in the existing executor and leave the facade responsible only for dependency wiring
- add paired `requestPreparation.test.ts` coverage without issuing network requests
- test default `store: false`, descriptor-driven `store` removal, and converted OpenAI tool payloads through `prepareOpenAIRequest`
- rebase onto current `main`, retaining the merged transport/response-adapter extractions and the existing architecture/Gemini test improvements
- reduce `openaiShim.ts` from 1,044 lines on the rebased base to 713 lines

## Why

Request shaping remained embedded in the facade after `requestPlanner.ts` and `requestExecutor.ts` landed. This extraction gives the orchestration step a focused source/test owner while preserving the existing executor boundary.

## Impact

No intended user-facing or provider behavior change. Prepared request data is passed into the existing executor unchanged. Future unpaired production modules under `openaiShim/` fail the architecture guard.

## Validation

- `bun test --feature=UNATTENDED_RETRY --max-concurrency=1 src/services/api/openaiShim/requestPreparation.test.ts` — 3 pass
- focused request-preparation, planner, executor, Gemini, architecture, and compression suites — 162 pass
- `bun run test:provider` — 1,488 pass; 12 xAI OAuth callback failures reproduce unchanged on `upstream/main` with `EADDRINUSE`
- `bun run typecheck`
- `bun run typecheck:type-tests`
- `bun run build`

## Contributor checklist

- Reviewed `CONTRIBUTING.md` and `AGENTS.md`.
- No linked issue; this is focused post-extraction architecture housekeeping.
- OpenAI-compatible request preparation and provider-shaping paths were tested.
- No UI changes or screenshots required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved OpenAI request handling across supported providers and routes.
  * Added route-specific storage settings with configurable defaults and overrides.
  * Improved chat-completion fields, tool selection, streaming usage, reasoning, and token settings.

* **Bug Fixes**
  * Improved compatibility for local, remote, GitHub, and provider-specific request configurations.

* **Tests**
  * Expanded coverage for request defaults, transformations, storage settings, tool handling, and streaming options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->