### PR TITLE
fix(ctx): let explicit overrides beat discovered context windows

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -522,12 +522,14 @@ addition to the `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` /
   key is `localhost:4000:my-model`, not `localhost:my-model`. Either field may be
   omitted to override only one limit.
 - **Precedence** — from highest to lowest: an **exact** env-var override → the
-  built-in catalog value → the discovery-cache value → a **prefix** env-var
-  override → `modelLimits` → the descriptor default. (The built-in catalog is
-  checked before the discovery cache.) So env-var overrides always win over
-  `modelLimits`, and `modelLimits` mainly fills in models that have no built-in
-  metadata (a known catalog model keeps its catalog limit unless you set an
-  *exact* env override for it).
+  built-in catalog value → a **prefix** env-var override → `modelLimits` → the
+  discovery-cache value (unless it is the generic 128k proxy default and a known
+  model descriptor is larger) → the descriptor default. So env-var overrides and
+  `modelLimits` always win over discovery, which matters when a gateway such as
+  OmniRoute reports `context_length: 128000` for every model. A known catalog
+  model keeps its catalog limit unless you set an *exact* env override for it.
+  Session-only: `/set-context-window <tokens>` also overrides for the current
+  session without editing settings.
 
 ### Exact-model pricing overrides (`settings.json`)
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -523,13 +523,16 @@ addition to the `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` /
   omitted to override only one limit.
 - **Precedence** — from highest to lowest: an **exact** env-var override → the
   built-in catalog value → a **prefix** env-var override → `modelLimits` → the
-  discovery-cache value (unless it is the generic 128k proxy default and a known
-  model descriptor is larger) → the descriptor default. So env-var overrides and
-  `modelLimits` always win over discovery, which matters when a gateway such as
-  OmniRoute reports `context_length: 128000` for every model. A known catalog
-  model keeps its catalog limit unless you set an *exact* env override for it.
-  Session-only: `/set-context-window <tokens>` also overrides for the current
-  session without editing settings.
+  discovery-cache value → the descriptor default. So env-var overrides and
+  `modelLimits` both win over discovery. A known catalog model keeps its catalog
+  limit unless you set an *exact* env override for it.
+- **When a gateway advertises the wrong window** — some OpenAI-compatible
+  gateways report a flat `context_length` (often `128000`) for every model they
+  proxy. OpenClaude keeps that value, because an advertised window can just as
+  easily be a real per-deployment cap, and budgeting above the endpoint's true
+  limit turns early auto-compact into a mid-session API failure. If you know the
+  real window, pin it with `modelLimits` or `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS`
+  above, or use `/set-context-window <tokens>` for the current session only.
 
 ### Exact-model pricing overrides (`settings.json`)
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -531,8 +531,10 @@ addition to the `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` /
   proxy. OpenClaude keeps that value, because an advertised window can just as
   easily be a real per-deployment cap, and budgeting above the endpoint's true
   limit turns early auto-compact into a mid-session API failure. If you know the
-  real window, pin it with `modelLimits` or `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS`
-  above, or use `/set-context-window <tokens>` for the current session only.
+  real window, use an **exact** `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` entry for a
+  catalogued model. For a custom or discovered model, use `modelLimits` or an
+  exact env entry. Use `/set-context-window <tokens>` for the current session
+  only.
 
 ### Exact-model pricing overrides (`settings.json`)
 

--- a/src/commands/set-context-window/set-context-window.ts
+++ b/src/commands/set-context-window/set-context-window.ts
@@ -14,8 +14,13 @@ Examples:
   /set-context-window gpt-4o 200000
   /set-context-window status
 
