### PR TITLE
fix(input): preserve text in DEL-coalesced chunks

### DIFF
--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -52,7 +52,7 @@ import { AGENT_COLOR_TO_THEME_COLOR, AGENT_COLORS, type AgentColorName } from '.
 import type { AgentDefinition } from '../../tools/AgentTool/loadAgentsDir.js';
 import type { Message } from '../../types/message.js';
 import type { PermissionMode } from '../../types/permissions.js';
-import type { BaseTextInputProps, PromptInputMode, VimMode } from '../../types/textInputTypes.js';
+import type { BaseTextInputProps, PromptInputMode, TextInputChangeContext, VimMode } from '../../types/textInputTypes.js';
 import { isAgentSwarmsEnabled } from '../../utils/agentSwarmsEnabled.js';
 import { count } from '../../utils/array.js';
 import type { AutoUpdaterResult } from '../../utils/autoUpdater.js';
@@ -123,7 +123,7 @@ import { useMaybeTruncateInput } from './useMaybeTruncateInput.js';
 import { usePromptInputPlaceholder } from './usePromptInputPlaceholder.js';
 import { useShowFastIconHint } from './useShowFastIconHint.js';
 import { useSwarmBanner } from './useSwarmBanner.js';
-import { isNonSpacePrintable, isVimModeEnabled } from './utils.js';
+import { canAcceptPromptSuggestion, isNonSpacePrintable, isVimModeEnabled, resolveCoalescedModeSubmission } from './utils.js';
 type Props = {
   debug: boolean;
   ideSelection: IDESelection | undefined;
@@ -174,6 +174,7 @@ type Props = {
   }, options?: {
     fromKeybinding?: boolean;
     slashCommandOverride?: Command;
+    inputModeOverride?: PromptInputMode;
   }) => Promise<void>;
   onAgentSubmit?: (input: string, task: InProcessTeammateTaskState | LocalAgentTaskState, helpers: PromptInputHelpers) => Promise<void>;
   isSearchingHistory: boolean;
@@ -869,7 +870,8 @@ function PromptInput({
     submitCount,
     viewingAgentName
   });
