### PR TITLE
fix(repomap): resolve file language by real extension, own-property only

### DIFF
--- a/src/context/repoMap/gitFiles.test.ts
+++ b/src/context/repoMap/gitFiles.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'bun:test'
+
+import { getLanguageForFile, isSupportedFile } from './gitFiles.js'
+
+test('resolves supported extensions to their language', () => {
+  expect(getLanguageForFile('src/index.ts')).toBe('typescript')
+  expect(getLanguageForFile('src/App.tsx')).toBe('tsx')
+  expect(getLanguageForFile('lib/util.js')).toBe('javascript')
+  expect(getLanguageForFile('worker.mjs')).toBe('javascript')
+  expect(getLanguageForFile('main.py')).toBe('python')
+})
+
+test('returns null for an unsupported extension', () => {
+  expect(getLanguageForFile('README.md')).toBeNull()
+  expect(getLanguageForFile('data.json')).toBeNull()
+  expect(isSupportedFile('notes.txt')).toBe(false)
+})
+
+test('returns null for an extensionless file instead of keying on the whole name', () => {
+  // lastIndexOf('.') === -1 previously fell back to substring(0), so the entire
+  // filename became the lookup key.
+  expect(getLanguageForFile('Makefile')).toBeNull()
+  expect(getLanguageForFile('Dockerfile')).toBeNull()
+  expect(isSupportedFile('LICENSE')).toBe(false)
+})
+
+test('does not treat an Object.prototype-member filename as a supported language', () => {
+  // A root file with no extension named after an inherited member would resolve
+  // SUPPORTED_EXTENSIONS['constructor'] to Object.prototype.constructor (truthy)
+  // and slip past the `?? null` guard, misclassifying the file as supported.
+  for (const name of [
+    'constructor',
+    '__proto__',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+    'isPrototypeOf',
+  ]) {
+    expect(getLanguageForFile(name)).toBeNull()
+    expect(isSupportedFile(name)).toBe(false)
+  }
+})

--- a/src/context/repoMap/gitFiles.ts
+++ b/src/context/repoMap/gitFiles.ts
@@ -38,8 +38,20 @@ const EXCLUDED_FILES = new Set([
 ])
 
 export function getLanguageForFile(filePath: string): SupportedLanguage | null {
-  const ext = filePath.substring(filePath.lastIndexOf('.'))
-  return SUPPORTED_EXTENSIONS[ext] ?? null
+  const dotIndex = filePath.lastIndexOf('.')
+  // No dot means no extension to match. Guard this explicitly: substring(-1)
+  // falls back to substring(0) and uses the whole path as the lookup key, which
+  // both misclassifies extensionless files and, for a root file named after an
+  // Object.prototype member (`constructor`, `__proto__`, `toString`, …), reads
+  // an inherited member that a bare `?? null` guard treats as a supported
+  // language. Gate the lookup on own-property for the same reason.
+  if (dotIndex === -1) {
+    return null
+  }
+  const ext = filePath.substring(dotIndex)
+  return Object.hasOwn(SUPPORTED_EXTENSIONS, ext)
+    ? SUPPORTED_EXTENSIONS[ext]!
+    : null
 }
 
 export function isSupportedFile(filePath: string): boolean {


### PR DESCRIPTION
## Problem

`getLanguageForFile` in the repo-map file classifier computes the extension as `filePath.substring(filePath.lastIndexOf('.'))` and looks it up in the plain `SUPPORTED_EXTENSIONS` object with a `?? null` guard.

For a path with **no dot**, `lastIndexOf('.')` returns `-1` and `substring(-1)` clamps to `substring(0)` — so the whole filename becomes the lookup key. Two consequences:

1. **Extensionless files are misclassified**: the entire name is matched against the extension table instead of yielding "no extension".
2. **Prototype-member bypass**: a repo-root file named after an `Object.prototype` member (`constructor`, `__proto__`, `toString`, `valueOf`, `hasOwnProperty`, …) resolves `SUPPORTED_EXTENSIONS['constructor']` to the inherited member (truthy), which slips past `?? null`. `isSupportedFile` then returns `true` and `getLanguageForFile` hands back a `Function`/`Object.prototype` value cast as a `SupportedLanguage`, so the file enters the repo-map candidate set / pagerank graph with a bogus language. The file paths come from `git ls-files` / directory walk, so the key is repo-controlled.

Same class as the earlier diff `FILENAME_LANGS` fix; this is a different, still-bare site.

## Fix

Return `null` when there is no dot (no extension to match), and gate the lookup on `Object.hasOwn` — mirroring `resolveOutputStyle`'s own-property guard.

## Tests

New `gitFiles.test.ts`: supported/unsupported extensions, extensionless files (`Makefile`, `LICENSE`) → null, and prototype-member filenames → null (the last fails without the fix). 37 pass across the repo-map suite, typecheck clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-language detection for extensionless filenames.
  * Unsupported file types are now correctly rejected.
  * Filenames matching built-in object property names no longer produce incorrect language mappings.

* **Tests**
  * Added coverage for supported, unsupported, extensionless, and edge-case filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->