-The override takes precedence over integration catalog and provider
-profile defaults. Use /clear-context-window to remove it.`
+The override takes precedence over discovery, catalog, and provider defaults
+for this session only. Use /clear-context-window to remove it.
+
+For a permanent override (survives restart), set modelLimits in settings.json
+or CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS, for example:
+  { "modelLimits": { "my-model": { "contextWindow": 1000000 } } }
+See docs/advanced-setup.md (Per-model limit overrides).`
 
 export const call: LocalCommandCall = async (args, context) => {
   const trimmed = args.trim()

--- a/src/commands/set-context-window/set-context-window.ts
+++ b/src/commands/set-context-window/set-context-window.ts
@@ -17,9 +17,11 @@ Examples:
 The override takes precedence over discovery, catalog, and provider defaults
 for this session only. Use /clear-context-window to remove it.
 
-For a permanent override (survives restart), set modelLimits in settings.json
-or CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS, for example:
+For a permanent override (survives restart), use modelLimits in settings.json
+for custom/discovered models, for example:
   { "modelLimits": { "my-model": { "contextWindow": 1000000 } } }
+For a catalogued model, use an exact CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS entry;
+catalog values take precedence over modelLimits and prefix env entries.
 See docs/advanced-setup.md (Per-model limit overrides).`
 
 export const call: LocalCommandCall = async (args, context) => {

--- a/src/integrations/runtimeMetadata.modelLimits.test.ts
+++ b/src/integrations/runtimeMetadata.modelLimits.test.ts
@@ -162,3 +162,58 @@ test('resolveModelRuntimeLimits lets a broad env-prefix override win over an exa
   expect(limits.contextWindow).toBe(111_111)
   expect(limits.maxOutputTokens).toBe(4_096)
 })
+
+test('resolveModelRuntimeLimits lets settings modelLimits beat discovery cache', async () => {
+  const { setCachedModels } = await import(`./discoveryCache.js?ts=${Date.now()}`)
+  const { getDiscoveryCacheKey } = await import(
+    `./discoveryService.js?ts=${Date.now()}`
+  )
+  const { mkdtempSync, rmSync } = await import('node:fs')
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+
+  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR
+  const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-model-limits-'))
+  process.env.CLAUDE_CONFIG_DIR = tempDir
+  try {
+    const baseUrl = 'http://localhost:20128/v1'
+    await setCachedModels(
+      getDiscoveryCacheKey('custom', { baseUrl }),
+      {
+        models: [
+          {
+            id: 'my-codex-combo',
+            apiName: 'my-codex-combo',
+            label: 'my-codex-combo',
+            contextWindow: 128_000,
+          },
+        ],
+      },
+    )
+
+    mockSettings = {
+      modelLimits: {
+        'my-codex-combo': { contextWindow: 1_000_000, maxOutputTokens: 32_768 },
+      },
+    }
+    const { resolveModelRuntimeLimits } = await importFresh()
+
+    const limits = resolveModelRuntimeLimits({
+      model: 'my-codex-combo',
+      processEnv: {
+        CLAUDE_CODE_USE_OPENAI: '1',
+        OPENAI_BASE_URL: baseUrl,
+      },
+    })
+
+    expect(limits.contextWindow).toBe(1_000_000)
+    expect(limits.maxOutputTokens).toBe(32_768)
+  } finally {
+    if (originalConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = originalConfigDir
+    }
+    rmSync(tempDir, { recursive: true, force: true })
+  }
+})

--- a/src/integrations/runtimeMetadata.modelLimits.test.ts
+++ b/src/integrations/runtimeMetadata.modelLimits.test.ts
@@ -164,17 +164,26 @@ test('resolveModelRuntimeLimits lets a broad env-prefix override win over an exa
 })
 
 test('resolveModelRuntimeLimits lets settings modelLimits beat discovery cache', async () => {
-  const { setCachedModels } = await import(`./discoveryCache.js?ts=${Date.now()}`)
+  const { clearDiscoveryCache, setCachedModels } = await import(
+    `./discoveryCache.js?ts=${Date.now()}`
+  )
   const { getDiscoveryCacheKey } = await import(
     `./discoveryService.js?ts=${Date.now()}`
   )
+  // The discovery cache path comes from getClaudeConfigHomeDir(), which ignores
+  // CLAUDE_CONFIG_DIR by design. Without this override the fixture below would
+  // be written into the caller's real ~/.openclaude.
+  const {
+    getClaudeConfigHomeDirOverrideForTesting,
+    setClaudeConfigHomeDirForTesting,
+  } = await import('../utils/envUtils.js')
   const { mkdtempSync, rmSync } = await import('node:fs')
   const { tmpdir } = await import('node:os')
   const { join } = await import('node:path')
 
-  const originalConfigDir = process.env.CLAUDE_CONFIG_DIR
+  const previousOverride = getClaudeConfigHomeDirOverrideForTesting()
   const tempDir = mkdtempSync(join(tmpdir(), 'openclaude-model-limits-'))
-  process.env.CLAUDE_CONFIG_DIR = tempDir
+  setClaudeConfigHomeDirForTesting(tempDir)
   try {
     const baseUrl = 'http://localhost:20128/v1'
     await setCachedModels(
@@ -186,34 +195,43 @@ test('resolveModelRuntimeLimits lets settings modelLimits beat discovery cache',
             apiName: 'my-codex-combo',
             label: 'my-codex-combo',
             contextWindow: 128_000,
+            maxOutputTokens: 8_192,
           },
         ],
       },
     )
+
+    const { resolveModelRuntimeLimits } = await importFresh()
+    const resolveWithDiscovery = () =>
+      resolveModelRuntimeLimits({
+        model: 'my-codex-combo',
+        processEnv: {
+          CLAUDE_CODE_USE_OPENAI: '1',
+          OPENAI_BASE_URL: baseUrl,
+        },
+      })
+
+    // Establish that the isolated cache is observable first, so the override
+    // assertion below proves precedence rather than passing on a missing fixture.
+    mockSettings = {}
+    const discovered = resolveWithDiscovery()
+    expect(discovered.contextWindow).toBe(128_000)
+    expect(discovered.maxOutputTokens).toBe(8_192)
 
     mockSettings = {
       modelLimits: {
         'my-codex-combo': { contextWindow: 1_000_000, maxOutputTokens: 32_768 },
       },
     }
-    const { resolveModelRuntimeLimits } = await importFresh()
+    const overridden = resolveWithDiscovery()
 
-    const limits = resolveModelRuntimeLimits({
-      model: 'my-codex-combo',
-      processEnv: {
-        CLAUDE_CODE_USE_OPENAI: '1',
-        OPENAI_BASE_URL: baseUrl,
-      },
-    })
-
-    expect(limits.contextWindow).toBe(1_000_000)
-    expect(limits.maxOutputTokens).toBe(32_768)
+    expect(overridden.contextWindow).toBe(1_000_000)
+    expect(overridden.maxOutputTokens).toBe(32_768)
   } finally {
-    if (originalConfigDir === undefined) {
-      delete process.env.CLAUDE_CONFIG_DIR
-    } else {
-      process.env.CLAUDE_CONFIG_DIR = originalConfigDir
-    }
+    // Clears the module-level sync snapshot as well, so the fixture cannot leak
+    // into a later suite once the temp dir is removed.
+    await clearDiscoveryCache()
+    setClaudeConfigHomeDirForTesting(previousOverride)
     rmSync(tempDir, { recursive: true, force: true })
   }
 })

--- a/src/integrations/runtimeMetadata.test.ts
+++ b/src/integrations/runtimeMetadata.test.ts
@@ -498,6 +498,48 @@ describe('resolveModelRuntimeLimits', () => {
       ).toBe(1_000_000)
     })
   })
+
+  it('lets env prefix overrides beat discovery for both context and max-output limits', async () => {
+    // CodeRabbit on #2082: exact-key and settings.modelLimits vs discovery are
+    // covered, but not CLAUDE_CODE_OPENAI_* prefix keys. A prefix pin is the
+    // documented way to cover a family of gateway model ids without listing
+    // each one, and must sit above the discovery cache for both limits.
+    await withTempConfigDir(async () => {
+      const baseUrl = 'http://localhost:20128/v1'
+      await setCachedModels(
+        getDiscoveryCacheKey('custom', {
+          baseUrl,
+        }),
+        {
+          models: [
+            {
+              id: 'my-codex-combo-v2',
+              apiName: 'my-codex-combo-v2',
+              label: 'my-codex-combo-v2',
+              contextWindow: 128_000,
+              maxOutputTokens: 8_192,
+            },
+          ],
+        },
+      )
+
+      expect(
+        resolveModelRuntimeLimits({
+          model: 'my-codex-combo-v2',
+          processEnv: {
+            CLAUDE_CODE_USE_OPENAI: '1',
+            OPENAI_BASE_URL: baseUrl,
+            CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS: JSON.stringify({
+              'my-codex-combo': 1_000_000,
+            }),
+            CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS: JSON.stringify({
+              'my-codex-combo': 32_768,
+            }),
+          },
+        }),
+      ).toEqual({ contextWindow: 1_000_000, maxOutputTokens: 32_768 })
+    })
+  })
 })
 
 describe('LLMTR runtime attribution', () => {

--- a/src/integrations/runtimeMetadata.test.ts
+++ b/src/integrations/runtimeMetadata.test.ts
@@ -8,6 +8,7 @@ import {
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock'
 import {
+  preferDiscoveredOrKnownContextWindow,
   resolveModelRuntimeLimits,
   resolveOpenAIShimRuntimeContext,
 } from '../integrations/runtimeMetadata'
@@ -419,6 +420,123 @@ describe('resolveModelRuntimeLimits', () => {
         }).contextWindow,
       ).toBe(2_000_000)
     })
+  })
+
+  it('ignores generic 128k discovery defaults when a known model descriptor is larger', async () => {
+    // OmniRoute and similar gateways report context_length: 128000 for every
+    // model when they lack per-model metadata. That must not shadow gpt-5.4's
+    // 1.05M descriptor (premature auto-compact).
+    await withTempConfigDir(async () => {
+      const baseUrl = 'http://localhost:20128/v1'
+      await setCachedModels(
+        getDiscoveryCacheKey('custom', {
+          baseUrl,
+        }),
+        {
+          models: [
+            {
+              id: 'gpt-5.4',
+              apiName: 'gpt-5.4',
+              label: 'gpt-5.4',
+              contextWindow: 128_000,
+            },
+            {
+              id: 'openai/gpt-5.4',
+              apiName: 'openai/gpt-5.4',
+              label: 'openai/gpt-5.4',
+              contextWindow: 128_000,
+            },
+          ],
+        },
+      )
+
+      for (const model of ['gpt-5.4', 'openai/gpt-5.4']) {
+        expect(
+          resolveModelRuntimeLimits({
+            model,
+            processEnv: {
+              CLAUDE_CODE_USE_OPENAI: '1',
+              OPENAI_BASE_URL: baseUrl,
+            },
+          }).contextWindow,
+        ).toBe(1_050_000)
+      }
+    })
+  })
+
+  it('still trusts non-default discovery values over a larger descriptor', async () => {
+    // If a proxy intentionally advertises a non-128k window (e.g. a real 200k
+    // cap), keep trusting discovery even when a descriptor is larger.
+    await withTempConfigDir(async () => {
+      const baseUrl = 'http://localhost:20128/v1'
+      await setCachedModels(
+        getDiscoveryCacheKey('custom', {
+          baseUrl,
+        }),
+        {
+          models: [
+            {
+              id: 'gpt-5.4',
+              apiName: 'gpt-5.4',
+              label: 'gpt-5.4',
+              contextWindow: 200_000,
+            },
+          ],
+        },
+      )
+
+      expect(
+        resolveModelRuntimeLimits({
+          model: 'gpt-5.4',
+          processEnv: {
+            CLAUDE_CODE_USE_OPENAI: '1',
+            OPENAI_BASE_URL: baseUrl,
+          },
+        }).contextWindow,
+      ).toBe(200_000)
+    })
+  })
+
+  it('lets an exact env override beat a wrong discovery-cache context window', async () => {
+    await withTempConfigDir(async () => {
+      const baseUrl = 'http://localhost:20128/v1'
+      await setCachedModels(
+        getDiscoveryCacheKey('custom', {
+          baseUrl,
+        }),
+        {
+          models: [
+            {
+              id: 'my-codex-combo',
+              apiName: 'my-codex-combo',
+              label: 'my-codex-combo',
+              contextWindow: 128_000,
+            },
+          ],
+        },
+      )
+
+      expect(
+        resolveModelRuntimeLimits({
+          model: 'my-codex-combo',
+          processEnv: {
+            CLAUDE_CODE_USE_OPENAI: '1',
+            OPENAI_BASE_URL: baseUrl,
+            CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS: JSON.stringify({
+              'my-codex-combo': 1_000_000,
+            }),
+          },
+        }).contextWindow,
+      ).toBe(1_000_000)
+    })
+  })
+
+  it('preferDiscoveredOrKnownContextWindow rescues known models from generic 128k discovery', () => {
+    expect(preferDiscoveredOrKnownContextWindow(128_000, 1_050_000)).toBe(1_050_000)
+    expect(preferDiscoveredOrKnownContextWindow(200_000, 1_050_000)).toBe(200_000)
+    expect(preferDiscoveredOrKnownContextWindow(128_000, 128_000)).toBe(128_000)
+    expect(preferDiscoveredOrKnownContextWindow(undefined, 1_050_000)).toBe(1_050_000)
+    expect(preferDiscoveredOrKnownContextWindow(1_000_000, undefined)).toBe(1_000_000)
   })
 })
 

--- a/src/integrations/runtimeMetadata.test.ts
+++ b/src/integrations/runtimeMetadata.test.ts
@@ -8,22 +8,22 @@ import {
   releaseSharedMutationLock,
 } from '../test/sharedMutationLock'
 import {
-  preferDiscoveredOrKnownContextWindow,
   resolveModelRuntimeLimits,
   resolveOpenAIShimRuntimeContext,
 } from '../integrations/runtimeMetadata'
-import { setCachedModels } from './discoveryCache'
+import { clearDiscoveryCache, setCachedModels } from './discoveryCache'
+import {
+  getClaudeConfigHomeDirOverrideForTesting,
+  setClaudeConfigHomeDirForTesting,
+} from '../utils/envUtils.js'
 import {
   getDiscoveryCacheKey,
   getRouteDiscoveryHeaders,
 } from './discoveryService'
 import { resolveActiveRouteIdFromEnv } from './routeMetadata.js'
-import { setClaudeConfigHomeDirForTesting } from '../utils/envUtils.js'
 import glmBrand from './brands/glm.js'
 import glmModels from './models/glm.js'
 import zaiVendor from './vendors/zai.js'
-
-const originalConfigDir = process.env.CLAUDE_CONFIG_DIR
 
 describe('Z.AI GLM-5.3 descriptor contract', () => {
   it('wires the verified GLM-5.3-Flash descriptor and direct catalog contract', () => {
@@ -115,25 +115,27 @@ describe('Z.AI GLM-5.3 descriptor contract', () => {
   })
 })
 
+// The discovery cache resolves its path through getClaudeConfigHomeDir(), which
+// deliberately ignores CLAUDE_CONFIG_DIR (OpenClaude config is independent of
+// Claude Code config). Use the explicit test override so these fixtures land in
+// the temp dir instead of the developer's real ~/.openclaude.
 async function withTempConfigDir<T>(fn: () => Promise<T>): Promise<T> {
   await acquireSharedMutationLock('integrations/runtimeMetadata.test.ts')
+  const previousOverride = getClaudeConfigHomeDirOverrideForTesting()
   let tempDir: string | null = null
   try {
     tempDir = mkdtempSync(join(tmpdir(), 'openclaude-runtime-metadata-test-'))
     setClaudeConfigHomeDirForTesting(tempDir)
-    process.env.CLAUDE_CONFIG_DIR = tempDir
     return await fn()
   } finally {
     try {
-      if (originalConfigDir === undefined) {
-        delete process.env.CLAUDE_CONFIG_DIR
-      } else {
-        process.env.CLAUDE_CONFIG_DIR = originalConfigDir
-      }
+      // Drops the module-level sync snapshot so a later suite cannot read this
+      // suite's fixture back out of memory after the temp dir is gone.
+      await clearDiscoveryCache()
+      setClaudeConfigHomeDirForTesting(previousOverride)
       if (tempDir) {
         rmSync(tempDir, { recursive: true, force: true })
       }
-      setClaudeConfigHomeDirForTesting(undefined)
     } finally {
       releaseSharedMutationLock()
     }
@@ -422,73 +424,46 @@ describe('resolveModelRuntimeLimits', () => {
     })
   })
 
-  it('ignores generic 128k discovery defaults when a known model descriptor is larger', async () => {
-    // User-reported path: OmniRoute + GPT-5.6 Sol ("gpt sol"). Gateways often
-    // report context_length: 128000 when they lack per-model metadata. That must
-    // not shadow the known gpt-5.6-sol descriptor (272k Codex-safe fallback on
-    // catalog-less custom routes; premature auto-compact at 128k).
-    await withTempConfigDir(async () => {
-      const baseUrl = 'http://localhost:20128/v1'
-      await setCachedModels(
-        getDiscoveryCacheKey('custom', {
-          baseUrl,
-        }),
-        {
-          models: [
-            {
-              id: 'gpt-5.6-sol',
-              apiName: 'gpt-5.6-sol',
-              label: 'gpt-5.6-sol',
-              contextWindow: 128_000,
-            },
-          ],
-        },
-      )
-
-      expect(
-        resolveModelRuntimeLimits({
-          model: 'gpt-5.6-sol',
-          processEnv: {
-            CLAUDE_CODE_USE_OPENAI: '1',
-            OPENAI_BASE_URL: baseUrl,
+  it.each([128_000, 200_000])(
+    'keeps a gateway-advertised %i window for a globally larger known model',
+    async advertised => {
+      // User-reported path: OmniRoute + GPT-5.6 Sol ("gpt sol"), whose gateway
+      // advertised a smaller window than the known descriptor. An advertised
+      // `context_length` is indistinguishable from a real per-deployment cap, so
+      // discovery stays authoritative — budgeting past the endpoint's real limit
+      // would trade an early compact for a mid-session API failure. 128k is
+      // covered explicitly because it is the value gateways most often report as
+      // a flat default.
+      await withTempConfigDir(async () => {
+        const baseUrl = 'http://localhost:20128/v1'
+        await setCachedModels(
+          getDiscoveryCacheKey('custom', {
+            baseUrl,
+          }),
+          {
+            models: [
+              {
+                id: 'gpt-5.6-sol',
+                apiName: 'gpt-5.6-sol',
+                label: 'gpt-5.6-sol',
+                contextWindow: advertised,
+              },
+            ],
           },
-        }).contextWindow,
-      ).toBe(272_000)
-    })
-  })
+        )
 
-  it('still trusts non-default discovery values over a larger descriptor', async () => {
-    // If a proxy intentionally advertises a non-128k window (e.g. a real 200k
-    // cap), keep trusting discovery even when a descriptor is larger.
-    await withTempConfigDir(async () => {
-      const baseUrl = 'http://localhost:20128/v1'
-      await setCachedModels(
-        getDiscoveryCacheKey('custom', {
-          baseUrl,
-        }),
-        {
-          models: [
-            {
-              id: 'gpt-5.6-sol',
-              apiName: 'gpt-5.6-sol',
-              label: 'gpt-5.6-sol',
-              contextWindow: 200_000,
+        expect(
+          resolveModelRuntimeLimits({
+            model: 'gpt-5.6-sol',
+            processEnv: {
+              CLAUDE_CODE_USE_OPENAI: '1',
+              OPENAI_BASE_URL: baseUrl,
             },
-          ],
-        },
-      )
-
-      expect(
-        resolveModelRuntimeLimits({
-          model: 'gpt-5.6-sol',
-          processEnv: {
-            CLAUDE_CODE_USE_OPENAI: '1',
-            OPENAI_BASE_URL: baseUrl,
-          },
-        }).contextWindow,
-      ).toBe(200_000)
-    })
-  })
+          }).contextWindow,
+        ).toBe(advertised)
+      })
+    },
+  )
 
   it('lets an exact env override beat a wrong discovery-cache context window', async () => {
     await withTempConfigDir(async () => {
@@ -522,14 +497,6 @@ describe('resolveModelRuntimeLimits', () => {
         }).contextWindow,
       ).toBe(1_000_000)
     })
-  })
-
-  it('preferDiscoveredOrKnownContextWindow rescues known models from generic 128k discovery', () => {
-    expect(preferDiscoveredOrKnownContextWindow(128_000, 1_050_000)).toBe(1_050_000)
-    expect(preferDiscoveredOrKnownContextWindow(200_000, 1_050_000)).toBe(200_000)
-    expect(preferDiscoveredOrKnownContextWindow(128_000, 128_000)).toBe(128_000)
-    expect(preferDiscoveredOrKnownContextWindow(undefined, 1_050_000)).toBe(1_050_000)
-    expect(preferDiscoveredOrKnownContextWindow(1_000_000, undefined)).toBe(1_000_000)
   })
 })
 

--- a/src/integrations/runtimeMetadata.test.ts
+++ b/src/integrations/runtimeMetadata.test.ts
@@ -423,9 +423,10 @@ describe('resolveModelRuntimeLimits', () => {
   })
 
   it('ignores generic 128k discovery defaults when a known model descriptor is larger', async () => {
-    // OmniRoute and similar gateways report context_length: 128000 for every
-    // model when they lack per-model metadata. That must not shadow gpt-5.4's
-    // 1.05M descriptor (premature auto-compact).
+    // User-reported path: OmniRoute + GPT-5.6 Sol ("gpt sol"). Gateways often
+    // report context_length: 128000 when they lack per-model metadata. That must
+    // not shadow the known gpt-5.6-sol descriptor (272k Codex-safe fallback on
+    // catalog-less custom routes; premature auto-compact at 128k).
     await withTempConfigDir(async () => {
       const baseUrl = 'http://localhost:20128/v1'
       await setCachedModels(
@@ -435,32 +436,24 @@ describe('resolveModelRuntimeLimits', () => {
         {
           models: [
             {
-              id: 'gpt-5.4',
-              apiName: 'gpt-5.4',
-              label: 'gpt-5.4',
-              contextWindow: 128_000,
-            },
-            {
-              id: 'openai/gpt-5.4',
-              apiName: 'openai/gpt-5.4',
-              label: 'openai/gpt-5.4',
+              id: 'gpt-5.6-sol',
+              apiName: 'gpt-5.6-sol',
+              label: 'gpt-5.6-sol',
               contextWindow: 128_000,
             },
           ],
         },
       )
 
-      for (const model of ['gpt-5.4', 'openai/gpt-5.4']) {
-        expect(
-          resolveModelRuntimeLimits({
-            model,
-            processEnv: {
-              CLAUDE_CODE_USE_OPENAI: '1',
-              OPENAI_BASE_URL: baseUrl,
-            },
-          }).contextWindow,
-        ).toBe(1_050_000)
-      }
+      expect(
+        resolveModelRuntimeLimits({
+          model: 'gpt-5.6-sol',
+          processEnv: {
+            CLAUDE_CODE_USE_OPENAI: '1',
+            OPENAI_BASE_URL: baseUrl,
+          },
+        }).contextWindow,
+      ).toBe(272_000)
     })
   })
 
@@ -476,9 +469,9 @@ describe('resolveModelRuntimeLimits', () => {
         {
           models: [
             {
-              id: 'gpt-5.4',
-              apiName: 'gpt-5.4',
-              label: 'gpt-5.4',
+              id: 'gpt-5.6-sol',
+              apiName: 'gpt-5.6-sol',
+              label: 'gpt-5.6-sol',
               contextWindow: 200_000,
             },
           ],
@@ -487,7 +480,7 @@ describe('resolveModelRuntimeLimits', () => {
 
       expect(
         resolveModelRuntimeLimits({
-          model: 'gpt-5.4',
+          model: 'gpt-5.6-sol',
           processEnv: {
             CLAUDE_CODE_USE_OPENAI: '1',
             OPENAI_BASE_URL: baseUrl,

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -486,6 +486,40 @@ function findCachedCatalogEntryForApiName(
   )
 }
 
+// Many OpenAI-compatible proxies (notably OmniRoute and similar gateways) report
+// a generic 128k context_length when they lack per-model metadata. That value
+// matches OPENAI_FALLBACK_CONTEXT_WINDOW's default in utils/context.ts. Prefer a
+// larger known descriptor over that generic discovery default so auto-compact
+// does not fire early on 1M-class models.
+const GENERIC_DISCOVERY_CONTEXT_FALLBACK = 128_000
+
+/**
+ * Choose between a discovered context window and a known descriptor limit.
+ *
+ * Trust discovery when it is present and does not look like the generic 128k
+ * proxy default. When discovery is that default and a known descriptor is larger,
+ * prefer the descriptor (wrong 128k from OmniRoute-style gateways was shadowing
+ * 1M models and triggering premature auto-compact).
+ */
+export function preferDiscoveredOrKnownContextWindow(
+  discovered: number | undefined,
+  known: number | undefined,
+): number | undefined {
+  if (discovered === undefined) {
+    return known
+  }
+  if (known === undefined) {
+    return discovered
+  }
+  if (
+    discovered === GENERIC_DISCOVERY_CONTEXT_FALLBACK &&
+    known > GENERIC_DISCOVERY_CONTEXT_FALLBACK
+  ) {
+    return known
+  }
+  return discovered
+}
+
 export function resolveModelRuntimeLimits(options: {
   model: string
   processEnv?: NodeJS.ProcessEnv
@@ -531,28 +565,35 @@ export function resolveModelRuntimeLimits(options: {
     runtimeEnv,
   )
 
-  // Precedence: an exact env override wins outright; then the built-in
-  // catalog / discovery-cache value (a `:cloud` variant must take its known
-  // catalog limit rather than inherit a broad base-model env *prefix*); then a
-  // broad env *prefix* override; then the settings.json `modelLimits` override;
-  // then the descriptor default. The key fix for the env/settings drift is
-  // keeping `settings` strictly below `prefix` so a broad env-prefix override is
+  // Precedence (high → low):
+  // 1. exact env override
+  // 2. built-in route catalog (so `:cloud` variants keep their catalog cap over
+  //    a broad base-model env *prefix*)
+  // 3. env *prefix* override
+  // 4. settings.json `modelLimits` (explicit user pin; must beat discovery so
+  //    wrong proxy metadata cannot lock users out of documented overrides)
+  // 5. discovery cache, unless it is the generic 128k proxy default and a known
+  //    model descriptor is larger
+  // 6. model descriptor default
+  // Keep `settings` strictly below `prefix` so a broad env-prefix override is
   // never silently overtaken by a settings entry — matching the scalar
   // getOpenAIContextWindow, where env (exact or prefix) beats settings.
   return {
     contextWindow:
       externalContextWindow.exact ??
       catalogEntry?.contextWindow ??
-      cachedCatalogEntry?.contextWindow ??
       externalContextWindow.prefix ??
       externalContextWindow.settings ??
-      modelDescriptor?.contextWindow,
+      preferDiscoveredOrKnownContextWindow(
+        cachedCatalogEntry?.contextWindow,
+        modelDescriptor?.contextWindow,
+      ),
     maxOutputTokens:
       externalMaxOutputTokens.exact ??
       catalogEntry?.maxOutputTokens ??
-      cachedCatalogEntry?.maxOutputTokens ??
       externalMaxOutputTokens.prefix ??
       externalMaxOutputTokens.settings ??
+      cachedCatalogEntry?.maxOutputTokens ??
       modelDescriptor?.maxOutputTokens,
   }
 }

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -486,40 +486,6 @@ function findCachedCatalogEntryForApiName(
   )
 }
 
-// Many OpenAI-compatible proxies (notably OmniRoute and similar gateways) report
-// a generic 128k context_length when they lack per-model metadata. That value
-// matches OPENAI_FALLBACK_CONTEXT_WINDOW's default in utils/context.ts. Prefer a
-// larger known descriptor over that generic discovery default so auto-compact
-// does not fire early on 1M-class models.
-const GENERIC_DISCOVERY_CONTEXT_FALLBACK = 128_000
-
-/**
- * Choose between a discovered context window and a known descriptor limit.
- *
- * Trust discovery when it is present and does not look like the generic 128k
- * proxy default. When discovery is that default and a known descriptor is larger,
- * prefer the descriptor (wrong 128k from OmniRoute-style gateways was shadowing
- * 1M models and triggering premature auto-compact).
- */
-export function preferDiscoveredOrKnownContextWindow(
-  discovered: number | undefined,
-  known: number | undefined,
-): number | undefined {
-  if (discovered === undefined) {
-    return known
-  }
-  if (known === undefined) {
-    return discovered
-  }
-  if (
-    discovered === GENERIC_DISCOVERY_CONTEXT_FALLBACK &&
-    known > GENERIC_DISCOVERY_CONTEXT_FALLBACK
-  ) {
-    return known
-  }
-  return discovered
-}
-
 export function resolveModelRuntimeLimits(options: {
   model: string
   processEnv?: NodeJS.ProcessEnv
@@ -570,11 +536,16 @@ export function resolveModelRuntimeLimits(options: {
   // 2. built-in route catalog (so `:cloud` variants keep their catalog cap over
   //    a broad base-model env *prefix*)
   // 3. env *prefix* override
-  // 4. settings.json `modelLimits` (explicit user pin; must beat discovery so
-  //    wrong proxy metadata cannot lock users out of documented overrides)
-  // 5. discovery cache, unless it is the generic 128k proxy default and a known
-  //    model descriptor is larger
+  // 4. settings.json `modelLimits` (explicit user pin)
+  // 5. discovery cache
   // 6. model descriptor default
+  // Discovery stays authoritative over the descriptor: a gateway's advertised
+  // `context_length` is the endpoint's real cap (it may legitimately be a
+  // smaller deployment/tenant limit for a globally larger model), and the
+  // OpenAI-compatible response carries no signal that would let us tell a
+  // synthetic gateway default apart from a real cap. Users whose gateway
+  // advertises a wrong window pin it explicitly via `modelLimits`, an env
+  // override, or `/set-context-window`; those all sit above discovery here.
   // Keep `settings` strictly below `prefix` so a broad env-prefix override is
   // never silently overtaken by a settings entry — matching the scalar
   // getOpenAIContextWindow, where env (exact or prefix) beats settings.
@@ -584,10 +555,8 @@ export function resolveModelRuntimeLimits(options: {
       catalogEntry?.contextWindow ??
       externalContextWindow.prefix ??
       externalContextWindow.settings ??
-      preferDiscoveredOrKnownContextWindow(
-        cachedCatalogEntry?.contextWindow,
-        modelDescriptor?.contextWindow,
-      ),
+      cachedCatalogEntry?.contextWindow ??
+      modelDescriptor?.contextWindow,
     maxOutputTokens:
       externalMaxOutputTokens.exact ??
       catalogEntry?.maxOutputTokens ??

--- a/src/integrations/runtimeMetadata.ts
+++ b/src/integrations/runtimeMetadata.ts
@@ -544,8 +544,9 @@ export function resolveModelRuntimeLimits(options: {
   // smaller deployment/tenant limit for a globally larger model), and the
   // OpenAI-compatible response carries no signal that would let us tell a
   // synthetic gateway default apart from a real cap. Users whose gateway
-  // advertises a wrong window pin it explicitly via `modelLimits`, an env
-  // override, or `/set-context-window`; those all sit above discovery here.
+  // advertises a wrong window pin it via an exact env override, `modelLimits`
+  // for an uncatalogued model, or `/set-context-window`; each applicable
+  // override sits above discovery here.
   // Keep `settings` strictly below `prefix` so a broad env-prefix override is
   // never silently overtaken by a settings entry — matching the scalar
   // getOpenAIContextWindow, where env (exact or prefix) beats settings.

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -10,8 +10,7 @@
  * matches and the settings `modelLimits` match); it does not decide the overall
  * precedence. The authoritative runtime chain — exact env override, then the
  * built-in catalog, then the prefix env override, then settings `modelLimits`,
- * then discovery (with a known-descriptor rescue for the generic 128k proxy
- * default), then the descriptor default — is applied by
+ * then the discovery cache, then the descriptor default — is applied by
  * resolveModelRuntimeLimits in integrations/runtimeMetadata.ts. Keep precedence
  * changes there, not duplicated here.
  */

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -9,8 +9,9 @@
  * This module only produces the *override candidates* (exact/prefix env-var
  * matches and the settings `modelLimits` match); it does not decide the overall
  * precedence. The authoritative runtime chain — exact env override, then the
- * catalog/discovery cache, then the prefix env override, then settings
- * `modelLimits`, then the descriptor default — is applied by
+ * built-in catalog, then the prefix env override, then settings `modelLimits`,
+ * then discovery (with a known-descriptor rescue for the generic 128k proxy
+ * default), then the descriptor default — is applied by
  * resolveModelRuntimeLimits in integrations/runtimeMetadata.ts. Keep precedence
  * changes there, not duplicated here.
  */

--- a/src/utils/model/openaiContextWindows.ts
+++ b/src/utils/model/openaiContextWindows.ts
@@ -27,7 +27,7 @@ export type OpenAILimitOverrideMatches = {
   // settings.json `modelLimits` match (exact or prefix). Just a candidate here;
   // its position in the overall precedence is decided by resolveModelRuntimeLimits
   // (integrations/runtimeMetadata.ts), which applies settings after the exact and
-  // prefix env overrides and the catalog/discovery cache.
+  // prefix env overrides and catalog, but before the discovery cache.
   settings?: number
   // Prefix env-var override match.
   prefix?: number


### PR DESCRIPTION
## Summary

OpenAI-compatible gateways can advertise a context window that does not match the model's real capability. A user on Discord (`#openclaude`) hit this with OmniRoute + **GPT-5.6 Sol** (`gpt-5.6-sol`): the gateway reported 128k, so OpenClaude budgeted 128k and auto-compacted after a few prompts.

This PR makes the **documented per-model overrides win over discovery**, so a user in that position can pin the real window and have it stick.

It deliberately does **not** try to detect a "wrong" discovery value automatically. An earlier revision of this branch rescued known models from a discovered `128000`, and that was wrong: the custom-gateway discovery mapper copies the endpoint's own `context_length` / `context_window` into the same plain `ModelCatalogEntry.contextWindow` field, and nothing on our side ever synthesizes 128k. So the number carries no provenance, and a flat 128k is indistinguishable from a real per-deployment or tenant cap. Budgeting a known-larger descriptor over a real cap would trade an early auto-compact for a late context-window API failure, which is the worse outcome. Discovery stays authoritative over the model descriptor.

Refs #2081

## Changes

### `src/integrations/runtimeMetadata.ts`
- Reorder `resolveModelRuntimeLimits` precedence to: exact env override -> built-in catalog -> env prefix override -> settings `modelLimits` -> discovery cache -> descriptor default
- Previously the discovery cache sat above both the env prefix override and `modelLimits`, so a gateway's advertised window could not be overridden by the documented settings path
- Same reorder applied to `maxOutputTokens` for consistency
- Comment documents why discovery outranks the descriptor and why no numeric heuristic is used

### Tests
- `runtimeMetadata.test.ts`: a gateway-advertised window (parameterized over **128k** and **200k**) is preserved for `gpt-5.6-sol`, a model the catalog knows is larger; an exact env override beats a discovered window
- `runtimeMetadata.modelLimits.test.ts`: the isolated discovery cache resolves on its own first (128k / 8k), then the `modelLimits` pin wins (1M / 32k), so the assertion proves precedence rather than passing on a missing fixture
- Both suites now isolate the discovery cache with `setClaudeConfigHomeDirForTesting` (saved and restored) instead of `CLAUDE_CONFIG_DIR`, which `getClaudeConfigHomeDir()` ignores by design, and clear the cache on teardown so the in-memory sync snapshot cannot leak

### Docs / UX
- `docs/advanced-setup.md`: corrected precedence list, plus a note on what to do when a gateway advertises the wrong window
- `/set-context-window` help: points at the permanent `modelLimits` / env override path

## User impact

- A user whose gateway advertises the wrong context window can now fix it permanently with `modelLimits` or `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS`, or for one session with `/set-context-window`. Before this change the discovery cache silently outranked all three.
- No automatic behavior change for anyone whose gateway reports an accurate window.

## Checks run

```
bun test ./src/integrations/ ./src/utils/context.test.ts ./src/utils/model/openaiContextWindows.test.ts ./src/commands/set-context-window/
  -> 397 pass, 0 fail

bun run typecheck
  -> 2 pre-existing errors in src/utils/permissions/permissions.test.ts (present on origin/main, untouched by this branch)

bun run typecheck:type-tests
  -> passed, 10 files checked
```

Mutation-checked both new guards: reordering discovery back above `modelLimits` fails the settings-precedence test, and re-adding the 128k rescue fails the advertised-window test. Restored after each.

## Notes

- Provider path tested: custom OpenAI-compatible route with a populated discovery cache (OmniRoute-style base URL)
- Reviewed `CONTRIBUTING.md` and `AGENTS.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer guidance for session-only context-window overrides through `/set-context-window`.
  - Documented permanent model-limit configuration options.

- **Bug Fixes**
  - Corrected precedence for context-window and maximum-output limits across settings, environment overrides, discovery data, and provider defaults.
  - Improved handling of discovered model limits and flat 128k gateway metadata.

- **Documentation**
  - Updated advanced setup documentation with revised precedence rules and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