-  const onChange = useCallback((value: string) => {
+  const pendingCoalescedModeSubmitRef = React.useRef<ReturnType<typeof detectModeEntry>>(null);
+  const onChange = useCallback((value: string, changeContext?: TextInputChangeContext) => {
     if (value === '?') {
       logEvent('tengu_help_toggled', {});
       setHelpOpen(v => !v);
@@ -888,19 +890,26 @@ function PromptInput({
     // mode itself is shown via the prompt prefix in the UI. Without this,
     // typing `!` into empty input would enter bash mode but leave the literal
     // `!` in the buffer (issue #662).
+    const previousValue = changeContext?.previousValue ?? input;
+    const previousCursorOffset = changeContext?.cursorOffset ?? cursorOffset;
     const modeEntry = detectModeEntry({
       value,
-      prevInputLength: input.length,
-      cursorOffset,
+      prevInputLength: previousValue.length,
+      cursorOffset: previousCursorOffset,
     });
     if (modeEntry) {
-      onModeChange(modeEntry.mode);
       const cleaned = modeEntry.strippedValue.replaceAll('\t', '    ');
-      pushToBuffer(input, cursorOffset, pastedContents);
+      pendingCoalescedModeSubmitRef.current = changeContext?.willSubmit ? {
+        ...modeEntry,
+        strippedValue: cleaned
+      } : null;
+      onModeChange(modeEntry.mode);
+      pushToBuffer(previousValue, previousCursorOffset, pastedContents);
       trackAndSetInput(cleaned);
       setCursorOffset(cleaned.length);
       return;
     }
+    pendingCoalescedModeSubmitRef.current = null;
     const processedValue = value.replaceAll('\t', '    ');
 
     // Push current state to buffer before making changes
@@ -998,6 +1007,11 @@ function PromptInput({
     setSuggestionsStateRaw(prev => typeof updater === 'function' ? updater(prev) : updater);
   }, []);
   const onSubmit = useCallback(async (inputParam: string, isSubmittingSlashCommand = false, slashCommandOverride?: Command) => {
+    const pendingModeEntry = pendingCoalescedModeSubmitRef.current;
+    pendingCoalescedModeSubmitRef.current = null;
+    const modeSubmission = resolveCoalescedModeSubmission(inputParam, mode, pendingModeEntry);
+    inputParam = modeSubmission.input;
+    const effectiveSubmissionMode = modeSubmission.mode;
     inputParam = inputParam.trimEnd();
 
     // Don't submit if a footer indicator is being opened. Read fresh from
@@ -1026,7 +1040,7 @@ function PromptInput({
     // Only in leader view — promptSuggestion is leader-context, not teammate.
     const suggestionText = promptSuggestionState.text;
     const inputMatchesSuggestion = inputParam.trim() === '' || inputParam === suggestionText;
-    if (inputMatchesSuggestion && suggestionText && !hasImages && !state.viewingAgentTaskId) {
+    if (canAcceptPromptSuggestion(effectiveSubmissionMode) && inputMatchesSuggestion && suggestionText && !hasImages && !state.viewingAgentTaskId) {
       // If speculation is active, inject messages immediately as they stream
       if (speculation.status === 'active') {
         markAccepted();
@@ -1042,7 +1056,9 @@ function PromptInput({
           state: speculation,
           speculationSessionTimeSavedMs: speculationSessionTimeSavedMs,
           setAppState
-        });
+        }, modeSubmission.inputModeOverride ? {
+          inputModeOverride: modeSubmission.inputModeOverride
+        } : undefined);
         return; // Skip normal query - speculation handled it
       }
 
@@ -1087,7 +1103,7 @@ function PromptInput({
     // PromptInput UX: Check if suggestions dropdown is showing
     // For directory suggestions, allow submission (Tab is used for completion)
     const hasDirectorySuggestions = suggestionsState.suggestions.length > 0 && suggestionsState.suggestions.every(s => s.description === 'directory');
-    if (suggestionsState.suggestions.length > 0 && !isSubmittingSlashCommand && !hasDirectorySuggestions) {
+    if (canAcceptPromptSuggestion(effectiveSubmissionMode) && suggestionsState.suggestions.length > 0 && !isSubmittingSlashCommand && !hasDirectorySuggestions) {
       logForDebugging(`[onSubmit] early return: suggestions showing (count=${suggestionsState.suggestions.length})`);
       return; // Don't submit, user needs to clear suggestions first
     }
@@ -1113,14 +1129,16 @@ function PromptInput({
     }
 
     // Normal leader submission
+    const submitOptions = slashCommandOverride || modeSubmission.inputModeOverride ? {
+      slashCommandOverride,
+      inputModeOverride: modeSubmission.inputModeOverride
+    } : undefined;
     await onSubmitProp(inputParam, {
       setCursorOffset,
       clearBuffer,
       resetHistory
-    }, undefined, slashCommandOverride ? {
-      slashCommandOverride
-    } : undefined);
-  }, [promptSuggestionState, speculation, speculationSessionTimeSavedMs, teamContext, store, footerItems, suggestionsState.suggestions, onSubmitProp, onAgentSubmit, clearBuffer, resetHistory, logOutcomeAtSubmission, setAppState, markAccepted, pastedContents, removeNotification]);
+    }, undefined, submitOptions);
+  }, [promptSuggestionState, speculation, speculationSessionTimeSavedMs, teamContext, store, footerItems, suggestionsState.suggestions, onSubmitProp, onAgentSubmit, clearBuffer, resetHistory, logOutcomeAtSubmission, setAppState, markAccepted, pastedContents, removeNotification, mode]);
   const {
     suggestions,
     selectedSuggestion,

--- a/src/components/PromptInput/PromptInput.tsx
+++ b/src/components/PromptInput/PromptInput.tsx
@@ -123,7 +123,7 @@ import { useMaybeTruncateInput } from './useMaybeTruncateInput.js';
 import { usePromptInputPlaceholder } from './usePromptInputPlaceholder.js';
 import { useShowFastIconHint } from './useShowFastIconHint.js';
 import { useSwarmBanner } from './useSwarmBanner.js';
-import { canAcceptPromptSuggestion, isNonSpacePrintable, isVimModeEnabled, resolveCoalescedModeSubmission } from './utils.js';
+import { canAcceptPromptSuggestion, isVimModeEnabled, normalizePromptInputChunk, resolveCoalescedModeSubmission, resolveHelpToggleChange } from './utils.js';
 type Props = {
   debug: boolean;
   ideSelection: IDESelection | undefined;
@@ -871,10 +871,18 @@ function PromptInput({
     viewingAgentName
   });
   const pendingCoalescedModeSubmitRef = React.useRef<ReturnType<typeof detectModeEntry>>(null);
+  const suppressNextCoalescedSubmitRef = React.useRef(false);
   const onChange = useCallback((value: string, changeContext?: TextInputChangeContext) => {
-    if (value === '?') {
+    const helpToggleChange = resolveHelpToggleChange(value, changeContext);
+    if (helpToggleChange) {
       logEvent('tengu_help_toggled', {});
       setHelpOpen(v => !v);
+      pendingCoalescedModeSubmitRef.current = null;
+      suppressNextCoalescedSubmitRef.current = helpToggleChange.suppressSubmit;
+      if (helpToggleChange.restore) {
+        trackAndSetInput(helpToggleChange.restore.value);
+        setCursorOffset(helpToggleChange.restore.cursorOffset);
+      }
       return;
     }
     setHelpOpen(false);
@@ -890,12 +898,12 @@ function PromptInput({
     // mode itself is shown via the prompt prefix in the UI. Without this,
     // typing `!` into empty input would enter bash mode but leave the literal
     // `!` in the buffer (issue #662).
-    const previousValue = changeContext?.previousValue ?? input;
-    const previousCursorOffset = changeContext?.cursorOffset ?? cursorOffset;
+    const modeDetectionValue = changeContext?.previousValue ?? input;
+    const modeDetectionCursorOffset = changeContext?.cursorOffset ?? cursorOffset;
     const modeEntry = detectModeEntry({
       value,
-      prevInputLength: previousValue.length,
-      cursorOffset: previousCursorOffset,
+      prevInputLength: modeDetectionValue.length,
+      cursorOffset: modeDetectionCursorOffset,
     });
     if (modeEntry) {
       const cleaned = modeEntry.strippedValue.replaceAll('\t', '    ');
@@ -904,7 +912,7 @@ function PromptInput({
         strippedValue: cleaned
       } : null;
       onModeChange(modeEntry.mode);
-      pushToBuffer(previousValue, previousCursorOffset, pastedContents);
+      pushToBuffer(input, cursorOffset, pastedContents);
       trackAndSetInput(cleaned);
       setCursorOffset(cleaned.length);
       return;
@@ -1007,6 +1015,10 @@ function PromptInput({
     setSuggestionsStateRaw(prev => typeof updater === 'function' ? updater(prev) : updater);
   }, []);
   const onSubmit = useCallback(async (inputParam: string, isSubmittingSlashCommand = false, slashCommandOverride?: Command) => {
+    if (suppressNextCoalescedSubmitRef.current) {
+      suppressNextCoalescedSubmitRef.current = false;
+      return;
+    }
     const pendingModeEntry = pendingCoalescedModeSubmitRef.current;
     pendingCoalescedModeSubmitRef.current = null;
     const modeSubmission = resolveCoalescedModeSubmission(inputParam, mode, pendingModeEntry);
@@ -1291,10 +1303,9 @@ function PromptInput({
     }
   }
   const lazySpaceInputFilter = useCallback((input: string, key: Key): string => {
-    if (!pendingSpaceAfterPillRef.current) return input;
+    const prependLazySpace = pendingSpaceAfterPillRef.current;
     pendingSpaceAfterPillRef.current = false;
-    if (isNonSpacePrintable(input, key)) return ' ' + input;
-    return input;
+    return normalizePromptInputChunk(input, key, prependLazySpace);
   }, []);
   // Ref mirrors cursorOffset for use in synchronous loops (e.g. multi-image
   // paste) where React batches state updates and the closure value is stale.

--- a/src/components/PromptInput/utils.test.ts
+++ b/src/components/PromptInput/utils.test.ts
@@ -21,6 +21,10 @@ test('does not classify DEL-coalesced replacement text as printable', () => {
   expect(isNonSpacePrintable('\x7fă', unmodifiedKey)).toBe(false)
 })
 
+test('does not classify End key input as printable', () => {
+  expect(isNonSpacePrintable('a', { end: true } as Key)).toBe(false)
+})
+
 test('resolves a coalesced mode submission independently of stale rendered mode', () => {
   expect(
     resolveCoalescedModeSubmission('\tignored', 'prompt', {
@@ -31,6 +35,13 @@ test('resolves a coalesced mode submission independently of stale rendered mode'
     input: '    foo',
     mode: 'bash',
     inputModeOverride: 'bash',
+  })
+})
+
+test('preserves input and rendered mode without a pending mode entry', () => {
+  expect(resolveCoalescedModeSubmission('echo ok', 'bash', null)).toEqual({
+    input: 'echo ok',
+    mode: 'bash',
   })
 })
 

--- a/src/components/PromptInput/utils.test.ts
+++ b/src/components/PromptInput/utils.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'bun:test'
+
+import type { Key } from '../../ink.js'
+import {
+  canAcceptPromptSuggestion,
+  isNonSpacePrintable,
+  resolveCoalescedModeSubmission,
+} from './utils.js'
+
+const unmodifiedKey = {} as Key
+
+test('classifies ordinary non-space text as printable', () => {
+  expect(isNonSpacePrintable('a', unmodifiedKey)).toBe(true)
+})
+
+test('does not classify leading whitespace as printable', () => {
+  expect(isNonSpacePrintable(' a', unmodifiedKey)).toBe(false)
+})
+
+test('does not classify DEL-coalesced replacement text as printable', () => {
+  expect(isNonSpacePrintable('\x7fă', unmodifiedKey)).toBe(false)
+})
+
+test('resolves a coalesced mode submission independently of stale rendered mode', () => {
+  expect(
+    resolveCoalescedModeSubmission('\tignored', 'prompt', {
+      mode: 'bash',
+      strippedValue: '\tfoo',
+    }),
+  ).toEqual({
+    input: '    foo',
+    mode: 'bash',
+    inputModeOverride: 'bash',
+  })
+})
+
+test('only prompt submissions can accept prompt suggestions', () => {
+  expect(canAcceptPromptSuggestion('prompt')).toBe(true)
+  expect(canAcceptPromptSuggestion('bash')).toBe(false)
+})

--- a/src/components/PromptInput/utils.test.ts
+++ b/src/components/PromptInput/utils.test.ts
@@ -4,6 +4,8 @@ import type { Key } from '../../ink.js'
 import {
   canAcceptPromptSuggestion,
   isNonSpacePrintable,
+  normalizePromptInputChunk,
+  resolveHelpToggleChange,
   resolveCoalescedModeSubmission,
 } from './utils.js'
 
@@ -19,6 +21,45 @@ test('does not classify leading whitespace as printable', () => {
 
 test('does not classify DEL-coalesced replacement text as printable', () => {
   expect(isNonSpacePrintable('\x7fă', unmodifiedKey)).toBe(false)
+})
+
+test('classifies printable text before a DEL byte as printable', () => {
+  expect(isNonSpacePrintable('x\x7fy', unmodifiedKey)).toBe(true)
+})
+
+test('normalizes tabs before a DEL-coalesced chunk reaches cursor editing', () => {
+  expect(normalizePromptInputChunk('\x7f\tfoo', unmodifiedKey, false)).toBe(
+    '\x7f    foo',
+  )
+})
+
+test('prepends a lazy image-pill space before printable text preceding DEL', () => {
+  expect(normalizePromptInputChunk('x\x7fy', unmodifiedKey, true)).toBe(
+    ' x\x7fy',
+  )
+})
+
+test('does not prepend a lazy image-pill space when DEL comes first', () => {
+  expect(normalizePromptInputChunk('\x7fy', unmodifiedKey, true)).toBe(
+    '\x7fy',
+  )
+})
+
+test('restores pre-character state and suppresses a coalesced help submission', () => {
+  expect(
+    resolveHelpToggleChange('?', {
+      previousValue: '',
+      cursorOffset: 0,
+      willSubmit: true,
+    }),
+  ).toEqual({
+    restore: { value: '', cursorOffset: 0 },
+    suppressSubmit: true,
+  })
+})
+
+test('ignores non-help input when resolving special input changes', () => {
+  expect(resolveHelpToggleChange('x')).toBeNull()
 })
 
 test('does not classify End key input as printable', () => {

--- a/src/components/PromptInput/utils.ts
+++ b/src/components/PromptInput/utils.ts
@@ -3,8 +3,10 @@ import {
   isShiftEnterKeyBindingInstalled,
 } from '../../commands/terminalSetup/terminalSetup.js'
 import type { Key } from '../../ink.js'
+import type { PromptInputMode } from '../../types/textInputTypes.js'
 import { getGlobalConfig } from '../../utils/config.js'
 import { env } from '../../utils/env.js'
+import type { ModeEntryDecision } from './inputModes.js'
 /**
  * Helper function to check if vim mode is currently enabled
  * @returns boolean indicating if vim mode is active
@@ -52,9 +54,34 @@ export function isNonSpacePrintable(input: string, key: Key): boolean {
     key.pageUp ||
     key.pageDown ||
     key.home ||
-    key.end
+    key.end ||
+    input.includes('\x7f')
   ) {
     return false
   }
   return input.length > 0 && !/^\s/.test(input) && !input.startsWith('\x1b')
+}
+
+export function resolveCoalescedModeSubmission(
+  input: string,
+  renderedMode: PromptInputMode,
+  pendingModeEntry: ModeEntryDecision | null,
+): {
+  input: string
+  mode: PromptInputMode
+  inputModeOverride?: PromptInputMode
+} {
+  if (!pendingModeEntry) {
+    return { input, mode: renderedMode }
+  }
+
+  return {
+    input: pendingModeEntry.strippedValue.replaceAll('\t', '    '),
+    mode: pendingModeEntry.mode,
+    inputModeOverride: pendingModeEntry.mode,
+  }
+}
+
+export function canAcceptPromptSuggestion(mode: PromptInputMode): boolean {
+  return mode === 'prompt'
 }

--- a/src/components/PromptInput/utils.ts
+++ b/src/components/PromptInput/utils.ts
@@ -3,7 +3,10 @@ import {
   isShiftEnterKeyBindingInstalled,
 } from '../../commands/terminalSetup/terminalSetup.js'
 import type { Key } from '../../ink.js'
-import type { PromptInputMode } from '../../types/textInputTypes.js'
+import type {
+  PromptInputMode,
+  TextInputChangeContext,
+} from '../../types/textInputTypes.js'
 import { getGlobalConfig } from '../../utils/config.js'
 import { env } from '../../utils/env.js'
 import type { ModeEntryDecision } from './inputModes.js'
@@ -54,12 +57,50 @@ export function isNonSpacePrintable(input: string, key: Key): boolean {
     key.pageUp ||
     key.pageDown ||
     key.home ||
-    key.end ||
-    input.includes('\x7f')
+    key.end
   ) {
     return false
   }
-  return input.length > 0 && !/^\s/.test(input) && !input.startsWith('\x1b')
+  const delIndex = input.indexOf('\x7f')
+  const leadingInput = delIndex === -1 ? input : input.slice(0, delIndex)
+  return (
+    leadingInput.length > 0 &&
+    !/^\s/.test(leadingInput) &&
+    !leadingInput.startsWith('\x1b')
+  )
+}
+
+export function normalizePromptInputChunk(
+  input: string,
+  key: Key,
+  prependLazySpace: boolean,
+): string {
+  const normalizedInput = input.replaceAll('\t', '    ')
+  return prependLazySpace && isNonSpacePrintable(normalizedInput, key)
+    ? ` ${normalizedInput}`
+    : normalizedInput
+}
+
+export function resolveHelpToggleChange(
+  value: string,
+  changeContext?: TextInputChangeContext,
+):
+  | {
+      restore?: { value: string; cursorOffset: number }
+      suppressSubmit: boolean
+    }
+  | null {
+  if (value !== '?') return null
+
+  return {
+    restore: changeContext
+      ? {
+          value: changeContext.previousValue,
+          cursorOffset: changeContext.cursorOffset,
+        }
+      : undefined,
+    suppressSubmit: changeContext?.willSubmit === true,
+  }
 }
 
 export function resolveCoalescedModeSubmission(

--- a/src/components/TextInput.test.tsx
+++ b/src/components/TextInput.test.tsx
@@ -1,6 +1,6 @@
 import { PassThrough } from 'node:stream'
 
-import { expect, test } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import React from 'react'
 import { stripVTControlCharacters as stripAnsi } from 'node:util'
 
@@ -9,6 +9,7 @@ import { useTextInput } from '../hooks/useTextInput.js'
 import { useVimInput } from '../hooks/useVimInput.js'
 import { AppStateProvider } from '../state/AppState.js'
 import type {
+  TextInputChangeContext,
   TextInputState,
   VimInputState,
 } from '../types/textInputTypes.js'
@@ -105,6 +106,20 @@ async function waitForOutput(
   }
 
   throw new Error('Timed out waiting for TextInput test output')
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 2500,
+): Promise<void> {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    if (predicate()) return
+    await Bun.sleep(5)
+  }
+
+  throw new Error('Timed out waiting for TextInput state')
 }
 
 function DelayedControlledTextInput(): React.ReactNode {
@@ -411,6 +426,7 @@ async function runInputScenario({
   submissions: string[]
 }> {
   let observedValue = initialValue
+  let receivedInputCount = 0
   const changes: string[] = []
   const submissions: string[] = []
 
@@ -432,7 +448,10 @@ async function runInputScenario({
           columns={60}
           cursorOffset={offset}
           onChangeCursorOffset={setOffset}
-          inputFilter={inputFilter}
+          inputFilter={(nextInput, key) => {
+            receivedInputCount++
+            return inputFilter ? inputFilter(nextInput, key) : nextInput
+          }}
           focus
           showCursor
           multiline
@@ -456,20 +475,15 @@ async function runInputScenario({
         ? output.includes(initialValue)
         : output.includes('Type here...'),
   )
+  const previousInputCount = receivedInputCount
   stdin.write(chunk)
-  await Bun.sleep(75)
+  await waitFor(() => receivedInputCount > previousInputCount)
 
   root.unmount()
   stdin.end()
   stdout.end()
 
   return { value: observedValue, changes, submissions }
-}
-
-type ModeChangeContext = {
-  previousValue: string
-  cursorOffset: number
-  willSubmit?: boolean
 }
 
 async function runPromptModeScenario({
@@ -485,6 +499,7 @@ async function runPromptModeScenario({
 }> {
   let observedMode = 'prompt'
   let observedValue = initialValue
+  let receivedInputCount = 0
   const submissions: Array<{ value: string; mode: string }> = []
 
   function PromptModeTextInput(): React.ReactNode {
@@ -497,7 +512,7 @@ async function runPromptModeScenario({
 
     const handleChange = (
       nextValue: string,
-      context?: ModeChangeContext,
+      context?: TextInputChangeContext,
     ): void => {
       const modeEntry = detectModeEntry({
         value: nextValue,
@@ -536,6 +551,10 @@ async function runPromptModeScenario({
           columns={60}
           cursorOffset={offset}
           onChangeCursorOffset={setOffset}
+          inputFilter={nextInput => {
+            receivedInputCount++
+            return nextInput
+          }}
           focus
           showCursor
           multiline
@@ -559,8 +578,9 @@ async function runPromptModeScenario({
         ? output.includes(initialValue)
         : output.includes('Type here...'),
   )
+  const previousInputCount = receivedInputCount
   stdin.write(chunk)
-  await Bun.sleep(75)
+  await waitFor(() => receivedInputCount > previousInputCount)
 
   root.unmount()
   stdin.end()
@@ -839,29 +859,30 @@ test('TextInput leaves ordinary Backspace and Delete key events unchanged', asyn
   expect(del.value).toBe('ac')
 })
 
-test('TextInput resets kill accumulation once for a raw DEL event', async () => {
-  clearKillRing()
-  pushToKillRing('first')
+describe('raw DEL kill and yank state', () => {
+  beforeEach(clearKillRing)
+  afterEach(clearKillRing)
 
-  await runInputScenario({ initialValue: 'a', chunk: '\x7fă' })
-  pushToKillRing('second')
+  test('TextInput resets kill accumulation once for a raw DEL event', async () => {
+    pushToKillRing('first')
 
-  expect(getKillRingSize()).toBe(2)
-  clearKillRing()
-})
+    await runInputScenario({ initialValue: 'a', chunk: '\x7fă' })
+    pushToKillRing('second')
 
-test('TextInput resets yank-pop state for a raw DEL event', async () => {
-  clearKillRing()
-  pushToKillRing('first')
-  resetKillAccumulation()
-  pushToKillRing('second')
-  recordYank(0, 'second'.length)
-  expect(canYankPop()).toBe(true)
+    expect(getKillRingSize()).toBe(2)
+  })
 
-  await runInputScenario({ initialValue: 'a', chunk: '\x7fă' })
+  test('TextInput resets yank-pop state for a raw DEL event', async () => {
+    pushToKillRing('first')
+    resetKillAccumulation()
+    pushToKillRing('second')
+    recordYank(0, 'second'.length)
+    expect(canYankPop()).toBe(true)
 
-  expect(canYankPop()).toBe(false)
-  clearKillRing()
+    await runInputScenario({ initialValue: 'a', chunk: '\x7fă' })
+
+    expect(canYankPop()).toBe(false)
+  })
 })
 
 test('VimTextInput dot-repeat does not record a raw DEL byte', async () => {
@@ -932,7 +953,7 @@ test('VimTextInput dot-repeat does not record a post-DEL mode sentinel', async (
 
     inputState = useVimInput({
       value,
-      onChange: (nextValue, context?: ModeChangeContext) => {
+      onChange: (nextValue, context?: TextInputChangeContext) => {
         const modeEntry = detectModeEntry({
           value: nextValue,
           prevInputLength: context?.previousValue.length ?? value.length,

--- a/src/components/TextInput.test.tsx
+++ b/src/components/TextInput.test.tsx
@@ -467,21 +467,23 @@ async function runInputScenario({
     patchConsole: false,
   })
 
-  root.render(<ScenarioTextInput />)
-  await waitForOutput(
-    getOutput,
-    output =>
-      initialValue.length > 0
-        ? output.includes(initialValue)
-        : output.includes('Type here...'),
-  )
-  const previousInputCount = receivedInputCount
-  stdin.write(chunk)
-  await waitFor(() => receivedInputCount > previousInputCount)
-
-  root.unmount()
-  stdin.end()
-  stdout.end()
+  try {
+    root.render(<ScenarioTextInput />)
+    await waitForOutput(
+      getOutput,
+      output =>
+        initialValue.length > 0
+          ? output.includes(initialValue)
+          : output.includes('Type here...'),
+    )
+    const previousInputCount = receivedInputCount
+    stdin.write(chunk)
+    await waitFor(() => receivedInputCount > previousInputCount)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
 
   return { value: observedValue, changes, submissions }
 }
@@ -570,21 +572,23 @@ async function runPromptModeScenario({
     patchConsole: false,
   })
 
-  root.render(<PromptModeTextInput />)
-  await waitForOutput(
-    getOutput,
-    output =>
-      initialValue.length > 0
-        ? output.includes(initialValue)
-        : output.includes('Type here...'),
-  )
-  const previousInputCount = receivedInputCount
-  stdin.write(chunk)
-  await waitFor(() => receivedInputCount > previousInputCount)
-
-  root.unmount()
-  stdin.end()
-  stdout.end()
+  try {
+    root.render(<PromptModeTextInput />)
+    await waitForOutput(
+      getOutput,
+      output =>
+        initialValue.length > 0
+          ? output.includes(initialValue)
+          : output.includes('Type here...'),
+    )
+    const previousInputCount = receivedInputCount
+    stdin.write(chunk)
+    await waitFor(() => receivedInputCount > previousInputCount)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
 
   return { mode: observedMode, value: observedValue, submissions }
 }

--- a/src/components/TextInput.test.tsx
+++ b/src/components/TextInput.test.tsx
@@ -4,9 +4,24 @@ import { expect, test } from 'bun:test'
 import React from 'react'
 import { stripVTControlCharacters as stripAnsi } from 'node:util'
 
-import { createRoot } from '../ink.js'
+import { createRoot, type Key } from '../ink.js'
+import { useTextInput } from '../hooks/useTextInput.js'
+import { useVimInput } from '../hooks/useVimInput.js'
 import { AppStateProvider } from '../state/AppState.js'
-import { maskTextWithVisibleEdges } from '../utils/Cursor.js'
+import type {
+  TextInputState,
+  VimInputState,
+} from '../types/textInputTypes.js'
+import {
+  canYankPop,
+  clearKillRing,
+  getKillRingSize,
+  maskTextWithVisibleEdges,
+  pushToKillRing,
+  recordYank,
+  resetKillAccumulation,
+} from '../utils/Cursor.js'
+import { detectModeEntry } from './PromptInput/inputModes.js'
 import TextInput from './TextInput.js'
 import VimTextInput from './VimTextInput.js'
 
@@ -376,4 +391,762 @@ test('VimTextInput preserves rapid typed characters before delayed parent value 
 
   expect(output).toContain('asdf')
   expect(output).not.toContain('Type here...')
+})
+
+type InputScenarioOptions = {
+  initialValue: string
+  chunk: string
+  cursorOffset?: number
+  inputFilter?: React.ComponentProps<typeof TextInput>['inputFilter']
+}
+
+async function runInputScenario({
+  initialValue,
+  chunk,
+  cursorOffset = initialValue.length,
+  inputFilter,
+}: InputScenarioOptions): Promise<{
+  value: string
+  changes: string[]
+  submissions: string[]
+}> {
+  let observedValue = initialValue
+  const changes: string[] = []
+  const submissions: string[] = []
+
+  function ScenarioTextInput(): React.ReactNode {
+    const [value, setValue] = React.useState(initialValue)
+    const [offset, setOffset] = React.useState(cursorOffset)
+
+    return (
+      <AppStateProvider>
+        <TextInput
+          value={value}
+          onChange={nextValue => {
+            observedValue = nextValue
+            changes.push(nextValue)
+            setValue(nextValue)
+          }}
+          onSubmit={nextValue => submissions.push(nextValue)}
+          placeholder="Type here..."
+          columns={60}
+          cursorOffset={offset}
+          onChangeCursorOffset={setOffset}
+          inputFilter={inputFilter}
+          focus
+          showCursor
+          multiline
+        />
+      </AppStateProvider>
+    )
+  }
+
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(<ScenarioTextInput />)
+  await waitForOutput(
+    getOutput,
+    output =>
+      initialValue.length > 0
+        ? output.includes(initialValue)
+        : output.includes('Type here...'),
+  )
+  stdin.write(chunk)
+  await Bun.sleep(75)
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+
+  return { value: observedValue, changes, submissions }
+}
+
+type ModeChangeContext = {
+  previousValue: string
+  cursorOffset: number
+  willSubmit?: boolean
+}
+
+async function runPromptModeScenario({
+  initialValue,
+  chunk,
+}: {
+  initialValue: string
+  chunk: string
+}): Promise<{
+  mode: string
+  value: string
+  submissions: Array<{ value: string; mode: string }>
+}> {
+  let observedMode = 'prompt'
+  let observedValue = initialValue
+  const submissions: Array<{ value: string; mode: string }> = []
+
+  function PromptModeTextInput(): React.ReactNode {
+    const [value, setValue] = React.useState(initialValue)
+    const [offset, setOffset] = React.useState(initialValue.length)
+    const [mode, setMode] = React.useState('prompt')
+    const pendingSubmitModeRef = React.useRef<
+      ReturnType<typeof detectModeEntry>
+    >(null)
+
+    const handleChange = (
+      nextValue: string,
+      context?: ModeChangeContext,
+    ): void => {
+      const modeEntry = detectModeEntry({
+        value: nextValue,
+        prevInputLength: context?.previousValue.length ?? value.length,
+        cursorOffset: context?.cursorOffset ?? offset,
+      })
+      if (modeEntry) {
+        pendingSubmitModeRef.current = context?.willSubmit ? modeEntry : null
+        observedMode = modeEntry.mode
+        observedValue = modeEntry.strippedValue
+        setMode(modeEntry.mode)
+        setValue(modeEntry.strippedValue)
+        setOffset(modeEntry.strippedValue.length)
+        return
+      }
+
+      pendingSubmitModeRef.current = null
+      observedValue = nextValue
+      setValue(nextValue)
+    }
+
+    return (
+      <AppStateProvider>
+        <TextInput
+          value={value}
+          onChange={handleChange}
+          onSubmit={nextValue => {
+            const pendingMode = pendingSubmitModeRef.current
+            pendingSubmitModeRef.current = null
+            submissions.push({
+              value: pendingMode?.strippedValue ?? nextValue,
+              mode: pendingMode?.mode ?? mode,
+            })
+          }}
+          placeholder="Type here..."
+          columns={60}
+          cursorOffset={offset}
+          onChangeCursorOffset={setOffset}
+          focus
+          showCursor
+          multiline
+        />
+      </AppStateProvider>
+    )
+  }
+
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(<PromptModeTextInput />)
+  await waitForOutput(
+    getOutput,
+    output =>
+      initialValue.length > 0
+        ? output.includes(initialValue)
+        : output.includes('Type here...'),
+  )
+  stdin.write(chunk)
+  await Bun.sleep(75)
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+
+  return { mode: observedMode, value: observedValue, submissions }
+}
+
+test('TextInput preserves replacement text coalesced after raw DEL', async () => {
+  const result = await runInputScenario({
+    initialValue: 'a',
+    chunk: '\x7fă',
+  })
+
+  expect(result.value).toBe('ă')
+})
+
+test('TextInput applies text and multiple raw DEL bytes in source order', async () => {
+  const result = await runInputScenario({
+    initialValue: 'abc',
+    chunk: 'xy\x7f\x7fă',
+  })
+
+  expect(result.value).toBe('abcă')
+})
+
+test('TextInput honors a filter that removes raw DEL', async () => {
+  const result = await runInputScenario({
+    initialValue: 'a',
+    chunk: '\x7fă',
+    inputFilter: input => input.replaceAll('\x7f', ''),
+  })
+
+  expect(result.value).toBe('aă')
+})
+
+test('TextInput honors a filter that changes replacement text', async () => {
+  const result = await runInputScenario({
+    initialValue: 'a',
+    chunk: '\x7fă',
+    inputFilter: input => input.replace('ă', 'ș'),
+  })
+
+  expect(result.value).toBe('ș')
+})
+
+test('TextInput honors a filter that rejects the complete chunk', async () => {
+  const result = await runInputScenario({
+    initialValue: 'a',
+    chunk: '\x7fă',
+    inputFilter: () => '',
+  })
+
+  expect(result.value).toBe('a')
+  expect(result.changes).toEqual([])
+})
+
+test('TextInput submits the final value for raw DEL plus trailing CR', async () => {
+  const result = await runInputScenario({
+    initialValue: 'a',
+    chunk: '\x7f\r',
+  })
+
+  expect(result.value).toBe('')
+  expect(result.submissions).toEqual([''])
+})
+
+test('TextInput submits replacement text after raw DEL plus trailing CR', async () => {
+  const result = await runInputScenario({
+    initialValue: 'a',
+    chunk: '\x7fă\r',
+  })
+
+  expect(result.value).toBe('ă')
+  expect(result.submissions).toEqual(['ă'])
+})
+
+test('TextInput preserves embedded CR semantics across a raw DEL boundary', async () => {
+  const result = await runInputScenario({
+    initialValue: '',
+    chunk: 'a\r\x7fb',
+  })
+
+  expect(result.value).toBe('ab')
+  expect(result.submissions).toEqual([])
+})
+
+test('TextInput preserves backslash plus CR semantics after raw DEL', async () => {
+  const result = await runInputScenario({
+    initialValue: 'a',
+    chunk: '\x7f\\\r',
+  })
+
+  expect(result.value).toBe('\\\n')
+  expect(result.submissions).toEqual([])
+})
+
+test('TextInput preserves ordinary coalesced Enter behavior', async () => {
+  const result = await runInputScenario({ initialValue: '', chunk: 'o\r' })
+
+  expect(result.value).toBe('o')
+  expect(result.submissions).toEqual(['o'])
+})
+
+test('TextInput preserves lone carriage-return submission', async () => {
+  const result = await runInputScenario({ initialValue: 'a', chunk: '\r' })
+
+  expect(result.value).toBe('a')
+  expect(result.submissions).toEqual(['a'])
+})
+
+test('TextInput preserves mode entry plus coalesced Enter submission', async () => {
+  const result = await runPromptModeScenario({
+    initialValue: '',
+    chunk: '!\r',
+  })
+
+  expect(result.mode).toBe('bash')
+  expect(result.value).toBe('')
+  expect(result.submissions).toEqual([{ value: '', mode: 'bash' }])
+})
+
+test('TextInput enters bash mode after DEL removes the last character', async () => {
+  const result = await runPromptModeScenario({
+    initialValue: 'a',
+    chunk: '\x7f!',
+  })
+
+  expect(result.mode).toBe('bash')
+  expect(result.value).toBe('')
+})
+
+test('TextInput submits fully transformed DEL plus mode text plus CR', async () => {
+  const result = await runPromptModeScenario({
+    initialValue: 'a',
+    chunk: '\x7f!\r',
+  })
+
+  expect(result.mode).toBe('bash')
+  expect(result.value).toBe('')
+  expect(result.submissions).toEqual([{ value: '', mode: 'bash' }])
+})
+
+test('TextInput carries DEL-coalesced bash text into submission mode', async () => {
+  const result = await runPromptModeScenario({
+    initialValue: 'a',
+    chunk: '\x7f!ls\r',
+  })
+
+  expect(result.mode).toBe('bash')
+  expect(result.value).toBe('ls')
+  expect(result.submissions).toEqual([{ value: 'ls', mode: 'bash' }])
+})
+
+test('TextInput retains mode entry across later edits in one submitted chunk', async () => {
+  const result = await runPromptModeScenario({
+    initialValue: 'a',
+    chunk: '\x7f!x\x7fy\r',
+  })
+
+  expect(result.mode).toBe('bash')
+  expect(result.value).toBe('y')
+  expect(result.submissions).toEqual([{ value: 'y', mode: 'bash' }])
+})
+
+test('TextInput retains mode after a later DEL consumes its sentinel', async () => {
+  const result = await runPromptModeScenario({
+    initialValue: 'b',
+    chunk: '\x7f!\x7fa\r',
+  })
+
+  expect(result.mode).toBe('bash')
+  expect(result.value).toBe('a')
+  expect(result.submissions).toEqual([{ value: 'a', mode: 'bash' }])
+})
+
+test('TextInput preserves a literal mode character typed after consuming the sentinel', async () => {
+  const result = await runPromptModeScenario({
+    initialValue: 'b',
+    chunk: '\x7f!\x7f!a\r',
+  })
+
+  expect(result.mode).toBe('bash')
+  expect(result.value).toBe('!a')
+  expect(result.submissions).toEqual([{ value: '!a', mode: 'bash' }])
+})
+
+test('useTextInput notifies mode entry when one raw chunk returns to the initial cursor', async () => {
+  let inputState: TextInputState | undefined
+  let observedMode = 'prompt'
+  const submissions: Array<{ value: string; mode: string }> = []
+
+  function EqualCursorModeInputHook(): React.ReactNode {
+    const [value, setValue] = React.useState('')
+    const [cursorOffset, setCursorOffset] = React.useState(0)
+    const [mode, setMode] = React.useState('prompt')
+    const pendingSubmitModeRef = React.useRef<
+      ReturnType<typeof detectModeEntry>
+    >(null)
+
+    inputState = useTextInput({
+      value,
+      onChange: (nextValue, context) => {
+        const modeEntry = detectModeEntry({
+          value: nextValue,
+          prevInputLength: context?.previousValue.length ?? value.length,
+          cursorOffset: context?.cursorOffset ?? cursorOffset,
+        })
+        if (modeEntry) {
+          pendingSubmitModeRef.current = context?.willSubmit
+            ? modeEntry
+            : null
+          observedMode = modeEntry.mode
+          setMode(modeEntry.mode)
+          setValue(modeEntry.strippedValue)
+          setCursorOffset(modeEntry.strippedValue.length)
+          return
+        }
+        setValue(nextValue)
+      },
+      onSubmit: nextValue => {
+        const pendingMode = pendingSubmitModeRef.current
+        submissions.push({
+          value: pendingMode?.strippedValue ?? nextValue,
+          mode: pendingMode?.mode ?? mode,
+        })
+      },
+      cursorChar: ' ',
+      invert: text => text,
+      themeText: text => text,
+      columns: 60,
+      externalOffset: cursorOffset,
+      onOffsetChange: setCursorOffset,
+      multiline: true,
+    })
+
+    return null
+  }
+
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(
+    <AppStateProvider>
+      <EqualCursorModeInputHook />
+    </AppStateProvider>,
+  )
+  await Bun.sleep(25)
+  inputState!.onInput('!\x7f\r', {} as Key)
+  await Bun.sleep(25)
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+
+  expect(observedMode).toBe('bash')
+  expect(submissions).toEqual([{ value: '', mode: 'bash' }])
+})
+
+test('TextInput leaves ordinary Backspace and Delete key events unchanged', async () => {
+  const backspace = await runInputScenario({
+    initialValue: 'abc',
+    chunk: '\x7f',
+  })
+  const del = await runInputScenario({
+    initialValue: 'abc',
+    cursorOffset: 1,
+    chunk: '\x1b[3~',
+  })
+
+  expect(backspace.value).toBe('ab')
+  expect(del.value).toBe('ac')
+})
+
+test('TextInput resets kill accumulation once for a raw DEL event', async () => {
+  clearKillRing()
+  pushToKillRing('first')
+
+  await runInputScenario({ initialValue: 'a', chunk: '\x7fă' })
+  pushToKillRing('second')
+
+  expect(getKillRingSize()).toBe(2)
+  clearKillRing()
+})
+
+test('TextInput resets yank-pop state for a raw DEL event', async () => {
+  clearKillRing()
+  pushToKillRing('first')
+  resetKillAccumulation()
+  pushToKillRing('second')
+  recordYank(0, 'second'.length)
+  expect(canYankPop()).toBe(true)
+
+  await runInputScenario({ initialValue: 'a', chunk: '\x7fă' })
+
+  expect(canYankPop()).toBe(false)
+  clearKillRing()
+})
+
+test('VimTextInput dot-repeat does not record a raw DEL byte', async () => {
+  let observedValue = ''
+  let inputState: VimInputState | undefined
+
+  function RawDelVimInputHook(): React.ReactNode {
+    const [value, setValue] = React.useState('')
+    const [cursorOffset, setCursorOffset] = React.useState(0)
+
+    inputState = useVimInput({
+      value,
+      onChange: nextValue => {
+        observedValue = nextValue
+        setValue(nextValue)
+      },
+      onSubmit: () => {},
+      cursorChar: ' ',
+      invert: text => text,
+      themeText: text => text,
+      columns: 60,
+      externalOffset: cursorOffset,
+      onOffsetChange: setCursorOffset,
+      multiline: true,
+    })
+
+    return null
+  }
+
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(
+    <AppStateProvider>
+      <RawDelVimInputHook />
+    </AppStateProvider>,
+  )
+  await Bun.sleep(25)
+  inputState!.onInput('a', {} as Key)
+  await Bun.sleep(25)
+  inputState!.onInput('\x7fb', {} as Key)
+  await Bun.sleep(25)
+  inputState!.onInput('', { escape: true } as Key)
+  await Bun.sleep(25)
+  inputState!.onInput('.', {} as Key)
+  await Bun.sleep(25)
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+
+  expect(observedValue).toBe('bb')
+  expect(observedValue).not.toContain('\x7f')
+})
+
+test('VimTextInput dot-repeat does not record a post-DEL mode sentinel', async () => {
+  let observedMode = 'prompt'
+  let observedValue = ''
+  let inputState: VimInputState | undefined
+
+  function RawDelModeVimInputHook(): React.ReactNode {
+    const [value, setValue] = React.useState('')
+    const [cursorOffset, setCursorOffset] = React.useState(0)
+
+    inputState = useVimInput({
+      value,
+      onChange: (nextValue, context?: ModeChangeContext) => {
+        const modeEntry = detectModeEntry({
+          value: nextValue,
+          prevInputLength: context?.previousValue.length ?? value.length,
+          cursorOffset: context?.cursorOffset ?? cursorOffset,
+        })
+        if (modeEntry) {
+          observedMode = modeEntry.mode
+          observedValue = modeEntry.strippedValue
+          setValue(modeEntry.strippedValue)
+          setCursorOffset(modeEntry.strippedValue.length)
+          return
+        }
+
+        observedValue = nextValue
+        setValue(nextValue)
+      },
+      onSubmit: () => {},
+      cursorChar: ' ',
+      invert: text => text,
+      themeText: text => text,
+      columns: 60,
+      externalOffset: cursorOffset,
+      onOffsetChange: setCursorOffset,
+      multiline: true,
+    })
+
+    return null
+  }
+
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(
+    <AppStateProvider>
+      <RawDelModeVimInputHook />
+    </AppStateProvider>,
+  )
+  await Bun.sleep(25)
+  inputState!.onInput('a', {} as Key)
+  await Bun.sleep(25)
+  inputState!.onInput('\x7f!', {} as Key)
+  await Bun.sleep(25)
+  inputState!.onInput('', { escape: true } as Key)
+  await Bun.sleep(25)
+  inputState!.onInput('.', {} as Key)
+  await Bun.sleep(25)
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+
+  expect(observedMode).toBe('bash')
+  expect(observedValue).toBe('')
+})
+
+test('VimTextInput records post-DEL text from the live cursor in one batch', async () => {
+  let observedValue = ''
+  let inputState: VimInputState | undefined
+
+  function BatchedVimInputHook(): React.ReactNode {
+    const [value, setValue] = React.useState('')
+    const [cursorOffset, setCursorOffset] = React.useState(0)
+
+    inputState = useVimInput({
+      value,
+      onChange: nextValue => {
+        observedValue = nextValue
+        setValue(nextValue)
+      },
+      onSubmit: () => {},
+      cursorChar: ' ',
+      invert: text => text,
+      themeText: text => text,
+      columns: 60,
+      externalOffset: cursorOffset,
+      onOffsetChange: setCursorOffset,
+      multiline: true,
+    })
+
+    return null
+  }
+
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(
+    <AppStateProvider>
+      <BatchedVimInputHook />
+    </AppStateProvider>,
+  )
+  await Bun.sleep(25)
+  inputState!.onInput('ab', {} as Key)
+  inputState!.onInput('', { leftArrow: true } as Key)
+  inputState!.onInput('\x7f!', {} as Key)
+  await Bun.sleep(25)
+  inputState!.onInput('', { escape: true } as Key)
+  await Bun.sleep(25)
+  inputState!.onInput('.', {} as Key)
+  await Bun.sleep(25)
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+
+  expect(observedValue).toBe('a!!b')
+})
+
+test('VimTextInput Escape uses the live cursor after same-batch insertion', async () => {
+  let inputState: VimInputState | undefined
+  let observedOffset = 0
+
+  function BatchedEscapeVimInputHook(): React.ReactNode {
+    const [value, setValue] = React.useState('')
+    const [cursorOffset, setCursorOffset] = React.useState(0)
+
+    inputState = useVimInput({
+      value,
+      onChange: setValue,
+      onSubmit: () => {},
+      cursorChar: ' ',
+      invert: text => text,
+      themeText: text => text,
+      columns: 60,
+      externalOffset: cursorOffset,
+      onOffsetChange: nextOffset => {
+        observedOffset = nextOffset
+        setCursorOffset(nextOffset)
+      },
+      multiline: true,
+    })
+
+    return null
+  }
+
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(
+    <AppStateProvider>
+      <BatchedEscapeVimInputHook />
+    </AppStateProvider>,
+  )
+  await Bun.sleep(25)
+  inputState!.onInput('ab', {} as Key)
+  inputState!.onInput('', { escape: true } as Key)
+
+  expect(observedOffset).toBe(1)
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+})
+
+test('VimTextInput operators use one live snapshot within a parser batch', async () => {
+  let observedValue = 'abc'
+  let inputState: VimInputState | undefined
+
+  function BatchedOperatorVimInputHook(): React.ReactNode {
+    const [value, setValue] = React.useState('abc')
+    const [cursorOffset, setCursorOffset] = React.useState(0)
+
+    inputState = useVimInput({
+      value,
+      onChange: nextValue => {
+        observedValue = nextValue
+        setValue(nextValue)
+      },
+      onSubmit: () => {},
+      cursorChar: ' ',
+      invert: text => text,
+      themeText: text => text,
+      columns: 60,
+      externalOffset: cursorOffset,
+      onOffsetChange: setCursorOffset,
+      multiline: true,
+    })
+
+    return null
+  }
+
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  root.render(
+    <AppStateProvider>
+      <BatchedOperatorVimInputHook />
+    </AppStateProvider>,
+  )
+  await Bun.sleep(25)
+  inputState!.setMode('NORMAL')
+  inputState!.onInput('x', {} as Key)
+  inputState!.onInput('', { rightArrow: true } as Key)
+  inputState!.onInput('x', {} as Key)
+  await Bun.sleep(25)
+
+  root.unmount()
+  stdin.end()
+  stdout.end()
+
+  expect(observedValue).toBe('b')
 })

--- a/src/components/TextInput.test.tsx
+++ b/src/components/TextInput.test.tsx
@@ -23,6 +23,10 @@ import {
   resetKillAccumulation,
 } from '../utils/Cursor.js'
 import { detectModeEntry } from './PromptInput/inputModes.js'
+import {
+  normalizePromptInputChunk,
+  resolveHelpToggleChange,
+} from './PromptInput/utils.js'
 import TextInput from './TextInput.js'
 import VimTextInput from './VimTextInput.js'
 
@@ -422,17 +426,23 @@ async function runInputScenario({
   inputFilter,
 }: InputScenarioOptions): Promise<{
   value: string
+  cursorOffset: number
   changes: string[]
   submissions: string[]
 }> {
   let observedValue = initialValue
+  let observedCursorOffset = cursorOffset
   let receivedInputCount = 0
   const changes: string[] = []
   const submissions: string[] = []
 
   function ScenarioTextInput(): React.ReactNode {
     const [value, setValue] = React.useState(initialValue)
-    const [offset, setOffset] = React.useState(cursorOffset)
+    const [offset, setOffsetState] = React.useState(cursorOffset)
+    const setOffset = (nextOffset: number): void => {
+      observedCursorOffset = nextOffset
+      setOffsetState(nextOffset)
+    }
 
     return (
       <AppStateProvider>
@@ -485,7 +495,12 @@ async function runInputScenario({
     stdout.end()
   }
 
-  return { value: observedValue, changes, submissions }
+  return {
+    value: observedValue,
+    cursorOffset: observedCursorOffset,
+    changes,
+    submissions,
+  }
 }
 
 async function runPromptModeScenario({
@@ -497,20 +512,26 @@ async function runPromptModeScenario({
 }): Promise<{
   mode: string
   value: string
+  cursorOffset: number
   submissions: Array<{ value: string; mode: string }>
 }> {
   let observedMode = 'prompt'
   let observedValue = initialValue
+  let observedCursorOffset = initialValue.length
   let receivedInputCount = 0
   const submissions: Array<{ value: string; mode: string }> = []
 
   function PromptModeTextInput(): React.ReactNode {
     const [value, setValue] = React.useState(initialValue)
-    const [offset, setOffset] = React.useState(initialValue.length)
+    const [offset, setOffsetState] = React.useState(initialValue.length)
     const [mode, setMode] = React.useState('prompt')
     const pendingSubmitModeRef = React.useRef<
       ReturnType<typeof detectModeEntry>
     >(null)
+    const setOffset = (nextOffset: number): void => {
+      observedCursorOffset = nextOffset
+      setOffsetState(nextOffset)
+    }
 
     const handleChange = (
       nextValue: string,
@@ -590,7 +611,12 @@ async function runPromptModeScenario({
     stdout.end()
   }
 
-  return { mode: observedMode, value: observedValue, submissions }
+  return {
+    mode: observedMode,
+    value: observedValue,
+    cursorOffset: observedCursorOffset,
+    submissions,
+  }
 }
 
 test('TextInput preserves replacement text coalesced after raw DEL', async () => {
@@ -629,6 +655,104 @@ test('TextInput honors a filter that changes replacement text', async () => {
   })
 
   expect(result.value).toBe('ș')
+})
+
+test('TextInput keeps the cursor aligned after filtering a coalesced tab', async () => {
+  const result = await runInputScenario({
+    initialValue: 'a',
+    chunk: '\x7f\tfoo',
+    inputFilter: (input, key) => normalizePromptInputChunk(input, key, false),
+  })
+
+  expect(result.value).toBe('    foo')
+  expect(result.cursorOffset).toBe(7)
+})
+
+test('TextInput restores state and suppresses submission for coalesced help', async () => {
+  let observedValue = 'a'
+  let observedCursorOffset = 1
+  let helpToggleCount = 0
+  let receivedInputCount = 0
+  const submissions: string[] = []
+
+  function HelpToggleTextInput(): React.ReactNode {
+    const [value, setValue] = React.useState('a')
+    const [offset, setOffsetState] = React.useState(1)
+    const suppressNextSubmitRef = React.useRef(false)
+    const setOffset = (nextOffset: number): void => {
+      observedCursorOffset = nextOffset
+      setOffsetState(nextOffset)
+    }
+
+    return (
+      <AppStateProvider>
+        <TextInput
+          value={value}
+          onChange={(nextValue, context) => {
+            const helpToggleChange = resolveHelpToggleChange(nextValue, context)
+            if (helpToggleChange) {
+              helpToggleCount++
+              suppressNextSubmitRef.current = helpToggleChange.suppressSubmit
+              if (helpToggleChange.restore) {
+                observedValue = helpToggleChange.restore.value
+                setValue(helpToggleChange.restore.value)
+                setOffset(helpToggleChange.restore.cursorOffset)
+              }
+              return
+            }
+            observedValue = nextValue
+            setValue(nextValue)
+          }}
+          onSubmit={nextValue => {
+            if (suppressNextSubmitRef.current) {
+              suppressNextSubmitRef.current = false
+              return
+            }
+            submissions.push(nextValue)
+          }}
+          placeholder="Type here..."
+          columns={60}
+          cursorOffset={offset}
+          onChangeCursorOffset={setOffset}
+          inputFilter={input => {
+            receivedInputCount++
+            return input
+          }}
+          focus
+          showCursor
+          multiline
+        />
+      </AppStateProvider>
+    )
+  }
+
+  const { stdout, stdin, getOutput } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  try {
+    root.render(<HelpToggleTextInput />)
+    await waitForOutput(getOutput, output => output.includes('a'))
+    const previousInputCount = receivedInputCount
+    stdin.write('\x7f?\r')
+    await waitFor(
+      () =>
+        receivedInputCount > previousInputCount && helpToggleCount === 1,
+    )
+    await Bun.sleep(25)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+
+  expect(observedValue).toBe('')
+  expect(observedCursorOffset).toBe(0)
+  expect(helpToggleCount).toBe(1)
+  expect(submissions).toEqual([])
 })
 
 test('TextInput honors a filter that rejects the complete chunk', async () => {
@@ -704,6 +828,7 @@ test('TextInput preserves mode entry plus coalesced Enter submission', async () 
 
   expect(result.mode).toBe('bash')
   expect(result.value).toBe('')
+  expect(result.cursorOffset).toBe(0)
   expect(result.submissions).toEqual([{ value: '', mode: 'bash' }])
 })
 
@@ -736,6 +861,7 @@ test('TextInput carries DEL-coalesced bash text into submission mode', async () 
 
   expect(result.mode).toBe('bash')
   expect(result.value).toBe('ls')
+  expect(result.cursorOffset).toBe(2)
   expect(result.submissions).toEqual([{ value: 'ls', mode: 'bash' }])
 })
 
@@ -1002,7 +1128,7 @@ test('VimTextInput dot-repeat does not record a post-DEL mode sentinel', async (
   await Bun.sleep(25)
   inputState!.onInput('a', {} as Key)
   await Bun.sleep(25)
-  inputState!.onInput('\x7f!', {} as Key)
+  inputState!.onInput('\x7f!ls', {} as Key)
   await Bun.sleep(25)
   inputState!.onInput('', { escape: true } as Key)
   await Bun.sleep(25)
@@ -1014,7 +1140,8 @@ test('VimTextInput dot-repeat does not record a post-DEL mode sentinel', async (
   stdout.end()
 
   expect(observedMode).toBe('bash')
-  expect(observedValue).toBe('')
+  expect(observedValue).toBe('llss')
+  expect(observedValue).not.toContain('!')
 })
 
 test('VimTextInput records post-DEL text from the live cursor in one batch', async () => {

--- a/src/components/TextInput.test.tsx
+++ b/src/components/TextInput.test.tsx
@@ -513,12 +513,14 @@ async function runPromptModeScenario({
   mode: string
   value: string
   cursorOffset: number
+  rawSubmissions: string[]
   submissions: Array<{ value: string; mode: string }>
 }> {
   let observedMode = 'prompt'
   let observedValue = initialValue
   let observedCursorOffset = initialValue.length
   let receivedInputCount = 0
+  const rawSubmissions: string[] = []
   const submissions: Array<{ value: string; mode: string }> = []
 
   function PromptModeTextInput(): React.ReactNode {
@@ -563,6 +565,7 @@ async function runPromptModeScenario({
           value={value}
           onChange={handleChange}
           onSubmit={nextValue => {
+            rawSubmissions.push(nextValue)
             const pendingMode = pendingSubmitModeRef.current
             pendingSubmitModeRef.current = null
             submissions.push({
@@ -615,6 +618,7 @@ async function runPromptModeScenario({
     mode: observedMode,
     value: observedValue,
     cursorOffset: observedCursorOffset,
+    rawSubmissions,
     submissions,
   }
 }
@@ -865,6 +869,17 @@ test('TextInput carries DEL-coalesced bash text into submission mode', async () 
   expect(result.submissions).toEqual([{ value: 'ls', mode: 'bash' }])
 })
 
+test('TextInput keeps later keys in one stdin batch on the stripped mode value', async () => {
+  const result = await runPromptModeScenario({
+    initialValue: 'a',
+    chunk: '\x7f!ls\x1b[Dx',
+  })
+
+  expect(result.mode).toBe('bash')
+  expect(result.value).toBe('lxs')
+  expect(result.cursorOffset).toBe(2)
+})
+
 test('TextInput retains mode entry across later edits in one submitted chunk', async () => {
   const result = await runPromptModeScenario({
     initialValue: 'a',
@@ -884,6 +899,7 @@ test('TextInput retains mode after a later DEL consumes its sentinel', async () 
 
   expect(result.mode).toBe('bash')
   expect(result.value).toBe('a')
+  expect(result.rawSubmissions).toEqual(['a'])
   expect(result.submissions).toEqual([{ value: 'a', mode: 'bash' }])
 })
 
@@ -895,6 +911,7 @@ test('TextInput preserves a literal mode character typed after consuming the sen
 
   expect(result.mode).toBe('bash')
   expect(result.value).toBe('!a')
+  expect(result.rawSubmissions).toEqual(['!a'])
   expect(result.submissions).toEqual([{ value: '!a', mode: 'bash' }])
 })
 
@@ -957,21 +974,23 @@ test('useTextInput notifies mode entry when one raw chunk returns to the initial
     patchConsole: false,
   })
 
-  root.render(
-    <AppStateProvider>
-      <EqualCursorModeInputHook />
-    </AppStateProvider>,
-  )
-  await Bun.sleep(25)
-  inputState!.onInput('!\x7f\r', {} as Key)
-  await Bun.sleep(25)
+  try {
+    root.render(
+      <AppStateProvider>
+        <EqualCursorModeInputHook />
+      </AppStateProvider>,
+    )
+    await waitFor(() => inputState !== undefined)
+    inputState!.onInput('!\x7f\r', {} as Key)
+    await waitFor(() => submissions.length === 1)
 
-  root.unmount()
-  stdin.end()
-  stdout.end()
-
-  expect(observedMode).toBe('bash')
-  expect(submissions).toEqual([{ value: '', mode: 'bash' }])
+    expect(observedMode).toBe('bash')
+    expect(submissions).toEqual([{ value: '', mode: 'bash' }])
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
 })
 
 test('TextInput leaves ordinary Backspace and Delete key events unchanged', async () => {
@@ -1049,27 +1068,28 @@ test('VimTextInput dot-repeat does not record a raw DEL byte', async () => {
     patchConsole: false,
   })
 
-  root.render(
-    <AppStateProvider>
-      <RawDelVimInputHook />
-    </AppStateProvider>,
-  )
-  await Bun.sleep(25)
-  inputState!.onInput('a', {} as Key)
-  await Bun.sleep(25)
-  inputState!.onInput('\x7fb', {} as Key)
-  await Bun.sleep(25)
-  inputState!.onInput('', { escape: true } as Key)
-  await Bun.sleep(25)
-  inputState!.onInput('.', {} as Key)
-  await Bun.sleep(25)
+  try {
+    root.render(
+      <AppStateProvider>
+        <RawDelVimInputHook />
+      </AppStateProvider>,
+    )
+    await waitFor(() => inputState !== undefined)
+    inputState!.onInput('a', {} as Key)
+    await waitFor(() => observedValue === 'a')
+    inputState!.onInput('\x7fb', {} as Key)
+    await waitFor(() => observedValue === 'b')
+    inputState!.onInput('', { escape: true } as Key)
+    inputState!.onInput('.', {} as Key)
+    await waitFor(() => observedValue === 'bb')
 
-  root.unmount()
-  stdin.end()
-  stdout.end()
-
-  expect(observedValue).toBe('bb')
-  expect(observedValue).not.toContain('\x7f')
+    expect(observedValue).toBe('bb')
+    expect(observedValue).not.toContain('\x7f')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
 })
 
 test('VimTextInput dot-repeat does not record a post-DEL mode sentinel', async () => {
@@ -1120,28 +1140,104 @@ test('VimTextInput dot-repeat does not record a post-DEL mode sentinel', async (
     patchConsole: false,
   })
 
-  root.render(
-    <AppStateProvider>
-      <RawDelModeVimInputHook />
-    </AppStateProvider>,
-  )
-  await Bun.sleep(25)
-  inputState!.onInput('a', {} as Key)
-  await Bun.sleep(25)
-  inputState!.onInput('\x7f!ls', {} as Key)
-  await Bun.sleep(25)
-  inputState!.onInput('', { escape: true } as Key)
-  await Bun.sleep(25)
-  inputState!.onInput('.', {} as Key)
-  await Bun.sleep(25)
+  try {
+    root.render(
+      <AppStateProvider>
+        <RawDelModeVimInputHook />
+      </AppStateProvider>,
+    )
+    await waitFor(() => inputState !== undefined)
+    inputState!.onInput('a', {} as Key)
+    await waitFor(() => observedValue === 'a')
+    inputState!.onInput('\x7f!ls', {} as Key)
+    await waitFor(() => observedMode === 'bash' && observedValue === 'ls')
+    inputState!.onInput('', { escape: true } as Key)
+    inputState!.onInput('.', {} as Key)
+    await waitFor(() => observedValue === 'llss')
 
-  root.unmount()
-  stdin.end()
-  stdout.end()
+    expect(observedMode).toBe('bash')
+    expect(observedValue).toBe('llss')
+    expect(observedValue).not.toContain('!')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
+})
 
-  expect(observedMode).toBe('bash')
-  expect(observedValue).toBe('llss')
-  expect(observedValue).not.toContain('!')
+test('VimTextInput dot-repeat excludes a mode sentinel entered before raw DEL', async () => {
+  let observedMode = 'prompt'
+  let observedValue = ''
+  let inputState: VimInputState | undefined
+
+  function OrdinaryModeThenDelVimInputHook(): React.ReactNode {
+    const [value, setValue] = React.useState('')
+    const [cursorOffset, setCursorOffset] = React.useState(0)
+
+    inputState = useVimInput({
+      value,
+      onChange: (nextValue, context?: TextInputChangeContext) => {
+        const modeEntry = detectModeEntry({
+          value: nextValue,
+          prevInputLength: context?.previousValue.length ?? value.length,
+          cursorOffset: context?.cursorOffset ?? cursorOffset,
+        })
+        if (modeEntry) {
+          observedMode = modeEntry.mode
+          observedValue = modeEntry.strippedValue
+          setValue(modeEntry.strippedValue)
+          setCursorOffset(modeEntry.strippedValue.length)
+          return
+        }
+
+        observedValue = nextValue
+        setValue(nextValue)
+      },
+      onSubmit: () => {},
+      cursorChar: ' ',
+      invert: text => text,
+      themeText: text => text,
+      columns: 60,
+      externalOffset: cursorOffset,
+      onOffsetChange: setCursorOffset,
+      multiline: true,
+    })
+
+    return null
+  }
+
+  const { stdout, stdin } = createTestStreams()
+  const root = await createRoot({
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    patchConsole: false,
+  })
+
+  try {
+    root.render(
+      <AppStateProvider>
+        <OrdinaryModeThenDelVimInputHook />
+      </AppStateProvider>,
+    )
+    await waitFor(() => inputState !== undefined)
+    inputState!.onInput('!', {} as Key)
+    await waitFor(() => observedMode === 'bash')
+    inputState!.onInput('ls', {} as Key)
+    await waitFor(() => observedValue === 'ls')
+    inputState!.onInput('\x7fb', {} as Key)
+    await waitFor(() => observedValue === 'lb')
+    inputState!.onInput('', { escape: true } as Key)
+    inputState!.onInput('.', {} as Key)
+    await waitFor(() => observedValue === 'llbb')
+
+    expect(observedMode).toBe('bash')
+    expect(observedValue).toBe('llbb')
+    expect(observedValue).not.toContain('!')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
 })
 
 test('VimTextInput records post-DEL text from the live cursor in one batch', async () => {
@@ -1178,26 +1274,26 @@ test('VimTextInput records post-DEL text from the live cursor in one batch', asy
     patchConsole: false,
   })
 
-  root.render(
-    <AppStateProvider>
-      <BatchedVimInputHook />
-    </AppStateProvider>,
-  )
-  await Bun.sleep(25)
-  inputState!.onInput('ab', {} as Key)
-  inputState!.onInput('', { leftArrow: true } as Key)
-  inputState!.onInput('\x7f!', {} as Key)
-  await Bun.sleep(25)
-  inputState!.onInput('', { escape: true } as Key)
-  await Bun.sleep(25)
-  inputState!.onInput('.', {} as Key)
-  await Bun.sleep(25)
+  try {
+    root.render(
+      <AppStateProvider>
+        <BatchedVimInputHook />
+      </AppStateProvider>,
+    )
+    await waitFor(() => inputState !== undefined)
+    inputState!.onInput('ab', {} as Key)
+    inputState!.onInput('', { leftArrow: true } as Key)
+    inputState!.onInput('\x7f!', {} as Key)
+    inputState!.onInput('', { escape: true } as Key)
+    inputState!.onInput('.', {} as Key)
+    await waitFor(() => observedValue === 'a!!b')
 
-  root.unmount()
-  stdin.end()
-  stdout.end()
-
-  expect(observedValue).toBe('a!!b')
+    expect(observedValue).toBe('a!!b')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
 })
 
 test('VimTextInput Escape uses the live cursor after same-batch insertion', async () => {
@@ -1234,20 +1330,23 @@ test('VimTextInput Escape uses the live cursor after same-batch insertion', asyn
     patchConsole: false,
   })
 
-  root.render(
-    <AppStateProvider>
-      <BatchedEscapeVimInputHook />
-    </AppStateProvider>,
-  )
-  await Bun.sleep(25)
-  inputState!.onInput('ab', {} as Key)
-  inputState!.onInput('', { escape: true } as Key)
+  try {
+    root.render(
+      <AppStateProvider>
+        <BatchedEscapeVimInputHook />
+      </AppStateProvider>,
+    )
+    await waitFor(() => inputState !== undefined)
+    inputState!.onInput('ab', {} as Key)
+    inputState!.onInput('', { escape: true } as Key)
+    await waitFor(() => observedOffset === 1)
 
-  expect(observedOffset).toBe(1)
-
-  root.unmount()
-  stdin.end()
-  stdout.end()
+    expect(observedOffset).toBe(1)
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
 })
 
 test('VimTextInput operators use one live snapshot within a parser batch', async () => {
@@ -1284,21 +1383,23 @@ test('VimTextInput operators use one live snapshot within a parser batch', async
     patchConsole: false,
   })
 
-  root.render(
-    <AppStateProvider>
-      <BatchedOperatorVimInputHook />
-    </AppStateProvider>,
-  )
-  await Bun.sleep(25)
-  inputState!.setMode('NORMAL')
-  inputState!.onInput('x', {} as Key)
-  inputState!.onInput('', { rightArrow: true } as Key)
-  inputState!.onInput('x', {} as Key)
-  await Bun.sleep(25)
+  try {
+    root.render(
+      <AppStateProvider>
+        <BatchedOperatorVimInputHook />
+      </AppStateProvider>,
+    )
+    await waitFor(() => inputState !== undefined)
+    inputState!.setMode('NORMAL')
+    inputState!.onInput('x', {} as Key)
+    inputState!.onInput('', { rightArrow: true } as Key)
+    inputState!.onInput('x', {} as Key)
+    await waitFor(() => observedValue === 'b')
 
-  root.unmount()
-  stdin.end()
-  stdout.end()
-
-  expect(observedValue).toBe('b')
+    expect(observedValue).toBe('b')
+  } finally {
+    root.unmount()
+    stdin.end()
+    stdout.end()
+  }
 })

--- a/src/hooks/useTextInput.test.ts
+++ b/src/hooks/useTextInput.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Cursor } from '../utils/Cursor.js'
+import {
+  applyCoalescedDelInput,
+  prepareTextInputEvent,
+} from './useTextInput.js'
+
+const insert = (cursor: Cursor, text: string): Cursor => cursor.insert(text)
+
+function apply(
+  text: string,
+  input: string,
+  offset = text.length,
+): ReturnType<typeof applyCoalescedDelInput> {
+  return applyCoalescedDelInput(
+    Cursor.fromText(text, 80, offset),
+    input,
+    insert,
+  )
+}
+
+describe('applyCoalescedDelInput', () => {
+  test('preserves the raw DEL workaround', () => {
+    expect(apply('abc', '\x7f').cursor.text).toBe('ab')
+  })
+
+  test('inserts replacement text after DEL', () => {
+    expect(apply('a', '\x7fă').cursor.text).toBe('ă')
+  })
+
+  test('applies text before and after DEL in source order', () => {
+    expect(apply('', 'ab\x7fc').cursor.text).toBe('ac')
+  })
+
+  test('applies multiple DEL bytes in source order', () => {
+    expect(apply('abc', '\x7f\x7fă').cursor.text).toBe('aă')
+  })
+
+  test('preserves text after a middle cursor', () => {
+    const result = apply('abXY', '\x7fă', 2)
+
+    expect(result.cursor.text).toBe('aăXY')
+    expect(result.cursor.offset).toBe(2)
+  })
+
+  test('deletes one complete Unicode grapheme before inserting', () => {
+    const graphemes = ['ă', 'a\u0306', '😀', '👨‍👩‍👧‍👦', '🇷🇴', '👍🏽']
+
+    for (const grapheme of graphemes) {
+      const initialCursor = Cursor.fromText(`${grapheme}X`, 80)
+      const cursorBeforeX = Cursor.fromText(
+        initialCursor.text,
+        80,
+        initialCursor.text.length - 1,
+      )
+      const result = applyCoalescedDelInput(
+        cursorBeforeX,
+        '\x7fă',
+        insert,
+      )
+
+      expect(result.cursor.text).toBe('ăX')
+      expect(result.cursor.offset).toBe(1)
+    }
+  })
+
+  test('prefers token-aware deletion before inserting', () => {
+    expect(apply('x [Pasted text #1]', '\x7fă').cursor.text).toBe('x ă')
+  })
+
+  test('preserves sequential token and grapheme deletion across a DEL run', () => {
+    expect(apply('a [Pasted text #1]', '\x7f\x7f').cursor.text).toBe('a')
+  })
+
+  test('bulk DEL runs match repeated token-aware grapheme deletion', () => {
+    const cases = [
+      { text: 'abc', offset: 3 },
+      { text: 'a [Pasted text #1]', offset: 'a [Pasted text #1]'.length },
+      { text: 'a [Pasted text #1] X', offset: 'a [Pasted text #1]'.length },
+      { text: 'a [Image #1] b', offset: 2 },
+      { text: 'a [Image #1] b', offset: 'a [Image #1] '.length },
+      {
+        text: '👨‍👩‍👧‍👦👍🏽X',
+        offset: '👨‍👩‍👧‍👦👍🏽'.length,
+      },
+      { text: 'a\n\u0301', offset: 2 },
+      { text: 'abXY', offset: 2 },
+    ]
+
+    for (const testCase of cases) {
+      for (let count = 1; count <= 4; count++) {
+        let sequential = Cursor.fromText(
+          testCase.text,
+          80,
+          testCase.offset,
+        )
+        for (let index = 0; index < count; index++) {
+          sequential =
+            sequential.deleteTokenBefore() ?? sequential.backspace()
+        }
+
+        const bulk = Cursor.fromText(
+          testCase.text,
+          80,
+          testCase.offset,
+        ).deleteManyBefore(count)
+        expect({ text: bulk.text, offset: bulk.offset }).toEqual({
+          text: sequential.text,
+          offset: sequential.offset,
+        })
+      }
+    }
+  })
+
+  test('bulk DEL at offset zero preserves selected image-chip deletion', () => {
+    const initial = Cursor.fromText('[Image #1]x', 80, 0)
+    const sequential = initial.deleteTokenBefore() ?? initial.backspace()
+    const bulk = initial.deleteManyBefore(1)
+
+    expect({ text: bulk.text, offset: bulk.offset }).toEqual({
+      text: sequential.text,
+      offset: sequential.offset,
+    })
+  })
+
+  test('reports every deletion in a coalesced DEL run', () => {
+    let deletedCount = 0
+    applyCoalescedDelInput(
+      Cursor.fromText('abc', 80, 3),
+      '\x7f\x7f',
+      insert,
+      count => {
+        deletedCount += count
+      },
+    )
+
+    expect(deletedCount).toBe(2)
+  })
+
+  test('preserves a final insertion callback no-commit result', () => {
+    const notifications: string[] = []
+    const result = applyCoalescedDelInput(
+      Cursor.fromText('a', 80, 1),
+      '\x7f!',
+      (cursor, text) => {
+        notifications.push(text)
+        return undefined
+      },
+    )
+
+    expect(result.cursor.text).toBe('')
+    expect(result.shouldCommit).toBe(false)
+    expect(notifications).toEqual(['!'])
+  })
+})
+
+describe('prepareTextInputEvent', () => {
+  test('marks text plus one trailing CR as coalesced Enter', () => {
+    expect(prepareTextInputEvent('o\r')).toEqual({
+      input: 'o',
+      shouldSubmit: true,
+    })
+  })
+
+  test('keeps lone CR as a newline without coalesced submission', () => {
+    expect(prepareTextInputEvent('\r')).toEqual({
+      input: '\n',
+      shouldSubmit: false,
+    })
+  })
+
+  test('removes a trailing CR adjacent to DEL before sequential editing', () => {
+    expect(prepareTextInputEvent('\x7f\r')).toEqual({
+      input: '\x7f',
+      shouldSubmit: true,
+    })
+  })
+
+  test('keeps replacement text and removes its coalesced trailing CR', () => {
+    expect(prepareTextInputEvent('\x7fă\r')).toEqual({
+      input: '\x7fă',
+      shouldSubmit: true,
+    })
+  })
+
+  test('converts a globally embedded CR before a later DEL', () => {
+    expect(prepareTextInputEvent('a\r\x7fb')).toEqual({
+      input: 'a\n\x7fb',
+      shouldSubmit: false,
+    })
+  })
+
+  test('preserves backslash plus CR as a newline insertion', () => {
+    expect(prepareTextInputEvent('\\\r')).toEqual({
+      input: '\\\n',
+      shouldSubmit: false,
+    })
+  })
+
+  test('classifies backslash plus ANSI plus CR by visible text', () => {
+    expect(prepareTextInputEvent('\\\x1b[0m\r')).toEqual({
+      input: '\\\x1b[0m\n',
+      shouldSubmit: false,
+    })
+  })
+})

--- a/src/hooks/useTextInput.test.ts
+++ b/src/hooks/useTextInput.test.ts
@@ -3,10 +3,25 @@ import { describe, expect, test } from 'bun:test'
 import { Cursor } from '../utils/Cursor.js'
 import {
   applyCoalescedDelInput,
+  applyPrintableInput,
   prepareTextInputEvent,
 } from './useTextInput.js'
 
 const insert = (cursor: Cursor, text: string): Cursor => cursor.insert(text)
+
+test('applyPrintableInput detects an ANSI-wrapped mode character', () => {
+  const notifications: string[] = []
+  const result = applyPrintableInput(
+    Cursor.fromText('', 80, 0),
+    '\x1b[0m!',
+    {
+      onModeCharacter: text => notifications.push(text),
+    },
+  )
+
+  expect(result).toBeUndefined()
+  expect(notifications).toEqual(['!'])
+})
 
 function apply(
   text: string,

--- a/src/hooks/useTextInput.test.ts
+++ b/src/hooks/useTextInput.test.ts
@@ -153,6 +153,22 @@ describe('applyCoalescedDelInput', () => {
     expect(result.shouldCommit).toBe(false)
     expect(notifications).toEqual(['!'])
   })
+
+  test('recommits after a DEL that follows a rejected insertion', () => {
+    const notifications: string[] = []
+    const result = applyCoalescedDelInput(
+      Cursor.fromText('', 80, 0),
+      '!\x7f',
+      (_cursor, text) => {
+        notifications.push(text)
+        return undefined
+      },
+    )
+
+    expect(notifications).toEqual(['!'])
+    expect(result.cursor.text).toBe('')
+    expect(result.shouldCommit).toBe(true)
+  })
 })
 
 describe('prepareTextInputEvent', () => {

--- a/src/hooks/useTextInput.test.ts
+++ b/src/hooks/useTextInput.test.ts
@@ -207,6 +207,13 @@ describe('prepareTextInputEvent', () => {
     })
   })
 
+  test('strips a final CR from embedded multiline paste without submitting', () => {
+    expect(prepareTextInputEvent('a\rb\r')).toEqual({
+      input: 'a\nb',
+      shouldSubmit: false,
+    })
+  })
+
   test('preserves backslash plus CR as a newline insertion', () => {
     expect(prepareTextInputEvent('\\\r')).toEqual({
       input: '\\\n',

--- a/src/hooks/useTextInput.ts
+++ b/src/hooks/useTextInput.ts
@@ -7,6 +7,7 @@ import { addToHistory } from '../history.js'
 import type { Key } from '../ink.js'
 import type {
   InlineGhostText,
+  TextInputChangeContext,
   TextInputState,
 } from '../types/textInputTypes.js'
 import {
@@ -36,9 +37,117 @@ function mapInput(input_map: Array<[string, InputHandler]>): InputMapper {
   }
 }
 
+export function prepareTextInputEvent(input: string): {
+  input: string
+  shouldSubmit: boolean
+} {
+  // SSH-coalesced Enter: on slow links, "o" + Enter can arrive as one
+  // chunk "o\r". Text with exactly one trailing \r is coalesced Enter;
+  // lone \r is Alt+Enter (newline), embedded \r is multi-line paste, and
+  // backslash+CR is a stale VS Code Shift+Enter binding.
+  const visibleInput = stripAnsi(input)
+  const shouldSubmit =
+    input.endsWith('\r') &&
+    visibleInput.length > 1 &&
+    !visibleInput.slice(0, -1).includes('\r') &&
+    visibleInput[visibleInput.length - 2] !== '\\'
+  const editableInput = shouldSubmit ? input.slice(0, -1) : input
+
+  return {
+    input: editableInput.replace(/\r/g, '\n'),
+    shouldSubmit,
+  }
+}
+
+type ApplyPrintableInputOptions = {
+  modeCharacterIsText?: boolean
+  onModeCharacter?: (text: string, context: TextInputChangeContext) => void
+}
+
+export function applyPrintableInput(
+  cursor: Cursor,
+  input: string,
+  options: ApplyPrintableInputOptions = {},
+): MaybeCursor {
+  if (input === '\x1b[H' || input === '\x1b[1~') {
+    return cursor.startOfLine()
+  }
+  if (input === '\x1b[F' || input === '\x1b[4~') {
+    return cursor.endOfLine()
+  }
+
+  const text = stripAnsi(input)
+  if (
+    !options.modeCharacterIsText &&
+    cursor.text.length === 0 &&
+    cursor.isAtStart() &&
+    isInputModeCharacter(input)
+  ) {
+    options.onModeCharacter?.(text, {
+      previousValue: cursor.text,
+      cursorOffset: cursor.offset,
+    })
+    return undefined
+  }
+
+  return cursor.insert(text)
+}
+
+export function applyCoalescedDelInput(
+  cursor: Cursor,
+  input: string,
+  insert: (cursor: Cursor, text: string) => MaybeCursor,
+  onDelete?: (count: number, before: Cursor, after: Cursor) => void,
+): { cursor: Cursor; shouldCommit: boolean } {
+  let nextCursor = cursor
+  let segmentStart = 0
+  let shouldCommit = true
+
+  for (let index = 0; index < input.length; index++) {
+    if (input[index] !== '\x7f') continue
+
+    if (index > segmentStart) {
+      const insertedCursor = insert(
+        nextCursor,
+        input.slice(segmentStart, index),
+      )
+      if (insertedCursor) {
+        nextCursor = insertedCursor
+        shouldCommit = true
+      } else {
+        shouldCommit = false
+      }
+    }
+
+    let delEnd = index + 1
+    while (delEnd < input.length && input[delEnd] === '\x7f') {
+      delEnd++
+    }
+    const delCount = delEnd - index
+    const beforeDelete = nextCursor
+    nextCursor = nextCursor.deleteManyBefore(delCount)
+    onDelete?.(delCount, beforeDelete, nextCursor)
+    shouldCommit = true
+    segmentStart = delEnd
+    index = delEnd - 1
+  }
+
+  if (segmentStart < input.length) {
+    const insertedCursor = insert(nextCursor, input.slice(segmentStart))
+    if (insertedCursor) {
+      nextCursor = insertedCursor
+      shouldCommit = true
+    } else {
+      shouldCommit = false
+    }
+  }
+
+  return { cursor: nextCursor, shouldCommit }
+}
+
 export type UseTextInputProps = {
   value: string
-  onChange: (value: string) => void
+  onChange: (value: string, context?: TextInputChangeContext) => void
   onSubmit?: (value: string) => void
   onExit?: () => void
   onExitMessage?: (show: boolean, key?: string) => void
@@ -142,7 +251,11 @@ export function useTextInput({
   const getLiveValue = (): string => liveValueRef.current
   const getLiveCursor = (): Cursor =>
     Cursor.fromText(liveValueRef.current, columns, liveOffsetRef.current)
-  const setValue = (nextValue: string, nextOffset = liveOffsetRef.current): void => {
+  const commitValue = (
+    nextValue: string,
+    nextOffset = liveOffsetRef.current,
+    changeContext?: TextInputChangeContext,
+  ): void => {
     const previousValue = liveValueRef.current
     const previousOffset = liveOffsetRef.current
 
@@ -153,12 +266,15 @@ export function useTextInput({
     updateRenderedInput(nextValue, nextOffset)
 
     if (previousValue !== nextValue) {
-      onChange(nextValue)
+      onChange(nextValue, changeContext)
     }
 
     if (previousOffset !== nextOffset) {
       onOffsetChange(nextOffset)
     }
+  }
+  const setValue = (nextValue: string, nextOffset = liveOffsetRef.current): void => {
+    commitValue(nextValue, nextOffset)
   }
   const setOffset = (nextOffset: number): void => {
     if (nextOffset === liveOffsetRef.current) {
@@ -399,7 +515,11 @@ export function useTextInput({
     return cursor
   }
 
-  function mapKey(key: Key, cursor: Cursor): InputMapper {
+  function mapKey(
+    key: Key,
+    cursor: Cursor,
+    modeCharacterIsText = false,
+  ): InputMapper {
     switch (true) {
       case key.escape:
         return () => {
@@ -462,53 +582,16 @@ export function useTextInput({
         return () => cursor.left()
       case key.rightArrow:
         return () => cursor.right()
-      default: {
-        return function (input: string) {
-          switch (true) {
-            // Home key
-            case input === '\x1b[H' || input === '\x1b[1~':
-              return cursor.startOfLine()
-            // End key
-            case input === '\x1b[F' || input === '\x1b[4~':
-              return cursor.endOfLine()
-            default: {
-              // Trailing \r after text is SSH-coalesced Enter ("o\r") —
-              // strip it so the Enter isn't inserted as content. Lone \r
-              // here is Alt+Enter leaking through (META_KEY_CODE_RE doesn't
-              // match \x1b\r) — leave it for the \r→\n below. Embedded \r
-              // is multi-line paste from a terminal without bracketed
-              // paste — convert to \n. Backslash+\r is a stale VS Code
-              // Shift+Enter binding (pre-#8991 /terminal-setup wrote
-              // args.text "\\\r\n" to keybindings.json); keep the \r so
-              // it becomes \n below (anthropics/claude-code#31316).
-              const text = stripAnsi(input)
-                // eslint-disable-next-line custom-rules/no-lookbehind-regex -- .replace(re, str) on 1-2 char keystrokes: no-match returns same string (Object.is), regex never runs
-                .replace(/(?<=[^\\\r\n])\r$/, '')
-                .replace(/\r/g, '\n')
-              if (
-                cursor.text.length === 0 &&
-                cursor.isAtStart() &&
-                isInputModeCharacter(input)
-              ) {
-                // Issue #1179: emit the mode character as a one-shot
-                // onChange notification but do NOT advance the local cursor
-                // mirror. Returning undefined here means setValue is not
-                // called, so liveValueRef="" / liveOffsetRef=0 stay clean
-                // and the parent's strip handler operates on (and renders
-                // into) an empty buffer. Previous behaviour was
-                // `cursor.insert(text).left()` which left `!` in the local
-                // mirror, and because the parent's strip leaves controlled
-                // props numerically equal to what they were before the
-                // keystroke, useLayoutEffect never resynced the mirror — so
-                // the next character landed beside the retained `!`.
-                onChange(text)
-                return undefined
-              }
-              return cursor.insert(text)
-            }
-          }
-        }
-      }
+      default:
+        return input =>
+          applyPrintableInput(cursor, input, {
+            modeCharacterIsText,
+            // Issue #1179: emit the mode character as a one-shot onChange
+            // notification without inserting it into the local cursor. The
+            // effective pre-insertion cursor lets controlled consumers make
+            // the same decision after earlier edits in this raw event.
+            onModeCharacter: (text, context) => onChange(text, context),
+          })
     }
   }
 
@@ -540,25 +623,108 @@ export function useTextInput({
       return
     }
 
+    const preparedInput = prepareTextInputEvent(filteredInput)
+
     // Fix Issue #1853: Filter DEL characters that interfere with backspace in SSH/tmux
     // In SSH/tmux environments, backspace generates both key events and raw DEL chars
-    if (!key.backspace && !key.delete && input.includes('\x7f')) {
-      const delCount = (input.match(/\x7f/g) || []).length
-
-      // Apply all DEL characters as backspace operations synchronously
-      // Try to delete tokens first, fall back to character backspace
-      let nextCursor = currentCursor
-      for (let i = 0; i < delCount; i++) {
-        nextCursor =
-          nextCursor.deleteTokenBefore() ?? nextCursor.backspace()
-      }
+    if (
+      !key.backspace &&
+      !key.delete &&
+      filteredInput.includes('\x7f')
+    ) {
+      let finalChangeContext: TextInputChangeContext | undefined
+      let modeEntryChangeContext:
+        | {
+            context: TextInputChangeContext
+            character: string
+            representedInCursor: boolean
+          }
+        | undefined
+      const result = applyCoalescedDelInput(
+        currentCursor,
+        preparedInput.input,
+        (segmentCursor, segment) => {
+          const nextCursor = mapKey(
+            key,
+            segmentCursor,
+            preparedInput.shouldSubmit,
+          )(segment)
+          const visibleSegment = stripAnsi(segment)
+          const firstVisibleCharacter = visibleSegment[0]
+          if (
+            !modeEntryChangeContext &&
+            nextCursor &&
+            segmentCursor.text.length === 0 &&
+            segmentCursor.isAtStart() &&
+            firstVisibleCharacter !== undefined &&
+            isInputModeCharacter(firstVisibleCharacter)
+          ) {
+            modeEntryChangeContext = {
+              context: {
+                previousValue: segmentCursor.text,
+                cursorOffset: segmentCursor.offset,
+                willSubmit: preparedInput.shouldSubmit,
+              },
+              character: firstVisibleCharacter,
+              representedInCursor: true,
+            }
+          }
+          finalChangeContext =
+            nextCursor && nextCursor.text !== segmentCursor.text
+              ? {
+                  previousValue: segmentCursor.text,
+                  cursorOffset: segmentCursor.offset,
+                  willSubmit: preparedInput.shouldSubmit,
+                }
+              : undefined
+          return nextCursor
+        },
+        (_count, beforeDelete, afterDelete) => {
+          finalChangeContext = undefined
+          if (
+            modeEntryChangeContext?.representedInCursor &&
+            beforeDelete.text.startsWith(modeEntryChangeContext.character) &&
+            !afterDelete.text.startsWith(modeEntryChangeContext.character)
+          ) {
+            modeEntryChangeContext.representedInCursor = false
+          }
+        },
+      )
 
       // Update state once with the final result
-      if (!currentCursor.equals(nextCursor)) {
-        setValue(nextCursor.text, nextCursor.offset)
+      if (!currentCursor.equals(result.cursor)) {
+        if (result.shouldCommit) {
+          const changeContext = modeEntryChangeContext?.context ?? finalChangeContext
+          const committedCursor =
+            modeEntryChangeContext &&
+            !modeEntryChangeContext.representedInCursor
+              ? Cursor.fromText(
+                  modeEntryChangeContext.character + result.cursor.text,
+                  columns,
+                  modeEntryChangeContext.character.length +
+                    result.cursor.offset,
+                )
+              : result.cursor
+          commitValue(
+            committedCursor.text,
+            committedCursor.offset,
+            changeContext,
+          )
+        } else {
+          // A final mode-character notification owns the parent value update,
+          // but preceding DELs must still advance the synchronous local mirror.
+          const previousOffset = liveOffsetRef.current
+          updateRenderedInput(result.cursor.text, result.cursor.offset)
+          if (previousOffset !== result.cursor.offset) {
+            onOffsetChange(result.cursor.offset)
+          }
+        }
       }
       resetKillAccumulation()
       resetYankState()
+      if (result.shouldCommit && preparedInput.shouldSubmit) {
+        onSubmit?.(result.cursor.text)
+      }
       return
     }
 
@@ -572,24 +738,26 @@ export function useTextInput({
       resetYankState()
     }
 
-    const nextCursor = mapKey(key, currentCursor)(filteredInput)
+    const nextCursor = mapKey(
+      key,
+      currentCursor,
+      preparedInput.shouldSubmit,
+    )(preparedInput.input)
     if (nextCursor) {
       if (!currentCursor.equals(nextCursor)) {
-        setValue(nextCursor.text, nextCursor.offset)
+        commitValue(
+          nextCursor.text,
+          nextCursor.offset,
+          preparedInput.shouldSubmit
+            ? {
+                previousValue: currentCursor.text,
+                cursorOffset: currentCursor.offset,
+                willSubmit: true,
+              }
+            : undefined,
+        )
       }
-      // SSH-coalesced Enter: on slow links, "o" + Enter can arrive as one
-      // chunk "o\r". parseKeypress only matches s === '\r', so it hit the
-      // default handler above (which stripped the trailing \r). Text with
-      // exactly one trailing \r is coalesced Enter; lone \r is Alt+Enter
-      // (newline); embedded \r is multi-line paste.
-      if (
-        filteredInput.length > 1 &&
-        filteredInput.endsWith('\r') &&
-        !filteredInput.slice(0, -1).includes('\r') &&
-        // Backslash+CR is a stale VS Code Shift+Enter binding, not
-        // coalesced Enter. See default handler above.
-        filteredInput[filteredInput.length - 2] !== '\\'
-      ) {
+      if (preparedInput.shouldSubmit) {
         onSubmit?.(nextCursor.text)
       }
     }
@@ -618,6 +786,7 @@ export function useTextInput({
     offset,
     setValue,
     setOffset,
+    getCursor: getLiveCursor,
     cursorLine: cursorPos.line - cursor.getViewportStartLine(maxVisibleLines),
     cursorColumn: cursorPos.column,
     viewportCharOffset: cursor.getViewportCharOffset(maxVisibleLines),

--- a/src/hooks/useTextInput.ts
+++ b/src/hooks/useTextInput.ts
@@ -89,7 +89,7 @@ export function applyPrintableInput(
     !options.modeCharacterIsText &&
     cursor.text.length === 0 &&
     cursor.isAtStart() &&
-    isInputModeCharacter(input)
+    isInputModeCharacter(text)
   ) {
     options.onModeCharacter?.(text, {
       previousValue: cursor.text,
@@ -711,6 +711,20 @@ export function useTextInput({
                   columns,
                   modeEntryChangeContext.character.length +
                     result.cursor.offset,
+                  )
+                : result.cursor
+          const acceptedCursor =
+            modeEntryChangeContext?.representedInCursor
+              ? Cursor.fromText(
+                  result.cursor.text.slice(
+                    modeEntryChangeContext.character.length,
+                  ),
+                  columns,
+                  Math.max(
+                    0,
+                    result.cursor.offset -
+                      modeEntryChangeContext.character.length,
+                  ),
                 )
               : result.cursor
           commitValue(
@@ -718,6 +732,11 @@ export function useTextInput({
             committedCursor.offset,
             changeContext,
           )
+          if (modeEntryChangeContext) {
+            // onChange consumes the mode sentinel. Keep the synchronous mirror
+            // on that accepted value for later keys from the same stdin read.
+            updateRenderedInput(acceptedCursor.text, acceptedCursor.offset)
+          }
         } else {
           // A final mode-character notification owns the parent value update,
           // but preceding DELs must still advance the synchronous local mirror.
@@ -731,6 +750,9 @@ export function useTextInput({
       resetKillAccumulation()
       resetYankState()
       if (result.shouldCommit && preparedInput.shouldSubmit) {
+        // committedCursor may contain a synthetic mode sentinel used only to
+        // notify onChange. Submit the actual final cursor; PromptInput carries
+        // the detected mode separately through its pending submission state.
         onSubmit?.(result.cursor.text)
       }
       return

--- a/src/hooks/useTextInput.ts
+++ b/src/hooks/useTextInput.ts
@@ -51,7 +51,15 @@ export function prepareTextInputEvent(input: string): {
     visibleInput.length > 1 &&
     !visibleInput.slice(0, -1).includes('\r') &&
     visibleInput[visibleInput.length - 2] !== '\\'
-  const editableInput = shouldSubmit ? input.slice(0, -1) : input
+  const shouldStripTrailingCr =
+    visibleInput.endsWith('\r') &&
+    visibleInput.length > 1 &&
+    !['\\', '\r', '\n'].includes(visibleInput[visibleInput.length - 2]!)
+  const editableInput = shouldStripTrailingCr
+    ? input.endsWith('\r')
+      ? input.slice(0, -1)
+      : visibleInput.slice(0, -1)
+    : input
 
   return {
     input: editableInput.replace(/\r/g, '\n'),
@@ -265,12 +273,12 @@ export function useTextInput({
 
     updateRenderedInput(nextValue, nextOffset)
 
-    if (previousValue !== nextValue) {
-      onChange(nextValue, changeContext)
-    }
-
     if (previousOffset !== nextOffset) {
       onOffsetChange(nextOffset)
+    }
+
+    if (previousValue !== nextValue) {
+      onChange(nextValue, changeContext)
     }
   }
   const setValue = (nextValue: string, nextOffset = liveOffsetRef.current): void => {

--- a/src/hooks/useVimInput.ts
+++ b/src/hooks/useVimInput.ts
@@ -1,3 +1,4 @@
+import { stripVTControlCharacters as stripAnsi } from 'node:util'
 import React, { useCallback, useState } from 'react'
 import { isInputModeCharacter } from '../components/PromptInput/inputModes.js'
 import type { Key } from '../ink.js'
@@ -270,9 +271,18 @@ export function useVimInput(props: UseVimInputProps): VimInputState {
           insertedText: insertedTextCursor.text,
         }
       } else {
+        const visibleInput = stripAnsi(input)
+        const modeCharacter = visibleInput[0]
+        const recordedInput =
+          cursor.text.length === 0 &&
+          cursor.isAtStart() &&
+          modeCharacter !== undefined &&
+          isInputModeCharacter(modeCharacter)
+            ? visibleInput.slice(modeCharacter.length)
+            : input
         vimStateRef.current = {
           mode: 'INSERT',
-          insertedText: state.insertedText + input,
+          insertedText: state.insertedText + recordedInput,
         }
       }
       textInput.onInput(input, key)

--- a/src/hooks/useVimInput.ts
+++ b/src/hooks/useVimInput.ts
@@ -23,7 +23,13 @@ import {
   type RecordedChange,
   type VimState,
 } from '../vim/types.js'
-import { type UseTextInputProps, useTextInput } from './useTextInput.js'
+import {
+  applyCoalescedDelInput,
+  applyPrintableInput,
+  prepareTextInputEvent,
+  type UseTextInputProps,
+  useTextInput,
+} from './useTextInput.js'
 
 type UseVimInputProps = Omit<UseTextInputProps, 'inputFilter'> & {
   onModeChange?: (mode: VimMode) => void
@@ -69,9 +75,9 @@ export function useVimInput(props: UseVimInputProps): VimInputState {
 
     // Vim behavior: move cursor left by 1 when exiting insert mode
     // (unless at beginning of line or at offset 0)
-    const offset = textInput.offset
-    if (offset > 0 && textInput.value[offset - 1] !== '\n') {
-      textInput.setOffset(offset - 1)
+    const cursor = textInput.getCursor()
+    if (cursor.offset > 0 && cursor.text[cursor.offset - 1] !== '\n') {
+      textInput.setOffset(cursor.offset - 1)
     }
 
     vimStateRef.current = { mode: 'NORMAL', command: { type: 'idle' } }
@@ -85,7 +91,7 @@ export function useVimInput(props: UseVimInputProps): VimInputState {
   ): OperatorContext {
     return {
       cursor,
-      text: textInput.value,
+      text: cursor.text,
       setText: (newText: string) => textInput.setValue(newText),
       setOffset: (offset: number) => textInput.setOffset(offset),
       enterInsert: (offset: number) => switchToInsertMode(offset),
@@ -110,11 +116,7 @@ export function useVimInput(props: UseVimInputProps): VimInputState {
     const change = persistentRef.current.lastChange
     if (!change) return
 
-    const cursor = Cursor.fromText(
-      textInput.value,
-      props.columns,
-      textInput.offset,
-    )
+    const cursor = textInput.getCursor()
     const ctx = createOperatorContext(cursor, true)
 
     switch (change.type) {
@@ -182,11 +184,7 @@ export function useVimInput(props: UseVimInputProps): VimInputState {
     // lookups expect single chars and a prepended space would break them.
     const filtered = inputFilter ? inputFilter(rawInput, key) : rawInput
     const input = state.mode === 'INSERT' ? filtered : rawInput
-    const cursor = Cursor.fromText(
-      textInput.value,
-      props.columns,
-      textInput.offset,
-    )
+    const cursor = textInput.getCursor()
 
     if (key.ctrl) {
       textInput.onInput(input, key)
@@ -224,6 +222,39 @@ export function useVimInput(props: UseVimInputProps): VimInputState {
               -(lastGrapheme(state.insertedText).length || 1),
             ),
           }
+        }
+      } else if (input.includes('\x7f')) {
+        const preparedInput = prepareTextInputEvent(input)
+        let insertedTextCursor = Cursor.fromText(
+          state.insertedText,
+          props.columns,
+          state.insertedText.length,
+        )
+        applyCoalescedDelInput(
+          cursor,
+          preparedInput.input,
+          (visibleCursor, text) => {
+            const visibleResult = applyPrintableInput(visibleCursor, text, {
+              modeCharacterIsText: preparedInput.shouldSubmit,
+            })
+            if (
+              visibleResult &&
+              visibleResult.text !== visibleCursor.text
+            ) {
+              insertedTextCursor =
+                applyPrintableInput(insertedTextCursor, text, {
+                  modeCharacterIsText: true,
+                }) ?? insertedTextCursor
+            }
+            return visibleResult
+          },
+          count => {
+            insertedTextCursor = insertedTextCursor.deleteManyBefore(count)
+          },
+        )
+        vimStateRef.current = {
+          mode: 'INSERT',
+          insertedText: insertedTextCursor.text,
         }
       } else {
         vimStateRef.current = {

--- a/src/hooks/useVimInput.ts
+++ b/src/hooks/useVimInput.ts
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react'
+import { isInputModeCharacter } from '../components/PromptInput/inputModes.js'
 import type { Key } from '../ink.js'
 import type { VimInputState, VimMode } from '../types/textInputTypes.js'
 import { Cursor } from '../utils/Cursor.js'
@@ -230,6 +231,7 @@ export function useVimInput(props: UseVimInputProps): VimInputState {
           props.columns,
           state.insertedText.length,
         )
+        let recordedModeEntry = false
         applyCoalescedDelInput(
           cursor,
           preparedInput.input,
@@ -241,8 +243,19 @@ export function useVimInput(props: UseVimInputProps): VimInputState {
               visibleResult &&
               visibleResult.text !== visibleCursor.text
             ) {
+              const modeCharacter = visibleResult.text[0]
+              const isModeEntry =
+                !recordedModeEntry &&
+                visibleCursor.text.length === 0 &&
+                visibleCursor.isAtStart() &&
+                modeCharacter !== undefined &&
+                isInputModeCharacter(modeCharacter)
+              recordedModeEntry ||= isModeEntry
+              const recordedText = isModeEntry
+                ? visibleResult.text.slice(modeCharacter.length)
+                : text
               insertedTextCursor =
-                applyPrintableInput(insertedTextCursor, text, {
+                applyPrintableInput(insertedTextCursor, recordedText, {
                   modeCharacterIsText: true,
                 }) ?? insertedTextCursor
             }

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -3548,7 +3548,9 @@ export function REPL({
     fromKeybinding?: boolean;
     slashCommandOverride?: Command;
     allowInterruptionCorrection?: boolean;
+    inputModeOverride?: PromptInputMode;
   }) => {
+    const effectiveInputMode = options?.inputModeOverride ?? inputMode;
     // Re-pin scroll to bottom on submit so the user always sees the new
     // exchange (matches OpenCode's auto-scroll behavior).
     repinScroll();
@@ -3718,12 +3720,12 @@ export function REPL({
     // Skip history for keybinding-triggered commands (user didn't type the command).
     if (!options?.fromKeybinding) {
       addToHistory({
-        display: speculationAccept ? input : prependModeCharacterToInput(input, inputMode),
+        display: speculationAccept ? input : prependModeCharacterToInput(input, effectiveInputMode),
         pastedContents: speculationAccept ? {} : pastedContents
       });
       // Add the just-submitted command to the front of the ghost-text
       // cache so it's suggested immediately (not after the 60s TTL).
-      if (inputMode === 'bash') {
+      if (effectiveInputMode === 'bash') {
         prependToShellHistoryCache(input.trim());
       }
     }
@@ -3762,7 +3764,7 @@ export function REPL({
       setInputMode('prompt');
       setIDESelection(undefined);
       setSubmitCount(_ => _ + 1);
-      if (isBuddyEnabled() && !isSlashCommand && inputMode === 'prompt') {
+      if (isBuddyEnabled() && !isSlashCommand && effectiveInputMode === 'prompt') {
         // Change token for the companion's signature action (one Enter = one
         // shot; queued messages intentionally don't re-fire on dequeue).
         // Real prompts only — slash commands and bash lines aren't "sending
@@ -3775,7 +3777,7 @@ export function REPL({
       // Show the placeholder in the same React batch as setInputValue('').
       // Skip for slash/bash (they have their own echo), speculation and remote
       // mode (both setMessages directly with no gap to bridge).
-      if (!isSlashCommand && inputMode === 'prompt' && !speculationAccept && !activeRemote.isRemoteMode) {
+      if (!isSlashCommand && effectiveInputMode === 'prompt' && !speculationAccept && !activeRemote.isRemoteMode) {
         setUserInputOnProcessing(input);
         // showSpinner includes userInputOnProcessing, so the spinner appears
         // on this render. Reset timing refs now (before queryGuard.reserve()
@@ -3902,7 +3904,7 @@ export function REPL({
       helpers,
       queryGuard,
       isExternalLoading,
-      mode: inputMode,
+      mode: effectiveInputMode,
       commands,
       onInputChange: setInputValue,
       setPastedContents,

--- a/src/types/textInputTypes.ts
+++ b/src/types/textInputTypes.ts
@@ -5,6 +5,7 @@ import type { PermissionResult } from '../entrypoints/agentSdkTypes.js'
 import type { Command } from '../commands.js'
 import type { Key } from '../ink.js'
 import type { PastedContent } from '../utils/config.js'
+import type { Cursor } from '../utils/Cursor.js'
 import type { ImageDimensions } from '../utils/imageResizer.js'
 import type { TextHighlight } from '../utils/textHighlighting.js'
 import type { AgentId } from './ids.js'
@@ -20,6 +21,15 @@ export type InlineGhostText = {
   readonly fullCommand: string
   /** Position in the input where the ghost text should appear */
   readonly insertPosition: number
+}
+
+export type TextInputChangeContext = {
+  /** Value visible to the input immediately before this change. */
+  readonly previousValue: string
+  /** Cursor offset immediately before this change. */
+  readonly cursorOffset: number
+  /** This change is immediately followed by a coalesced Enter submission. */
+  readonly willSubmit?: boolean
 }
 
 /**
@@ -75,7 +85,7 @@ export type BaseTextInputProps = {
   /**
    * Function to call when value updates.
    */
-  readonly onChange: (value: string) => void
+  readonly onChange: (value: string, context?: TextInputChangeContext) => void
 
   /**
    * Function to call when `Enter` is pressed, where first argument is a value of the input.
@@ -252,12 +262,15 @@ export type BaseInputState = {
 /**
  * State for text input
  */
-export type TextInputState = BaseInputState
+export type TextInputState = BaseInputState & {
+  /** Read the synchronous cursor mirror, including earlier parser-batch items. */
+  getCursor: () => Cursor
+}
 
 /**
  * State for vim input with mode
  */
-export type VimInputState = BaseInputState & {
+export type VimInputState = TextInputState & {
   mode: VimMode
   setMode: (mode: VimMode) => void
 }

--- a/src/utils/Cursor.ts
+++ b/src/utils/Cursor.ts
@@ -907,6 +907,84 @@ export class Cursor {
     return this.left().modifyText(this)
   }
 
+  /**
+   * Apply repeated token-aware backspaces while rebuilding measured text once.
+   * This is equivalent to calling deleteTokenBefore() ?? backspace() `count`
+   * times, including image-chip behavior, but avoids quadratic reconstruction
+   * for a coalesced run of raw DEL bytes.
+   */
+  deleteManyBefore(count: number): Cursor {
+    const deleteCount = Math.max(0, Math.floor(count))
+    if (deleteCount === 0) {
+      return this
+    }
+
+    // Removing text in the middle can expose a combining mark, emoji
+    // modifier, or other suffix whose grapheme boundaries change after NFC
+    // normalization. Preserve exact sequential semantics on that rare path.
+    if (!this.isAtEnd()) {
+      let cursor: Cursor = this
+      for (let remaining = deleteCount; remaining > 0; remaining--) {
+        const nextCursor = cursor.deleteTokenBefore() ?? cursor.backspace()
+        if (nextCursor.equals(cursor)) {
+          break
+        }
+        cursor = nextCursor
+      }
+      return cursor
+    }
+
+    // Index token boundaries once. Looking for a token with a full-prefix
+    // slice and regex on every DEL makes token-rich input quadratic.
+    const tokenStartByEnd = new Map<number, number>()
+    const tokenPattern =
+      /(^|\s)\[(Pasted text #\d+(?: \+\d+ lines)?|Image #\d+|\.\.\.Truncated text #\d+ \+\d+ lines\.\.\.)\]/g
+    let tokenMatch: RegExpExecArray | null
+    while ((tokenMatch = tokenPattern.exec(this.text)) !== null) {
+      tokenStartByEnd.set(
+        tokenMatch.index + tokenMatch[0].length,
+        tokenMatch.index + tokenMatch[1]!.length,
+      )
+    }
+
+    const imageStartByEnd = new Map<number, number>()
+    const imagePattern = /\[Image #\d+\]/g
+    let imageMatch: RegExpExecArray | null
+    while ((imageMatch = imagePattern.exec(this.text)) !== null) {
+      imageStartByEnd.set(
+        imageMatch.index + imageMatch[0].length,
+        imageMatch.index,
+      )
+    }
+
+    let startOffset = this.offset
+    for (let remaining = deleteCount; remaining > 0; remaining--) {
+      if (startOffset === 0) {
+        break
+      }
+
+      const tokenStart = tokenStartByEnd.get(startOffset)
+      if (tokenStart !== undefined) {
+        startOffset = tokenStart
+        continue
+      }
+
+      const imageStart = imageStartByEnd.get(startOffset)
+      if (imageStart !== undefined) {
+        startOffset = imageStart
+        continue
+      }
+
+      startOffset = this.measuredText.prevOffset(startOffset)
+    }
+
+    if (startOffset === this.offset) {
+      return this
+    }
+
+    return new Cursor(this.measuredText, startOffset).modifyText(this)
+  }
+
   deleteToLineStart(): { cursor: Cursor; killed: string } {
     // If cursor is right after a newline (at start of line), delete just that
     // newline — symmetric with deleteToLineEnd's newline handling. This lets


### PR DESCRIPTION
## Summary

- process filtered terminal chunks containing raw DEL bytes and printable text in source order
- preserve grapheme-aware and token-aware deletion, cursor state, Vim replay, and coalesced Enter submission
- carry same-event bash mode context through PromptInput and REPL without changing ordinary Backspace/Delete handling

The SSH/tmux raw-DEL workaround previously counted DEL bytes, applied only those deletions, and returned. Terminal or IME replacement chunks such as `\x7fă` therefore discarded the printable replacement text. This change routes every printable segment through the existing insertion semantics and applies DEL runs between segments through the existing cursor abstraction.

## Impact

- user-facing impact: replacement text delivered alongside raw DEL bytes is no longer lost, including Unicode graphemes and interleaved chunks
- developer/maintainer impact: the transformation is isolated in deterministic helpers with coverage for filters, tokens, mode changes, Vim batching, and submission state

Most of the diff is regression coverage for the terminal input matrix and same-event React/Vim state transitions; no dependency, timeout, parser, or normalization policy changed.

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check`
- [x] focused tests: `bun test src/components/PromptInput/utils.test.ts src/components/TextInput.test.tsx src/hooks/useTextInput.test.ts src/hooks/usePasteHandler.test.ts src/utils/Cursor.nfc.test.ts src/components/PromptInput/inputModes.test.ts` — 80 passed
- [x] `bun run typecheck`
- [x] `bun run typecheck:type-tests`
- [x] `bun run test:provider` — 1,479 passed
- [x] `npm run test:provider-recommendation` — 129 passed
- [x] `bun run security:pr-scan -- --base upstream/main --head HEAD`
- [x] `bun run web:typecheck` and `bun run web:build`

The local full suite completed with 7,844 passing and 2 skipped tests. Its 41 failures are environment-dependent baseline failures reproduced on the untouched base; the exact upstream base SHA has green hosted smoke-and-tests, typecheck, and web jobs.

## Notes

- provider/model path tested: not applicable; the input transformation is provider-independent
- screenshots attached: not applicable; this corrects input behavior without visual presentation changes
- reviewer focus: `applyCoalescedDelInput`, bulk token-aware deletion equivalence, and same-event mode submission override
- known limitation: physical terminals may fragment or decorate IME byte streams differently; deterministic raw and ANSI-bearing chunks are covered without broadening global timeouts
- AI assistance was used during implementation and adversarial review; all accepted findings were verified and fixed before submission


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved prompt submission across input modes, including mode-aware history and command handling.
  * Prompt suggestions and autocomplete now activate only in supported modes.
  * Enhanced text editing with reliable multi-character deletion and cursor preservation.

* **Bug Fixes**
  * Fixed combined Enter and Delete input, including SSH and Unicode scenarios.
  * Improved Vim insert-mode deletion, repeat behavior, and live-cursor updates.
  * Improved tab, spacing, help-toggle, and pasted-text handling.
  * Prevented unintended submissions from unsupported suggestion contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->