### PR TITLE
fix(ollama): send think=false by default so hybrid-reasoning models actually stop thinking

### DIFF
--- a/src/services/api/openaiShim/requestPlanner.ts
+++ b/src/services/api/openaiShim/requestPlanner.ts
@@ -424,11 +424,24 @@ export function createRequestBodyPlanner(context: RequestBodyPlannerContext) {
       options.temperature = params.temperature
     if (params.top_p !== undefined) options.top_p = params.top_p
 
+    // Ollama's hybrid-thinking models (e.g. Qwen3.x) default to thinking
+    // ENABLED when the `think` field is simply absent from the request —
+    // this was previously never set here, so every Ollama request silently
+    // ran in thinking mode regardless of --effort, burning a full reasoning
+    // trace even for trivial prompts with no way to disable it. Mirrors the
+    // effort handling already done above for the Anthropic/Gemini paths.
+    const think: boolean | string = request.reasoning?.effort
+      ? ['xhigh', 'max', 'ultracode'].includes(request.reasoning.effort)
+        ? 'high'
+        : request.reasoning.effort
+      : false
+
     return {
       model: request.resolvedModel,
       messages: normalizeOllamaNativeMessages(body.messages),
       stream: params.stream ?? false,
       options,
+      think,
       ...(body.tools ? { tools: body.tools } : {}),
     }
   }


### PR DESCRIPTION
I have read `CONTRIBUTING.md` and `AGENTS.md`.

## What changed and why

`buildOllamaChatBody()` never set a top-level `think` field on outgoing Ollama requests. Ollama's hybrid-thinking models (e.g. Qwen3.x) interpret the field's absence as thinking *enabled* — so every Ollama request ran in thinking mode regardless of `--effort`, with no way to disable it. The existing client-side thinking filter only hides the trace from *display*; the model still generates the full reasoning chain either way, so the latency cost was paid whether or not it was visible.

This mirrors the effort-handling already implemented for the Anthropic/Gemini paths just above this function in the same file: no `--effort` specified → `think: false`; an explicit effort level is passed through (`xhigh`/`max`/`ultracode` collapse to Ollama's `"high"`, matching its three-tier scale).

## Impact

Any user running a hybrid-thinking model through the Ollama provider gets a working, silent-by-default non-thinking mode instead of an unremovable reasoning trace on every request.

Measured on `qwen3.6:35b-a3b-coding` (Apple Silicon, Ollama):
- Before: 15-21s per trivial response, full visible reasoning trace every time
- After: ~1.3s via the raw Ollama API with `think=false`, ~5s through the full CLI (Node startup + OpenAI↔Ollama format conversion overhead) — no reasoning trace in either case

## Checks run

- `bun run typecheck` — clean
- `bun run check` — 21 pre-existing failures, confirmed present on unmodified `main` (same count before and after this change, all unrelated model-context-window tests, not touched by this diff)
- `bun run smoke` — builds and runs cleanly

## Provider path tested

Ollama only — this change is scoped to `buildOllamaChatBody()` and doesn't touch other providers.

No linked issue — searched open/closed issues and PRs first (including #1442/#1443, a related but different and unmerged proposal for adaptive thinking budgets); didn't find an existing report of this specific bug, so per `CONTRIBUTING.md` this is submitted as a small, self-explanatory fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ollama chat requests now support reasoning effort settings.
  * High-effort modes are mapped appropriately, while unspecified reasoning defaults to disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->