### PR TITLE
fix(provider): match MiniMax and Venice base URLs by hostname, not substring

### DIFF
--- a/src/utils/providerProfile.test.ts
+++ b/src/utils/providerProfile.test.ts
@@ -7,6 +7,7 @@ import test, { afterEach, beforeEach } from 'node:test'
 import { acquireEnvMutex, releaseEnvMutex } from '../entrypoints/sdk/shared.js'
 import {
   resolveActiveRouteIdFromEnv,
+  resolveEnvOnlyProviderRouteId,
   resolveRouteCredentialValue,
 } from '../integrations/routeMetadata.js'
 import { DEFAULT_CODEX_BASE_URL } from '../services/api/providerConfig.js'
@@ -256,6 +257,67 @@ test('openai launch preserves persisted dedicated vendor credentials across rest
   assert.equal(env.OPENAI_MODEL, 'deepseek-ai/deepseek-v4-pro')
   assert.equal(env.OPENAI_API_KEY, 'atlas-secret-key')
   assert.equal(env.ATLAS_CLOUD_API_KEY, 'atlas-secret-key')
+})
+
+test('openai launch preserves a persisted MiniMax credential and reselects the native route after restart', async () => {
+  // A generic OpenAI profile pointed at the canonical MiniMax host persists its
+  // key as MINIMAX_API_KEY. buildLaunchEnv must carry that dedicated credential
+  // into the clean-shell launch environment; the MiniMax client only enters its
+  // native setup while MINIMAX_API_KEY is present, so dropping it on restart
+  // would silently fall back to generic OpenAI behavior.
+  const env = await buildLaunchEnv({
+    profile: 'openai',
+    persisted: profile('openai', {
+      OPENAI_BASE_URL: 'https://api.minimax.io/v1',
+      OPENAI_MODEL: 'MiniMax-M2.5',
+      OPENAI_API_KEY: 'minimax-secret-key',
+      MINIMAX_API_KEY: 'minimax-secret-key',
+    }),
+    goal: 'coding',
+    processEnv: {},
+  })
+
+  assert.equal(env.OPENAI_BASE_URL, 'https://api.minimax.io/v1')
+  assert.equal(env.MINIMAX_API_KEY, 'minimax-secret-key')
+  // Assert the reconstructed launch environment actually selects the native
+  // MiniMax route, not merely that the key survived serialization.
+  assert.equal(resolveEnvOnlyProviderRouteId(env), 'minimax')
+})
+
+test('openai launch prefers a live MiniMax key over the persisted one', async () => {
+  const env = await buildLaunchEnv({
+    profile: 'openai',
+    persisted: profile('openai', {
+      OPENAI_BASE_URL: 'https://api.minimax.io/v1',
+      OPENAI_MODEL: 'MiniMax-M2.5',
+      OPENAI_API_KEY: 'persisted-key',
+      MINIMAX_API_KEY: 'persisted-key',
+    }),
+    goal: 'coding',
+    processEnv: { MINIMAX_API_KEY: 'live-shell-key' },
+  })
+
+  assert.equal(env.MINIMAX_API_KEY, 'live-shell-key')
+  assert.equal(resolveEnvOnlyProviderRouteId(env), 'minimax')
+})
+
+test('openai launch does not synthesize a MiniMax credential for a generic profile', async () => {
+  // A generic OpenAI-compatible profile on an unrelated host never persisted a
+  // MINIMAX_API_KEY (the host guard on the persistence side withholds it), so a
+  // clean relaunch must not conjure one or route to MiniMax.
+  const env = await buildLaunchEnv({
+    profile: 'openai',
+    persisted: profile('openai', {
+      OPENAI_BASE_URL: 'https://api.example.com/v1',
+      OPENAI_MODEL: 'gpt-4o',
+      OPENAI_API_KEY: 'generic-key',
+    }),
+    goal: 'coding',
+    processEnv: {},
+  })
+
+  assert.equal(env.MINIMAX_API_KEY, undefined)
+  assert.notEqual(resolveEnvOnlyProviderRouteId(env), 'minimax')
 })
 
 test('openai launch preserves persisted ApiSmart dedicated credentials across restart', async () => {

--- a/src/utils/providerProfile.ts
+++ b/src/utils/providerProfile.ts
@@ -2119,6 +2119,7 @@ export async function buildLaunchEnv(options: {
     'FIREWORKS_API_KEY',
     'LONGCAT_API_KEY',
     'AIMLAPI_API_KEY',
+    'MINIMAX_API_KEY',
     'MIMO_API_KEY',
     'NVIDIA_API_KEY',
     'VENICE_API_KEY',

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1957,6 +1957,63 @@ describe('applyActiveProviderProfileFromConfig', () => {
     expect(process.env.OPENAI_MODEL!).toBe('kimi-k2.6')
   })
 
+  test('reconciliation restores a cleared MINIMAX_API_KEY (dedicated cred is part of the alignment contract)', async () => {
+    // P2b: MiniMax's transport needs the dedicated key. After activation, if
+    // MINIMAX_API_KEY drifts (cleared/replaced), the env is no longer aligned
+    // with the profile, so reconciliation must reapply and restore it. The
+    // alignment check previously ignored MINIMAX_API_KEY, so it considered the
+    // env aligned and left the wrong/absent credential in place.
+    const { applyProviderProfileToProcessEnv, applyActiveProviderProfileFromConfig } =
+      await importFreshProviderProfileModules()
+    const profile = buildProfile({
+      id: 'minimax_generic',
+      name: 'MiniMax generic',
+      provider: 'openai',
+      baseUrl: 'https://api.minimax.io/v1',
+      model: 'MiniMax-M2',
+      apiKey: 'minimax-real-key',
+    })
+
+    applyProviderProfileToProcessEnv(profile)
+    expect(process.env.MINIMAX_API_KEY).toBe('minimax-real-key')
+
+    // Credential drift after activation.
+    delete process.env.MINIMAX_API_KEY
+
+    const applied = applyActiveProviderProfileFromConfig({
+      providerProfiles: [profile],
+      activeProviderProfileId: 'minimax_generic',
+    } as any)
+
+    expect(applied?.id).toBe('minimax_generic')
+    // Cast past control-flow narrowing: TS pins this to `undefined` after the
+    // delete above, since the reconciliation call is opaque to it.
+    expect(process.env.MINIMAX_API_KEY as string | undefined).toBe(
+      'minimax-real-key',
+    )
+  })
+
+  test('reconciliation never mirrors a MiniMax key for a lookalike host', async () => {
+    const { applyProviderProfileToProcessEnv, applyActiveProviderProfileFromConfig } =
+      await importFreshProviderProfileModules()
+    const profile = buildProfile({
+      id: 'minimax_lookalike',
+      name: 'MiniMax lookalike',
+      provider: 'openai',
+      baseUrl: 'https://api.minimax.io.attacker.example/v1',
+      model: 'gpt-4o',
+      apiKey: 'attacker-key',
+    })
+
+    applyProviderProfileToProcessEnv(profile)
+    applyActiveProviderProfileFromConfig({
+      providerProfiles: [profile],
+      activeProviderProfileId: 'minimax_lookalike',
+    } as any)
+
+    expect(process.env.MINIMAX_API_KEY).toBeUndefined()
+  })
+
   test('still respects complete shell selection with USE flag + BASE_URL', async () => {
     // Counter-example: when the user really did set both the flag AND a
     // concrete BASE_URL, that IS explicit intent and wins over the saved
@@ -2845,6 +2902,77 @@ describe('getProviderPresetDefaults', () => {
 })
 
 describe('setActiveProviderProfile', () => {
+  // P2a: a keyed generic OpenAI-compatible profile on a canonical dedicated
+  // host must persist its dedicated credential in the startup file, so a
+  // restart re-authenticates. The strict-env branch previously returned before
+  // mirroring these, so Venice persisted only OPENAI_API_KEY and MiniMax had no
+  // mirror at all.
+  for (const vendor of [
+    { name: 'Venice', baseUrl: 'https://api.venice.ai/api/v1', key: 'VENICE_API_KEY' },
+    { name: 'MiniMax', baseUrl: 'https://api.minimax.io/v1', key: 'MINIMAX_API_KEY' },
+  ]) {
+    test(`persists ${vendor.key} for a generic profile on the canonical ${vendor.name} host`, async () => {
+      const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
+      process.env.CLAUDE_CONFIG_DIR = configDir
+      try {
+        const { setActiveProviderProfile } =
+          await importFreshProviderProfileModules()
+        const profile = buildProfile({
+          id: 'vendor_url_prof',
+          name: `${vendor.name} via URL`,
+          provider: 'openai',
+          baseUrl: vendor.baseUrl,
+          apiKey: 'vendor-url-key',
+        })
+        saveMockGlobalConfig(current => ({
+          ...current,
+          providerProfiles: [profile],
+        }))
+
+        const result = setActiveProviderProfile('vendor_url_prof', { configDir })
+        const persisted = JSON.parse(
+          readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
+        )
+
+        expect(result?.id).toBe('vendor_url_prof')
+        expect(persisted.env[vendor.key]).toBe('vendor-url-key')
+      } finally {
+        rmSync(configDir, { recursive: true, force: true })
+      }
+    })
+  }
+
+  test('does not persist a dedicated key for a canonical-lookalike host', async () => {
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
+    process.env.CLAUDE_CONFIG_DIR = configDir
+    try {
+      const { setActiveProviderProfile } =
+        await importFreshProviderProfileModules()
+      const profile = buildProfile({
+        id: 'lookalike_prof',
+        name: 'MiniMax lookalike',
+        provider: 'openai',
+        baseUrl: 'https://api.minimax.io.attacker.example/v1',
+        apiKey: 'attacker-key',
+      })
+      saveMockGlobalConfig(current => ({
+        ...current,
+        providerProfiles: [profile],
+      }))
+
+      const result = setActiveProviderProfile('lookalike_prof', { configDir })
+      const persisted = JSON.parse(
+        readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
+      )
+
+      expect(result?.id).toBe('lookalike_prof')
+      expect(persisted.env.MINIMAX_API_KEY).toBeUndefined()
+      expect(persisted.env.VENICE_API_KEY).toBeUndefined()
+    } finally {
+      rmSync(configDir, { recursive: true, force: true })
+    }
+  })
+
   test('sets OPENAI_MODEL env var when switching to an openai-type provider', async () => {
     const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
     process.env.CLAUDE_CONFIG_DIR = configDir

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -1519,6 +1519,44 @@ describe('applyProviderProfileToProcessEnv', () => {
     expect(getFreshAPIProvider()).not.toBe('xai')
   })
 
+  test('does not mirror MINIMAX_API_KEY for a lookalike host containing "minimax"', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+
+    // A bare includes('minimax') matched any URL carrying that word — a proxy
+    // host or a lookalike like `api.minimax.io.evil.com` — and mirrored the key
+    // into MINIMAX_API_KEY, which providerAutoDetect then redirects to the real
+    // api.minimax.io. Match by hostname (isMiniMaxBaseUrl), not substring.
+    applyProviderProfileToProcessEnv(
+      buildProfile({
+        provider: 'openai',
+        baseUrl: 'https://minimax-proxy.example.com/v1',
+        model: 'some-model',
+        apiKey: 'not-a-minimax-key',
+      }),
+    )
+
+    expect(process.env.MINIMAX_API_KEY).toBeUndefined()
+    expect(process.env.OPENAI_API_KEY).toBe('not-a-minimax-key')
+  })
+
+  test('does not mirror VENICE_API_KEY for a lookalike host containing "api.venice.ai"', async () => {
+    const { applyProviderProfileToProcessEnv } =
+      await importFreshProviderProfileModules()
+
+    applyProviderProfileToProcessEnv(
+      buildProfile({
+        provider: 'openai',
+        baseUrl: 'https://api.venice.ai.evil.com/v1',
+        model: 'some-model',
+        apiKey: 'not-a-venice-key',
+      }),
+    )
+
+    expect(process.env.VENICE_API_KEY).toBeUndefined()
+    expect(process.env.OPENAI_API_KEY).toBe('not-a-venice-key')
+  })
+
   test('openai-compatible profile applies maxContextLength env override', async () => {
     const { applyProviderProfileToProcessEnv } =
       await importFreshProviderProfileModules()

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -57,7 +57,9 @@ import {
   isCanonicalApismartInferenceBaseUrl,
   isFireworksBaseUrl,
   isLongcatBaseUrl,
+  isMiniMaxBaseUrl,
   isNearaiBaseUrl,
+  isVeniceBaseUrl,
   isXaiBaseUrl,
   isXiaomiMimoBaseUrl,
   resolveEnvOnlyProviderRouteId,
@@ -797,7 +799,7 @@ function isProcessEnvAlignedWithProfile(
       ? !includeApiKey ||
         sameOptionalEnvValue(processEnv.AIMLAPI_API_KEY, profile.apiKey)
       : true) &&
-    (profile.baseUrl?.toLowerCase().includes('api.venice.ai')
+    (isVeniceBaseUrl(profile.baseUrl)
       ? !includeApiKey ||
         sameOptionalEnvValue(processEnv.VENICE_API_KEY, profile.apiKey)
       : true) &&
@@ -1003,7 +1005,7 @@ export function applyProviderProfileToProcessEnv(
       route.routeId === 'apismart' && !isApismartProfile(profile)
     if (profile.apiKey && !withholdRetargetedApismartCredential) {
       openAIProfileEnv.OPENAI_API_KEY = profile.apiKey
-      if (route.vendorId === 'minimax' || normalizedProfileBaseUrl.toLowerCase().includes('minimax')) {
+      if (route.vendorId === 'minimax' || isMiniMaxBaseUrl(profile.baseUrl)) {
         openAIProfileEnv.MINIMAX_API_KEY = profile.apiKey
       }
       if (
@@ -1022,7 +1024,7 @@ export function applyProviderProfileToProcessEnv(
       if (isAimlapiProfile) {
         openAIProfileEnv.AIMLAPI_API_KEY = profile.apiKey
       }
-      if (route.routeId === 'venice' || normalizedProfileBaseUrl.toLowerCase().includes('api.venice.ai')) {
+      if (route.routeId === 'venice' || isVeniceBaseUrl(profile.baseUrl)) {
         openAIProfileEnv.VENICE_API_KEY = profile.apiKey
       }
       if (
@@ -1479,7 +1481,7 @@ function buildOpenAICompatibleStartupEnv(
     if (isAimlapiProfile) {
       env.AIMLAPI_API_KEY = activeProfile.apiKey
     }
-    if (activeProfile.baseUrl?.toLowerCase().includes('api.venice.ai')) {
+    if (isVeniceBaseUrl(activeProfile.baseUrl)) {
       env.VENICE_API_KEY = activeProfile.apiKey
     }
     if (

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -640,6 +640,62 @@ function sameOptionalEnvValue(
   return trimOrUndefined(left) === trimOrUndefined(right)
 }
 
+/**
+ * Dedicated provider credential env vars a profile's API key must be mirrored
+ * into, for the family of vendors detected by exact base-URL host (and, where
+ * the caller has it, the resolved route id / vendor id). Single source of truth
+ * so live application, startup-env persistence, and env/profile alignment agree
+ * on which host owns which dedicated key — previously each path reconstructed
+ * the mapping independently and drifted (MiniMax was absent from the startup
+ * builder and the alignment check; MiMo used a substring match). Credentials
+ * detected by route id or profile shape (aimlapi, apismart, atlas, cloudflare,
+ * bankr, nvidia, …) keep their own predicates at each site.
+ */
+function getHostDedicatedCredentialEnv(
+  baseUrl: string | undefined,
+  apiKey: string,
+  route?: { routeId?: string; vendorId?: string },
+): Record<string, string> {
+  const env: Record<string, string> = {}
+  if (route?.routeId === 'xai' || isXaiBaseUrl(baseUrl)) {
+    env.XAI_API_KEY = apiKey
+  }
+  if (route?.vendorId === 'minimax' || isMiniMaxBaseUrl(baseUrl)) {
+    env.MINIMAX_API_KEY = apiKey
+  }
+  if (route?.routeId === 'venice' || isVeniceBaseUrl(baseUrl)) {
+    env.VENICE_API_KEY = apiKey
+  }
+  if (
+    route?.routeId === 'xiaomi-mimo' ||
+    route?.routeId === 'xiaomi-mimo-token' ||
+    isXiaomiMimoBaseUrl(baseUrl)
+  ) {
+    env.MIMO_API_KEY = apiKey
+  }
+  return env
+}
+
+/**
+ * Whether the process env carries the profile-owned value for every dedicated
+ * host credential the profile expects. Uses getHostDedicatedCredentialEnv so
+ * the alignment contract can never fall behind what application/persistence
+ * mirror. Vacuously true when the key is excluded or the profile has none.
+ */
+function hostDedicatedCredentialsAligned(
+  processEnv: NodeJS.ProcessEnv,
+  profile: ProviderProfile,
+  includeApiKey: boolean,
+): boolean {
+  if (!includeApiKey || !profile.apiKey) {
+    return true
+  }
+  const dedicated = getHostDedicatedCredentialEnv(profile.baseUrl, profile.apiKey)
+  return Object.entries(dedicated).every(([key, value]) =>
+    sameOptionalEnvValue(processEnv[key], value),
+  )
+}
+
 function isProcessEnvAlignedWithProfile(
   processEnv: NodeJS.ProcessEnv,
   profile: ProviderProfile,
@@ -791,22 +847,10 @@ function isProcessEnvAlignedWithProfile(
       ? !includeApiKey ||
         sameOptionalEnvValue(processEnv.BNKR_API_KEY, profile.apiKey)
       : true) &&
-    (isXaiBaseUrl(profile.baseUrl)
-      ? !includeApiKey ||
-        sameOptionalEnvValue(processEnv.XAI_API_KEY, profile.apiKey)
-      : true) &&
+    hostDedicatedCredentialsAligned(processEnv, profile, includeApiKey) &&
     (isAimlapiRoute
       ? !includeApiKey ||
         sameOptionalEnvValue(processEnv.AIMLAPI_API_KEY, profile.apiKey)
-      : true) &&
-    (isVeniceBaseUrl(profile.baseUrl)
-      ? !includeApiKey ||
-        sameOptionalEnvValue(processEnv.VENICE_API_KEY, profile.apiKey)
-      : true) &&
-    (profile.baseUrl?.toLowerCase().includes('api.xiaomimimo.com') ||
-      profile.baseUrl?.toLowerCase().includes('api.mimo-v2.com')
-      ? !includeApiKey ||
-        sameOptionalEnvValue(processEnv.MIMO_API_KEY, profile.apiKey)
       : true) &&
     (profile.baseUrl?.toLowerCase().includes('atlascloud')
       ? !includeApiKey ||
@@ -1005,9 +1049,13 @@ export function applyProviderProfileToProcessEnv(
       route.routeId === 'apismart' && !isApismartProfile(profile)
     if (profile.apiKey && !withholdRetargetedApismartCredential) {
       openAIProfileEnv.OPENAI_API_KEY = profile.apiKey
-      if (route.vendorId === 'minimax' || isMiniMaxBaseUrl(profile.baseUrl)) {
-        openAIProfileEnv.MINIMAX_API_KEY = profile.apiKey
-      }
+      // Host/route-detected dedicated keys (xai, minimax, venice, mimo) come
+      // from the shared mapping so this path, startup persistence, and env
+      // alignment stay in lockstep.
+      Object.assign(
+        openAIProfileEnv,
+        getHostDedicatedCredentialEnv(profile.baseUrl, profile.apiKey, route),
+      )
       if (
         route.gatewayId === 'nvidia-nim' ||
         normalizedProfileBaseUrl.toLowerCase().includes('nvidia') ||
@@ -1018,21 +1066,8 @@ export function applyProviderProfileToProcessEnv(
       if (route.routeId === 'bankr' || normalizedProfileBaseUrl.toLowerCase().includes('bankr')) {
         openAIProfileEnv.BNKR_API_KEY = profile.apiKey
       }
-      if (route.routeId === 'xai' || isXaiBaseUrl(profile.baseUrl)) {
-        openAIProfileEnv.XAI_API_KEY = profile.apiKey
-      }
       if (isAimlapiProfile) {
         openAIProfileEnv.AIMLAPI_API_KEY = profile.apiKey
-      }
-      if (route.routeId === 'venice' || isVeniceBaseUrl(profile.baseUrl)) {
-        openAIProfileEnv.VENICE_API_KEY = profile.apiKey
-      }
-      if (
-        route.routeId === 'xiaomi-mimo' ||
-        route.routeId === 'xiaomi-mimo-token' ||
-        isXiaomiMimoBaseUrl(profile.baseUrl)
-      ) {
-        openAIProfileEnv.MIMO_API_KEY = profile.apiKey
       }
       if (route.routeId === 'atlas-cloud' || normalizedProfileBaseUrl.toLowerCase().includes('atlascloud')) {
         openAIProfileEnv.ATLAS_CLOUD_API_KEY = profile.apiKey
@@ -1405,6 +1440,17 @@ function buildOpenAICompatibleStartupEnv(
       processEnv: {},
     })
     if (strictEnv) {
+      // The strict env omitted the host-detected dedicated keys, so a keyed
+      // generic profile on a canonical MiniMax/Venice/xAI/MiMo host persisted
+      // only OPENAI_API_KEY and relaunched without its dedicated credential.
+      // Mirror them from the shared mapping, same as the fallback path below.
+      Object.assign(
+        strictEnv,
+        getHostDedicatedCredentialEnv(
+          activeProfile.baseUrl,
+          activeProfile.apiKey,
+        ),
+      )
       if (isAimlapiProfile) {
         strictEnv.AIMLAPI_API_KEY = activeProfile.apiKey
         strictEnv.CLAUDE_CODE_PROVIDER_ROUTE_ID = 'aimlapi'
@@ -1472,23 +1518,18 @@ function buildOpenAICompatibleStartupEnv(
   }
   if (activeProfile.apiKey && !withholdRetargetedApismartCredential) {
     env.OPENAI_API_KEY = activeProfile.apiKey
+    // Host-detected dedicated keys (xai, minimax, venice, mimo) from the shared
+    // mapping — this adds the previously-absent MiniMax mirror and replaces the
+    // MiMo substring match with the exact-host predicate.
+    Object.assign(
+      env,
+      getHostDedicatedCredentialEnv(activeProfile.baseUrl, activeProfile.apiKey),
+    )
     if (activeProfile.baseUrl?.toLowerCase().includes('bankr')) {
       env.BNKR_API_KEY = activeProfile.apiKey
     }
-    if (isXaiBaseUrl(activeProfile.baseUrl)) {
-      env.XAI_API_KEY = activeProfile.apiKey
-    }
     if (isAimlapiProfile) {
       env.AIMLAPI_API_KEY = activeProfile.apiKey
-    }
-    if (isVeniceBaseUrl(activeProfile.baseUrl)) {
-      env.VENICE_API_KEY = activeProfile.apiKey
-    }
-    if (
-      activeProfile.baseUrl?.toLowerCase().includes('api.xiaomimimo.com') ||
-      activeProfile.baseUrl?.toLowerCase().includes('api.mimo-v2.com')
-    ) {
-      env.MIMO_API_KEY = activeProfile.apiKey
     }
     if (activeProfile.baseUrl?.toLowerCase().includes('atlascloud')) {
       env.ATLAS_CLOUD_API_KEY = activeProfile.apiKey


### PR DESCRIPTION
## Problem

The provider credential-mirroring chains in `providerProfiles.ts` decide which vendor API-key env var to populate from a profile's `baseUrl`. xAI, Cloudflare and Xiaomi are matched by their exact-hostname predicates (`isXaiBaseUrl`, `isCloudflareBaseUrl`, `isXiaomiMimoBaseUrl`), but the **MiniMax** and **Venice** branches were left on raw substring checks — `baseUrl.toLowerCase().includes('minimax')` and `includes('api.venice.ai')` — even though `isMiniMaxBaseUrl` and `isVeniceBaseUrl` already exist in `routeMetadata.ts`.

A proxy or lookalike host therefore mirrors the profile key into the wrong vendor env var:

- `https://minimax-proxy.example.com/v1` or `https://api.minimax.io.evil.com` → `MINIMAX_API_KEY`. `providerAutoDetect` then classifies the session as MiniMax purely from that env var and `providerFlag` rewrites `ANTHROPIC_BASE_URL` to the real `https://api.minimax.io/anthropic` — a host the user never configured.
- `https://api.venice.ai.evil.com/v1` → `VENICE_API_KEY`.

The substring `'minimax'` is especially loose — a bare word anywhere in the URL (path/query included).

## Fix

Route all four MiniMax/Venice sites (`isProcessEnvAlignedWithProfile`, `buildOpenAICompatibleStartupEnv`, and the active-profile env builder) through `isMiniMaxBaseUrl` / `isVeniceBaseUrl`, which match on `new URL().hostname` exactly — consistent with the neighbouring providers in the same chains. Same hardening as the earlier `isXaiBaseUrl` change.

`bankr` / `atlascloud` / `nvidia` are intentionally left as-is: they have no exact-hostname helper, so they're out of scope here.

## Tests

Added lookalike-host regressions asserting a `minimax-proxy.example.com` / `api.venice.ai.evil.com` profile does **not** mirror into `MINIMAX_API_KEY` / `VENICE_API_KEY` (both fail without the fix). 143 pass in `providerProfiles.test.ts`, typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented provider-specific API credentials from being incorrectly copied for OpenAI-compatible profiles using lookalike hostnames.
  * Improved provider detection for MiniMax and Venice across profile activation and startup configuration.
  * Preserved the generic OpenAI API key while leaving unrelated provider credentials unset.
  * Restored cleared credentials for canonical provider profiles during configuration reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->