### PR TITLE
fix(types): give tool progress payloads real shapes instead of `any`

### DIFF
--- a/src/services/mcp/client.activity.test.ts
+++ b/src/services/mcp/client.activity.test.ts
@@ -6,6 +6,7 @@ import {
 import { createAssistantMessage } from '../../utils/messages.js'
 import { fetchToolsForClient } from './client.js'
 import type { ConnectedMCPServer } from './types.js'
+import type { ToolProgress, ToolProgressData } from '../../Tool.js'
 
 describe('MCP tool activity', () => {
   afterEach(() => {
@@ -178,8 +179,8 @@ describe('MCP tool activity', () => {
     } as unknown as ConnectedMCPServer
     const [tool] = await fetchToolsForClient(connection)
     expect(tool).toBeDefined()
-    const onProgress = vi.fn(({ data }: { data: { status: string } }) => {
-      if (data.status === 'started') {
+    const onProgress = vi.fn(({ data }: ToolProgress<ToolProgressData>) => {
+      if (data.type === 'mcp_progress' && data.status === 'started') {
         throw new Error('progress consumer failure')
       }
     })
@@ -239,8 +240,8 @@ describe('MCP tool activity', () => {
     } as unknown as ConnectedMCPServer
     const [tool] = await fetchToolsForClient(connection)
     expect(tool).toBeDefined()
-    const onProgress = vi.fn(({ data }: { data: { status: string } }) => {
-      if (data.status === 'progress') {
+    const onProgress = vi.fn(({ data }: ToolProgress<ToolProgressData>) => {
+      if (data.type === 'mcp_progress' && data.status === 'progress') {
         throw new Error('progress consumer failure')
       }
     })
@@ -301,8 +302,8 @@ describe('MCP tool activity', () => {
     } as unknown as ConnectedMCPServer
     const [tool] = await fetchToolsForClient(connection)
     expect(tool).toBeDefined()
-    const onProgress = vi.fn(({ data }: { data: { status: string } }) => {
-      if (data.status === 'completed') {
+    const onProgress = vi.fn(({ data }: ToolProgress<ToolProgressData>) => {
+      if (data.type === 'mcp_progress' && data.status === 'completed') {
         throw new Error('progress consumer failure')
       }
     })
@@ -357,8 +358,8 @@ describe('MCP tool activity', () => {
     } as unknown as ConnectedMCPServer
     const [tool] = await fetchToolsForClient(connection)
     expect(tool).toBeDefined()
-    const onProgress = vi.fn(({ data }: { data: { status: string } }) => {
-      if (data.status === 'failed') {
+    const onProgress = vi.fn(({ data }: ToolProgress<ToolProgressData>) => {
+      if (data.type === 'mcp_progress' && data.status === 'failed') {
         throw new Error('progress consumer failure')
       }
     })
@@ -423,8 +424,8 @@ describe('MCP tool activity', () => {
     } as unknown as ConnectedMCPServer
     const [tool] = await fetchToolsForClient(connection)
     expect(tool).toBeDefined()
-    const onProgress = vi.fn(({ data }: { data: { status: string } }) => {
-      if (data.status === 'progress') {
+    const onProgress = vi.fn(({ data }: ToolProgress<ToolProgressData>) => {
+      if (data.type === 'mcp_progress' && data.status === 'progress') {
         throw new Error('progress consumer failure')
       }
     })

--- a/src/tools/AgentTool/AgentTool.tsx
+++ b/src/tools/AgentTool/AgentTool.tsx
@@ -279,10 +279,11 @@ type TeammateSpawnedOutput = {
 // Combined output type including both public and internal types
 // Note: TeammateSpawnedOutput type is fine - TypeScript types are erased at compile time
 type InternalOutput = Output | TeammateSpawnedOutput;
-import type { AgentToolProgress, ShellProgress } from '../../types/tools.js';
-// AgentTool forwards both its own progress events and shell progress
-// events from the sub-agent so the SDK receives tool_progress updates during bash/powershell runs.
-export type Progress = AgentToolProgress | ShellProgress;
+import type { AgentToolProgress, MCPProgress, ShellProgress, TaskOutputProgress } from '../../types/tools.js';
+// AgentTool forwards both its own progress events and shell, MCP, and
+// waiting-for-task progress events from the sub-agent so the SDK receives
+// tool_progress updates during bash/powershell/MCP calls and background tasks.
+export type Progress = AgentToolProgress | ShellProgress | MCPProgress | TaskOutputProgress;
 export const AgentTool = buildTool({
   async prompt({
     agents,

--- a/src/tools/AgentTool/UI.tsx
+++ b/src/tools/AgentTool/UI.tsx
@@ -373,7 +373,7 @@ export function renderToolUseProgressMessage(progressMessages: ProgressMessage<P
       return message.message.content.some(content => content.type === 'tool_use');
     });
     const latestAssistant = progressMessages.findLast((msg): msg is ProgressMessage<AgentToolProgress> => hasProgressMessage(msg.data) && msg.data.message.type === 'assistant');
-    let tokens = null;
+    let tokens: number | null = null;
     if (latestAssistant?.data.message.type === 'assistant') {
       const usage = latestAssistant.data.message.message.usage;
       tokens = (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0) + usage.input_tokens + usage.output_tokens;
@@ -524,7 +524,7 @@ function calculateAgentStats(progressMessages: ProgressMessage<Progress>[]): {
     return message.type === 'user' && message.message.content.some(content => content.type === 'tool_result');
   });
   const latestAssistant = progressMessages.findLast((msg): msg is ProgressMessage<AgentToolProgress> => hasProgressMessage(msg.data) && msg.data.message.type === 'assistant');
-  let tokens = null;
+  let tokens: number | null = null;
   if (latestAssistant?.data.message.type === 'assistant') {
     const usage = latestAssistant.data.message.message.usage;
     tokens = (usage.cache_creation_input_tokens ?? 0) + (usage.cache_read_input_tokens ?? 0) + usage.input_tokens + usage.output_tokens;

--- a/src/types/tools.ts
+++ b/src/types/tools.ts
@@ -1,17 +1,140 @@
-/**
- * Stub — tool type definitions not included in source snapshot. See
- * src/types/message.ts for the same scoping caveat (issue #473).
- */
+import type {
+  AssistantMessage,
+  NormalizedAssistantMessage,
+  NormalizedUserMessage,
+} from './message.js'
+import type { AgentId } from './ids.js'
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-export type ShellProgress = any
-export type AgentToolProgress = any
-export type BashProgress = any
-export type MCPProgress = any
-export type PowerShellProgress = any
-export type REPLToolProgress = any
-export type SdkWorkflowProgress = any
-export type SkillToolProgress = any
-export type TaskOutputProgress = any
-export type ToolProgressData = any
-export type WebSearchProgress = any
+// ---------------------------------------------------------------------------
+// NOTE: This file was reconstructed from usage sites — the original was a
+// type-only module erased at compile time and absent from cli.js.map.
+// Shapes are inferred from onProgress construction sites in
+// src/tools/BashTool/BashTool.tsx, src/tools/PowerShellTool/PowerShellTool.tsx,
+// src/tools/AgentTool/AgentTool.tsx, src/tools/SkillTool/SkillTool.ts,
+// src/tools/TaskOutputTool/TaskOutputTool.tsx,
+// src/tools/WebSearchTool/WebSearchTool.ts and src/services/mcp/client.ts.
+// See issue #473 for the typecheck-foundation effort.
+// ---------------------------------------------------------------------------
+
+export type BashProgress = {
+  type: 'bash_progress'
+  output: string
+  fullOutput: string
+  elapsedTimeSeconds: number
+  totalLines: number
+  totalBytes: number
+  taskId: string
+  timeoutMs: number
+}
+
+export type PowerShellProgress = {
+  type: 'powershell_progress'
+  output: string
+  fullOutput: string
+  elapsedTimeSeconds: number
+  totalLines: number
+  totalBytes: number
+  timeoutMs: number
+  taskId: string
+}
+
+/**
+ * Shared shell-progress payload forwarded by AgentTool from a sub-agent's
+ * bash/powershell tool calls, and consumed generically by BashModeProgress
+ * for `!`-prefixed bash-mode commands (either backend).
+ */
+export type ShellProgress = BashProgress | PowerShellProgress
+
+/**
+ * `message` is usually normalized (one content block) via normalizeMessages,
+ * but processSlashCommand.tsx forwards a raw (un-normalized) AssistantMessage
+ * for forked-command agent progress — so both shapes are accepted.
+ */
+export type AgentToolProgress = {
+  type: 'agent_progress'
+  message: NormalizedUserMessage | NormalizedAssistantMessage | AssistantMessage
+  prompt: string
+  agentId: AgentId
+}
+
+export type SkillToolProgress = {
+  type: 'skill_progress'
+  message: NormalizedUserMessage | NormalizedAssistantMessage
+  prompt: string
+  agentId: AgentId
+}
+
+/**
+ * Flat (not per-status-discriminated) shape — MCPTool/UI.tsx destructures
+ * progress/total/progressMessage off `.data` unconditionally, without first
+ * narrowing on `status`, so those fields must be optional on every status.
+ */
+export type MCPProgress = {
+  type: 'mcp_progress'
+  status: 'started' | 'completed' | 'failed' | 'progress'
+  serverName: string
+  toolName: string
+  elapsedTimeMs?: number
+  /** MCP protocol progress notification fields (SDK Progress type), status==='progress' only */
+  progress?: number
+  total?: number
+  progressMessage?: string
+}
+
+export type TaskOutputProgress = {
+  type: 'waiting_for_task'
+  taskDescription: string
+  taskType: string
+}
+
+export type WebSearchProgress =
+  | {
+      type: 'query_update'
+      query: string
+    }
+  | {
+      type: 'search_results_received'
+      resultCount: number
+      query: string
+    }
+
+/**
+ * Emitted by the REPL tool's inner-tool-call progress (verified from a
+ * single consumption site — no construction site survives in this source,
+ * so `phase` beyond 'start' is unconfirmed).
+ */
+export type REPLToolProgress = {
+  type: 'repl_tool_call'
+  phase: string
+  toolName: string
+  toolInput: unknown
+}
+
+/**
+ * Element of the `workflow_progress` delta batch emitted alongside
+ * `task_progress` SDK events (src/utils/sdkEventQueue.ts). The consumer
+ * (PhaseProgress.tsx, referenced by comment at sdkEventQueue.ts:29-31) is not
+ * present in this source — no construction site exists here either, so this
+ * shape is inferred only from that comment ("upsert by `${type}:${index}`
+ * then group by phaseIndex"). Low confidence.
+ */
+export type SdkWorkflowProgress = {
+  type: string
+  index: number
+  phaseIndex: number
+}
+
+/**
+ * Union of all built-in tools' progress payloads. Excludes HookProgress
+ * (src/types/hooks.ts), which is combined separately into `Progress` in
+ * src/Tool.ts (`Progress = ToolProgressData | HookProgress`).
+ */
+export type ToolProgressData =
+  | BashProgress
+  | PowerShellProgress
+  | AgentToolProgress
+  | SkillToolProgress
+  | MCPProgress
+  | TaskOutputProgress
+  | WebSearchProgress
+  | REPLToolProgress

--- a/src/utils/messages/factories.test.ts
+++ b/src/utils/messages/factories.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test'
 import type { Message } from '../../types/message.js'
+import type { Progress } from '../../Tool.js'
 
 const factories = (await import(
   `./factories.js?factory-test=${Date.now()}-${Math.random()}`
@@ -186,7 +187,7 @@ test('createProgressMessage preserves tool IDs and payload', () => {
   const message = createProgressMessage({
     toolUseID: 'toolu_child',
     parentToolUseID: 'toolu_parent',
-    data: { message: 'working' },
+    data: { message: 'working' } as unknown as Progress,
   })
 
   expect(message).toMatchObject({


### PR DESCRIPTION
## Summary

- what changed
- why it changed

ToolProgressData and its members (BashProgress, PowerShellProgress, AgentToolProgress, SkillToolProgress, MCPProgress, TaskOutputProgress, WebSearchProgress, REPLToolProgress, SdkWorkflowProgress) were all `any` stubs, so onProgress callbacks across every built-in tool typechecked regardless of what shape they actually passed.

Reconstruct each type from its real construction/consumption sites (BashTool, PowerShellTool, AgentTool, SkillTool, TaskOutputTool, WebSearchTool, services/mcp/client.ts) instead of leaving them as placeholders.

Turning the `any` off surfaced three latent bugs that were previously invisible:

- AgentTool's local Progress alias only covered AgentToolProgress | ShellProgress, even though it forwards MCPProgress and TaskOutputProgress from sub-agent tool calls too. Widen it.
- calculateAgentStats and renderToolUseProgressMessage both had `let tokens = null`, inferred as the literal type `null`, silently discarding the type of the count assigned to it a few lines later. Annotate as `number | null`.
- Two test files (client.activity.test.ts, factories.test.ts) passed progress payloads too loosely typed to satisfy the real union; narrow/cast them to what's actually under test.

tsc --noEmit is clean and the full suite passes (one pre-existing unrelated flake in knowledge.test.ts, confirmed by running that file alone).
## Impact

- user-facing impact:
   nope
- developer/maintainer impact:
  nope, just make the type system works

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check`
- [x] focused tests:
  tsc --noEmit 
## Notes

- provider/model path tested:
- screenshots attached (if UI changed):
- follow-up work or known limitations: I will commit the other types fix in another PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress event handling across MCP, PowerShell, task output, agent, and shell activities.
  * Ensured progress statuses are correctly recognized for started, active, completed, and failed events.

* **Refactor**
  * Added stronger typing for tool progress data, improving consistency and reliability across progress updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->