### PR TITLE
fix(lsp): synchronize document versions across restarts

### DIFF
--- a/src/services/lsp/LSPClient.test.ts
+++ b/src/services/lsp/LSPClient.test.ts
@@ -167,11 +167,12 @@ describe('LSP client notification delivery', () => {
     await client.stop()
   })
 
-  test('active connection failures make the client unavailable exactly once', async () => {
+  test('connection-only failures stay outside crash recovery until a nonzero exit', async () => {
+    const child = createFakeProcess()
     const fakeConnection = createFakeConnection()
     const onCrash = mock((_error: Error) => {})
     const client = createLSPClient('typescript', onCrash, {
-      spawnProcess: spawnFakeProcess,
+      spawnProcess: (() => child) as LSPClientDependencies['spawnProcess'],
       createConnection: () => fakeConnection.connection,
     })
 
@@ -181,8 +182,46 @@ describe('LSP client notification delivery', () => {
     fakeConnection.emitClose()
 
     expect(client.isInitialized).toBe(false)
+    expect(onCrash).not.toHaveBeenCalled()
+
+    child.emit('exit', 1, null)
     expect(onCrash).toHaveBeenCalledTimes(1)
-    await client.stop()
+    await client.stop({ force: true })
+  })
+
+  test('only nonzero process exits enter crash recovery', async () => {
+    const createStartedClient = async () => {
+      const child = createFakeProcess()
+      const fakeConnection = createFakeConnection()
+      const onCrash = mock((_error: Error) => {})
+      const client = createLSPClient('typescript', onCrash, {
+        spawnProcess: (() => child) as LSPClientDependencies['spawnProcess'],
+        createConnection: () => fakeConnection.connection,
+      })
+      await client.start('unused', [])
+      await client.initialize(initializeParams())
+      return { child, client, onCrash }
+    }
+
+    const cleanExit = await createStartedClient()
+    cleanExit.child.emit('exit', 0, null)
+    expect(cleanExit.onCrash).not.toHaveBeenCalled()
+    await cleanExit.client.stop({ force: true })
+
+    const signalExit = await createStartedClient()
+    signalExit.child.emit('exit', null, 'SIGTERM')
+    expect(signalExit.onCrash).not.toHaveBeenCalled()
+    await signalExit.client.stop({ force: true })
+
+    const processError = await createStartedClient()
+    processError.child.emit('error', new Error('process transport error'))
+    expect(processError.onCrash).not.toHaveBeenCalled()
+    await processError.client.stop({ force: true })
+
+    const crash = await createStartedClient()
+    crash.child.emit('exit', 1, null)
+    expect(crash.onCrash).toHaveBeenCalledTimes(1)
+    await crash.client.stop({ force: true })
   })
 
   test('ignores a stale close callback after connection replacement', async () => {
@@ -255,19 +294,10 @@ describe('LSP client notification delivery', () => {
       spawnProcess: (() => child) as LSPClientDependencies['spawnProcess'],
     })
 
-    const startOutcome = client.start('unused', []).then(
-      () => 'resolved',
-      () => 'rejected',
-    )
+    const start = client.start('unused', [])
     await client.stop({ force: true })
 
-    const outcome = await Promise.race([
-      startOutcome,
-      new Promise<'pending'>(resolve =>
-        setTimeout(() => resolve('pending'), 30),
-      ),
-    ])
-    expect(outcome).toBe('rejected')
+    await expect(start).rejects.toThrow('cancelled during spawn')
   })
 
   test('transport failure rejects a pending initialization', async () => {
@@ -278,24 +308,15 @@ describe('LSP client notification delivery', () => {
     })
 
     await client.start('unused', [])
-    const initializeOutcome = client.initialize(initializeParams()).then(
-      () => 'resolved',
-      () => 'rejected',
-    )
+    const initialize = client.initialize(initializeParams())
     fakeConnection.emitError(new Error('connection lost'))
 
     try {
-      const outcome = await Promise.race([
-        initializeOutcome,
-        new Promise<'pending'>(resolve =>
-          setTimeout(() => resolve('pending'), 30),
-        ),
-      ])
-      expect(outcome).toBe('rejected')
+      await expect(initialize).rejects.toThrow('connection disposed')
       expect(client.isInitialized).toBe(false)
     } finally {
       await client.stop({ force: true }).catch(() => {})
-      await initializeOutcome
+      await initialize.catch(() => {})
     }
   })
 

--- a/src/services/lsp/LSPClient.test.ts
+++ b/src/services/lsp/LSPClient.test.ts
@@ -1,0 +1,189 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { afterAll, describe, expect, mock, test } from 'bun:test'
+import type { ChildProcess } from 'child_process'
+import type { MessageConnection } from 'vscode-jsonrpc/node.js'
+import type { LSPClientDependencies } from './LSPClient.js'
+
+let baselineConnectionFactory: (() => MessageConnection) | undefined
+let installedBaselineMocks = false
+
+type FakeConnection = {
+  connection: MessageConnection
+  notificationMethods: string[]
+  requestMethods: string[]
+  emitError(error: Error): void
+}
+
+function createFakeProcess(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess
+  Object.assign(child, {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: mock(() => true),
+  })
+  queueMicrotask(() => child.emit('spawn'))
+  return child
+}
+
+const spawnFakeProcess = (() => createFakeProcess()) as
+  LSPClientDependencies['spawnProcess']
+
+function createFakeConnection(
+  rejectNotification?: string,
+): FakeConnection {
+  const notificationMethods: string[] = []
+  const requestMethods: string[] = []
+  let errorHandler: ((error: [Error, unknown, number]) => void) | undefined
+  let closeHandler: (() => void) | undefined
+
+  const connection = {
+    listen: mock(() => {}),
+    trace: mock(async () => {}),
+    onError: mock((handler: (error: [Error, unknown, number]) => void) => {
+      errorHandler = handler
+    }),
+    onClose: mock((handler: () => void) => {
+      closeHandler = handler
+    }),
+    onNotification: mock((method: string) => {
+      notificationMethods.push(method)
+    }),
+    onRequest: mock((method: string) => {
+      requestMethods.push(method)
+    }),
+    sendRequest: mock(async (method: string) =>
+      method === 'initialize' ? { capabilities: {} } : null,
+    ),
+    sendNotification: mock(async (method: string) => {
+      if (method === rejectNotification) {
+        throw new Error('writer rejected')
+      }
+    }),
+    dispose: mock(() => {
+      errorHandler = undefined
+      closeHandler = undefined
+    }),
+  } as unknown as MessageConnection
+
+  return {
+    connection,
+    notificationMethods,
+    requestMethods,
+    emitError(error) {
+      errorHandler?.([error, undefined, 0])
+    },
+  }
+}
+
+try {
+  await import('./documentIdentity.js')
+} catch {
+  // The prior head lacks the dependency-injection seam. Keep its transport
+  // fakes isolated so the same behavioral checks can run without a real server.
+  installedBaselineMocks = true
+  mock.module('child_process', () => ({
+    spawn: () => createFakeProcess(),
+  }))
+  mock.module('vscode-jsonrpc/node.js', () => ({
+    createMessageConnection: () => baselineConnectionFactory?.(),
+    StreamMessageReader: class {},
+    StreamMessageWriter: class {},
+    Trace: { Verbose: 'verbose' },
+  }))
+}
+
+const { createLSPClient } = await import('./LSPClient.js')
+
+afterAll(() => {
+  if (installedBaselineMocks) mock.restore()
+})
+
+function initializeParams() {
+  return {
+    processId: process.pid,
+    rootUri: null,
+    capabilities: {},
+  }
+}
+
+describe('LSP client notification delivery', () => {
+  test('best-effort notifications preserve lifecycle preflight errors', async () => {
+    const fakeConnection = createFakeConnection()
+    baselineConnectionFactory = () => fakeConnection.connection
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: spawnFakeProcess,
+      createConnection: () => fakeConnection.connection,
+    })
+
+    await expect(
+      client.sendNotification('textDocument/didSave', {}),
+    ).rejects.toThrow('LSP client not started')
+
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+    fakeConnection.emitError(new Error('connection failed'))
+
+    await expect(
+      client.sendNotification('textDocument/didSave', {}),
+    ).rejects.toThrow('connection failed')
+    await client.stop()
+  })
+
+  test('strict notifications reject while best-effort notifications keep resolving', async () => {
+    const fakeConnection = createFakeConnection('textDocument/didOpen')
+    baselineConnectionFactory = () => fakeConnection.connection
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: spawnFakeProcess,
+      createConnection: () => fakeConnection.connection,
+    })
+
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+
+    await expect(
+      client.sendNotificationStrict('textDocument/didOpen', {}),
+    ).rejects.toThrow('writer rejected')
+    await expect(
+      client.sendNotification('textDocument/didOpen', {}),
+    ).resolves.toBeUndefined()
+
+    await client.stop()
+  })
+
+  test('reinstalls registered handlers on a replacement connection', async () => {
+    const connections: FakeConnection[] = []
+    const nextConnection = () => {
+      const fake = createFakeConnection()
+      connections.push(fake)
+      return fake.connection
+    }
+    baselineConnectionFactory = nextConnection
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: spawnFakeProcess,
+      createConnection: nextConnection,
+    })
+
+    client.onNotification('textDocument/publishDiagnostics', () => {})
+    client.onRequest('workspace/configuration', () => [])
+
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+    await client.stop()
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+
+    expect(connections).toHaveLength(2)
+    expect(connections[0]?.notificationMethods).toEqual([
+      'textDocument/publishDiagnostics',
+    ])
+    expect(connections[1]?.notificationMethods).toEqual([
+      'textDocument/publishDiagnostics',
+    ])
+    expect(connections[0]?.requestMethods).toEqual(['workspace/configuration'])
+    expect(connections[1]?.requestMethods).toEqual(['workspace/configuration'])
+
+    await client.stop()
+  })
+})

--- a/src/services/lsp/LSPClient.test.ts
+++ b/src/services/lsp/LSPClient.test.ts
@@ -148,7 +148,7 @@ function initializeParams() {
   }
 }
 
-describe('LSP client notification delivery', () => {
+describe('LSP client transport lifecycle', () => {
   test('best-effort notifications preserve lifecycle preflight errors', async () => {
     const fakeConnection = createFakeConnection()
     const client = createLSPClient('typescript', undefined, {

--- a/src/services/lsp/LSPClient.test.ts
+++ b/src/services/lsp/LSPClient.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { PassThrough } from 'node:stream'
-import { describe, expect, mock, test } from 'bun:test'
+import { describe, expect, jest, mock, test } from 'bun:test'
 import type { ChildProcess } from 'child_process'
 import type { MessageConnection } from 'vscode-jsonrpc/node.js'
 import {
@@ -349,6 +349,7 @@ describe('LSP client transport lifecycle', () => {
   })
 
   test('bounds an unanswered graceful shutdown exchange', async () => {
+    jest.useFakeTimers()
     const child = createFakeProcess()
     const fakeConnection = createFakeConnection({ pendingRequest: 'shutdown' })
     const client = createLSPClient('typescript', undefined, {
@@ -360,18 +361,15 @@ describe('LSP client transport lifecycle', () => {
     await client.start('unused', [])
     await client.initialize(initializeParams())
     const gracefulStop = client.stop()
-    const outcome = await Promise.race([
-      gracefulStop.then(() => 'stopped' as const),
-      new Promise<'timed-out'>(resolve =>
-        setTimeout(() => resolve('timed-out'), 50),
-      ),
-    ])
 
     try {
-      expect(outcome).toBe('stopped')
+      jest.advanceTimersByTime(5)
+      await expect(gracefulStop).resolves.toBeUndefined()
       expect(child.kill).toHaveBeenCalledTimes(1)
     } finally {
       fakeConnection.connection.dispose()
+      jest.runAllTimers()
+      jest.useRealTimers()
       await gracefulStop.catch(() => {})
     }
   })

--- a/src/services/lsp/LSPClient.test.ts
+++ b/src/services/lsp/LSPClient.test.ts
@@ -1,18 +1,19 @@
 import { EventEmitter } from 'node:events'
 import { PassThrough } from 'node:stream'
-import { afterAll, describe, expect, mock, test } from 'bun:test'
+import { describe, expect, mock, test } from 'bun:test'
 import type { ChildProcess } from 'child_process'
 import type { MessageConnection } from 'vscode-jsonrpc/node.js'
-import type { LSPClientDependencies } from './LSPClient.js'
-
-let baselineConnectionFactory: (() => MessageConnection) | undefined
-let installedBaselineMocks = false
+import {
+  createLSPClient,
+  type LSPClientDependencies,
+} from './LSPClient.js'
 
 type FakeConnection = {
   connection: MessageConnection
   notificationMethods: string[]
   requestMethods: string[]
   emitError(error: Error): void
+  emitClose(): void
 }
 
 function createFakeProcess(): ChildProcess {
@@ -74,31 +75,11 @@ function createFakeConnection(
     emitError(error) {
       errorHandler?.([error, undefined, 0])
     },
+    emitClose() {
+      closeHandler?.()
+    },
   }
 }
-
-try {
-  await import('./documentIdentity.js')
-} catch {
-  // The prior head lacks the dependency-injection seam. Keep its transport
-  // fakes isolated so the same behavioral checks can run without a real server.
-  installedBaselineMocks = true
-  mock.module('child_process', () => ({
-    spawn: () => createFakeProcess(),
-  }))
-  mock.module('vscode-jsonrpc/node.js', () => ({
-    createMessageConnection: () => baselineConnectionFactory?.(),
-    StreamMessageReader: class {},
-    StreamMessageWriter: class {},
-    Trace: { Verbose: 'verbose' },
-  }))
-}
-
-const { createLSPClient } = await import('./LSPClient.js')
-
-afterAll(() => {
-  if (installedBaselineMocks) mock.restore()
-})
 
 function initializeParams() {
   return {
@@ -111,7 +92,6 @@ function initializeParams() {
 describe('LSP client notification delivery', () => {
   test('best-effort notifications preserve lifecycle preflight errors', async () => {
     const fakeConnection = createFakeConnection()
-    baselineConnectionFactory = () => fakeConnection.connection
     const client = createLSPClient('typescript', undefined, {
       spawnProcess: spawnFakeProcess,
       createConnection: () => fakeConnection.connection,
@@ -133,7 +113,6 @@ describe('LSP client notification delivery', () => {
 
   test('strict notifications reject while best-effort notifications keep resolving', async () => {
     const fakeConnection = createFakeConnection('textDocument/didOpen')
-    baselineConnectionFactory = () => fakeConnection.connection
     const client = createLSPClient('typescript', undefined, {
       spawnProcess: spawnFakeProcess,
       createConnection: () => fakeConnection.connection,
@@ -152,6 +131,46 @@ describe('LSP client notification delivery', () => {
     await client.stop()
   })
 
+  test('active connection failures make the client unavailable exactly once', async () => {
+    const fakeConnection = createFakeConnection()
+    const onCrash = mock((_error: Error) => {})
+    const client = createLSPClient('typescript', onCrash, {
+      spawnProcess: spawnFakeProcess,
+      createConnection: () => fakeConnection.connection,
+    })
+
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+    fakeConnection.emitError(new Error('connection failed'))
+    fakeConnection.emitClose()
+
+    expect(client.isInitialized).toBe(false)
+    expect(onCrash).toHaveBeenCalledTimes(1)
+    await client.stop()
+  })
+
+  test('ignores a stale close callback after connection replacement', async () => {
+    const connections: FakeConnection[] = []
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: spawnFakeProcess,
+      createConnection: () => {
+        const fake = createFakeConnection()
+        connections.push(fake)
+        return fake.connection
+      },
+    })
+
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+
+    connections[0]?.emitClose()
+    expect(client.isInitialized).toBe(true)
+
+    await client.stop()
+  })
+
   test('reinstalls registered handlers on a replacement connection', async () => {
     const connections: FakeConnection[] = []
     const nextConnection = () => {
@@ -159,7 +178,6 @@ describe('LSP client notification delivery', () => {
       connections.push(fake)
       return fake.connection
     }
-    baselineConnectionFactory = nextConnection
     const client = createLSPClient('typescript', undefined, {
       spawnProcess: spawnFakeProcess,
       createConnection: nextConnection,

--- a/src/services/lsp/LSPClient.test.ts
+++ b/src/services/lsp/LSPClient.test.ts
@@ -13,6 +13,8 @@ type FakeConnection = {
   notificationMethods: string[]
   requestMethods: string[]
   sentRequestMethods: string[]
+  emitNotification(method: string, params: unknown): void
+  emitRequest(method: string, params: unknown): Promise<unknown>
   emitError(error: Error): void
   emitClose(): void
 }
@@ -49,6 +51,14 @@ function createFakeConnection(
   let errorHandler: ((error: [Error, unknown, number]) => void) | undefined
   let closeHandler: (() => void) | undefined
   let pendingRequestReject: ((error: Error) => void) | undefined
+  const notificationHandlers = new Map<
+    string,
+    (params: unknown) => void
+  >()
+  const requestHandlers = new Map<
+    string,
+    (params: unknown) => unknown | Promise<unknown>
+  >()
 
   const connection = {
     listen: mock(() => {}),
@@ -59,12 +69,19 @@ function createFakeConnection(
     onClose: mock((handler: () => void) => {
       closeHandler = handler
     }),
-    onNotification: mock((method: string) => {
+    onNotification: mock((method: string, handler: (params: unknown) => void) => {
       notificationMethods.push(method)
+      notificationHandlers.set(method, handler)
     }),
-    onRequest: mock((method: string) => {
+    onRequest: mock(
+      (
+        method: string,
+        handler: (params: unknown) => unknown | Promise<unknown>,
+      ) => {
       requestMethods.push(method)
-    }),
+        requestHandlers.set(method, handler)
+      },
+    ),
     sendRequest: mock(async (method: string) => {
       sentRequestMethods.push(method)
       if (method === options.pendingRequest) {
@@ -106,6 +123,14 @@ function createFakeConnection(
     notificationMethods,
     requestMethods,
     sentRequestMethods,
+    emitNotification(method, params) {
+      notificationHandlers.get(method)?.(params)
+    },
+    async emitRequest(method, params) {
+      const handler = requestHandlers.get(method)
+      if (!handler) throw new Error(`No request handler registered for ${method}`)
+      return await handler(params)
+    },
     emitError(error) {
       errorHandler?.([error, undefined, 0])
     },
@@ -167,29 +192,7 @@ describe('LSP client notification delivery', () => {
     await client.stop()
   })
 
-  test('connection-only failures stay outside crash recovery until a nonzero exit', async () => {
-    const child = createFakeProcess()
-    const fakeConnection = createFakeConnection()
-    const onCrash = mock((_error: Error) => {})
-    const client = createLSPClient('typescript', onCrash, {
-      spawnProcess: (() => child) as LSPClientDependencies['spawnProcess'],
-      createConnection: () => fakeConnection.connection,
-    })
-
-    await client.start('unused', [])
-    await client.initialize(initializeParams())
-    fakeConnection.emitError(new Error('connection failed'))
-    fakeConnection.emitClose()
-
-    expect(client.isInitialized).toBe(false)
-    expect(onCrash).not.toHaveBeenCalled()
-
-    child.emit('exit', 1, null)
-    expect(onCrash).toHaveBeenCalledTimes(1)
-    await client.stop({ force: true })
-  })
-
-  test('only nonzero process exits enter crash recovery', async () => {
+  test('every unexpected transport termination enters crash recovery once', async () => {
     const createStartedClient = async () => {
       const child = createFakeProcess()
       const fakeConnection = createFakeConnection()
@@ -200,28 +203,55 @@ describe('LSP client notification delivery', () => {
       })
       await client.start('unused', [])
       await client.initialize(initializeParams())
-      return { child, client, onCrash }
+      return { child, client, fakeConnection, onCrash }
     }
 
-    const cleanExit = await createStartedClient()
-    cleanExit.child.emit('exit', 0, null)
-    expect(cleanExit.onCrash).not.toHaveBeenCalled()
-    await cleanExit.client.stop({ force: true })
+    type StartedClient = Awaited<ReturnType<typeof createStartedClient>>
+    const scenarios: Array<{
+      name: string
+      terminate: (started: StartedClient) => void
+    }> = [
+      {
+        name: 'JSON-RPC error',
+        terminate: ({ fakeConnection }) =>
+          fakeConnection.emitError(new Error('connection failed')),
+      },
+      {
+        name: 'JSON-RPC close',
+        terminate: ({ fakeConnection }) => fakeConnection.emitClose(),
+      },
+      {
+        name: 'child-process error',
+        terminate: ({ child }) =>
+          child.emit('error', new Error('process transport error')),
+      },
+      {
+        name: 'clean child exit',
+        terminate: ({ child }) => child.emit('exit', 0, null),
+      },
+      {
+        name: 'signal child exit',
+        terminate: ({ child }) => child.emit('exit', null, 'SIGTERM'),
+      },
+      {
+        name: 'nonzero child exit',
+        terminate: ({ child }) => child.emit('exit', 1, null),
+      },
+    ]
 
-    const signalExit = await createStartedClient()
-    signalExit.child.emit('exit', null, 'SIGTERM')
-    expect(signalExit.onCrash).not.toHaveBeenCalled()
-    await signalExit.client.stop({ force: true })
+    for (const scenario of scenarios) {
+      const started = await createStartedClient()
+      scenario.terminate(started)
 
-    const processError = await createStartedClient()
-    processError.child.emit('error', new Error('process transport error'))
-    expect(processError.onCrash).not.toHaveBeenCalled()
-    await processError.client.stop({ force: true })
+      expect(started.client.isInitialized, scenario.name).toBe(false)
+      expect(started.onCrash, scenario.name).toHaveBeenCalledTimes(1)
+      expect(started.child.kill, scenario.name).toHaveBeenCalledTimes(1)
 
-    const crash = await createStartedClient()
-    crash.child.emit('exit', 1, null)
-    expect(crash.onCrash).toHaveBeenCalledTimes(1)
-    await crash.client.stop({ force: true })
+      started.fakeConnection.emitClose()
+      started.child.emit('exit', 1, null)
+      expect(started.onCrash, scenario.name).toHaveBeenCalledTimes(1)
+      await started.client.stop({ force: true })
+    }
   })
 
   test('ignores a stale close callback after connection replacement', async () => {
@@ -288,6 +318,64 @@ describe('LSP client notification delivery', () => {
     expect(fakeConnection.sentRequestMethods).toEqual(['initialize'])
   })
 
+  test('force stop supersedes an in-flight graceful shutdown', async () => {
+    const child = createFakeProcess()
+    const fakeConnection = createFakeConnection({ pendingRequest: 'shutdown' })
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: (() => child) as LSPClientDependencies['spawnProcess'],
+      createConnection: () => fakeConnection.connection,
+    })
+
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+    const gracefulStop = client.stop()
+    await Promise.resolve()
+
+    const forcedStop = client.stop({ force: true })
+    const outcome = await Promise.race([
+      forcedStop.then(() => 'stopped' as const),
+      new Promise<'timed-out'>(resolve =>
+        setTimeout(() => resolve('timed-out'), 50),
+      ),
+    ])
+
+    try {
+      expect(outcome).toBe('stopped')
+      expect(child.kill).toHaveBeenCalledTimes(1)
+    } finally {
+      fakeConnection.connection.dispose()
+      await Promise.allSettled([gracefulStop, forcedStop])
+    }
+  })
+
+  test('bounds an unanswered graceful shutdown exchange', async () => {
+    const child = createFakeProcess()
+    const fakeConnection = createFakeConnection({ pendingRequest: 'shutdown' })
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: (() => child) as LSPClientDependencies['spawnProcess'],
+      createConnection: () => fakeConnection.connection,
+      gracefulShutdownTimeoutMs: 5,
+    })
+
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+    const gracefulStop = client.stop()
+    const outcome = await Promise.race([
+      gracefulStop.then(() => 'stopped' as const),
+      new Promise<'timed-out'>(resolve =>
+        setTimeout(() => resolve('timed-out'), 50),
+      ),
+    ])
+
+    try {
+      expect(outcome).toBe('stopped')
+      expect(child.kill).toHaveBeenCalledTimes(1)
+    } finally {
+      fakeConnection.connection.dispose()
+      await gracefulStop.catch(() => {})
+    }
+  })
+
   test('an immediate stop settles an in-flight spawn wait', async () => {
     const child = createFakeProcess(false)
     const client = createLSPClient('typescript', undefined, {
@@ -298,6 +386,9 @@ describe('LSP client notification delivery', () => {
     await client.stop({ force: true })
 
     await expect(start).rejects.toThrow('cancelled during spawn')
+    expect(() =>
+      child.emit('error', new Error('late missing-command ENOENT')),
+    ).not.toThrow()
   })
 
   test('transport failure rejects a pending initialization', async () => {
@@ -356,14 +447,35 @@ describe('LSP client notification delivery', () => {
       createConnection: nextConnection,
     })
 
-    client.onNotification('textDocument/publishDiagnostics', () => {})
-    client.onRequest('workspace/configuration', () => [])
+    const notificationHandler = mock((_params: unknown) => {})
+    const requestHandler = mock((params: unknown) => ({ configured: params }))
+    client.onNotification(
+      'textDocument/publishDiagnostics',
+      notificationHandler,
+    )
+    client.onRequest('workspace/configuration', requestHandler)
 
     await client.start('unused', [])
     await client.initialize(initializeParams())
+    connections[0]?.emitNotification('textDocument/publishDiagnostics', {
+      generation: 1,
+    })
+    expect(
+      await connections[0]?.emitRequest('workspace/configuration', {
+        generation: 1,
+      }),
+    ).toEqual({ configured: { generation: 1 } })
     await client.stop()
     await client.start('unused', [])
     await client.initialize(initializeParams())
+    connections[1]?.emitNotification('textDocument/publishDiagnostics', {
+      generation: 2,
+    })
+    expect(
+      await connections[1]?.emitRequest('workspace/configuration', {
+        generation: 2,
+      }),
+    ).toEqual({ configured: { generation: 2 } })
 
     expect(connections).toHaveLength(2)
     expect(connections[0]?.notificationMethods).toEqual([
@@ -374,6 +486,10 @@ describe('LSP client notification delivery', () => {
     ])
     expect(connections[0]?.requestMethods).toEqual(['workspace/configuration'])
     expect(connections[1]?.requestMethods).toEqual(['workspace/configuration'])
+    expect(notificationHandler).toHaveBeenCalledTimes(2)
+    expect(notificationHandler).toHaveBeenNthCalledWith(1, { generation: 1 })
+    expect(notificationHandler).toHaveBeenNthCalledWith(2, { generation: 2 })
+    expect(requestHandler).toHaveBeenCalledTimes(2)
 
     await client.stop()
   })

--- a/src/services/lsp/LSPClient.test.ts
+++ b/src/services/lsp/LSPClient.test.ts
@@ -12,11 +12,20 @@ type FakeConnection = {
   connection: MessageConnection
   notificationMethods: string[]
   requestMethods: string[]
+  sentRequestMethods: string[]
   emitError(error: Error): void
   emitClose(): void
 }
 
-function createFakeProcess(): ChildProcess {
+type FakeConnectionOptions = {
+  failTransportDuringRequest?: { method: string; error: Error }
+  pendingRequest?: string
+  rejectNotification?: string
+  rejectRequest?: string
+  retainHandlersOnDispose?: boolean
+}
+
+function createFakeProcess(autoSpawn = true): ChildProcess {
   const child = new EventEmitter() as ChildProcess
   Object.assign(child, {
     stdin: new PassThrough(),
@@ -24,7 +33,7 @@ function createFakeProcess(): ChildProcess {
     stderr: new PassThrough(),
     kill: mock(() => true),
   })
-  queueMicrotask(() => child.emit('spawn'))
+  if (autoSpawn) queueMicrotask(() => child.emit('spawn'))
   return child
 }
 
@@ -32,12 +41,14 @@ const spawnFakeProcess = (() => createFakeProcess()) as
   LSPClientDependencies['spawnProcess']
 
 function createFakeConnection(
-  rejectNotification?: string,
+  options: FakeConnectionOptions = {},
 ): FakeConnection {
   const notificationMethods: string[] = []
   const requestMethods: string[] = []
+  const sentRequestMethods: string[] = []
   let errorHandler: ((error: [Error, unknown, number]) => void) | undefined
   let closeHandler: (() => void) | undefined
+  let pendingRequestReject: ((error: Error) => void) | undefined
 
   const connection = {
     listen: mock(() => {}),
@@ -54,17 +65,39 @@ function createFakeConnection(
     onRequest: mock((method: string) => {
       requestMethods.push(method)
     }),
-    sendRequest: mock(async (method: string) =>
-      method === 'initialize' ? { capabilities: {} } : null,
-    ),
+    sendRequest: mock(async (method: string) => {
+      sentRequestMethods.push(method)
+      if (method === options.pendingRequest) {
+        return await new Promise((_resolve, reject) => {
+          pendingRequestReject = reject
+        })
+      }
+      if (method === options.rejectRequest) {
+        throw new Error('request rejected')
+      }
+      if (method === options.failTransportDuringRequest?.method) {
+        queueMicrotask(() => {
+          errorHandler?.([
+            options.failTransportDuringRequest!.error,
+            undefined,
+            0,
+          ])
+        })
+      }
+      return method === 'initialize' ? { capabilities: {} } : null
+    }),
     sendNotification: mock(async (method: string) => {
-      if (method === rejectNotification) {
+      if (method === options.rejectNotification) {
         throw new Error('writer rejected')
       }
     }),
     dispose: mock(() => {
-      errorHandler = undefined
-      closeHandler = undefined
+      pendingRequestReject?.(new Error('connection disposed'))
+      pendingRequestReject = undefined
+      if (!options.retainHandlersOnDispose) {
+        errorHandler = undefined
+        closeHandler = undefined
+      }
     }),
   } as unknown as MessageConnection
 
@@ -72,6 +105,7 @@ function createFakeConnection(
     connection,
     notificationMethods,
     requestMethods,
+    sentRequestMethods,
     emitError(error) {
       errorHandler?.([error, undefined, 0])
     },
@@ -112,7 +146,9 @@ describe('LSP client notification delivery', () => {
   })
 
   test('strict notifications reject while best-effort notifications keep resolving', async () => {
-    const fakeConnection = createFakeConnection('textDocument/didOpen')
+    const fakeConnection = createFakeConnection({
+      rejectNotification: 'textDocument/didOpen',
+    })
     const client = createLSPClient('typescript', undefined, {
       spawnProcess: spawnFakeProcess,
       createConnection: () => fakeConnection.connection,
@@ -154,7 +190,7 @@ describe('LSP client notification delivery', () => {
     const client = createLSPClient('typescript', undefined, {
       spawnProcess: spawnFakeProcess,
       createConnection: () => {
-        const fake = createFakeConnection()
+        const fake = createFakeConnection({ retainHandlersOnDispose: true })
         connections.push(fake)
         return fake.connection
       },
@@ -169,6 +205,122 @@ describe('LSP client notification delivery', () => {
     expect(client.isInitialized).toBe(true)
 
     await client.stop()
+  })
+
+  test('starts after an overlapping shutdown request fails', async () => {
+    const shutdownErrorConnection = createFakeConnection({
+      rejectRequest: 'shutdown',
+    })
+    const replacementConnection = createFakeConnection()
+    const connections = [shutdownErrorConnection, replacementConnection]
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: spawnFakeProcess,
+      createConnection: () => connections.shift()!.connection,
+    })
+
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+
+    const stopOutcome = client.stop().then(
+      () => undefined,
+      error => error,
+    )
+    const restart = client.start('unused', [])
+
+    expect(await stopOutcome).toEqual(new Error('request rejected'))
+    await expect(restart).resolves.toBeUndefined()
+    await client.initialize(initializeParams())
+    expect(client.isInitialized).toBe(true)
+
+    await client.stop()
+  })
+
+  test('force stop skips the graceful shutdown request', async () => {
+    const fakeConnection = createFakeConnection()
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: spawnFakeProcess,
+      createConnection: () => fakeConnection.connection,
+    })
+
+    await client.start('unused', [])
+    await client.initialize(initializeParams())
+    await client.stop({ force: true })
+
+    expect(fakeConnection.sentRequestMethods).toEqual(['initialize'])
+  })
+
+  test('an immediate stop settles an in-flight spawn wait', async () => {
+    const child = createFakeProcess(false)
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: (() => child) as LSPClientDependencies['spawnProcess'],
+    })
+
+    const startOutcome = client.start('unused', []).then(
+      () => 'resolved',
+      () => 'rejected',
+    )
+    await client.stop({ force: true })
+
+    const outcome = await Promise.race([
+      startOutcome,
+      new Promise<'pending'>(resolve =>
+        setTimeout(() => resolve('pending'), 30),
+      ),
+    ])
+    expect(outcome).toBe('rejected')
+  })
+
+  test('transport failure rejects a pending initialization', async () => {
+    const fakeConnection = createFakeConnection({ pendingRequest: 'initialize' })
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: spawnFakeProcess,
+      createConnection: () => fakeConnection.connection,
+    })
+
+    await client.start('unused', [])
+    const initializeOutcome = client.initialize(initializeParams()).then(
+      () => 'resolved',
+      () => 'rejected',
+    )
+    fakeConnection.emitError(new Error('connection lost'))
+
+    try {
+      const outcome = await Promise.race([
+        initializeOutcome,
+        new Promise<'pending'>(resolve =>
+          setTimeout(() => resolve('pending'), 30),
+        ),
+      ])
+      expect(outcome).toBe('rejected')
+      expect(client.isInitialized).toBe(false)
+    } finally {
+      await client.stop({ force: true }).catch(() => {})
+      await initializeOutcome
+    }
+  })
+
+  test('transport failure cannot be overwritten by initialization success', async () => {
+    const transportError = new Error('late transport failure')
+    const fakeConnection = createFakeConnection({
+      failTransportDuringRequest: {
+        method: 'initialize',
+        error: transportError,
+      },
+    })
+    const client = createLSPClient('typescript', undefined, {
+      spawnProcess: spawnFakeProcess,
+      createConnection: () => fakeConnection.connection,
+    })
+
+    await client.start('unused', [])
+    try {
+      await expect(client.initialize(initializeParams())).rejects.toBe(
+        transportError,
+      )
+      expect(client.isInitialized).toBe(false)
+    } finally {
+      await client.stop().catch(() => {})
+    }
   })
 
   test('reinstalls registered handlers on a replacement connection', async () => {

--- a/src/services/lsp/LSPClient.ts
+++ b/src/services/lsp/LSPClient.ts
@@ -44,11 +44,13 @@ export type LSPClient = {
 export type LSPClientDependencies = {
   spawnProcess: typeof spawn
   createConnection: typeof createMessageConnection
+  gracefulShutdownTimeoutMs: number
 }
 
 const DEFAULT_DEPENDENCIES: LSPClientDependencies = {
   spawnProcess: spawn,
   createConnection: createMessageConnection,
+  gracefulShutdownTimeoutMs: 2_000,
 }
 
 /**
@@ -75,6 +77,8 @@ export function createLSPClient(
   let isStopping = false // Track intentional shutdown to avoid spurious error logging
   let unavailableReported = false
   let stopPromise: Promise<void> | undefined
+  let stopMode: 'graceful' | 'force' | undefined
+  let forceCurrentStop: (() => void) | undefined
   let spawnWait:
     | { process: ChildProcess; reject: (error: Error) => void }
     | undefined
@@ -92,17 +96,6 @@ export function createLSPClient(
     if (startFailed) {
       throw startError || new Error(`LSP server ${serverName} failed to start`)
     }
-  }
-
-  function reportTransportUnavailable(error: Error): void {
-    if (isStopping) return
-    isInitialized = false
-    capabilities = undefined
-    startFailed = true
-    startError = error
-    const unavailableConnection = connection
-    connection = undefined
-    disposeResources(unavailableConnection, undefined)
   }
 
   function reportUnavailable(error: Error): void {
@@ -135,13 +128,21 @@ export function createLSPClient(
     }
 
     if (!targetProcess) return
-    if (spawnWait?.process === targetProcess) {
-      spawnWait.reject(
+    const activeSpawnWait = spawnWait
+    const cancelledDuringSpawn = activeSpawnWait?.process === targetProcess
+    if (cancelledDuringSpawn) {
+      activeSpawnWait.reject(
         new Error(`LSP server ${serverName} start was cancelled during spawn`),
       )
     }
     targetProcess.removeAllListeners('error')
     targetProcess.removeAllListeners('exit')
+    if (cancelledDuringSpawn) {
+      // spawn() may report a real launch error after an immediate force-stop.
+      // Keep a one-shot sink after detaching the cancelled start listener so
+      // that late error cannot become an uncaught EventEmitter error.
+      targetProcess.once('error', () => {})
+    }
     targetProcess.stdin?.removeAllListeners('error')
     targetProcess.stderr?.removeAllListeners('data')
     try {
@@ -261,21 +262,18 @@ export function createLSPClient(
         // Handle process errors (after successful spawn, e.g., crash during operation)
         spawnedProcess.on('error', error => {
           if (process !== spawnedProcess || isStopping) return
-          reportTransportUnavailable(error)
-          if (!isStopping) {
-            logError(
-              new Error(
-                `LSP server ${serverName} failed to start: ${error.message}`,
-              ),
-            )
-          }
+          reportUnavailable(error)
+          logError(
+            new Error(
+              `LSP server ${serverName} failed to start: ${error.message}`,
+            ),
+          )
         })
 
         spawnedProcess.on('exit', (code, signal) => {
           if (process !== spawnedProcess || isStopping) return
-          if (code === 0 || code === null) return
           const exitDetail =
-            signal !== null ? `signal ${signal}` : `exit code ${code}`
+            code !== null ? `exit code ${code}` : `signal ${signal ?? 'unknown'}`
           const crashError = new Error(
             `LSP server ${serverName} exited unexpectedly with ${exitDetail}`,
           )
@@ -304,15 +302,12 @@ export function createLSPClient(
         // This prevents unhandled promise rejections when the server crashes or closes unexpectedly
         startedConnection.onError(([error, _message, _code]) => {
           if (connection !== startedConnection || isStopping) return
-          reportTransportUnavailable(error)
-          // Only log if not intentionally stopping (avoid spurious errors during shutdown)
-          if (!isStopping) {
-            logError(
-              new Error(
-                `LSP server ${serverName} connection error: ${error.message}`,
-              ),
-            )
-          }
+          reportUnavailable(error)
+          logError(
+            new Error(
+              `LSP server ${serverName} connection error: ${error.message}`,
+            ),
+          )
         })
 
         startedConnection.onClose(() => {
@@ -322,7 +317,7 @@ export function createLSPClient(
             `LSP server ${serverName} connection closed unexpectedly`,
           )
           logForDebugging(closeError.message)
-          reportTransportUnavailable(closeError)
+          reportUnavailable(closeError)
         })
 
         // 3. Start listening for messages
@@ -498,10 +493,23 @@ export function createLSPClient(
     },
 
     stop(options?: { force?: boolean }): Promise<void> {
-      if (stopPromise) return stopPromise
+      const force = options?.force === true
+      if (stopPromise) {
+        if (force && stopMode === 'graceful') {
+          stopMode = 'force'
+          forceCurrentStop?.()
+        }
+        return stopPromise
+      }
 
       const stoppingConnection = connection
       const stoppingProcess = process
+      let requestForce!: () => void
+      const forceRequested = new Promise<void>(resolve => {
+        requestForce = resolve
+      })
+      stopMode = force ? 'force' : 'graceful'
+      forceCurrentStop = requestForce
       const pending = (async () => {
         let shutdownError: Error | undefined
 
@@ -509,10 +517,36 @@ export function createLSPClient(
         isStopping = true
 
         try {
-          if (stoppingConnection && !options?.force) {
-            // Try to send shutdown request and exit notification
-            await stoppingConnection.sendRequest('shutdown', {})
-            await stoppingConnection.sendNotification('exit', {})
+          if (stoppingConnection && !force) {
+            let timeout: ReturnType<typeof setTimeout> | undefined
+            const gracefulExchange = (async () => {
+              await stoppingConnection.sendRequest('shutdown', {})
+              await stoppingConnection.sendNotification('exit', {})
+              return 'completed' as const
+            })()
+            const timedOut = new Promise<'timed-out'>(resolve => {
+              timeout = setTimeout(
+                () => resolve('timed-out'),
+                dependencies.gracefulShutdownTimeoutMs,
+              )
+            })
+            const forced = forceRequested.then(() => 'forced' as const)
+
+            let outcome: 'completed' | 'timed-out' | 'forced'
+            try {
+              outcome = await Promise.race([
+                gracefulExchange,
+                timedOut,
+                forced,
+              ])
+            } finally {
+              if (timeout) clearTimeout(timeout)
+            }
+            if (outcome === 'timed-out') {
+              logForDebugging(
+                `LSP server ${serverName} graceful shutdown timed out after ${dependencies.gracefulShutdownTimeoutMs}ms`,
+              )
+            }
           }
         } catch (error) {
           const err = error as Error
@@ -547,6 +581,8 @@ export function createLSPClient(
 
       stopPromise = pending.finally(() => {
         stopPromise = undefined
+        stopMode = undefined
+        forceCurrentStop = undefined
       })
       return stopPromise
     },

--- a/src/services/lsp/LSPClient.ts
+++ b/src/services/lsp/LSPClient.ts
@@ -38,7 +38,7 @@ export type LSPClient = {
     method: string,
     handler: (params: TParams) => TResult | Promise<TResult>,
   ) => void
-  stop: () => Promise<void>
+  stop: (options?: { force?: boolean }) => Promise<void>
 }
 
 export type LSPClientDependencies = {
@@ -75,6 +75,9 @@ export function createLSPClient(
   let isStopping = false // Track intentional shutdown to avoid spurious error logging
   let unavailableReported = false
   let stopPromise: Promise<void> | undefined
+  let spawnWait:
+    | { process: ChildProcess; reject: (error: Error) => void }
+    | undefined
   // Retain handlers for the client lifetime so replacement connections receive them.
   const notificationHandlers: Array<{
     method: string
@@ -95,8 +98,14 @@ export function createLSPClient(
     if (isStopping || unavailableReported) return
     unavailableReported = true
     isInitialized = false
+    capabilities = undefined
     startFailed = true
     startError = error
+    const unavailableConnection = connection
+    const unavailableProcess = process
+    connection = undefined
+    process = undefined
+    disposeResources(unavailableConnection, unavailableProcess)
     onCrash?.(error)
   }
 
@@ -115,6 +124,11 @@ export function createLSPClient(
     }
 
     if (!targetProcess) return
+    if (spawnWait?.process === targetProcess) {
+      spawnWait.reject(
+        new Error(`LSP server ${serverName} start was cancelled during spawn`),
+      )
+    }
     targetProcess.removeAllListeners('error')
     targetProcess.removeAllListeners('exit')
     targetProcess.stdin?.removeAllListeners('error')
@@ -132,11 +146,10 @@ export function createLSPClient(
     method: string,
     params: unknown,
   ): Promise<void> {
+    checkStartFailed()
     if (!connection) {
       throw new Error('LSP client not started')
     }
-
-    checkStartFailed()
 
     try {
       await connection.sendNotification(method, params)
@@ -166,7 +179,7 @@ export function createLSPClient(
         cwd?: string
       },
     ): Promise<void> {
-      if (stopPromise) await stopPromise
+      if (stopPromise) await stopPromise.catch(() => {})
 
       // A crashed transport may leave handles behind even though its owner has
       // already marked the server unavailable. Detach those handles before a
@@ -206,20 +219,22 @@ export function createLSPClient(
         // If we use the streams before confirming spawn succeeded, we get
         // unhandled promise rejections when writes fail on invalid streams.
         await new Promise<void>((resolve, reject) => {
-          const onSpawn = (): void => {
+          const resolveWait = (): void => {
             cleanup()
             resolve()
           }
-          const onError = (error: Error): void => {
+          const rejectWait = (error: Error): void => {
             cleanup()
             reject(error)
           }
           const cleanup = (): void => {
-            spawnedProcess.removeListener('spawn', onSpawn)
-            spawnedProcess.removeListener('error', onError)
+            spawnedProcess.removeListener('spawn', resolveWait)
+            spawnedProcess.removeListener('error', rejectWait)
+            if (spawnWait?.process === spawnedProcess) spawnWait = undefined
           }
-          spawnedProcess.once('spawn', onSpawn)
-          spawnedProcess.once('error', onError)
+          spawnWait = { process: spawnedProcess, reject: rejectWait }
+          spawnedProcess.once('spawn', resolveWait)
+          spawnedProcess.once('error', rejectWait)
         })
 
         // Capture stderr for server diagnostics and errors
@@ -344,21 +359,27 @@ export function createLSPClient(
     },
 
     async initialize(params: InitializeParams): Promise<InitializeResult> {
+      checkStartFailed()
       if (!connection) {
         throw new Error('LSP client not started')
       }
       const initializingConnection = connection
-
-      checkStartFailed()
 
       try {
         const result: InitializeResult = await initializingConnection.sendRequest(
           'initialize',
           params,
         )
+        checkStartFailed()
+        if (connection !== initializingConnection) {
+          throw new Error(
+            `LSP server ${serverName} connection changed during initialization`,
+          )
+        }
 
         // Send initialized notification
         await initializingConnection.sendNotification('initialized', {})
+        checkStartFailed()
 
         if (connection !== initializingConnection) {
           throw new Error(
@@ -386,11 +407,10 @@ export function createLSPClient(
       method: string,
       params: unknown,
     ): Promise<TResult> {
+      checkStartFailed()
       if (!connection) {
         throw new Error('LSP client not started')
       }
-
-      checkStartFailed()
 
       if (!isInitialized) {
         throw new Error('LSP server not initialized')
@@ -410,11 +430,10 @@ export function createLSPClient(
     },
 
     async sendNotification(method: string, params: unknown): Promise<void> {
+      checkStartFailed()
       if (!connection) {
         throw new Error('LSP client not started')
       }
-
-      checkStartFailed()
 
       try {
         await connection.sendNotification(method, params)
@@ -466,7 +485,7 @@ export function createLSPClient(
       connection.onRequest(method, handler)
     },
 
-    stop(): Promise<void> {
+    stop(options?: { force?: boolean }): Promise<void> {
       if (stopPromise) return stopPromise
 
       const stoppingConnection = connection
@@ -478,7 +497,7 @@ export function createLSPClient(
         isStopping = true
 
         try {
-          if (stoppingConnection) {
+          if (stoppingConnection && !options?.force) {
             // Try to send shutdown request and exit notification
             await stoppingConnection.sendRequest('shutdown', {})
             await stoppingConnection.sendNotification('exit', {})

--- a/src/services/lsp/LSPClient.ts
+++ b/src/services/lsp/LSPClient.ts
@@ -32,12 +32,23 @@ export type LSPClient = {
   initialize: (params: InitializeParams) => Promise<InitializeResult>
   sendRequest: <TResult>(method: string, params: unknown) => Promise<TResult>
   sendNotification: (method: string, params: unknown) => Promise<void>
+  sendNotificationStrict: (method: string, params: unknown) => Promise<void>
   onNotification: (method: string, handler: (params: unknown) => void) => void
   onRequest: <TParams, TResult>(
     method: string,
     handler: (params: TParams) => TResult | Promise<TResult>,
   ) => void
   stop: () => Promise<void>
+}
+
+export type LSPClientDependencies = {
+  spawnProcess: typeof spawn
+  createConnection: typeof createMessageConnection
+}
+
+const DEFAULT_DEPENDENCIES: LSPClientDependencies = {
+  spawnProcess: spawn,
+  createConnection: createMessageConnection,
 }
 
 /**
@@ -51,7 +62,9 @@ export type LSPClient = {
 export function createLSPClient(
   serverName: string,
   onCrash?: (error: Error) => void,
+  dependencyOverrides: Partial<LSPClientDependencies> = {},
 ): LSPClient {
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependencyOverrides }
   // State variables in closure
   let process: ChildProcess | undefined
   let connection: MessageConnection | undefined
@@ -60,12 +73,12 @@ export function createLSPClient(
   let startFailed = false
   let startError: Error | undefined
   let isStopping = false // Track intentional shutdown to avoid spurious error logging
-  // Queue handlers registered before connection ready (lazy initialization support)
-  const pendingHandlers: Array<{
+  // Retain handlers for the client lifetime so replacement connections receive them.
+  const notificationHandlers: Array<{
     method: string
     handler: (params: unknown) => void
   }> = []
-  const pendingRequestHandlers: Array<{
+  const requestHandlers: Array<{
     method: string
     handler: (params: unknown) => unknown | Promise<unknown>
   }> = []
@@ -73,6 +86,27 @@ export function createLSPClient(
   function checkStartFailed(): void {
     if (startFailed) {
       throw startError || new Error(`LSP server ${serverName} failed to start`)
+    }
+  }
+
+  async function sendNotificationStrict(
+    method: string,
+    params: unknown,
+  ): Promise<void> {
+    if (!connection) {
+      throw new Error('LSP client not started')
+    }
+
+    checkStartFailed()
+
+    try {
+      await connection.sendNotification(method, params)
+    } catch (error) {
+      const notificationError = new Error(
+        `LSP server ${serverName} notification ${method} failed: ${errorMessage(error)}`,
+      )
+      logError(notificationError)
+      throw notificationError
     }
   }
 
@@ -95,7 +129,7 @@ export function createLSPClient(
     ): Promise<void> {
       try {
         // 1. Spawn LSP server process
-        process = spawn(command, args, {
+        process = dependencies.spawnProcess(command, args, {
           stdio: ['pipe', 'pipe', 'pipe'],
           env: { ...subprocessEnv(), ...options?.env },
           cwd: options?.cwd,
@@ -180,7 +214,7 @@ export function createLSPClient(
         // 2. Create JSON-RPC connection
         const reader = new StreamMessageReader(process.stdout)
         const writer = new StreamMessageWriter(process.stdin)
-        connection = createMessageConnection(reader, writer)
+        connection = dependencies.createConnection(reader, writer)
 
         // 2.5. Register error/close handlers BEFORE listen() to catch all errors
         // This prevents unhandled promise rejections when the server crashes or closes unexpectedly
@@ -225,23 +259,21 @@ export function createLSPClient(
             )
           })
 
-        // 4. Apply any queued notification handlers
-        for (const { method, handler } of pendingHandlers) {
+        // 4. Apply all retained notification handlers to this connection
+        for (const { method, handler } of notificationHandlers) {
           connection.onNotification(method, handler)
           logForDebugging(
-            `Applied queued notification handler for ${serverName}.${method}`,
+            `Applied notification handler for ${serverName}.${method}`,
           )
         }
-        pendingHandlers.length = 0 // Clear the queue
 
-        // 5. Apply any queued request handlers
-        for (const { method, handler } of pendingRequestHandlers) {
+        // 5. Apply all retained request handlers to this connection
+        for (const { method, handler } of requestHandlers) {
           connection.onRequest(method, handler)
           logForDebugging(
-            `Applied queued request handler for ${serverName}.${method}`,
+            `Applied request handler for ${serverName}.${method}`,
           )
         }
-        pendingRequestHandlers.length = 0 // Clear the queue
 
         logForDebugging(`LSP client started for ${serverName}`)
       } catch (error) {
@@ -334,10 +366,11 @@ export function createLSPClient(
       }
     },
 
+    sendNotificationStrict,
+
     onNotification(method: string, handler: (params: unknown) => void): void {
+      notificationHandlers.push({ method, handler })
       if (!connection) {
-        // Queue handler for application when connection is ready (lazy initialization)
-        pendingHandlers.push({ method, handler })
         logForDebugging(
           `Queued notification handler for ${serverName}.${method} (connection not ready)`,
         )
@@ -353,12 +386,11 @@ export function createLSPClient(
       method: string,
       handler: (params: TParams) => TResult | Promise<TResult>,
     ): void {
+      requestHandlers.push({
+        method,
+        handler: handler as (params: unknown) => unknown | Promise<unknown>,
+      })
       if (!connection) {
-        // Queue handler for application when connection is ready (lazy initialization)
-        pendingRequestHandlers.push({
-          method,
-          handler: handler as (params: unknown) => unknown | Promise<unknown>,
-        })
         logForDebugging(
           `Queued request handler for ${serverName}.${method} (connection not ready)`,
         )

--- a/src/services/lsp/LSPClient.ts
+++ b/src/services/lsp/LSPClient.ts
@@ -55,9 +55,9 @@ const DEFAULT_DEPENDENCIES: LSPClientDependencies = {
  * Create an LSP client wrapper using vscode-jsonrpc.
  * Manages communication with an LSP server process via stdio.
  *
- * @param onCrash - Called when the server process exits unexpectedly (non-zero
- *   exit code during operation, not during intentional stop). Allows the owner
- *   to propagate crash state so the server can be restarted on next use.
+ * @param onCrash - Called when the active process or JSON-RPC connection becomes
+ *   unavailable outside intentional shutdown. Allows the owner to propagate
+ *   crash state so the server can be restarted on next use.
  */
 export function createLSPClient(
   serverName: string,
@@ -73,6 +73,8 @@ export function createLSPClient(
   let startFailed = false
   let startError: Error | undefined
   let isStopping = false // Track intentional shutdown to avoid spurious error logging
+  let unavailableReported = false
+  let stopPromise: Promise<void> | undefined
   // Retain handlers for the client lifetime so replacement connections receive them.
   const notificationHandlers: Array<{
     method: string
@@ -86,6 +88,43 @@ export function createLSPClient(
   function checkStartFailed(): void {
     if (startFailed) {
       throw startError || new Error(`LSP server ${serverName} failed to start`)
+    }
+  }
+
+  function reportUnavailable(error: Error): void {
+    if (isStopping || unavailableReported) return
+    unavailableReported = true
+    isInitialized = false
+    startFailed = true
+    startError = error
+    onCrash?.(error)
+  }
+
+  function disposeResources(
+    targetConnection: MessageConnection | undefined,
+    targetProcess: ChildProcess | undefined,
+  ): void {
+    if (targetConnection) {
+      try {
+        targetConnection.dispose()
+      } catch (error) {
+        logForDebugging(
+          `Connection disposal failed for ${serverName}: ${errorMessage(error)}`,
+        )
+      }
+    }
+
+    if (!targetProcess) return
+    targetProcess.removeAllListeners('error')
+    targetProcess.removeAllListeners('exit')
+    targetProcess.stdin?.removeAllListeners('error')
+    targetProcess.stderr?.removeAllListeners('data')
+    try {
+      targetProcess.kill()
+    } catch (error) {
+      logForDebugging(
+        `Process kill failed for ${serverName} (may already be dead): ${errorMessage(error)}`,
+      )
     }
   }
 
@@ -127,17 +166,37 @@ export function createLSPClient(
         cwd?: string
       },
     ): Promise<void> {
+      if (stopPromise) await stopPromise
+
+      // A crashed transport may leave handles behind even though its owner has
+      // already marked the server unavailable. Detach those handles before a
+      // replacement is installed so they cannot leak across generations.
+      if (connection || process) {
+        const staleConnection = connection
+        const staleProcess = process
+        connection = undefined
+        process = undefined
+        disposeResources(staleConnection, staleProcess)
+      }
+
       try {
+        unavailableReported = false
+        startFailed = false
+        startError = undefined
+        isInitialized = false
+        capabilities = undefined
+
         // 1. Spawn LSP server process
-        process = dependencies.spawnProcess(command, args, {
+        const spawnedProcess = dependencies.spawnProcess(command, args, {
           stdio: ['pipe', 'pipe', 'pipe'],
           env: { ...subprocessEnv(), ...options?.env },
           cwd: options?.cwd,
           // Prevent visible console window on Windows (no-op on other platforms)
           windowsHide: true,
         })
+        process = spawnedProcess
 
-        if (!process.stdout || !process.stdin) {
+        if (!spawnedProcess.stdout || !spawnedProcess.stdin) {
           throw new Error('LSP server process stdio not available')
         }
 
@@ -146,7 +205,6 @@ export function createLSPClient(
         // (e.g., ENOENT for command not found) fires asynchronously.
         // If we use the streams before confirming spawn succeeded, we get
         // unhandled promise rejections when writes fail on invalid streams.
-        const spawnedProcess = process // Capture for closure
         await new Promise<void>((resolve, reject) => {
           const onSpawn = (): void => {
             cleanup()
@@ -165,8 +223,8 @@ export function createLSPClient(
         })
 
         // Capture stderr for server diagnostics and errors
-        if (process.stderr) {
-          process.stderr.on('data', (data: Buffer) => {
+        if (spawnedProcess.stderr) {
+          spawnedProcess.stderr.on('data', (data: Buffer) => {
             const output = data.toString().trim()
             if (output) {
               logForDebugging(`[LSP SERVER ${serverName}] ${output}`)
@@ -175,10 +233,10 @@ export function createLSPClient(
         }
 
         // Handle process errors (after successful spawn, e.g., crash during operation)
-        process.on('error', error => {
+        spawnedProcess.on('error', error => {
+          if (process !== spawnedProcess || isStopping) return
+          reportUnavailable(error)
           if (!isStopping) {
-            startFailed = true
-            startError = error
             logError(
               new Error(
                 `LSP server ${serverName} failed to start: ${error.message}`,
@@ -187,23 +245,21 @@ export function createLSPClient(
           }
         })
 
-        process.on('exit', (code, _signal) => {
-          if (code !== 0 && code !== null && !isStopping) {
-            isInitialized = false
-            startFailed = false
-            startError = undefined
-            const crashError = new Error(
-              `LSP server ${serverName} crashed with exit code ${code}`,
-            )
-            logError(crashError)
-            onCrash?.(crashError)
-          }
+        spawnedProcess.on('exit', (code, signal) => {
+          if (process !== spawnedProcess || isStopping) return
+          const exitDetail =
+            signal !== null ? `signal ${signal}` : `exit code ${code}`
+          const crashError = new Error(
+            `LSP server ${serverName} exited unexpectedly with ${exitDetail}`,
+          )
+          logError(crashError)
+          reportUnavailable(crashError)
         })
 
         // Handle stdin stream errors to prevent unhandled promise rejections
         // when the LSP server process exits before we finish writing
-        process.stdin.on('error', (error: Error) => {
-          if (!isStopping) {
+        spawnedProcess.stdin.on('error', (error: Error) => {
+          if (process === spawnedProcess && !isStopping) {
             logForDebugging(
               `LSP server ${serverName} stdin error: ${error.message}`,
             )
@@ -212,17 +268,18 @@ export function createLSPClient(
         })
 
         // 2. Create JSON-RPC connection
-        const reader = new StreamMessageReader(process.stdout)
-        const writer = new StreamMessageWriter(process.stdin)
-        connection = dependencies.createConnection(reader, writer)
+        const reader = new StreamMessageReader(spawnedProcess.stdout)
+        const writer = new StreamMessageWriter(spawnedProcess.stdin)
+        const startedConnection = dependencies.createConnection(reader, writer)
+        connection = startedConnection
 
         // 2.5. Register error/close handlers BEFORE listen() to catch all errors
         // This prevents unhandled promise rejections when the server crashes or closes unexpectedly
-        connection.onError(([error, _message, _code]) => {
+        startedConnection.onError(([error, _message, _code]) => {
+          if (connection !== startedConnection || isStopping) return
+          reportUnavailable(error)
           // Only log if not intentionally stopping (avoid spurious errors during shutdown)
           if (!isStopping) {
-            startFailed = true
-            startError = error
             logError(
               new Error(
                 `LSP server ${serverName} connection error: ${error.message}`,
@@ -231,23 +288,24 @@ export function createLSPClient(
           }
         })
 
-        connection.onClose(() => {
+        startedConnection.onClose(() => {
+          if (connection !== startedConnection || isStopping) return
           // Only treat as error if not intentionally stopping
-          if (!isStopping) {
-            isInitialized = false
-            // Don't set startFailed here - the connection may close after graceful shutdown
-            logForDebugging(`LSP server ${serverName} connection closed`)
-          }
+          const closeError = new Error(
+            `LSP server ${serverName} connection closed unexpectedly`,
+          )
+          logForDebugging(closeError.message)
+          reportUnavailable(closeError)
         })
 
         // 3. Start listening for messages
-        connection.listen()
+        startedConnection.listen()
 
         // 3.5. Enable protocol tracing for debugging
         // Note: trace() sends a $/setTrace notification which can fail if the server
         // process has already exited. We catch and log the error rather than letting
         // it become an unhandled promise rejection.
-        connection
+        startedConnection
           .trace(Trace.Verbose, {
             log: (message: string) => {
               logForDebugging(`[LSP PROTOCOL ${serverName}] ${message}`)
@@ -261,7 +319,7 @@ export function createLSPClient(
 
         // 4. Apply all retained notification handlers to this connection
         for (const { method, handler } of notificationHandlers) {
-          connection.onNotification(method, handler)
+          startedConnection.onNotification(method, handler)
           logForDebugging(
             `Applied notification handler for ${serverName}.${method}`,
           )
@@ -269,7 +327,7 @@ export function createLSPClient(
 
         // 5. Apply all retained request handlers to this connection
         for (const { method, handler } of requestHandlers) {
-          connection.onRequest(method, handler)
+          startedConnection.onRequest(method, handler)
           logForDebugging(
             `Applied request handler for ${serverName}.${method}`,
           )
@@ -289,20 +347,26 @@ export function createLSPClient(
       if (!connection) {
         throw new Error('LSP client not started')
       }
+      const initializingConnection = connection
 
       checkStartFailed()
 
       try {
-        const result: InitializeResult = await connection.sendRequest(
+        const result: InitializeResult = await initializingConnection.sendRequest(
           'initialize',
           params,
         )
 
-        capabilities = result.capabilities
-
         // Send initialized notification
-        await connection.sendNotification('initialized', {})
+        await initializingConnection.sendNotification('initialized', {})
 
+        if (connection !== initializingConnection) {
+          throw new Error(
+            `LSP server ${serverName} connection changed during initialization`,
+          )
+        }
+
+        capabilities = result.capabilities
         isInitialized = true
         logForDebugging(`LSP server ${serverName} initialized`)
 
@@ -402,78 +466,58 @@ export function createLSPClient(
       connection.onRequest(method, handler)
     },
 
-    async stop(): Promise<void> {
-      let shutdownError: Error | undefined
+    stop(): Promise<void> {
+      if (stopPromise) return stopPromise
 
-      // Mark as stopping to prevent error handlers from logging spurious errors
-      isStopping = true
+      const stoppingConnection = connection
+      const stoppingProcess = process
+      const pending = (async () => {
+        let shutdownError: Error | undefined
 
-      try {
-        if (connection) {
-          // Try to send shutdown request and exit notification
-          await connection.sendRequest('shutdown', {})
-          await connection.sendNotification('exit', {})
-        }
-      } catch (error) {
-        const err = error as Error
-        logError(
-          new Error(`LSP server ${serverName} stop failed: ${err.message}`),
-        )
-        shutdownError = err
-        // Continue to cleanup despite shutdown failure
-      } finally {
-        // Always cleanup resources, even if shutdown/exit failed
-        if (connection) {
-          try {
-            connection.dispose()
-          } catch (error) {
-            // Log but don't throw - disposal errors are less critical
-            logForDebugging(
-              `Connection disposal failed for ${serverName}: ${errorMessage(error)}`,
-            )
+        // Mark as stopping to prevent error handlers from logging spurious errors
+        isStopping = true
+
+        try {
+          if (stoppingConnection) {
+            // Try to send shutdown request and exit notification
+            await stoppingConnection.sendRequest('shutdown', {})
+            await stoppingConnection.sendNotification('exit', {})
           }
-          connection = undefined
-        }
+        } catch (error) {
+          const err = error as Error
+          logError(
+            new Error(`LSP server ${serverName} stop failed: ${err.message}`),
+          )
+          shutdownError = err
+          // Continue to cleanup despite shutdown failure
+        } finally {
+          // Always cleanup the resources captured for this stop attempt.
+          if (connection === stoppingConnection) connection = undefined
+          if (process === stoppingProcess) process = undefined
+          disposeResources(stoppingConnection, stoppingProcess)
 
-        if (process) {
-          // Remove event listeners to prevent memory leaks
-          process.removeAllListeners('error')
-          process.removeAllListeners('exit')
-          if (process.stdin) {
-            process.stdin.removeAllListeners('error')
+          if (!connection) {
+            isInitialized = false
+            capabilities = undefined
           }
-          if (process.stderr) {
-            process.stderr.removeAllListeners('data')
+          isStopping = false // Reset for potential restart
+          // Don't reset startFailed - preserve error state for diagnostics
+          if (shutdownError) {
+            startFailed = true
+            startError = shutdownError
           }
 
-          try {
-            process.kill()
-          } catch (error) {
-            // Process might already be dead, which is fine
-            logForDebugging(
-              `Process kill failed for ${serverName} (may already be dead): ${errorMessage(error)}`,
-            )
-          }
-          process = undefined
+          logForDebugging(`LSP client stopped for ${serverName}`)
         }
 
-        isInitialized = false
-        capabilities = undefined
-        isStopping = false // Reset for potential restart
-        // Don't reset startFailed - preserve error state for diagnostics
-        // startFailed and startError remain as-is
-        if (shutdownError) {
-          startFailed = true
-          startError = shutdownError
-        }
+        // Re-throw shutdown error after cleanup is complete
+        if (shutdownError) throw shutdownError
+      })()
 
-        logForDebugging(`LSP client stopped for ${serverName}`)
-      }
-
-      // Re-throw shutdown error after cleanup is complete
-      if (shutdownError) {
-        throw shutdownError
-      }
+      stopPromise = pending.finally(() => {
+        stopPromise = undefined
+      })
+      return stopPromise
     },
   }
 }

--- a/src/services/lsp/LSPClient.ts
+++ b/src/services/lsp/LSPClient.ts
@@ -94,6 +94,17 @@ export function createLSPClient(
     }
   }
 
+  function reportTransportUnavailable(error: Error): void {
+    if (isStopping) return
+    isInitialized = false
+    capabilities = undefined
+    startFailed = true
+    startError = error
+    const unavailableConnection = connection
+    connection = undefined
+    disposeResources(unavailableConnection, undefined)
+  }
+
   function reportUnavailable(error: Error): void {
     if (isStopping || unavailableReported) return
     unavailableReported = true
@@ -250,7 +261,7 @@ export function createLSPClient(
         // Handle process errors (after successful spawn, e.g., crash during operation)
         spawnedProcess.on('error', error => {
           if (process !== spawnedProcess || isStopping) return
-          reportUnavailable(error)
+          reportTransportUnavailable(error)
           if (!isStopping) {
             logError(
               new Error(
@@ -262,6 +273,7 @@ export function createLSPClient(
 
         spawnedProcess.on('exit', (code, signal) => {
           if (process !== spawnedProcess || isStopping) return
+          if (code === 0 || code === null) return
           const exitDetail =
             signal !== null ? `signal ${signal}` : `exit code ${code}`
           const crashError = new Error(
@@ -292,7 +304,7 @@ export function createLSPClient(
         // This prevents unhandled promise rejections when the server crashes or closes unexpectedly
         startedConnection.onError(([error, _message, _code]) => {
           if (connection !== startedConnection || isStopping) return
-          reportUnavailable(error)
+          reportTransportUnavailable(error)
           // Only log if not intentionally stopping (avoid spurious errors during shutdown)
           if (!isStopping) {
             logError(
@@ -310,7 +322,7 @@ export function createLSPClient(
             `LSP server ${serverName} connection closed unexpectedly`,
           )
           logForDebugging(closeError.message)
-          reportUnavailable(closeError)
+          reportTransportUnavailable(closeError)
         })
 
         // 3. Start listening for messages

--- a/src/services/lsp/LSPServerInstance.test.ts
+++ b/src/services/lsp/LSPServerInstance.test.ts
@@ -19,8 +19,17 @@ type FakeClientController = {
   crash(error?: Error): void
   failNextInitialize(error: Error): void
   failNextRequest(error: Error): { called: Promise<void> }
+  failNextStop(error: Error): void
+  finishNextInitializeUnhealthy(): void
+  holdNextRequest<TResult>(result: TResult): {
+    started: Promise<void>
+    release(): void
+  }
   holdNextInitialize(): { started: Promise<void>; release(): void }
-  holdNextStop(): { started: Promise<void>; release(): void }
+  holdNextStop(options?: { blockForce?: boolean }): {
+    started: Promise<void>
+    release(): void
+  }
   startCalls: ReturnType<typeof mock>
   initializeCalls: ReturnType<typeof mock>
   stopCalls: ReturnType<typeof mock>
@@ -31,6 +40,8 @@ function createFakeClientController(): FakeClientController {
   let initialized = false
   let onCrash: ((error: Error) => void) | undefined
   let initializeError: Error | undefined
+  let initializeUnhealthy = false
+  let stopError: Error | undefined
   let requestFailure:
     | { error: Error; calledResolve: () => void }
     | undefined
@@ -43,6 +54,15 @@ function createFakeClientController(): FakeClientController {
     | undefined
   let stopGate:
     | {
+        startedResolve: () => void
+        wait: Promise<void>
+        release: () => void
+        blockForce: boolean
+      }
+    | undefined
+  let requestGate:
+    | {
+        result: unknown
         startedResolve: () => void
         wait: Promise<void>
         release: () => void
@@ -61,19 +81,34 @@ function createFakeClientController(): FakeClientController {
       initializeError = undefined
       throw error
     }
-    initialized = true
+    initialized = !initializeUnhealthy
+    initializeUnhealthy = false
     return { capabilities: {} } satisfies InitializeResult
   })
 
-  const stopCalls = mock(async () => {
-    stopGate?.startedResolve()
-    if (stopGate) {
+  const stopCalls = mock(async (options?: { force?: boolean }) => {
+    const shouldBlock =
+      stopGate && (!options?.force || stopGate.blockForce)
+    if (shouldBlock) stopGate?.startedResolve()
+    if (stopGate && shouldBlock) {
       await stopGate.wait
       stopGate = undefined
     }
     initialized = false
+    if (stopError) {
+      const error = stopError
+      stopError = undefined
+      throw error
+    }
   })
   const sendRequestCalls = mock(async <TResult>() => {
+    if (requestGate) {
+      const gate = requestGate
+      gate.startedResolve()
+      await gate.wait
+      requestGate = undefined
+      return gate.result as TResult
+    }
     if (requestFailure) {
       const failure = requestFailure
       requestFailure = undefined
@@ -120,6 +155,24 @@ function createFakeClientController(): FakeClientController {
       requestFailure = { error, calledResolve }
       return { called }
     },
+    failNextStop(error) {
+      stopError = error
+    },
+    finishNextInitializeUnhealthy() {
+      initializeUnhealthy = true
+    },
+    holdNextRequest(result) {
+      let startedResolve!: () => void
+      let release!: () => void
+      const started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      const wait = new Promise<void>(resolve => {
+        release = resolve
+      })
+      requestGate = { result, startedResolve, wait, release }
+      return { started, release }
+    },
     holdNextInitialize() {
       let startedResolve!: () => void
       let release!: () => void
@@ -132,7 +185,7 @@ function createFakeClientController(): FakeClientController {
       initializeGate = { startedResolve, wait, release }
       return { started, release }
     },
-    holdNextStop() {
+    holdNextStop(options = {}) {
       let startedResolve!: () => void
       let release!: () => void
       const started = new Promise<void>(resolve => {
@@ -141,7 +194,12 @@ function createFakeClientController(): FakeClientController {
       const wait = new Promise<void>(resolve => {
         release = resolve
       })
-      stopGate = { startedResolve, wait, release }
+      stopGate = {
+        startedResolve,
+        wait,
+        release,
+        blockForce: options.blockForce ?? true,
+      }
       return { started, release }
     },
     startCalls,
@@ -286,6 +344,112 @@ describe('LSP server generations', () => {
     await instance.start()
     expect(fake.startCalls).toHaveBeenCalledTimes(2)
     expect(instance.generation).toBe(1)
+  })
+
+  test('starts after an overlapping stop fails', async () => {
+    const fake = createFakeClientController()
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+    await instance.start()
+    const stopError = new Error('shutdown rejected')
+    fake.failNextStop(stopError)
+
+    const stopOutcome = instance.stop().then(
+      () => undefined,
+      error => error,
+    )
+    const restart = instance.start()
+
+    expect(await stopOutcome).toBe(stopError)
+    await expect(restart).resolves.toBeUndefined()
+    expect(instance.state).toBe('running')
+    expect(instance.generation).toBe(2)
+  })
+
+  test('a stop during initialization wins over the cancelled start', async () => {
+    const fake = createFakeClientController()
+    const initializeGate = fake.holdNextInitialize()
+    const stopGate = fake.holdNextStop()
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+
+    const start = instance.start()
+    await initializeGate.started
+    const stop = instance.stop()
+    await stopGate.started
+
+    initializeGate.release()
+    await Promise.resolve()
+    stopGate.release()
+
+    await expect(start).rejects.toThrow('start was cancelled')
+    await expect(stop).resolves.toBeUndefined()
+    expect(instance.state).toBe('stopped')
+    expect(instance.generation).toBe(0)
+  })
+
+  test('startup timeout uses immediate cleanup instead of graceful shutdown', async () => {
+    const fake = createFakeClientController()
+    const initializeGate = fake.holdNextInitialize()
+    const stopGate = fake.holdNextStop({ blockForce: false })
+    const instance = createLSPServerInstance(
+      'typescript',
+      { ...CONFIG, startupTimeout: 5 },
+      { createClient: fake.createClient },
+    )
+
+    const startOutcome = instance.start().then(
+      () => 'resolved',
+      () => 'rejected',
+    )
+    await initializeGate.started
+
+    try {
+      const outcome = await Promise.race([
+        startOutcome,
+        new Promise<'pending'>(resolve =>
+          setTimeout(() => resolve('pending'), 30),
+        ),
+      ])
+      expect(outcome).toBe('rejected')
+      expect(fake.stopCalls).toHaveBeenCalledWith({ force: true })
+    } finally {
+      initializeGate.release()
+      stopGate.release()
+      await startOutcome
+    }
+  })
+
+  test('does not publish a generation when initialization reports unhealthy', async () => {
+    const fake = createFakeClientController()
+    fake.finishNextInitializeUnhealthy()
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+
+    await expect(instance.start()).rejects.toThrow('did not finish initialization')
+    expect(instance.state).toBe('error')
+    expect(instance.generation).toBe(0)
+  })
+
+  test('rejects a successful response from a replaced generation', async () => {
+    const fake = createFakeClientController()
+    const requestGate = fake.holdNextRequest('stale response')
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+    await instance.start()
+
+    const request = instance.sendRequest<string>('textDocument/hover', {})
+    await requestGate.started
+    fake.crash()
+    await instance.start()
+    requestGate.release()
+
+    await expect(request).rejects.toThrow('changed generation')
+    expect(instance.generation).toBe(2)
   })
 
   test('does not retry ContentModified on a replacement generation', async () => {

--- a/src/services/lsp/LSPServerInstance.test.ts
+++ b/src/services/lsp/LSPServerInstance.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, mock, test } from 'bun:test'
+import { describe, expect, jest, mock, test } from 'bun:test'
 import type { InitializeParams, InitializeResult } from 'vscode-languageserver-protocol'
 import type { LSPClient } from './LSPClient.js'
 import { createLSPServerInstance } from './LSPServerInstance.js'
@@ -447,6 +447,7 @@ describe('LSP server generations', () => {
   })
 
   test('startup timeout also bounds the process spawn wait', async () => {
+    jest.useFakeTimers()
     const fake = createFakeClientController()
     const startGate = fake.holdNextStart()
     const instance = createLSPServerInstance('typescript', CONFIG, {
@@ -456,34 +457,26 @@ describe('LSP server generations', () => {
 
     const start = instance.start()
     await startGate.started
-    const outcome = await Promise.race([
-      start.then(
-        () => ({ status: 'resolved' as const }),
-        error => ({ status: 'rejected' as const, error }),
-      ),
-      new Promise<{ status: 'pending' }>(resolve =>
-        setTimeout(() => resolve({ status: 'pending' }), 20),
-      ),
-    ])
 
     try {
-      expect(outcome).toMatchObject({
-        status: 'rejected',
-        error: expect.objectContaining({
-          message: expect.stringContaining(
-            'timed out after 5ms during process startup',
-          ),
-        }),
-      })
+      jest.advanceTimersByTime(4)
+      expect(instance.state).toBe('starting')
+      jest.advanceTimersByTime(1)
+      await expect(start).rejects.toThrow(
+        'timed out after 5ms during process startup',
+      )
       expect(fake.initializeCalls).not.toHaveBeenCalled()
       expect(fake.stopCalls).toHaveBeenCalledWith({ force: true })
     } finally {
       startGate.release()
+      jest.runAllTimers()
+      jest.useRealTimers()
       await start.catch(() => {})
     }
   })
 
   test('applies a bounded default when startupTimeout is omitted', async () => {
+    jest.useFakeTimers()
     const fake = createFakeClientController()
     const initializeGate = fake.holdNextInitialize()
     const instance = createLSPServerInstance('typescript', CONFIG, {
@@ -493,26 +486,17 @@ describe('LSP server generations', () => {
 
     const start = instance.start()
     await initializeGate.started
-    const outcome = await Promise.race([
-      start.then(
-        () => ({ status: 'resolved' as const }),
-        error => ({ status: 'rejected' as const, error }),
-      ),
-      new Promise<{ status: 'pending' }>(resolve =>
-        setTimeout(() => resolve({ status: 'pending' }), 20),
-      ),
-    ])
 
     try {
-      expect(outcome).toMatchObject({
-        status: 'rejected',
-        error: expect.objectContaining({
-          message: expect.stringContaining('timed out after 5ms'),
-        }),
-      })
+      jest.advanceTimersByTime(4)
+      expect(instance.state).toBe('starting')
+      jest.advanceTimersByTime(1)
+      await expect(start).rejects.toThrow('timed out after 5ms')
       expect(fake.stopCalls).toHaveBeenCalledWith({ force: true })
     } finally {
       initializeGate.release()
+      jest.runAllTimers()
+      jest.useRealTimers()
       await start.catch(() => {})
     }
   })

--- a/src/services/lsp/LSPServerInstance.test.ts
+++ b/src/services/lsp/LSPServerInstance.test.ts
@@ -529,7 +529,7 @@ describe('LSP server generations', () => {
     fake.crash()
 
     await expect(instance.start()).rejects.toThrow(
-      'exceeded max crash recovery attempts (2)',
+      'exceeded max automatic recovery attempts (2)',
     )
     expect(fake.startCalls).toHaveBeenCalledTimes(3)
     expect(instance.generation).toBe(3)
@@ -574,7 +574,7 @@ describe('LSP server generations', () => {
     await instance.stop()
     expect(instance.state).toBe('stopped')
     await expect(instance.start()).rejects.toThrow(
-      'exceeded max crash recovery attempts (0)',
+      'exceeded max automatic recovery attempts (0)',
     )
     expect(instance.isCrashRecoveryExhausted).toBe(true)
     expect(fake.startCalls).toHaveBeenCalledTimes(1)

--- a/src/services/lsp/LSPServerInstance.test.ts
+++ b/src/services/lsp/LSPServerInstance.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, mock, test } from 'bun:test'
+import type { InitializeParams, InitializeResult } from 'vscode-languageserver-protocol'
+import type { LSPClient } from './LSPClient.js'
+import { createLSPServerInstance } from './LSPServerInstance.js'
+import type { ScopedLspServerConfig } from './types.js'
+
+const CONFIG: ScopedLspServerConfig = {
+  command: 'unused-test-lsp',
+  extensionToLanguage: { '.ts': 'typescript' },
+  scope: 'project',
+  source: 'test',
+}
+
+type FakeClientController = {
+  createClient: (
+    serverName: string,
+    onCrash?: (error: Error) => void,
+  ) => LSPClient
+  crash(error?: Error): void
+  failNextInitialize(error: Error): void
+  holdNextInitialize(): { started: Promise<void>; release(): void }
+  startCalls: ReturnType<typeof mock>
+  initializeCalls: ReturnType<typeof mock>
+}
+
+function createFakeClientController(): FakeClientController {
+  let initialized = false
+  let onCrash: ((error: Error) => void) | undefined
+  let initializeError: Error | undefined
+  let initializeGate:
+    | {
+        startedResolve: () => void
+        wait: Promise<void>
+        release: () => void
+      }
+    | undefined
+
+  const startCalls = mock(async () => {})
+  const initializeCalls = mock(async (_params: InitializeParams) => {
+    initializeGate?.startedResolve()
+    if (initializeGate) {
+      await initializeGate.wait
+      initializeGate = undefined
+    }
+    if (initializeError) {
+      const error = initializeError
+      initializeError = undefined
+      throw error
+    }
+    initialized = true
+    return { capabilities: {} } satisfies InitializeResult
+  })
+
+  const client: LSPClient = {
+    get capabilities() {
+      return {}
+    },
+    get isInitialized() {
+      return initialized
+    },
+    start: startCalls,
+    initialize: initializeCalls,
+    sendRequest: async <TResult>() => undefined as TResult,
+    sendNotification: async () => {},
+    sendNotificationStrict: async () => {},
+    onNotification: () => {},
+    onRequest: () => {},
+    stop: async () => {
+      initialized = false
+    },
+  }
+
+  return {
+    createClient: (_serverName, crashHandler) => {
+      onCrash = crashHandler
+      return client
+    },
+    crash(error = new Error('test crash')) {
+      initialized = false
+      onCrash?.(error)
+    },
+    failNextInitialize(error) {
+      initializeError = error
+    },
+    holdNextInitialize() {
+      let startedResolve!: () => void
+      let release!: () => void
+      const started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      const wait = new Promise<void>(resolve => {
+        release = resolve
+      })
+      initializeGate = { startedResolve, wait, release }
+      return { started, release }
+    },
+    startCalls,
+    initializeCalls,
+  }
+}
+
+describe('LSP server generations', () => {
+  test('advance only after successful initialization and change after restart', async () => {
+    const fake = createFakeClientController()
+    const unavailableGenerations: number[] = []
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+      onUnavailable: generation => unavailableGenerations.push(generation),
+    })
+
+    expect(instance.generation).toBe(0)
+
+    await instance.start()
+    expect(instance.generation).toBe(1)
+    await instance.start()
+    expect(instance.generation).toBe(1)
+    expect(fake.initializeCalls).toHaveBeenCalledTimes(1)
+
+    await instance.stop()
+    expect(instance.generation).toBe(1)
+    expect(unavailableGenerations).toEqual([1])
+
+    await instance.start()
+    expect(instance.generation).toBe(2)
+
+    fake.crash()
+    expect(instance.state).toBe('error')
+    expect(instance.generation).toBe(2)
+    expect(unavailableGenerations).toEqual([1, 2])
+
+    await instance.start()
+    expect(instance.generation).toBe(3)
+
+    await instance.stop()
+    fake.failNextInitialize(new Error('initialize rejected'))
+    await expect(instance.start()).rejects.toThrow('initialize rejected')
+    expect(instance.generation).toBe(3)
+  })
+
+  test('concurrent callers await one in-flight initialization', async () => {
+    const fake = createFakeClientController()
+    const gate = fake.holdNextInitialize()
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+
+    const firstStart = instance.start()
+    await gate.started
+    const secondStart = instance.start()
+
+    expect(fake.startCalls).toHaveBeenCalledTimes(1)
+    expect(fake.initializeCalls).toHaveBeenCalledTimes(1)
+    expect(instance.state).toBe('starting')
+
+    gate.release()
+    await Promise.all([firstStart, secondStart])
+
+    expect(instance.state).toBe('running')
+    expect(instance.generation).toBe(1)
+    expect(fake.startCalls).toHaveBeenCalledTimes(1)
+    expect(fake.initializeCalls).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/services/lsp/LSPServerInstance.test.ts
+++ b/src/services/lsp/LSPServerInstance.test.ts
@@ -19,6 +19,7 @@ type FakeClientController = {
   crash(error?: Error): void
   failNextInitialize(error: Error): void
   failNextRequest(error: Error): { called: Promise<void> }
+  failNextStrictNotification(error: Error): void
   failNextStop(error: Error): void
   finishNextInitializeUnhealthy(): void
   holdNextRequest<TResult>(result: TResult): {
@@ -42,6 +43,7 @@ function createFakeClientController(): FakeClientController {
   let onCrash: ((error: Error) => void) | undefined
   let initializeError: Error | undefined
   let initializeUnhealthy = false
+  let strictNotificationError: Error | undefined
   let stopError: Error | undefined
   let requestFailure:
     | { error: Error; calledResolve: () => void }
@@ -131,6 +133,13 @@ function createFakeClientController(): FakeClientController {
     }
     return undefined as TResult
   })
+  const sendNotificationStrictCalls = mock(async () => {
+    if (strictNotificationError) {
+      const error = strictNotificationError
+      strictNotificationError = undefined
+      throw error
+    }
+  })
 
   const client: LSPClient = {
     get capabilities() {
@@ -143,7 +152,7 @@ function createFakeClientController(): FakeClientController {
     initialize: initializeCalls,
     sendRequest: sendRequestCalls as LSPClient['sendRequest'],
     sendNotification: async () => {},
-    sendNotificationStrict: async () => {},
+    sendNotificationStrict: sendNotificationStrictCalls,
     onNotification: () => {},
     onRequest: () => {},
     stop: stopCalls,
@@ -168,6 +177,9 @@ function createFakeClientController(): FakeClientController {
       })
       requestFailure = { error, calledResolve }
       return { called }
+    },
+    failNextStrictNotification(error) {
+      strictNotificationError = error
     },
     failNextStop(error) {
       stopError = error
@@ -236,6 +248,34 @@ function createFakeClientController(): FakeClientController {
 }
 
 describe('LSP server generations', () => {
+  test('rejects strict notifications while the server is unhealthy', async () => {
+    const fake = createFakeClientController()
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+
+    await expect(
+      instance.sendNotificationStrict('textDocument/didOpen', {}),
+    ).rejects.toThrow(
+      "Cannot send notification to LSP server 'typescript': server is stopped",
+    )
+  })
+
+  test('wraps strict notification client failures with instance context', async () => {
+    const fake = createFakeClientController()
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+    await instance.start()
+    fake.failNextStrictNotification(new Error('writer rejected'))
+
+    await expect(
+      instance.sendNotificationStrict('textDocument/didOpen', {}),
+    ).rejects.toThrow(
+      "LSP notification 'textDocument/didOpen' failed for server 'typescript': writer rejected",
+    )
+  })
+
   test('advance only after successful initialization and change after restart', async () => {
     const fake = createFakeClientController()
     const unavailableGenerations: number[] = []

--- a/src/services/lsp/LSPServerInstance.test.ts
+++ b/src/services/lsp/LSPServerInstance.test.ts
@@ -400,25 +400,16 @@ describe('LSP server generations', () => {
       { createClient: fake.createClient },
     )
 
-    const startOutcome = instance.start().then(
-      () => 'resolved',
-      () => 'rejected',
-    )
+    const start = instance.start()
     await initializeGate.started
 
     try {
-      const outcome = await Promise.race([
-        startOutcome,
-        new Promise<'pending'>(resolve =>
-          setTimeout(() => resolve('pending'), 30),
-        ),
-      ])
-      expect(outcome).toBe('rejected')
+      await expect(start).rejects.toThrow('timed out')
       expect(fake.stopCalls).toHaveBeenCalledWith({ force: true })
     } finally {
       initializeGate.release()
       stopGate.release()
-      await startOutcome
+      await start.catch(() => {})
     }
   })
 

--- a/src/services/lsp/LSPServerInstance.test.ts
+++ b/src/services/lsp/LSPServerInstance.test.ts
@@ -25,6 +25,7 @@ type FakeClientController = {
     started: Promise<void>
     release(): void
   }
+  holdNextStart(): { started: Promise<void>; release(): void }
   holdNextInitialize(): { started: Promise<void>; release(): void }
   holdNextStop(options?: { blockForce?: boolean }): {
     started: Promise<void>
@@ -44,6 +45,13 @@ function createFakeClientController(): FakeClientController {
   let stopError: Error | undefined
   let requestFailure:
     | { error: Error; calledResolve: () => void }
+    | undefined
+  let startGate:
+    | {
+        startedResolve: () => void
+        wait: Promise<void>
+        release: () => void
+      }
     | undefined
   let initializeGate:
     | {
@@ -69,7 +77,13 @@ function createFakeClientController(): FakeClientController {
       }
     | undefined
 
-  const startCalls = mock(async () => {})
+  const startCalls = mock(async () => {
+    startGate?.startedResolve()
+    if (startGate) {
+      await startGate.wait
+      startGate = undefined
+    }
+  })
   const initializeCalls = mock(async (_params: InitializeParams) => {
     initializeGate?.startedResolve()
     if (initializeGate) {
@@ -173,6 +187,18 @@ function createFakeClientController(): FakeClientController {
       requestGate = { result, startedResolve, wait, release }
       return { started, release }
     },
+    holdNextStart() {
+      let startedResolve!: () => void
+      let release!: () => void
+      const started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      const wait = new Promise<void>(resolve => {
+        release = resolve
+      })
+      startGate = { startedResolve, wait, release }
+      return { started, release }
+    },
     holdNextInitialize() {
       let startedResolve!: () => void
       let release!: () => void
@@ -257,10 +283,17 @@ describe('LSP server generations', () => {
     const firstStart = instance.start()
     await gate.started
     const secondStart = instance.start()
+    let secondSettled = false
+    void secondStart.finally(() => {
+      secondSettled = true
+    })
 
     expect(fake.startCalls).toHaveBeenCalledTimes(1)
     expect(fake.initializeCalls).toHaveBeenCalledTimes(1)
     expect(instance.state).toBe('starting')
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(secondSettled).toBe(false)
 
     gate.release()
     await Promise.all([firstStart, secondStart])
@@ -413,6 +446,77 @@ describe('LSP server generations', () => {
     }
   })
 
+  test('startup timeout also bounds the process spawn wait', async () => {
+    const fake = createFakeClientController()
+    const startGate = fake.holdNextStart()
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+      defaultStartupTimeoutMs: 5,
+    })
+
+    const start = instance.start()
+    await startGate.started
+    const outcome = await Promise.race([
+      start.then(
+        () => ({ status: 'resolved' as const }),
+        error => ({ status: 'rejected' as const, error }),
+      ),
+      new Promise<{ status: 'pending' }>(resolve =>
+        setTimeout(() => resolve({ status: 'pending' }), 20),
+      ),
+    ])
+
+    try {
+      expect(outcome).toMatchObject({
+        status: 'rejected',
+        error: expect.objectContaining({
+          message: expect.stringContaining(
+            'timed out after 5ms during process startup',
+          ),
+        }),
+      })
+      expect(fake.initializeCalls).not.toHaveBeenCalled()
+      expect(fake.stopCalls).toHaveBeenCalledWith({ force: true })
+    } finally {
+      startGate.release()
+      await start.catch(() => {})
+    }
+  })
+
+  test('applies a bounded default when startupTimeout is omitted', async () => {
+    const fake = createFakeClientController()
+    const initializeGate = fake.holdNextInitialize()
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+      defaultStartupTimeoutMs: 5,
+    })
+
+    const start = instance.start()
+    await initializeGate.started
+    const outcome = await Promise.race([
+      start.then(
+        () => ({ status: 'resolved' as const }),
+        error => ({ status: 'rejected' as const, error }),
+      ),
+      new Promise<{ status: 'pending' }>(resolve =>
+        setTimeout(() => resolve({ status: 'pending' }), 20),
+      ),
+    ])
+
+    try {
+      expect(outcome).toMatchObject({
+        status: 'rejected',
+        error: expect.objectContaining({
+          message: expect.stringContaining('timed out after 5ms'),
+        }),
+      })
+      expect(fake.stopCalls).toHaveBeenCalledWith({ force: true })
+    } finally {
+      initializeGate.release()
+      await start.catch(() => {})
+    }
+  })
+
   test('does not publish a generation when initialization reports unhealthy', async () => {
     const fake = createFakeClientController()
     fake.finishNextInitializeUnhealthy()
@@ -423,6 +527,89 @@ describe('LSP server generations', () => {
     await expect(instance.start()).rejects.toThrow('did not finish initialization')
     expect(instance.state).toBe('error')
     expect(instance.generation).toBe(0)
+  })
+
+  test('caps repeated crash recovery across successful replacement generations', async () => {
+    const fake = createFakeClientController()
+    const instance = createLSPServerInstance(
+      'typescript',
+      { ...CONFIG, maxRestarts: 2 },
+      { createClient: fake.createClient },
+    )
+
+    await instance.start()
+    fake.crash()
+    await instance.start()
+    fake.crash()
+    await instance.start()
+    fake.crash()
+
+    await expect(instance.start()).rejects.toThrow(
+      'exceeded max crash recovery attempts (2)',
+    )
+    expect(fake.startCalls).toHaveBeenCalledTimes(3)
+    expect(instance.generation).toBe(3)
+  })
+
+  test('explicit restart resets an exhausted automatic recovery budget', async () => {
+    const fake = createFakeClientController()
+    const instance = createLSPServerInstance(
+      'typescript',
+      { ...CONFIG, maxRestarts: 2 },
+      { createClient: fake.createClient },
+    )
+
+    await instance.start()
+    fake.crash()
+    await instance.start()
+    fake.crash()
+    await instance.start()
+    fake.crash()
+
+    expect(instance.isCrashRecoveryExhausted).toBe(true)
+
+    await instance.restart()
+    expect(instance.isCrashRecoveryExhausted).toBe(false)
+
+    fake.crash()
+    await expect(instance.start()).resolves.toBeUndefined()
+    expect(instance.generation).toBe(5)
+  })
+
+  test('ordinary stop does not reset or bypass an exhausted automatic recovery budget', async () => {
+    const fake = createFakeClientController()
+    const instance = createLSPServerInstance(
+      'typescript',
+      { ...CONFIG, maxRestarts: 0 },
+      { createClient: fake.createClient },
+    )
+
+    await instance.start()
+    fake.crash()
+
+    await instance.stop()
+    expect(instance.state).toBe('stopped')
+    await expect(instance.start()).rejects.toThrow(
+      'exceeded max crash recovery attempts (0)',
+    )
+    expect(instance.isCrashRecoveryExhausted).toBe(true)
+    expect(fake.startCalls).toHaveBeenCalledTimes(1)
+  })
+
+  test('notifies one unavailable transition when a crashed generation is later stopped', async () => {
+    const fake = createFakeClientController()
+    const unavailableGenerations: number[] = []
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+      onUnavailable: generation => unavailableGenerations.push(generation),
+    })
+
+    await instance.start()
+    fake.crash()
+    expect(unavailableGenerations).toEqual([1])
+
+    await instance.stop()
+    expect(unavailableGenerations).toEqual([1])
   })
 
   test('rejects a successful response from a replaced generation', async () => {

--- a/src/services/lsp/LSPServerInstance.test.ts
+++ b/src/services/lsp/LSPServerInstance.test.ts
@@ -18,16 +18,30 @@ type FakeClientController = {
   ) => LSPClient
   crash(error?: Error): void
   failNextInitialize(error: Error): void
+  failNextRequest(error: Error): { called: Promise<void> }
   holdNextInitialize(): { started: Promise<void>; release(): void }
+  holdNextStop(): { started: Promise<void>; release(): void }
   startCalls: ReturnType<typeof mock>
   initializeCalls: ReturnType<typeof mock>
+  stopCalls: ReturnType<typeof mock>
+  sendRequestCalls: ReturnType<typeof mock>
 }
 
 function createFakeClientController(): FakeClientController {
   let initialized = false
   let onCrash: ((error: Error) => void) | undefined
   let initializeError: Error | undefined
+  let requestFailure:
+    | { error: Error; calledResolve: () => void }
+    | undefined
   let initializeGate:
+    | {
+        startedResolve: () => void
+        wait: Promise<void>
+        release: () => void
+      }
+    | undefined
+  let stopGate:
     | {
         startedResolve: () => void
         wait: Promise<void>
@@ -51,6 +65,24 @@ function createFakeClientController(): FakeClientController {
     return { capabilities: {} } satisfies InitializeResult
   })
 
+  const stopCalls = mock(async () => {
+    stopGate?.startedResolve()
+    if (stopGate) {
+      await stopGate.wait
+      stopGate = undefined
+    }
+    initialized = false
+  })
+  const sendRequestCalls = mock(async <TResult>() => {
+    if (requestFailure) {
+      const failure = requestFailure
+      requestFailure = undefined
+      failure.calledResolve()
+      throw failure.error
+    }
+    return undefined as TResult
+  })
+
   const client: LSPClient = {
     get capabilities() {
       return {}
@@ -60,14 +92,12 @@ function createFakeClientController(): FakeClientController {
     },
     start: startCalls,
     initialize: initializeCalls,
-    sendRequest: async <TResult>() => undefined as TResult,
+    sendRequest: sendRequestCalls as LSPClient['sendRequest'],
     sendNotification: async () => {},
     sendNotificationStrict: async () => {},
     onNotification: () => {},
     onRequest: () => {},
-    stop: async () => {
-      initialized = false
-    },
+    stop: stopCalls,
   }
 
   return {
@@ -82,6 +112,14 @@ function createFakeClientController(): FakeClientController {
     failNextInitialize(error) {
       initializeError = error
     },
+    failNextRequest(error) {
+      let calledResolve!: () => void
+      const called = new Promise<void>(resolve => {
+        calledResolve = resolve
+      })
+      requestFailure = { error, calledResolve }
+      return { called }
+    },
     holdNextInitialize() {
       let startedResolve!: () => void
       let release!: () => void
@@ -94,8 +132,22 @@ function createFakeClientController(): FakeClientController {
       initializeGate = { startedResolve, wait, release }
       return { started, release }
     },
+    holdNextStop() {
+      let startedResolve!: () => void
+      let release!: () => void
+      const started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      const wait = new Promise<void>(resolve => {
+        release = resolve
+      })
+      stopGate = { startedResolve, wait, release }
+      return { started, release }
+    },
     startCalls,
     initializeCalls,
+    stopCalls,
+    sendRequestCalls,
   }
 }
 
@@ -159,5 +211,101 @@ describe('LSP server generations', () => {
     expect(instance.generation).toBe(1)
     expect(fake.startCalls).toHaveBeenCalledTimes(1)
     expect(fake.initializeCalls).toHaveBeenCalledTimes(1)
+  })
+
+  test('concurrent callers share one rejection and a later start retries', async () => {
+    const fake = createFakeClientController()
+    const gate = fake.holdNextInitialize()
+    const initializeError = new Error('initialize rejected')
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+
+    fake.failNextInitialize(initializeError)
+    const firstStart = instance.start()
+    await gate.started
+    const secondStart = instance.start()
+
+    gate.release()
+    const [firstResult, secondResult] = await Promise.allSettled([
+      firstStart,
+      secondStart,
+    ])
+
+    expect(firstResult.status).toBe('rejected')
+    expect(secondResult.status).toBe('rejected')
+    if (firstResult.status === 'rejected') {
+      expect(firstResult.reason).toBe(initializeError)
+    }
+    if (secondResult.status === 'rejected') {
+      expect(secondResult.reason).toBe(initializeError)
+    }
+    expect(fake.initializeCalls).toHaveBeenCalledTimes(1)
+    expect(instance.generation).toBe(0)
+
+    await instance.start()
+    expect(fake.initializeCalls).toHaveBeenCalledTimes(2)
+    expect(instance.generation).toBe(1)
+  })
+
+  test('waits for failed-start cleanup before allowing a retry', async () => {
+    const fake = createFakeClientController()
+    const initializeError = new Error('initialize rejected')
+    const stopGate = fake.holdNextStop()
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+    fake.failNextInitialize(initializeError)
+
+    let firstSettled = false
+    const firstOutcome = instance.start().then(
+      () => undefined,
+      error => error,
+    )
+    void firstOutcome.then(() => {
+      firstSettled = true
+    })
+
+    await stopGate.started
+    await Promise.resolve()
+    const secondOutcome = instance.start().then(
+      () => undefined,
+      error => error,
+    )
+
+    try {
+      expect(firstSettled).toBe(false)
+      expect(fake.startCalls).toHaveBeenCalledTimes(1)
+    } finally {
+      stopGate.release()
+    }
+
+    expect(await firstOutcome).toBe(initializeError)
+    expect(await secondOutcome).toBe(initializeError)
+
+    await instance.start()
+    expect(fake.startCalls).toHaveBeenCalledTimes(2)
+    expect(instance.generation).toBe(1)
+  })
+
+  test('does not retry ContentModified on a replacement generation', async () => {
+    const fake = createFakeClientController()
+    const contentModified = Object.assign(new Error('content modified'), {
+      code: -32801,
+    })
+    const failure = fake.failNextRequest(contentModified)
+    const instance = createLSPServerInstance('typescript', CONFIG, {
+      createClient: fake.createClient,
+    })
+    await instance.start()
+
+    const request = instance.sendRequest('textDocument/hover', {})
+    await failure.called
+    fake.crash()
+    await instance.start()
+
+    await expect(request).rejects.toThrow('changed generation')
+    expect(fake.sendRequestCalls).toHaveBeenCalledTimes(1)
+    expect(instance.generation).toBe(2)
   })
 })

--- a/src/services/lsp/LSPServerInstance.ts
+++ b/src/services/lsp/LSPServerInstance.ts
@@ -26,6 +26,8 @@ const MAX_RETRIES_FOR_TRANSIENT_ERRORS = 3
  * Actual delays: 500ms, 1000ms, 2000ms
  */
 const RETRY_BASE_DELAY_MS = 500
+
+const DEFAULT_LSP_STARTUP_TIMEOUT_MS = 30_000
 /**
  * LSP server instance interface returned by createLSPServerInstance.
  * Manages the lifecycle of a single LSP server with state tracking and health monitoring.
@@ -45,6 +47,8 @@ export type LSPServerInstance = {
   readonly restartCount: number
   /** Successful initialization generation for the current process lifecycle */
   readonly generation: number
+  /** Whether automatic recovery has exhausted the configured crash budget */
+  readonly isCrashRecoveryExhausted: boolean
   /** Start the server and initialize it */
   start(): Promise<void>
   /** Stop the server gracefully */
@@ -71,6 +75,7 @@ export type LSPServerInstance = {
 export type LSPServerInstanceOptions = {
   createClient?: typeof createLSPClientType
   onUnavailable?: (generation: number) => void
+  defaultStartupTimeoutMs?: number
 }
 
 /**
@@ -125,6 +130,7 @@ export function createLSPServerInstance(
     createLSPClient = clientModule.createLSPClient
   }
   let state: LspServerState = 'stopped'
+  const maxRestarts = config.maxRestarts ?? 3
   let startTime: Date | undefined
   let lastError: Error | undefined
   let restartCount = 0
@@ -133,6 +139,12 @@ export function createLSPServerInstance(
   let startEpoch = 0
   let startPromise: Promise<void> | undefined
   let stopPromise: Promise<void> | undefined
+  let lastUnavailableGeneration: number | undefined
+  const notifyUnavailable = (unavailableGeneration: number): void => {
+    if (lastUnavailableGeneration === unavailableGeneration) return
+    lastUnavailableGeneration = unavailableGeneration
+    options.onUnavailable?.(unavailableGeneration)
+  }
   // Propagate crash state so ensureServerStarted can restart on next use.
   // Without this, state stays 'running' after crash and the server is never
   // restarted (zombie state).
@@ -141,7 +153,7 @@ export function createLSPServerInstance(
     state = 'error'
     lastError = error
     crashRecoveryCount++
-    options.onUnavailable?.(generation)
+    notifyUnavailable(generation)
   })
 
   /**
@@ -169,8 +181,7 @@ export function createLSPServerInstance(
   async function startInternal(epoch: number): Promise<void> {
     // Cap crash-recovery attempts so a persistently crashing server doesn't
     // spawn unbounded child processes on every incoming request.
-    const maxRestarts = config.maxRestarts ?? 3
-    if (state === 'error' && crashRecoveryCount > maxRestarts) {
+    if (crashRecoveryCount > maxRestarts) {
       const error = new Error(
         `LSP server '${name}' exceeded max crash recovery attempts (${maxRestarts})`,
       )
@@ -184,11 +195,20 @@ export function createLSPServerInstance(
       state = 'starting'
       logForDebugging(`Starting LSP server instance: ${name}`)
 
+      const startupTimeoutMs =
+        config.startupTimeout ??
+        options.defaultStartupTimeoutMs ??
+        DEFAULT_LSP_STARTUP_TIMEOUT_MS
+
       // Start the client
-      await client.start(config.command, config.args || [], {
-        env: config.env,
-        cwd: config.workspaceFolder,
-      })
+      await withTimeout(
+        client.start(config.command, config.args || [], {
+          env: config.env,
+          cwd: config.workspaceFolder,
+        }),
+        startupTimeoutMs,
+        `LSP server '${name}' timed out after ${startupTimeoutMs}ms during process startup`,
+      )
       if (epoch !== startEpoch) {
         throw new Error(`LSP server '${name}' start was cancelled`)
       }
@@ -270,15 +290,11 @@ export function createLSPServerInstance(
       }
 
       initPromise = client.initialize(initParams)
-      if (config.startupTimeout !== undefined) {
-        await withTimeout(
-          initPromise,
-          config.startupTimeout,
-          `LSP server '${name}' timed out after ${config.startupTimeout}ms during initialization`,
-        )
-      } else {
-        await initPromise
-      }
+      await withTimeout(
+        initPromise,
+        startupTimeoutMs,
+        `LSP server '${name}' timed out after ${startupTimeoutMs}ms during initialization`,
+      )
       if (epoch !== startEpoch) {
         throw new Error(`LSP server '${name}' start was cancelled`)
       }
@@ -291,7 +307,6 @@ export function createLSPServerInstance(
       generation++
       state = 'running'
       startTime = new Date()
-      crashRecoveryCount = 0
       logForDebugging(`LSP server instance started: ${name}`)
     } catch (error) {
       // Clean up the spawned child process on timeout/error
@@ -341,7 +356,7 @@ export function createLSPServerInstance(
     }
 
     await startPromise?.catch(() => {})
-    options.onUnavailable?.(stoppedGeneration)
+    notifyUnavailable(stoppedGeneration)
 
     if (stopError) {
       state = 'error'
@@ -375,7 +390,6 @@ export function createLSPServerInstance(
 
     restartCount++
 
-    const maxRestarts = config.maxRestarts ?? 3
     if (restartCount > maxRestarts) {
       const error = new Error(
         `Max restart attempts (${maxRestarts}) exceeded for server '${name}'`,
@@ -383,6 +397,10 @@ export function createLSPServerInstance(
       logError(error)
       throw error
     }
+
+    // A manual restart is the explicit operator action that resets the
+    // automatic crash-recovery budget. Ordinary stop/start cleanup must not.
+    crashRecoveryCount = 0
 
     try {
       await start()
@@ -587,6 +605,9 @@ export function createLSPServerInstance(
     },
     get generation() {
       return generation
+    },
+    get isCrashRecoveryExhausted() {
+      return crashRecoveryCount > maxRestarts
     },
     start,
     stop,

--- a/src/services/lsp/LSPServerInstance.ts
+++ b/src/services/lsp/LSPServerInstance.ts
@@ -137,6 +137,7 @@ export function createLSPServerInstance(
   // Without this, state stays 'running' after crash and the server is never
   // restarted (zombie state).
   const client = createLSPClient(name, error => {
+    startEpoch++
     state = 'error'
     lastError = error
     crashRecoveryCount++
@@ -153,7 +154,7 @@ export function createLSPServerInstance(
    * @throws {Error} If server fails to start or initialize
    */
   function start(): Promise<void> {
-    if (stopPromise) return stopPromise.then(start)
+    if (stopPromise) return stopPromise.catch(() => {}).then(start)
     if (state === 'running') return Promise.resolve()
     if (startPromise) return startPromise
 
@@ -281,6 +282,11 @@ export function createLSPServerInstance(
       if (epoch !== startEpoch) {
         throw new Error(`LSP server '${name}' start was cancelled`)
       }
+      if (state !== 'starting' || !client.isInitialized) {
+        throw new Error(
+          `LSP server '${name}' did not finish initialization in a healthy state`,
+        )
+      }
 
       generation++
       state = 'running'
@@ -289,7 +295,7 @@ export function createLSPServerInstance(
       logForDebugging(`LSP server instance started: ${name}`)
     } catch (error) {
       // Clean up the spawned child process on timeout/error
-      await client.stop().catch(() => {})
+      await client.stop({ force: true }).catch(() => {})
       // Prevent unhandled rejection from abandoned initialize promise
       initPromise?.catch(() => {})
       if (epoch === startEpoch) {
@@ -324,11 +330,12 @@ export function createLSPServerInstance(
 
   async function stopInternal(): Promise<void> {
     const stoppedGeneration = generation
+    const force = state === 'starting'
     startEpoch++
     let stopError: unknown
     state = 'stopping'
     try {
-      await client.stop()
+      await client.stop({ force })
     } catch (error) {
       stopError = error
     }
@@ -434,7 +441,13 @@ export function createLSPServerInstance(
         )
       }
       try {
-        return await client.sendRequest(method, params)
+        const result = await client.sendRequest<T>(method, params)
+        if (generation !== requestGeneration || !isHealthy()) {
+          throw new Error(
+            `LSP request '${method}' aborted because server '${name}' changed generation or became unavailable`,
+          )
+        }
+        return result
       } catch (error) {
         lastAttemptError = error as Error
 

--- a/src/services/lsp/LSPServerInstance.ts
+++ b/src/services/lsp/LSPServerInstance.ts
@@ -47,7 +47,7 @@ export type LSPServerInstance = {
   readonly restartCount: number
   /** Successful initialization generation for the current process lifecycle */
   readonly generation: number
-  /** Whether automatic recovery has exhausted the configured crash budget */
+  /** Whether automatic recovery has exhausted the configured failure budget */
   readonly isCrashRecoveryExhausted: boolean
   /** Start the server and initialize it */
   start(): Promise<void>
@@ -134,7 +134,7 @@ export function createLSPServerInstance(
   let startTime: Date | undefined
   let lastError: Error | undefined
   let restartCount = 0
-  let crashRecoveryCount = 0
+  let automaticRecoveryFailureCount = 0
   let generation = 0
   let startEpoch = 0
   let startPromise: Promise<void> | undefined
@@ -145,15 +145,24 @@ export function createLSPServerInstance(
     lastUnavailableGeneration = unavailableGeneration
     options.onUnavailable?.(unavailableGeneration)
   }
+
+  // Automatic recovery is bounded across both startup failures and unexpected
+  // transport loss. Successful lazy replacement does not reset this budget;
+  // only an explicit restart does. Intentional stop/cancellation is excluded.
+  const recordAutomaticRecoveryFailure = (error: unknown): void => {
+    state = 'error'
+    lastError =
+      error instanceof Error ? error : new Error(errorMessage(error))
+    automaticRecoveryFailureCount++
+    notifyUnavailable(generation)
+  }
+
   // Propagate crash state so ensureServerStarted can restart on next use.
   // Without this, state stays 'running' after crash and the server is never
   // restarted (zombie state).
   const client = createLSPClient(name, error => {
     startEpoch++
-    state = 'error'
-    lastError = error
-    crashRecoveryCount++
-    notifyUnavailable(generation)
+    recordAutomaticRecoveryFailure(error)
   })
 
   /**
@@ -179,11 +188,11 @@ export function createLSPServerInstance(
   }
 
   async function startInternal(epoch: number): Promise<void> {
-    // Cap crash-recovery attempts so a persistently crashing server doesn't
-    // spawn unbounded child processes on every incoming request.
-    if (crashRecoveryCount > maxRestarts) {
+    // Cap automatic recovery so a persistently crashing or unstartable server
+    // doesn't spawn unbounded child processes on every incoming request.
+    if (automaticRecoveryFailureCount > maxRestarts) {
       const error = new Error(
-        `LSP server '${name}' exceeded max crash recovery attempts (${maxRestarts})`,
+        `LSP server '${name}' exceeded max automatic recovery attempts (${maxRestarts})`,
       )
       lastError = error
       logError(error)
@@ -314,8 +323,7 @@ export function createLSPServerInstance(
       // Prevent unhandled rejection from abandoned initialize promise
       initPromise?.catch(() => {})
       if (epoch === startEpoch) {
-        state = 'error'
-        lastError = error as Error
+        recordAutomaticRecoveryFailure(error)
         logError(error)
       }
       throw error
@@ -399,8 +407,8 @@ export function createLSPServerInstance(
     }
 
     // A manual restart is the explicit operator action that resets the
-    // automatic crash-recovery budget. Ordinary stop/start cleanup must not.
-    crashRecoveryCount = 0
+    // automatic-recovery budget. Ordinary stop/start cleanup must not.
+    automaticRecoveryFailureCount = 0
 
     try {
       await start()
@@ -607,7 +615,7 @@ export function createLSPServerInstance(
       return generation
     },
     get isCrashRecoveryExhausted() {
-      return crashRecoveryCount > maxRestarts
+      return automaticRecoveryFailureCount > maxRestarts
     },
     start,
     stop,

--- a/src/services/lsp/LSPServerInstance.ts
+++ b/src/services/lsp/LSPServerInstance.ts
@@ -43,6 +43,8 @@ export type LSPServerInstance = {
   readonly lastError: Error | undefined
   /** Number of times restart() has been called */
   readonly restartCount: number
+  /** Successful initialization generation for the current process lifecycle */
+  readonly generation: number
   /** Start the server and initialize it */
   start(): Promise<void>
   /** Stop the server gracefully */
@@ -55,6 +57,8 @@ export type LSPServerInstance = {
   sendRequest<T>(method: string, params: unknown): Promise<T>
   /** Send an LSP notification to the server (fire-and-forget) */
   sendNotification(method: string, params: unknown): Promise<void>
+  /** Send an LSP notification and surface transport/write failure */
+  sendNotificationStrict(method: string, params: unknown): Promise<void>
   /** Register a handler for LSP notifications */
   onNotification(method: string, handler: (params: unknown) => void): void
   /** Register a handler for LSP requests from the server */
@@ -62,6 +66,11 @@ export type LSPServerInstance = {
     method: string,
     handler: (params: TParams) => TResult | Promise<TResult>,
   ): void
+}
+
+export type LSPServerInstanceOptions = {
+  createClient?: typeof createLSPClientType
+  onUnavailable?: (generation: number) => void
 }
 
 /**
@@ -90,6 +99,7 @@ export type LSPServerInstance = {
 export function createLSPServerInstance(
   name: string,
   config: ScopedLspServerConfig,
+  options: LSPServerInstanceOptions = {},
 ): LSPServerInstance {
   // Validate that unimplemented fields are not set
   if (config.restartOnCrash !== undefined) {
@@ -106,15 +116,21 @@ export function createLSPServerInstance(
   // Private state encapsulated via closures. Lazy-require LSPClient so
   // vscode-jsonrpc (~129KB) only loads when an LSP server is actually
   // instantiated, not when the static import chain reaches this module.
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { createLSPClient } = require('./LSPClient.js') as {
-    createLSPClient: typeof createLSPClientType
+  let createLSPClient = options.createClient
+  if (!createLSPClient) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const clientModule = require('./LSPClient.js') as {
+      createLSPClient: typeof createLSPClientType
+    }
+    createLSPClient = clientModule.createLSPClient
   }
   let state: LspServerState = 'stopped'
   let startTime: Date | undefined
   let lastError: Error | undefined
   let restartCount = 0
   let crashRecoveryCount = 0
+  let generation = 0
+  let startPromise: Promise<void> | undefined
   // Propagate crash state so ensureServerStarted can restart on next use.
   // Without this, state stays 'running' after crash and the server is never
   // restarted (zombie state).
@@ -122,21 +138,30 @@ export function createLSPServerInstance(
     state = 'error'
     lastError = error
     crashRecoveryCount++
+    options.onUnavailable?.(generation)
   })
 
   /**
    * Starts the LSP server and initializes it with workspace information.
    *
-   * If the server is already running or starting, this method returns immediately.
+   * If the server is already running it returns immediately. Concurrent callers
+   * while starting share and await the same initialization promise.
    * On failure, sets state to 'error', logs for monitoring, and throws.
    *
    * @throws {Error} If server fails to start or initialize
    */
-  async function start(): Promise<void> {
-    if (state === 'running' || state === 'starting') {
-      return
-    }
+  function start(): Promise<void> {
+    if (state === 'running') return Promise.resolve()
+    if (startPromise) return startPromise
 
+    const pending = startInternal()
+    startPromise = pending.finally(() => {
+      startPromise = undefined
+    })
+    return startPromise
+  }
+
+  async function startInternal(): Promise<void> {
     // Cap crash-recovery attempts so a persistently crashing server doesn't
     // spawn unbounded child processes on every incoming request.
     const maxRestarts = config.maxRestarts ?? 3
@@ -247,6 +272,7 @@ export function createLSPServerInstance(
         await initPromise
       }
 
+      generation++
       state = 'running'
       startTime = new Date()
       crashRecoveryCount = 0
@@ -276,14 +302,17 @@ export function createLSPServerInstance(
       return
     }
 
+    const stoppedGeneration = generation
     try {
       state = 'stopping'
       await client.stop()
       state = 'stopped'
+      options.onUnavailable?.(stoppedGeneration)
       logForDebugging(`LSP server instance stopped: ${name}`)
     } catch (error) {
       state = 'error'
       lastError = error as Error
+      options.onUnavailable?.(stoppedGeneration)
       logError(error)
       throw error
     }
@@ -437,6 +466,33 @@ export function createLSPServerInstance(
   }
 
   /**
+   * Send a notification while preserving transport/write failure for callers
+   * whose local state depends on acceptance by the JSON-RPC writer.
+   */
+  async function sendNotificationStrict(
+    method: string,
+    params: unknown,
+  ): Promise<void> {
+    if (!isHealthy()) {
+      const error = new Error(
+        `Cannot send notification to LSP server '${name}': server is ${state}`,
+      )
+      logError(error)
+      throw error
+    }
+
+    try {
+      await client.sendNotificationStrict(method, params)
+    } catch (error) {
+      const notificationError = new Error(
+        `LSP notification '${method}' failed for server '${name}': ${errorMessage(error)}`,
+      )
+      logError(notificationError)
+      throw notificationError
+    }
+  }
+
+  /**
    * Registers a handler for LSP notifications from the server.
    *
    * @param method - LSP notification method (e.g., 'window/logMessage')
@@ -481,12 +537,16 @@ export function createLSPServerInstance(
     get restartCount() {
       return restartCount
     },
+    get generation() {
+      return generation
+    },
     start,
     stop,
     restart,
     isHealthy,
     sendRequest,
     sendNotification,
+    sendNotificationStrict,
     onNotification,
     onRequest,
   }

--- a/src/services/lsp/LSPServerInstance.ts
+++ b/src/services/lsp/LSPServerInstance.ts
@@ -130,7 +130,9 @@ export function createLSPServerInstance(
   let restartCount = 0
   let crashRecoveryCount = 0
   let generation = 0
+  let startEpoch = 0
   let startPromise: Promise<void> | undefined
+  let stopPromise: Promise<void> | undefined
   // Propagate crash state so ensureServerStarted can restart on next use.
   // Without this, state stays 'running' after crash and the server is never
   // restarted (zombie state).
@@ -151,17 +153,19 @@ export function createLSPServerInstance(
    * @throws {Error} If server fails to start or initialize
    */
   function start(): Promise<void> {
+    if (stopPromise) return stopPromise.then(start)
     if (state === 'running') return Promise.resolve()
     if (startPromise) return startPromise
 
-    const pending = startInternal()
+    const epoch = ++startEpoch
+    const pending = startInternal(epoch)
     startPromise = pending.finally(() => {
       startPromise = undefined
     })
     return startPromise
   }
 
-  async function startInternal(): Promise<void> {
+  async function startInternal(epoch: number): Promise<void> {
     // Cap crash-recovery attempts so a persistently crashing server doesn't
     // spawn unbounded child processes on every incoming request.
     const maxRestarts = config.maxRestarts ?? 3
@@ -184,6 +188,9 @@ export function createLSPServerInstance(
         env: config.env,
         cwd: config.workspaceFolder,
       })
+      if (epoch !== startEpoch) {
+        throw new Error(`LSP server '${name}' start was cancelled`)
+      }
 
       // Initialize with workspace info
       const workspaceFolder = config.workspaceFolder || getCwd()
@@ -271,6 +278,9 @@ export function createLSPServerInstance(
       } else {
         await initPromise
       }
+      if (epoch !== startEpoch) {
+        throw new Error(`LSP server '${name}' start was cancelled`)
+      }
 
       generation++
       state = 'running'
@@ -279,12 +289,14 @@ export function createLSPServerInstance(
       logForDebugging(`LSP server instance started: ${name}`)
     } catch (error) {
       // Clean up the spawned child process on timeout/error
-      client.stop().catch(() => {})
+      await client.stop().catch(() => {})
       // Prevent unhandled rejection from abandoned initialize promise
       initPromise?.catch(() => {})
-      state = 'error'
-      lastError = error as Error
-      logError(error)
+      if (epoch === startEpoch) {
+        state = 'error'
+        lastError = error as Error
+        logError(error)
+      }
       throw error
     }
   }
@@ -297,25 +309,42 @@ export function createLSPServerInstance(
    *
    * @throws {Error} If server fails to stop
    */
-  async function stop(): Promise<void> {
+  function stop(): Promise<void> {
     if (state === 'stopped' || state === 'stopping') {
-      return
+      return stopPromise ?? Promise.resolve()
+    }
+    if (stopPromise) return stopPromise
+
+    const pending = stopInternal()
+    stopPromise = pending.finally(() => {
+      stopPromise = undefined
+    })
+    return stopPromise
+  }
+
+  async function stopInternal(): Promise<void> {
+    const stoppedGeneration = generation
+    startEpoch++
+    let stopError: unknown
+    state = 'stopping'
+    try {
+      await client.stop()
+    } catch (error) {
+      stopError = error
     }
 
-    const stoppedGeneration = generation
-    try {
-      state = 'stopping'
-      await client.stop()
-      state = 'stopped'
-      options.onUnavailable?.(stoppedGeneration)
-      logForDebugging(`LSP server instance stopped: ${name}`)
-    } catch (error) {
+    await startPromise?.catch(() => {})
+    options.onUnavailable?.(stoppedGeneration)
+
+    if (stopError) {
       state = 'error'
-      lastError = error as Error
-      options.onUnavailable?.(stoppedGeneration)
-      logError(error)
-      throw error
+      lastError = stopError as Error
+      logError(stopError)
+      throw stopError
     }
+
+    state = 'stopped'
+    logForDebugging(`LSP server instance stopped: ${name}`)
   }
 
   /**
@@ -391,6 +420,7 @@ export function createLSPServerInstance(
       throw error
     }
 
+    const requestGeneration = generation
     let lastAttemptError: Error | undefined
 
     for (
@@ -398,6 +428,11 @@ export function createLSPServerInstance(
       attempt <= MAX_RETRIES_FOR_TRANSIENT_ERRORS;
       attempt++
     ) {
+      if (generation !== requestGeneration || !isHealthy()) {
+        throw new Error(
+          `LSP request '${method}' aborted because server '${name}' changed generation or became unavailable`,
+        )
+      }
       try {
         return await client.sendRequest(method, params)
       } catch (error) {

--- a/src/services/lsp/LSPServerManager.protocol.test.ts
+++ b/src/services/lsp/LSPServerManager.protocol.test.ts
@@ -1,0 +1,236 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+import { afterAll, afterEach, beforeEach, expect, mock, test } from 'bun:test'
+import type { ScopedLspServerConfig } from './types.js'
+
+type ProtocolEvent = {
+  generation: number
+  kind: 'notification' | 'request'
+  method: string
+  params: unknown
+}
+
+type FakeServer = {
+  server: Record<string, unknown>
+  events: ProtocolEvent[]
+  crash(): void
+}
+
+const CONFIG = {
+  command: 'unused-test-lsp',
+  extensionToLanguage: { '.ts': 'typescript' },
+  scope: 'project',
+  source: 'test',
+} satisfies ScopedLspServerConfig
+
+let currentServer: FakeServer | undefined
+let installedBaselineMocks = false
+const managers: Array<{ shutdown(): Promise<void> }> = []
+const activityPaths: string[] = []
+
+function createFakeServer(
+  onUnavailable?: (generation: number) => void,
+): FakeServer {
+  let state = 'stopped'
+  let generation = 0
+  const events: ProtocolEvent[] = []
+
+  const server = {
+    name: 'typescript',
+    config: CONFIG,
+    get state() {
+      return state
+    },
+    get generation() {
+      return generation
+    },
+    get startTime() {
+      return undefined
+    },
+    get lastError() {
+      return undefined
+    },
+    get restartCount() {
+      return 0
+    },
+    async start() {
+      if (state === 'running') return
+      generation++
+      state = 'running'
+    },
+    async stop() {
+      const stoppedGeneration = generation
+      state = 'stopped'
+      onUnavailable?.(stoppedGeneration)
+    },
+    async restart() {
+      await server.stop()
+      await server.start()
+    },
+    isHealthy() {
+      return state === 'running'
+    },
+    async sendRequest(method: string, params: unknown) {
+      events.push({ generation, kind: 'request', method, params })
+      return null
+    },
+    async sendNotification(method: string, params: unknown) {
+      events.push({ generation, kind: 'notification', method, params })
+    },
+    async sendNotificationStrict(method: string, params: unknown) {
+      events.push({ generation, kind: 'notification', method, params })
+    },
+    onNotification() {},
+    onRequest() {},
+  }
+
+  return {
+    server,
+    events,
+    crash() {
+      const crashedGeneration = generation
+      state = 'error'
+      onUnavailable?.(crashedGeneration)
+    },
+  }
+}
+
+try {
+  await import('./documentIdentity.js')
+} catch {
+  // The prior head has no dependency-injection seam. These mocks are installed
+  // only for that compatibility path so the same behavioral checks can execute
+  // without launching a real server.
+  installedBaselineMocks = true
+  mock.module('./config.js', () => ({
+    getAllLspServers: async () => ({ servers: { typescript: CONFIG } }),
+  }))
+  mock.module('./LSPDiagnosticRegistry.js', () => ({
+    recordLSPDiagnosticFileActivity: (filePath: string) => {
+      activityPaths.push(filePath)
+    },
+  }))
+  mock.module('./LSPServerInstance.js', () => ({
+    createLSPServerInstance: (
+      _name: string,
+      _config: unknown,
+      options?: { onUnavailable?: (generation: number) => void },
+    ) => {
+      currentServer = createFakeServer(options?.onUnavailable)
+      return currentServer.server
+    },
+  }))
+}
+
+const { createLSPServerManager } = await import('./LSPServerManager.js')
+
+afterEach(async () => {
+  await Promise.allSettled(managers.splice(0).map(manager => manager.shutdown()))
+  currentServer = undefined
+})
+
+beforeEach(() => {
+  activityPaths.length = 0
+})
+
+afterAll(() => {
+  if (installedBaselineMocks) mock.restore()
+})
+
+async function createManager() {
+  const manager = createLSPServerManager({
+    loadServerConfigs: async () => ({
+      servers: { typescript: CONFIG },
+    }),
+    createServerInstance: (
+      _name: string,
+      _config: unknown,
+      options: { onUnavailable?: (generation: number) => void },
+    ) => {
+      currentServer = createFakeServer(options.onUnavailable)
+      return currentServer.server as never
+    },
+    readDocument: filePath => readFile(filePath, 'utf-8'),
+    recordFileActivity: filePath => {
+      activityPaths.push(filePath)
+    },
+  })
+  managers.push(manager)
+  await manager.initialize()
+  return { manager, server: currentServer! }
+}
+
+test('delivers monotonically increasing versions for one document', async () => {
+  const { manager, server } = await createManager()
+  const file = '/repo/src/version.ts'
+  const uri = pathToFileURL(file).href
+
+  await manager.openFile(file, 'one')
+  await manager.changeFile(file, 'two')
+  await manager.changeFile(file, 'three')
+
+  expect(
+    server.events
+      .filter(event => event.kind === 'notification')
+      .map(event => ({
+        method: event.method,
+        version: (event.params as { textDocument: { version: number } })
+          .textDocument.version,
+        uri: (event.params as { textDocument: { uri: string } }).textDocument
+          .uri,
+      })),
+  ).toEqual([
+    { method: 'textDocument/didOpen', version: 1, uri },
+    { method: 'textDocument/didChange', version: 2, uri },
+    { method: 'textDocument/didChange', version: 3, uri },
+  ])
+})
+
+test('resends current contents after restart before making a request', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'openclaude-lsp-protocol-'))
+  const file = join(directory, 'restart.ts')
+  try {
+    writeFileSync(file, 'current contents')
+    const { manager, server } = await createManager()
+
+    await manager.openFile(file, 'before restart')
+    server.crash()
+    await manager.sendRequest(file, 'textDocument/hover', {})
+
+    expect(server.events.slice(-2)).toMatchObject([
+      {
+        generation: 2,
+        kind: 'notification',
+        method: 'textDocument/didOpen',
+        params: {
+          textDocument: { text: 'current contents', version: 1 },
+        },
+      },
+      {
+        generation: 2,
+        kind: 'request',
+        method: 'textDocument/hover',
+      },
+    ])
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('records Windows activity with the same canonical path as diagnostics', async () => {
+  const { manager } = await createManager()
+  const firstSpelling = String.raw`C:\Repo\Source File.ts`
+  const secondSpelling = 'c:/repo/source file.ts'
+  const canonicalUri = 'file:///c:/repo/source%20file.ts'
+
+  await manager.openFile(firstSpelling, 'one')
+  await manager.changeFile(secondSpelling, 'two')
+
+  expect(activityPaths).toEqual([
+    fileURLToPath(canonicalUri),
+    fileURLToPath(canonicalUri),
+  ])
+})

--- a/src/services/lsp/LSPServerManager.protocol.test.ts
+++ b/src/services/lsp/LSPServerManager.protocol.test.ts
@@ -3,8 +3,10 @@ import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath, pathToFileURL } from 'node:url'
-import { afterAll, afterEach, beforeEach, expect, mock, test } from 'bun:test'
-import type { ScopedLspServerConfig } from './types.js'
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+import { createLSPServerManager } from './LSPServerManager.js'
+import type { LSPServerInstance } from './LSPServerInstance.js'
+import type { LspServerState, ScopedLspServerConfig } from './types.js'
 
 type ProtocolEvent = {
   generation: number
@@ -14,7 +16,7 @@ type ProtocolEvent = {
 }
 
 type FakeServer = {
-  server: Record<string, unknown>
+  server: LSPServerInstance
   events: ProtocolEvent[]
   crash(): void
 }
@@ -27,18 +29,17 @@ const CONFIG = {
 } satisfies ScopedLspServerConfig
 
 let currentServer: FakeServer | undefined
-let installedBaselineMocks = false
 const managers: Array<{ shutdown(): Promise<void> }> = []
 const activityPaths: string[] = []
 
 function createFakeServer(
   onUnavailable?: (generation: number) => void,
 ): FakeServer {
-  let state = 'stopped'
+  let state: LspServerState = 'stopped'
   let generation = 0
   const events: ProtocolEvent[] = []
 
-  const server = {
+  const server: LSPServerInstance = {
     name: 'typescript',
     config: CONFIG,
     get state() {
@@ -73,9 +74,9 @@ function createFakeServer(
     isHealthy() {
       return state === 'running'
     },
-    async sendRequest(method: string, params: unknown) {
+    async sendRequest<TResult>(method: string, params: unknown) {
       events.push({ generation, kind: 'request', method, params })
-      return null
+      return null as TResult
     },
     async sendNotification(method: string, params: unknown) {
       events.push({ generation, kind: 'notification', method, params })
@@ -98,35 +99,6 @@ function createFakeServer(
   }
 }
 
-try {
-  await import('./documentIdentity.js')
-} catch {
-  // The prior head has no dependency-injection seam. These mocks are installed
-  // only for that compatibility path so the same behavioral checks can execute
-  // without launching a real server.
-  installedBaselineMocks = true
-  mock.module('./config.js', () => ({
-    getAllLspServers: async () => ({ servers: { typescript: CONFIG } }),
-  }))
-  mock.module('./LSPDiagnosticRegistry.js', () => ({
-    recordLSPDiagnosticFileActivity: (filePath: string) => {
-      activityPaths.push(filePath)
-    },
-  }))
-  mock.module('./LSPServerInstance.js', () => ({
-    createLSPServerInstance: (
-      _name: string,
-      _config: unknown,
-      options?: { onUnavailable?: (generation: number) => void },
-    ) => {
-      currentServer = createFakeServer(options?.onUnavailable)
-      return currentServer.server
-    },
-  }))
-}
-
-const { createLSPServerManager } = await import('./LSPServerManager.js')
-
 afterEach(async () => {
   await Promise.allSettled(managers.splice(0).map(manager => manager.shutdown()))
   currentServer = undefined
@@ -134,10 +106,6 @@ afterEach(async () => {
 
 beforeEach(() => {
   activityPaths.length = 0
-})
-
-afterAll(() => {
-  if (installedBaselineMocks) mock.restore()
 })
 
 async function createManager() {
@@ -151,7 +119,7 @@ async function createManager() {
       options: { onUnavailable?: (generation: number) => void },
     ) => {
       currentServer = createFakeServer(options.onUnavailable)
-      return currentServer.server as never
+      return currentServer.server
     },
     readDocument: filePath => readFile(filePath, 'utf-8'),
     recordFileActivity: filePath => {
@@ -220,17 +188,18 @@ test('resends current contents after restart before making a request', async () 
   }
 })
 
-test('records Windows activity with the same canonical path as diagnostics', async () => {
+test('records Windows activity without losing supplied path casing', async () => {
   const { manager } = await createManager()
   const firstSpelling = String.raw`C:\Repo\Source File.ts`
   const secondSpelling = 'c:/repo/source file.ts'
-  const canonicalUri = 'file:///c:/repo/source%20file.ts'
+  const openedUri = 'file:///c:/Repo/Source%20File.ts'
+  const changedUri = 'file:///c:/repo/source%20file.ts'
 
   await manager.openFile(firstSpelling, 'one')
   await manager.changeFile(secondSpelling, 'two')
 
   expect(activityPaths).toEqual([
-    fileURLToPath(canonicalUri),
-    fileURLToPath(canonicalUri),
+    fileURLToPath(openedUri),
+    fileURLToPath(changedUri),
   ])
 })

--- a/src/services/lsp/LSPServerManager.protocol.test.ts
+++ b/src/services/lsp/LSPServerManager.protocol.test.ts
@@ -188,18 +188,17 @@ test('resends current contents after restart before making a request', async () 
   }
 })
 
-test('records Windows activity without losing supplied path casing', async () => {
+test('records Windows activity with the opened document casing', async () => {
   const { manager } = await createManager()
   const firstSpelling = String.raw`C:\Repo\Source File.ts`
   const secondSpelling = 'c:/repo/source file.ts'
   const openedUri = 'file:///c:/Repo/Source%20File.ts'
-  const changedUri = 'file:///c:/repo/source%20file.ts'
 
   await manager.openFile(firstSpelling, 'one')
   await manager.changeFile(secondSpelling, 'two')
 
   expect(activityPaths).toEqual([
     fileURLToPath(openedUri),
-    fileURLToPath(changedUri),
+    fileURLToPath(openedUri),
   ])
 })

--- a/src/services/lsp/LSPServerManager.protocol.test.ts
+++ b/src/services/lsp/LSPServerManager.protocol.test.ts
@@ -57,6 +57,9 @@ function createFakeServer(
     get restartCount() {
       return 0
     },
+    get isCrashRecoveryExhausted() {
+      return false
+    },
     async start() {
       if (state === 'running') return
       generation++

--- a/src/services/lsp/LSPServerManager.protocol.test.ts
+++ b/src/services/lsp/LSPServerManager.protocol.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { fileURLToPath, pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 import { afterEach, beforeEach, expect, test } from 'bun:test'
 import { createLSPServerManager } from './LSPServerManager.js'
 import type { LSPServerInstance } from './LSPServerInstance.js'
@@ -136,8 +136,8 @@ async function createManager() {
 
 test('delivers monotonically increasing versions for one document', async () => {
   const { manager, server } = await createManager()
-  const file = '/repo/src/version.ts'
-  const uri = pathToFileURL(file).href
+  const file = String.raw`C:\repo\src\version.ts`
+  const uri = 'file:///c:/repo/src/version.ts'
 
   await manager.openFile(file, 'one')
   await manager.changeFile(file, 'two')

--- a/src/services/lsp/LSPServerManager.test.ts
+++ b/src/services/lsp/LSPServerManager.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
 import { fileURLToPath } from 'node:url'
-import { describe, expect, mock, test } from 'bun:test'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
 import type { ChildProcess } from 'child_process'
 import type { MessageConnection } from 'vscode-jsonrpc/node.js'
 import {
@@ -44,6 +44,12 @@ const PYTHON_CONFIG: ScopedLspServerConfig = {
   scope: 'project',
   source: 'test',
 }
+
+const managers: LSPServerManager[] = []
+
+afterEach(async () => {
+  await Promise.allSettled(managers.splice(0).map(manager => manager.shutdown()))
+})
 
 type ServerEvent =
   | {
@@ -330,6 +336,7 @@ async function createManager(options?: {
       options?.lifecycleNotificationTimeoutMs,
   })
   await manager.initialize()
+  managers.push(manager)
   return { manager, controls }
 }
 

--- a/src/services/lsp/LSPServerManager.test.ts
+++ b/src/services/lsp/LSPServerManager.test.ts
@@ -55,7 +55,12 @@ type FakeServerControl = {
   server: LSPServerInstance
   events: ServerEvent[]
   startCalls: ReturnType<typeof mock>
+  stopCalls: ReturnType<typeof mock>
   blockNextNotification(method: string): {
+    started: Promise<void>
+    release(): void
+  }
+  blockNextRequest(method: string, error?: Error): {
     started: Promise<void>
     release(): void
   }
@@ -73,6 +78,7 @@ function createFakeServer(
 ): FakeServerControl {
   let state: LspServerState = 'stopped'
   let generation = 0
+  let startEpoch = 0
   let startPromise: Promise<void> | undefined
   let nextStartGate:
     | { startedResolve: () => void; wait: Promise<void>; release: () => void }
@@ -86,6 +92,15 @@ function createFakeServer(
       }
     | undefined
   let notificationFailure: { method: string; error: Error } | undefined
+  let requestGate:
+    | {
+        method: string
+        error: Error
+        startedResolve: () => void
+        wait: Promise<void>
+        release: () => void
+      }
+    | undefined
   let startInvocationCount = 0
   const startWaiters: Array<{ count: number; resolve: () => void }> = []
   const events: ServerEvent[] = []
@@ -98,12 +113,14 @@ function createFakeServer(
     if (state === 'running') return
     if (startPromise) return startPromise
     state = 'starting'
+    const epoch = startEpoch
     const pending = (async () => {
       nextStartGate?.startedResolve()
       if (nextStartGate) {
         await nextStartGate.wait
         nextStartGate = undefined
       }
+      if (epoch !== startEpoch) return
       generation++
       state = 'running'
     })()
@@ -111,6 +128,15 @@ function createFakeServer(
       startPromise = undefined
     })
     return startPromise
+  })
+
+  const stopCalls = mock(async () => {
+    const stoppedGeneration = generation
+    startEpoch++
+    state = 'stopped'
+    nextStartGate?.release()
+    nextStartGate = undefined
+    options.onUnavailable?.(stoppedGeneration)
   })
 
   const server: LSPServerInstance = {
@@ -132,11 +158,7 @@ function createFakeServer(
       return 0
     },
     start: startCalls,
-    async stop() {
-      const stoppedGeneration = generation
-      state = 'stopped'
-      options.onUnavailable?.(stoppedGeneration)
-    },
+    stop: stopCalls,
     async restart() {
       await server.stop()
       await server.start()
@@ -146,6 +168,13 @@ function createFakeServer(
     },
     async sendRequest<TResult>(method: string, params: unknown) {
       events.push({ kind: 'request', generation, method, params })
+      if (requestGate?.method === method) {
+        const gate = requestGate
+        gate.startedResolve()
+        await gate.wait
+        requestGate = undefined
+        throw gate.error
+      }
       return null as TResult
     },
     async sendNotification(method: string, params: unknown) {
@@ -184,6 +213,7 @@ function createFakeServer(
     server,
     events,
     startCalls,
+    stopCalls,
     blockNextNotification(method) {
       let startedResolve!: () => void
       let release!: () => void
@@ -194,6 +224,18 @@ function createFakeServer(
         release = resolve
       })
       notificationGate = { method, startedResolve, wait, release }
+      return { started, release }
+    },
+    blockNextRequest(method, error = new Error('request interrupted')) {
+      let startedResolve!: () => void
+      let release!: () => void
+      const started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      const wait = new Promise<void>(resolve => {
+        release = resolve
+      })
+      requestGate = { method, error, startedResolve, wait, release }
       return { started, release }
     },
     failNextNotification(method, error = new Error('transport rejected')) {
@@ -453,6 +495,38 @@ describe('LSP generation resynchronization', () => {
     ])
   })
 
+  test('resynchronizes before retrying a request interrupted by a generation change', async () => {
+    const { manager, controls } = await createManager({
+      readDocument: async () => 'replacement contents',
+    })
+    const server = controls.get('typescript')!
+    const file = '/repo/src/retry-generation.ts'
+    const uri = getLspDocumentIdentity(file).fileUri
+
+    await manager.openFile(file, 'old contents')
+    const gate = server.blockNextRequest(
+      'textDocument/hover',
+      new Error('generation changed'),
+    )
+    const request = manager.sendRequest(file, 'textDocument/hover', {
+      textDocument: { uri },
+    })
+    await gate.started
+    server.replaceGeneration()
+    gate.release()
+
+    await expect(request).resolves.toBeNull()
+    expect(server.events.slice(-3)).toMatchObject([
+      { kind: 'request', generation: 1, method: 'textDocument/hover' },
+      {
+        kind: 'notification',
+        generation: 2,
+        method: 'textDocument/didOpen',
+      },
+      { kind: 'request', generation: 2, method: 'textDocument/hover' },
+    ])
+  })
+
   test('stopping one server clears only that server generation documents', async () => {
     const { manager, controls } = await createManager({
       configs: { typescript: TYPESCRIPT_CONFIG, python: PYTHON_CONFIG },
@@ -527,6 +601,30 @@ describe('LSP request concurrency', () => {
     expect(server.server.generation).toBe(1)
     expect(server.events.filter(event => event.kind === 'request')).toHaveLength(2)
   })
+
+  test('shutdown stops a starting server and rejects its in-flight request', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const gate = server.holdNextStart()
+    const requestOutcome = manager
+      .sendRequest('/repo/src/shutdown.ts', 'textDocument/hover', {})
+      .then(
+        () => undefined,
+        error => error,
+      )
+
+    await gate.started
+    try {
+      await manager.shutdown()
+      expect(server.stopCalls).toHaveBeenCalledTimes(1)
+      expect(await requestOutcome).toBeInstanceOf(Error)
+      expect(server.server.state).toBe('stopped')
+      expect(manager.getAllServers().size).toBe(0)
+    } finally {
+      gate.release()
+      await requestOutcome
+    }
+  })
 })
 
 describe('LSP document identity and diagnostics activity', () => {
@@ -554,9 +652,9 @@ describe('LSP document identity and diagnostics activity', () => {
 
     const firstIdentity = getLspDocumentIdentity(firstSpelling)
     const secondIdentity = getLspDocumentIdentity(secondSpelling)
-    expect(firstIdentity.fileUri).toBe('file:///c:/repo/source%20file.ts')
+    expect(firstIdentity.fileUri).toBe('file:///c:/Repo/Source%20File.ts')
     expect(secondIdentity).toMatchObject({
-      fileUri: firstIdentity.fileUri,
+      fileUri: 'file:///c:/repo/source%20file.ts',
       stateKey: firstIdentity.stateKey,
     })
 
@@ -571,7 +669,34 @@ describe('LSP document identity and diagnostics activity', () => {
     ])
     expect(activityPaths).toEqual([
       fileURLToPath(firstIdentity.fileUri),
-      fileURLToPath(firstIdentity.fileUri),
+      fileURLToPath(secondIdentity.fileUri),
+    ])
+  })
+
+  test('reuses the opened Windows URI for requests through a case alias', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const firstSpelling = String.raw`C:\Repo\Source File.ts`
+    const secondSpelling = 'c:/repo/source file.ts'
+    const openedUri = getLspDocumentIdentity(firstSpelling).fileUri
+    const aliasUri = getLspDocumentIdentity(secondSpelling).fileUri
+
+    await manager.openFile(firstSpelling, 'one')
+    await manager.sendRequest(secondSpelling, 'textDocument/hover', {
+      textDocument: { uri: aliasUri },
+    })
+
+    expect(server.events.slice(-2)).toMatchObject([
+      {
+        kind: 'notification',
+        method: 'textDocument/didOpen',
+        params: { textDocument: { uri: openedUri } },
+      },
+      {
+        kind: 'request',
+        method: 'textDocument/hover',
+        params: { textDocument: { uri: openedUri } },
+      },
     ])
   })
 

--- a/src/services/lsp/LSPServerManager.test.ts
+++ b/src/services/lsp/LSPServerManager.test.ts
@@ -669,7 +669,7 @@ describe('LSP document identity and diagnostics activity', () => {
     ])
     expect(activityPaths).toEqual([
       fileURLToPath(firstIdentity.fileUri),
-      fileURLToPath(secondIdentity.fileUri),
+      fileURLToPath(firstIdentity.fileUri),
     ])
   })
 

--- a/src/services/lsp/LSPServerManager.test.ts
+++ b/src/services/lsp/LSPServerManager.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PassThrough } from 'node:stream'
 import { fileURLToPath } from 'node:url'
-import { afterEach, describe, expect, mock, test } from 'bun:test'
+import { afterEach, describe, expect, jest, mock, test } from 'bun:test'
 import type { ChildProcess } from 'child_process'
 import type { MessageConnection } from 'vscode-jsonrpc/node.js'
 import {
@@ -602,6 +602,7 @@ describe('LSP lifecycle notification failures', () => {
   })
 
   test('bounds shutdown while a lifecycle notification is stuck', async () => {
+    jest.useFakeTimers()
     const { manager, controls } = await createManager({
       lifecycleNotificationTimeoutMs: 5,
     })
@@ -610,23 +611,21 @@ describe('LSP lifecycle notification failures', () => {
     const open = manager.openFile('/repo/src/stuck-open.ts', 'contents')
     await gate.started
     const shutdown = manager.shutdown()
-    const outcome = await Promise.race([
-      shutdown.then(() => 'settled' as const),
-      new Promise<'pending'>(resolve =>
-        setTimeout(() => resolve('pending'), 20),
-      ),
-    ])
 
     try {
-      expect(outcome).toBe('settled')
+      jest.advanceTimersByTime(5)
+      await expect(shutdown).resolves.toBeUndefined()
       await expect(open).rejects.toThrow('timed out after 5ms')
     } finally {
       gate.release()
+      jest.runAllTimers()
+      jest.useRealTimers()
       await Promise.allSettled([open, shutdown])
     }
   })
 
   test('a stale lifecycle timeout does not stop the replacement generation', async () => {
+    jest.useFakeTimers()
     const { manager, controls } = await createManager({
       lifecycleNotificationTimeoutMs: 5,
     })
@@ -636,23 +635,16 @@ describe('LSP lifecycle notification failures', () => {
     await gate.started
     server.replaceGeneration()
 
-    const outcome = await Promise.race([
-      open.then(
-        () => 'resolved' as const,
-        () => 'rejected' as const,
-      ),
-      new Promise<'pending'>(resolve =>
-        setTimeout(() => resolve('pending'), 20),
-      ),
-    ])
-
     try {
-      expect(outcome).toBe('rejected')
+      jest.advanceTimersByTime(5)
+      await expect(open).rejects.toThrow('timed out after 5ms')
       expect(server.server.state).toBe('running')
       expect(server.server.generation).toBe(2)
       expect(server.stopCalls).not.toHaveBeenCalled()
     } finally {
       gate.release()
+      jest.runAllTimers()
+      jest.useRealTimers()
       await open.catch(() => {})
     }
   })

--- a/src/services/lsp/LSPServerManager.test.ts
+++ b/src/services/lsp/LSPServerManager.test.ts
@@ -1,0 +1,612 @@
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, mock, test } from 'bun:test'
+import {
+  getLspDocumentIdentity,
+  LspDocumentTooLargeError,
+  MAX_LSP_FILE_SIZE_BYTES,
+  readLspDocumentContents,
+} from './documentIdentity.js'
+import {
+  createLSPServerManager,
+  type LSPServerManager,
+} from './LSPServerManager.js'
+import type {
+  LSPServerInstance,
+  LSPServerInstanceOptions,
+} from './LSPServerInstance.js'
+import type { LspServerState, ScopedLspServerConfig } from './types.js'
+
+const TYPESCRIPT_CONFIG: ScopedLspServerConfig = {
+  command: 'unused-typescript-lsp',
+  extensionToLanguage: {
+    '.ts': 'typescript',
+    '.tsx': 'typescriptreact',
+  },
+  scope: 'project',
+  source: 'test',
+}
+
+const PYTHON_CONFIG: ScopedLspServerConfig = {
+  command: 'unused-python-lsp',
+  extensionToLanguage: { '.py': 'python' },
+  scope: 'project',
+  source: 'test',
+}
+
+type ServerEvent =
+  | {
+      kind: 'notification'
+      generation: number
+      method: string
+      params: unknown
+      strict: boolean
+    }
+  | {
+      kind: 'request'
+      generation: number
+      method: string
+      params: unknown
+    }
+
+type FakeServerControl = {
+  server: LSPServerInstance
+  events: ServerEvent[]
+  startCalls: ReturnType<typeof mock>
+  blockNextNotification(method: string): {
+    started: Promise<void>
+    release(): void
+  }
+  failNextNotification(method: string, error?: Error): void
+  holdNextStart(): { started: Promise<void>; release(): void }
+  waitForStartCalls(count: number): Promise<void>
+  simulateCrash(notifyManager?: boolean): void
+  replaceGeneration(): void
+}
+
+function createFakeServer(
+  name: string,
+  config: ScopedLspServerConfig,
+  options: LSPServerInstanceOptions = {},
+): FakeServerControl {
+  let state: LspServerState = 'stopped'
+  let generation = 0
+  let startPromise: Promise<void> | undefined
+  let nextStartGate:
+    | { startedResolve: () => void; wait: Promise<void>; release: () => void }
+    | undefined
+  let notificationGate:
+    | {
+        method: string
+        startedResolve: () => void
+        wait: Promise<void>
+        release: () => void
+      }
+    | undefined
+  let notificationFailure: { method: string; error: Error } | undefined
+  let startInvocationCount = 0
+  const startWaiters: Array<{ count: number; resolve: () => void }> = []
+  const events: ServerEvent[] = []
+
+  const startCalls = mock(async () => {
+    startInvocationCount++
+    for (const waiter of startWaiters) {
+      if (startInvocationCount >= waiter.count) waiter.resolve()
+    }
+    if (state === 'running') return
+    if (startPromise) return startPromise
+    state = 'starting'
+    const pending = (async () => {
+      nextStartGate?.startedResolve()
+      if (nextStartGate) {
+        await nextStartGate.wait
+        nextStartGate = undefined
+      }
+      generation++
+      state = 'running'
+    })()
+    startPromise = pending.finally(() => {
+      startPromise = undefined
+    })
+    return startPromise
+  })
+
+  const server: LSPServerInstance = {
+    name,
+    config,
+    get state() {
+      return state
+    },
+    get generation() {
+      return generation
+    },
+    get startTime() {
+      return undefined
+    },
+    get lastError() {
+      return undefined
+    },
+    get restartCount() {
+      return 0
+    },
+    start: startCalls,
+    async stop() {
+      const stoppedGeneration = generation
+      state = 'stopped'
+      options.onUnavailable?.(stoppedGeneration)
+    },
+    async restart() {
+      await server.stop()
+      await server.start()
+    },
+    isHealthy() {
+      return state === 'running'
+    },
+    async sendRequest<TResult>(method: string, params: unknown) {
+      events.push({ kind: 'request', generation, method, params })
+      return null as TResult
+    },
+    async sendNotification(method: string, params: unknown) {
+      events.push({
+        kind: 'notification',
+        generation,
+        method,
+        params,
+        strict: false,
+      })
+    },
+    async sendNotificationStrict(method: string, params: unknown) {
+      events.push({
+        kind: 'notification',
+        generation,
+        method,
+        params,
+        strict: true,
+      })
+      if (notificationGate?.method === method) {
+        notificationGate.startedResolve()
+        await notificationGate.wait
+        notificationGate = undefined
+      }
+      if (notificationFailure?.method === method) {
+        const error = notificationFailure.error
+        notificationFailure = undefined
+        throw error
+      }
+    },
+    onNotification() {},
+    onRequest() {},
+  }
+
+  return {
+    server,
+    events,
+    startCalls,
+    blockNextNotification(method) {
+      let startedResolve!: () => void
+      let release!: () => void
+      const started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      const wait = new Promise<void>(resolve => {
+        release = resolve
+      })
+      notificationGate = { method, startedResolve, wait, release }
+      return { started, release }
+    },
+    failNextNotification(method, error = new Error('transport rejected')) {
+      notificationFailure = { method, error }
+    },
+    holdNextStart() {
+      let startedResolve!: () => void
+      let release!: () => void
+      const started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      const wait = new Promise<void>(resolve => {
+        release = resolve
+      })
+      nextStartGate = { startedResolve, wait, release }
+      return { started, release }
+    },
+    waitForStartCalls(count) {
+      if (startInvocationCount >= count) return Promise.resolve()
+      return new Promise<void>(resolve => {
+        startWaiters.push({ count, resolve })
+      })
+    },
+    simulateCrash(notifyManager = true) {
+      const crashedGeneration = generation
+      state = 'error'
+      if (notifyManager) options.onUnavailable?.(crashedGeneration)
+    },
+    replaceGeneration() {
+      generation++
+      state = 'running'
+    },
+  }
+}
+
+async function createManager(options?: {
+  configs?: Record<string, ScopedLspServerConfig>
+  readDocument?: (filePath: string) => Promise<string>
+  recordFileActivity?: (filePath: string) => void
+}): Promise<{
+  manager: LSPServerManager
+  controls: Map<string, FakeServerControl>
+}> {
+  const configs = options?.configs ?? { typescript: TYPESCRIPT_CONFIG }
+  const controls = new Map<string, FakeServerControl>()
+  const manager = createLSPServerManager({
+    loadServerConfigs: async () => ({ servers: configs }),
+    createServerInstance: (name, config, instanceOptions) => {
+      const control = createFakeServer(name, config, instanceOptions)
+      controls.set(name, control)
+      return control.server
+    },
+    readDocument: options?.readDocument ?? (async () => 'current contents'),
+    recordFileActivity: options?.recordFileActivity ?? (() => {}),
+  })
+  await manager.initialize()
+  return { manager, controls }
+}
+
+function documentVersions(
+  events: ServerEvent[],
+  uri: string,
+): Array<{ method: string; version: number }> {
+  return events.flatMap(event => {
+    if (event.kind !== 'notification') return []
+    const params = event.params as {
+      textDocument?: { uri?: string; version?: number }
+    }
+    if (params.textDocument?.uri !== uri) return []
+    const version = params.textDocument.version
+    return typeof version === 'number'
+      ? [{ method: event.method, version }]
+      : []
+  })
+}
+
+describe('LSP document versions', () => {
+  test('increments changes monotonically and independently per document', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const first = '/repo/src/first.ts'
+    const second = '/repo/src/second.tsx'
+
+    await manager.openFile(first, 'one')
+    await manager.changeFile(first, 'two')
+    await manager.changeFile(first, 'three')
+    await manager.openFile(second, 'alpha')
+    await manager.changeFile(second, 'beta')
+
+    expect(
+      documentVersions(server.events, getLspDocumentIdentity(first).fileUri),
+    ).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didChange', version: 2 },
+      { method: 'textDocument/didChange', version: 3 },
+    ])
+    expect(
+      documentVersions(server.events, getLspDocumentIdentity(second).fileUri),
+    ).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didChange', version: 2 },
+    ])
+  })
+
+  test('close and reopen starts a new lifecycle at version one', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/reopen.ts'
+
+    await manager.openFile(file, 'one')
+    await manager.changeFile(file, 'two')
+    await manager.closeFile(file)
+    await manager.openFile(file, 'three')
+
+    expect(
+      server.events
+        .filter(event => event.kind === 'notification')
+        .map(event => ({
+          method: event.method,
+          version: (event.params as { textDocument?: { version?: number } })
+            .textDocument?.version,
+        })),
+    ).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didChange', version: 2 },
+      { method: 'textDocument/didClose', version: undefined },
+      { method: 'textDocument/didOpen', version: 1 },
+    ])
+  })
+})
+
+describe('LSP lifecycle notification failures', () => {
+  test('failed open creates no state and a later open retries', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/open-failure.ts'
+    server.failNextNotification('textDocument/didOpen')
+
+    await expect(manager.openFile(file, 'one')).rejects.toThrow(
+      'Failed to sync file open',
+    )
+    expect(manager.isFileOpen(file)).toBe(false)
+
+    await manager.openFile(file, 'two')
+    expect(manager.isFileOpen(file)).toBe(true)
+    expect(
+      documentVersions(server.events, getLspDocumentIdentity(file).fileUri),
+    ).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didOpen', version: 1 },
+    ])
+  })
+
+  test('failed change invalidates state and the next request performs a full open', async () => {
+    const readDocument = mock(async () => 'latest complete contents')
+    const { manager, controls } = await createManager({ readDocument })
+    const server = controls.get('typescript')!
+    const file = '/repo/src/change-failure.ts'
+
+    await manager.openFile(file, 'one')
+    server.failNextNotification('textDocument/didChange')
+    await expect(manager.changeFile(file, 'two')).rejects.toThrow(
+      'Failed to sync file change',
+    )
+    expect(manager.isFileOpen(file)).toBe(false)
+    await manager.saveFile(file)
+    expect(
+      server.events.some(
+        event =>
+          event.kind === 'notification' &&
+          event.method === 'textDocument/didSave',
+      ),
+    ).toBe(false)
+
+    await manager.sendRequest(file, 'textDocument/hover', {})
+
+    expect(readDocument).toHaveBeenCalledTimes(1)
+    expect(
+      documentVersions(server.events, getLspDocumentIdentity(file).fileUri),
+    ).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didChange', version: 2 },
+      { method: 'textDocument/didOpen', version: 1 },
+    ])
+    expect(server.events.at(-1)?.kind).toBe('request')
+  })
+
+  test('failed close removes local state and allows a version-one reopen', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/close-failure.ts'
+
+    await manager.openFile(file, 'one')
+    server.failNextNotification('textDocument/didClose')
+    await expect(manager.closeFile(file)).rejects.toThrow(
+      'Failed to sync file close',
+    )
+    expect(manager.isFileOpen(file)).toBe(false)
+
+    await manager.openFile(file, 'two')
+    expect(
+      documentVersions(server.events, getLspDocumentIdentity(file).fileUri),
+    ).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didOpen', version: 1 },
+    ])
+  })
+})
+
+describe('LSP generation resynchronization', () => {
+  test('opens current contents on a replacement generation before the request', async () => {
+    const readDocument = mock(async () => 'contents after crash')
+    const { manager, controls } = await createManager({ readDocument })
+    const server = controls.get('typescript')!
+    const file = '/repo/src/restart.ts'
+
+    await manager.openFile(file, 'before crash')
+    server.simulateCrash(false)
+    expect(manager.isFileOpen(file)).toBe(false)
+
+    await manager.sendRequest(file, 'textDocument/definition', {})
+
+    expect(server.server.generation).toBe(2)
+    expect(readDocument).toHaveBeenCalledTimes(1)
+    expect(server.events.slice(-2).map(event => event.kind)).toEqual([
+      'notification',
+      'request',
+    ])
+    const reopen = server.events.at(-2)
+    expect(reopen).toMatchObject({
+      kind: 'notification',
+      generation: 2,
+      method: 'textDocument/didOpen',
+      params: { textDocument: { version: 1, text: 'contents after crash' } },
+    })
+  })
+
+  test('generation mismatch is sufficient even when prior cleanup did not run', async () => {
+    const { manager, controls } = await createManager({
+      readDocument: async () => 'replacement contents',
+    })
+    const server = controls.get('typescript')!
+    const file = '/repo/src/generation.ts'
+
+    await manager.openFile(file, 'old')
+    server.replaceGeneration()
+    await manager.sendRequest(file, 'textDocument/hover', {})
+
+    expect(server.events.slice(-2)).toMatchObject([
+      {
+        kind: 'notification',
+        generation: 2,
+        method: 'textDocument/didOpen',
+        params: { textDocument: { version: 1, text: 'replacement contents' } },
+      },
+      { kind: 'request', generation: 2, method: 'textDocument/hover' },
+    ])
+  })
+
+  test('stopping one server clears only that server generation documents', async () => {
+    const { manager, controls } = await createManager({
+      configs: { typescript: TYPESCRIPT_CONFIG, python: PYTHON_CONFIG },
+    })
+    const tsFile = '/repo/src/file.ts'
+    const pyFile = '/repo/src/file.py'
+
+    await manager.openFile(tsFile, 'const value = 1')
+    await manager.openFile(pyFile, 'value = 1')
+    await controls.get('typescript')!.server.stop()
+
+    expect(manager.isFileOpen(tsFile)).toBe(false)
+    expect(manager.isFileOpen(pyFile)).toBe(true)
+  })
+})
+
+describe('LSP request concurrency', () => {
+  test('two simultaneous first requests send one open before either request', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const gate = server.blockNextNotification('textDocument/didOpen')
+    const file = '/repo/src/concurrent.ts'
+
+    const first = manager.sendRequest(file, 'textDocument/hover', { request: 1 })
+    await gate.started
+    const second = manager.sendRequest(file, 'textDocument/definition', {
+      request: 2,
+    })
+
+    expect(server.events.filter(event => event.kind === 'request')).toHaveLength(0)
+    expect(
+      server.events.filter(
+        event =>
+          event.kind === 'notification' &&
+          event.method === 'textDocument/didOpen',
+      ),
+    ).toHaveLength(1)
+
+    gate.release()
+    await Promise.all([first, second])
+
+    expect(
+      server.events.filter(
+        event =>
+          event.kind === 'notification' &&
+          event.method === 'textDocument/didOpen',
+      ),
+    ).toHaveLength(1)
+    expect(server.events.filter(event => event.kind === 'request')).toHaveLength(2)
+  })
+
+  test('different documents await one shared lazy server initialization', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const gate = server.holdNextStart()
+
+    const first = manager.sendRequest('/repo/src/one.ts', 'textDocument/hover', {})
+    await gate.started
+    const second = manager.sendRequest(
+      '/repo/src/two.tsx',
+      'textDocument/definition',
+      {},
+    )
+    await server.waitForStartCalls(2)
+
+    expect(server.startCalls).toHaveBeenCalledTimes(2)
+    expect(server.events).toHaveLength(0)
+
+    gate.release()
+    await Promise.all([first, second])
+
+    expect(server.server.generation).toBe(1)
+    expect(server.events.filter(event => event.kind === 'request')).toHaveLength(2)
+  })
+})
+
+describe('LSP document identity and diagnostics activity', () => {
+  test('keeps POSIX document identity canonical and case-sensitive', () => {
+    const mixedCase = getLspDocumentIdentity('/repo/Source File.ts')
+    const lowerCase = getLspDocumentIdentity('/repo/source file.ts')
+
+    expect(mixedCase).toEqual({
+      resolvedPath: '/repo/Source File.ts',
+      fileUri: 'file:///repo/Source%20File.ts',
+      stateKey: 'file:///repo/Source%20File.ts',
+      activityPath: '/repo/Source File.ts',
+    })
+    expect(lowerCase.stateKey).not.toBe(mixedCase.stateKey)
+  })
+
+  test('normalizes Windows drive paths into one stable URI and state key', async () => {
+    const activityPaths: string[] = []
+    const { manager, controls } = await createManager({
+      recordFileActivity: filePath => activityPaths.push(filePath),
+    })
+    const server = controls.get('typescript')!
+    const firstSpelling = String.raw`C:\Repo\Source File.ts`
+    const secondSpelling = 'c:/repo/source file.ts'
+
+    const firstIdentity = getLspDocumentIdentity(firstSpelling)
+    const secondIdentity = getLspDocumentIdentity(secondSpelling)
+    expect(firstIdentity.fileUri).toBe('file:///c:/repo/source%20file.ts')
+    expect(secondIdentity).toMatchObject({
+      fileUri: firstIdentity.fileUri,
+      stateKey: firstIdentity.stateKey,
+    })
+
+    await manager.openFile(firstSpelling, 'one')
+    await manager.changeFile(secondSpelling, 'two')
+
+    expect(manager.isFileOpen(firstSpelling)).toBe(true)
+    expect(manager.isFileOpen(secondSpelling)).toBe(true)
+    expect(documentVersions(server.events, firstIdentity.fileUri)).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didChange', version: 2 },
+    ])
+    expect(activityPaths).toEqual([
+      fileURLToPath(firstIdentity.fileUri),
+      fileURLToPath(firstIdentity.fileUri),
+    ])
+  })
+
+  test('records activity once for open, change fallback, change, save, and request reopen', async () => {
+    const recordFileActivity = mock((_filePath: string) => {})
+    const { manager, controls } = await createManager({ recordFileActivity })
+    const server = controls.get('typescript')!
+    const file = '/repo/src/activity.ts'
+
+    await manager.changeFile(file, 'opened through change')
+    await manager.changeFile(file, 'changed')
+    await manager.saveFile(file)
+    server.replaceGeneration()
+    await manager.sendRequest(file, 'textDocument/hover', {})
+
+    expect(recordFileActivity).toHaveBeenCalledTimes(4)
+    expect(recordFileActivity.mock.calls.map(call => call[0])).toEqual([
+      file,
+      file,
+      file,
+      file,
+    ])
+  })
+
+  test('the shared document reader rejects files above the tool limit', async () => {
+    const directory = mkdtempSync(join(tmpdir(), 'openclaude-lsp-size-'))
+    const file = join(directory, 'large.ts')
+    try {
+      writeFileSync(file, '')
+      truncateSync(file, MAX_LSP_FILE_SIZE_BYTES + 1)
+      await expect(readLspDocumentContents(file)).rejects.toBeInstanceOf(
+        LspDocumentTooLargeError,
+      )
+    } finally {
+      rmSync(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/services/lsp/LSPServerManager.test.ts
+++ b/src/services/lsp/LSPServerManager.test.ts
@@ -368,6 +368,56 @@ describe('LSP document versions', () => {
 })
 
 describe('LSP lifecycle notification failures', () => {
+  test('generation replacement during open leaves no committed state', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/open-generation-change.ts'
+    const gate = server.blockNextNotification('textDocument/didOpen')
+
+    const open = manager.openFile(file, 'one')
+    await gate.started
+    server.replaceGeneration()
+    gate.release()
+
+    await expect(open).rejects.toThrow('generation changed')
+    expect(manager.isFileOpen(file)).toBe(false)
+
+    await manager.changeFile(file, 'two')
+    expect(manager.isFileOpen(file)).toBe(true)
+    expect(
+      documentVersions(server.events, getLspDocumentIdentity(file).fileUri),
+    ).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didOpen', version: 1 },
+    ])
+  })
+
+  test('generation replacement during change forces a version-one reopen', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/change-generation-change.ts'
+
+    await manager.openFile(file, 'one')
+    const gate = server.blockNextNotification('textDocument/didChange')
+    const change = manager.changeFile(file, 'two')
+    await gate.started
+    server.replaceGeneration()
+    gate.release()
+
+    await expect(change).rejects.toThrow('generation changed')
+    expect(manager.isFileOpen(file)).toBe(false)
+
+    await manager.changeFile(file, 'three')
+    expect(manager.isFileOpen(file)).toBe(true)
+    expect(
+      documentVersions(server.events, getLspDocumentIdentity(file).fileUri),
+    ).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didChange', version: 2 },
+      { method: 'textDocument/didOpen', version: 1 },
+    ])
+  })
+
   test('failed open creates no state and a later open retries', async () => {
     const { manager, controls } = await createManager()
     const server = controls.get('typescript')!
@@ -446,6 +496,31 @@ describe('LSP lifecycle notification failures', () => {
 })
 
 describe('LSP generation resynchronization', () => {
+  test('generation-bound requests reject instead of replaying opaque params', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/generation-bound.ts'
+
+    await manager.openFile(file, 'one')
+    const gate = server.blockNextRequest('callHierarchy/incomingCalls')
+    const request = manager.sendRequestWithGeneration(
+      file,
+      'callHierarchy/incomingCalls',
+      { item: { data: { generation: 1 } } },
+      { expectedGeneration: 1 },
+    )
+    await gate.started
+    server.replaceGeneration()
+    gate.release()
+
+    await expect(request).rejects.toMatchObject({
+      code: 'LSP_SERVER_GENERATION_CHANGED',
+    })
+    expect(
+      server.events.filter(event => event.kind === 'request'),
+    ).toHaveLength(1)
+  })
+
   test('opens current contents on a replacement generation before the request', async () => {
     const readDocument = mock(async () => 'contents after crash')
     const { manager, controls } = await createManager({ readDocument })
@@ -719,6 +794,26 @@ describe('LSP document identity and diagnostics activity', () => {
       file,
       file,
     ])
+  })
+
+  test('records save activity when no document lifecycle is tracked', async () => {
+    const recordFileActivity = mock((_filePath: string) => {})
+    const { manager, controls } = await createManager({ recordFileActivity })
+    const server = controls.get('typescript')!
+    const file = '/repo/src/unopened-save.ts'
+
+    await manager.ensureServerStarted(file)
+    await manager.saveFile(file)
+
+    expect(recordFileActivity).toHaveBeenCalledTimes(1)
+    expect(recordFileActivity).toHaveBeenCalledWith(file)
+    expect(
+      server.events.some(
+        event =>
+          event.kind === 'notification' &&
+          event.method === 'textDocument/didSave',
+      ),
+    ).toBe(false)
   })
 
   test('the shared document reader rejects files above the tool limit', async () => {

--- a/src/services/lsp/LSPServerManager.test.ts
+++ b/src/services/lsp/LSPServerManager.test.ts
@@ -1,8 +1,12 @@
+import { EventEmitter } from 'node:events'
 import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { PassThrough } from 'node:stream'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, mock, test } from 'bun:test'
+import type { ChildProcess } from 'child_process'
+import type { MessageConnection } from 'vscode-jsonrpc/node.js'
 import {
   getLspDocumentIdentity,
   LspDocumentTooLargeError,
@@ -10,12 +14,17 @@ import {
   readLspDocumentContents,
 } from './documentIdentity.js'
 import {
+  createLSPClient,
+  type LSPClientDependencies,
+} from './LSPClient.js'
+import {
   createLSPServerManager,
   type LSPServerManager,
 } from './LSPServerManager.js'
-import type {
-  LSPServerInstance,
-  LSPServerInstanceOptions,
+import {
+  createLSPServerInstance,
+  type LSPServerInstance,
+  type LSPServerInstanceOptions,
 } from './LSPServerInstance.js'
 import type { LspServerState, ScopedLspServerConfig } from './types.js'
 
@@ -64,11 +73,16 @@ type FakeServerControl = {
     started: Promise<void>
     release(): void
   }
+  holdNextRequest<TResult>(method: string, result: TResult): {
+    started: Promise<void>
+    release(): void
+  }
   failNextNotification(method: string, error?: Error): void
   holdNextStart(): { started: Promise<void>; release(): void }
   waitForStartCalls(count: number): Promise<void>
   simulateCrash(notifyManager?: boolean): void
   replaceGeneration(): void
+  setCrashRecoveryExhausted(exhausted: boolean): void
 }
 
 function createFakeServer(
@@ -95,13 +109,15 @@ function createFakeServer(
   let requestGate:
     | {
         method: string
-        error: Error
+        result?: unknown
+        error?: Error
         startedResolve: () => void
         wait: Promise<void>
         release: () => void
       }
     | undefined
   let startInvocationCount = 0
+  let crashRecoveryExhausted = false
   const startWaiters: Array<{ count: number; resolve: () => void }> = []
   const events: ServerEvent[] = []
 
@@ -157,6 +173,9 @@ function createFakeServer(
     get restartCount() {
       return 0
     },
+    get isCrashRecoveryExhausted() {
+      return crashRecoveryExhausted
+    },
     start: startCalls,
     stop: stopCalls,
     async restart() {
@@ -173,7 +192,8 @@ function createFakeServer(
         gate.startedResolve()
         await gate.wait
         requestGate = undefined
-        throw gate.error
+        if (gate.error) throw gate.error
+        return gate.result as TResult
       }
       return null as TResult
     },
@@ -238,6 +258,18 @@ function createFakeServer(
       requestGate = { method, error, startedResolve, wait, release }
       return { started, release }
     },
+    holdNextRequest(method, result) {
+      let startedResolve!: () => void
+      let release!: () => void
+      const started = new Promise<void>(resolve => {
+        startedResolve = resolve
+      })
+      const wait = new Promise<void>(resolve => {
+        release = resolve
+      })
+      requestGate = { method, result, startedResolve, wait, release }
+      return { started, release }
+    },
     failNextNotification(method, error = new Error('transport rejected')) {
       notificationFailure = { method, error }
     },
@@ -268,6 +300,9 @@ function createFakeServer(
       generation++
       state = 'running'
     },
+    setCrashRecoveryExhausted(exhausted) {
+      crashRecoveryExhausted = exhausted
+    },
   }
 }
 
@@ -275,6 +310,7 @@ async function createManager(options?: {
   configs?: Record<string, ScopedLspServerConfig>
   readDocument?: (filePath: string) => Promise<string>
   recordFileActivity?: (filePath: string) => void
+  lifecycleNotificationTimeoutMs?: number
 }): Promise<{
   manager: LSPServerManager
   controls: Map<string, FakeServerControl>
@@ -290,9 +326,72 @@ async function createManager(options?: {
     },
     readDocument: options?.readDocument ?? (async () => 'current contents'),
     recordFileActivity: options?.recordFileActivity ?? (() => {}),
+    lifecycleNotificationTimeoutMs:
+      options?.lifecycleNotificationTimeoutMs,
   })
   await manager.initialize()
   return { manager, controls }
+}
+
+type IntegratedConnectionEvent = {
+  kind: 'notification' | 'request'
+  method: string
+  params: unknown
+}
+
+type IntegratedTransport = {
+  child: ChildProcess
+  connection: MessageConnection
+  events: IntegratedConnectionEvent[]
+  emitConnectionError(error: Error): void
+  emitConnectionClose(): void
+}
+
+function createIntegratedTransport(): IntegratedTransport {
+  const child = new EventEmitter() as ChildProcess
+  Object.assign(child, {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: mock(() => true),
+  })
+  queueMicrotask(() => child.emit('spawn'))
+
+  const events: IntegratedConnectionEvent[] = []
+  let errorHandler: ((error: [Error, unknown, number]) => void) | undefined
+  let closeHandler: (() => void) | undefined
+  const connection = {
+    listen: mock(() => {}),
+    trace: mock(async () => {}),
+    onError: mock((handler: (error: [Error, unknown, number]) => void) => {
+      errorHandler = handler
+    }),
+    onClose: mock((handler: () => void) => {
+      closeHandler = handler
+    }),
+    onNotification: mock(() => {}),
+    onRequest: mock(() => {}),
+    sendRequest: mock(async (method: string, params: unknown) => {
+      events.push({ kind: 'request', method, params })
+      return method === 'initialize' ? { capabilities: {} } : null
+    }),
+    sendNotification: mock(async (method: string, params: unknown) => {
+      events.push({ kind: 'notification', method, params })
+    }),
+    dispose: mock(() => {}),
+  } as unknown as MessageConnection
+
+  return {
+    child,
+    connection,
+    events,
+    emitConnectionError(error) {
+      errorHandler?.([error, undefined, 0])
+    },
+    emitConnectionClose() {
+      closeHandler?.()
+    },
+  }
 }
 
 function documentVersions(
@@ -450,6 +549,7 @@ describe('LSP lifecycle notification failures', () => {
     await expect(manager.changeFile(file, 'two')).rejects.toThrow(
       'Failed to sync file change',
     )
+    expect(server.stopCalls).toHaveBeenCalledTimes(1)
     expect(manager.isFileOpen(file)).toBe(false)
     await manager.saveFile(file)
     expect(
@@ -493,9 +593,85 @@ describe('LSP lifecycle notification failures', () => {
       { method: 'textDocument/didOpen', version: 1 },
     ])
   })
+
+  test('bounds shutdown while a lifecycle notification is stuck', async () => {
+    const { manager, controls } = await createManager({
+      lifecycleNotificationTimeoutMs: 5,
+    })
+    const server = controls.get('typescript')!
+    const gate = server.blockNextNotification('textDocument/didOpen')
+    const open = manager.openFile('/repo/src/stuck-open.ts', 'contents')
+    await gate.started
+    const shutdown = manager.shutdown()
+    const outcome = await Promise.race([
+      shutdown.then(() => 'settled' as const),
+      new Promise<'pending'>(resolve =>
+        setTimeout(() => resolve('pending'), 20),
+      ),
+    ])
+
+    try {
+      expect(outcome).toBe('settled')
+      await expect(open).rejects.toThrow('timed out after 5ms')
+    } finally {
+      gate.release()
+      await Promise.allSettled([open, shutdown])
+    }
+  })
+
+  test('a stale lifecycle timeout does not stop the replacement generation', async () => {
+    const { manager, controls } = await createManager({
+      lifecycleNotificationTimeoutMs: 5,
+    })
+    const server = controls.get('typescript')!
+    const gate = server.blockNextNotification('textDocument/didOpen')
+    const open = manager.openFile('/repo/src/stale-open.ts', 'contents')
+    await gate.started
+    server.replaceGeneration()
+
+    const outcome = await Promise.race([
+      open.then(
+        () => 'resolved' as const,
+        () => 'rejected' as const,
+      ),
+      new Promise<'pending'>(resolve =>
+        setTimeout(() => resolve('pending'), 20),
+      ),
+    ])
+
+    try {
+      expect(outcome).toBe('rejected')
+      expect(server.server.state).toBe('running')
+      expect(server.server.generation).toBe(2)
+      expect(server.stopCalls).not.toHaveBeenCalled()
+    } finally {
+      gate.release()
+      await open.catch(() => {})
+    }
+  })
 })
 
 describe('LSP generation resynchronization', () => {
+  test('recognizes request-context changes without throwing on non-object errors', async () => {
+    const {
+      isLspDocumentRevisionChanged,
+      isLspServerGenerationChanged,
+      LSP_DOCUMENT_REVISION_CHANGED,
+      LSP_SERVER_GENERATION_CHANGED,
+    } = await import('./LSPServerManager.js')
+
+    for (const value of [null, undefined, 'context changed']) {
+      expect(isLspServerGenerationChanged(value)).toBe(false)
+      expect(isLspDocumentRevisionChanged(value)).toBe(false)
+    }
+    expect(
+      isLspServerGenerationChanged({ code: LSP_SERVER_GENERATION_CHANGED }),
+    ).toBe(true)
+    expect(
+      isLspDocumentRevisionChanged({ code: LSP_DOCUMENT_REVISION_CHANGED }),
+    ).toBe(true)
+  })
+
   test('generation-bound requests reject instead of replaying opaque params', async () => {
     const { manager, controls } = await createManager()
     const server = controls.get('typescript')!
@@ -618,6 +794,110 @@ describe('LSP generation resynchronization', () => {
   })
 })
 
+describe('LSP transport recovery integration', () => {
+  const scenarios: Array<{
+    name: string
+    terminate(transport: IntegratedTransport): void
+  }> = [
+    {
+      name: 'JSON-RPC error',
+      terminate: transport =>
+        transport.emitConnectionError(new Error('connection failed')),
+    },
+    {
+      name: 'JSON-RPC close',
+      terminate: transport => transport.emitConnectionClose(),
+    },
+    {
+      name: 'child-process error',
+      terminate: transport =>
+        transport.child.emit('error', new Error('process transport error')),
+    },
+    {
+      name: 'clean child exit',
+      terminate: transport => transport.child.emit('exit', 0, null),
+    },
+    {
+      name: 'signal child exit',
+      terminate: transport =>
+        transport.child.emit('exit', null, 'SIGTERM'),
+    },
+    {
+      name: 'nonzero child exit',
+      terminate: transport => transport.child.emit('exit', 1, null),
+    },
+  ]
+
+  for (const scenario of scenarios) {
+    test(`${scenario.name} recreates the full stack and opens current contents`, async () => {
+      const transports: IntegratedTransport[] = []
+      let currentContent = 'before termination'
+      const manager = createLSPServerManager({
+        loadServerConfigs: async () => ({
+          servers: { typescript: TYPESCRIPT_CONFIG },
+        }),
+        createServerInstance: (name, config, instanceOptions) =>
+          createLSPServerInstance(name, config, {
+            ...instanceOptions,
+            createClient: (clientName, onCrash) =>
+              createLSPClient(clientName, onCrash, {
+                spawnProcess: (() => {
+                  const transport = createIntegratedTransport()
+                  transports.push(transport)
+                  return transport.child
+                }) as LSPClientDependencies['spawnProcess'],
+                createConnection: () => transports.at(-1)!.connection,
+                gracefulShutdownTimeoutMs: 5,
+              }),
+          }),
+        readDocument: async () => currentContent,
+        recordFileActivity: () => {},
+      })
+      await manager.initialize()
+
+      try {
+        const file = '/repo/src/integration.ts'
+        await manager.openFile(file, currentContent)
+        const server = manager.getServerForFile(file)!
+        expect(server.generation).toBe(1)
+
+        scenario.terminate(transports[0]!)
+        expect(server.state).toBe('error')
+        currentContent = 'after termination'
+
+        await manager.sendRequest(file, 'textDocument/hover', {
+          textDocument: { uri: 'stale-uri' },
+          position: { line: 0, character: 0 },
+        })
+
+        expect(server.generation).toBe(2)
+        expect(transports).toHaveLength(2)
+        const replacementEvents = transports[1]!.events
+        const openIndex = replacementEvents.findIndex(
+          event =>
+            event.kind === 'notification' &&
+            event.method === 'textDocument/didOpen',
+        )
+        const requestIndex = replacementEvents.findIndex(
+          event =>
+            event.kind === 'request' && event.method === 'textDocument/hover',
+        )
+        expect(openIndex).toBeGreaterThan(-1)
+        expect(requestIndex).toBeGreaterThan(openIndex)
+        expect(replacementEvents[openIndex]!.params).toMatchObject({
+          textDocument: {
+            uri: getLspDocumentIdentity(file).fileUri,
+            version: 1,
+            text: 'after termination',
+          },
+        })
+      } finally {
+        await manager.shutdown()
+      }
+    })
+  }
+})
+
 describe('LSP request concurrency', () => {
   test('two simultaneous first requests send one open before either request', async () => {
     const { manager, controls } = await createManager()
@@ -651,6 +931,273 @@ describe('LSP request concurrency', () => {
       ),
     ).toHaveLength(1)
     expect(server.events.filter(event => event.kind === 'request')).toHaveLength(2)
+  })
+
+  test('delivers document changes while a stale request is still pending', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/pending-request.ts'
+    await manager.openFile(file, 'before')
+    const gate = server.holdNextRequest('textDocument/hover', 'stale response')
+    const request = manager.sendRequest<string>(file, 'textDocument/hover', {})
+    await gate.started
+
+    const changeGate = server.blockNextNotification('textDocument/didChange')
+    const change = manager.changeFile(file, 'after')
+    await changeGate.started
+
+    try {
+      expect(
+        server.events.filter(event => event.kind === 'request'),
+      ).toHaveLength(1)
+      changeGate.release()
+      await change
+      expect(
+        documentVersions(server.events, getLspDocumentIdentity(file).fileUri),
+      ).toEqual([
+        { method: 'textDocument/didOpen', version: 1 },
+        { method: 'textDocument/didChange', version: 2 },
+      ])
+    } finally {
+      gate.release()
+    }
+
+    await expect(request).resolves.toBeNull()
+    expect(
+      server.events.filter(event => event.kind === 'request'),
+    ).toHaveLength(2)
+  })
+
+  test('waits for a queued didChange before publishing a response', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/change-before-response.ts'
+    await manager.openFile(file, 'before')
+    const requestGate = server.holdNextRequest(
+      'textDocument/hover',
+      'stale response',
+    )
+    const request = manager.sendRequest<string>(file, 'textDocument/hover', {})
+    await requestGate.started
+
+    const changeGate = server.blockNextNotification('textDocument/didChange')
+    const change = manager.changeFile(file, 'after')
+    await changeGate.started
+
+    try {
+      requestGate.release()
+      const outcome = await Promise.race([
+        request.then(() => 'settled' as const),
+        new Promise<'pending'>(resolve =>
+          setTimeout(() => resolve('pending'), 20),
+        ),
+      ])
+      expect(outcome).toBe('pending')
+    } finally {
+      changeGate.release()
+      await Promise.allSettled([change, request])
+    }
+
+    await expect(change).resolves.toBeUndefined()
+    await expect(request).resolves.toBeNull()
+    expect(
+      server.events.filter(event => event.kind === 'request'),
+    ).toHaveLength(2)
+  })
+
+  test('does not replay a pending request after close and reopen', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/closed-pending-request.ts'
+    const fileUri = getLspDocumentIdentity(file).fileUri
+    await manager.openFile(file, 'before close')
+    const gate = server.holdNextRequest('textDocument/hover', 'stale response')
+    const request = manager.sendRequest<string>(file, 'textDocument/hover', {})
+    await gate.started
+
+    await manager.closeFile(file)
+    expect(manager.isFileOpen(file)).toBe(false)
+    await manager.openFile(file, 'after reopen')
+    expect(manager.isFileOpen(file)).toBe(true)
+    expect(
+      server.events.map(event => ({ kind: event.kind, method: event.method })),
+    ).toEqual([
+      { kind: 'notification', method: 'textDocument/didOpen' },
+      { kind: 'request', method: 'textDocument/hover' },
+      { kind: 'notification', method: 'textDocument/didClose' },
+      { kind: 'notification', method: 'textDocument/didOpen' },
+    ])
+
+    gate.release()
+    await expect(request).rejects.toMatchObject({
+      code: 'LSP_DOCUMENT_CLOSED',
+    })
+    expect(manager.isFileOpen(file)).toBe(true)
+    expect(
+      documentVersions(server.events, fileUri).filter(
+        event => event.method === 'textDocument/didOpen',
+      ),
+    ).toHaveLength(2)
+    expect(
+      server.events.filter(event => event.kind === 'request'),
+    ).toHaveLength(1)
+  })
+
+  test('does not retry a closed document after its server generation changes', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/closed-before-replacement.ts'
+    const fileUri = getLspDocumentIdentity(file).fileUri
+    await manager.openFile(file, 'before close')
+    const gate = server.holdNextRequest('textDocument/hover', 'stale response')
+    const request = manager.sendRequest<string>(file, 'textDocument/hover', {})
+    await gate.started
+
+    await manager.closeFile(file)
+    server.replaceGeneration()
+    gate.release()
+
+    await expect(request).rejects.toMatchObject({
+      code: 'LSP_DOCUMENT_CLOSED',
+    })
+    expect(manager.isFileOpen(file)).toBe(false)
+    expect(documentVersions(server.events, fileUri)).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+    ])
+    expect(
+      server.events.filter(event => event.kind === 'request'),
+    ).toHaveLength(1)
+  })
+
+  test('does not recover a request after close is queued behind didChange', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/close-queued-behind-change.ts'
+    const fileUri = getLspDocumentIdentity(file).fileUri
+    await manager.openFile(file, 'before')
+    const requestGate = server.blockNextRequest('textDocument/hover')
+    const request = manager.sendRequest(file, 'textDocument/hover', {})
+    const requestOutcome = request.then(
+      result => ({ status: 'resolved' as const, result }),
+      error => ({ status: 'rejected' as const, error }),
+    )
+    await requestGate.started
+
+    const changeGate = server.blockNextNotification('textDocument/didChange')
+    const change = manager.changeFile(file, 'after')
+    const changeOutcome = change.then(
+      () => undefined,
+      error => error,
+    )
+    await changeGate.started
+    const close = manager.closeFile(file)
+
+    server.replaceGeneration()
+    requestGate.release()
+    changeGate.release()
+    await expect(changeOutcome).resolves.toBeInstanceOf(Error)
+    await expect(close).resolves.toBeUndefined()
+
+    expect(await requestOutcome).toMatchObject({ status: 'rejected' })
+    expect(manager.isFileOpen(file)).toBe(false)
+    expect(documentVersions(server.events, fileUri)).toEqual([
+      { method: 'textDocument/didOpen', version: 1 },
+      { method: 'textDocument/didChange', version: 2 },
+    ])
+    expect(
+      server.events.filter(event => event.kind === 'request'),
+    ).toHaveLength(1)
+  })
+
+  test('does not recover after close interrupts the initial didOpen', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/close-during-initial-open.ts'
+    const gate = server.blockNextNotification('textDocument/didOpen')
+    const request = manager.sendRequest(file, 'textDocument/hover', {})
+    await gate.started
+    const close = manager.closeFile(file)
+    server.simulateCrash(false)
+    gate.release()
+
+    await expect(request).rejects.toMatchObject({
+      code: 'LSP_DOCUMENT_CLOSED',
+    })
+    await expect(close).resolves.toBeUndefined()
+    expect(manager.isFileOpen(file)).toBe(false)
+    expect(
+      server.events.filter(
+        event =>
+          event.kind === 'notification' &&
+          event.method === 'textDocument/didOpen',
+      ),
+    ).toHaveLength(1)
+    expect(
+      server.events.filter(event => event.kind === 'request'),
+    ).toHaveLength(0)
+  })
+
+  test('generation-bound requests also require the prepared document revision', async () => {
+    const { manager } = await createManager()
+    const file = '/repo/src/revision-bound.ts'
+    await manager.openFile(file, 'version one')
+
+    const prepared = await manager.sendRequestWithGeneration<unknown>(
+      file,
+      'textDocument/prepareCallHierarchy',
+      {},
+    )
+    expect(prepared).toBeDefined()
+    await manager.changeFile(file, 'version two')
+
+    await expect(
+      manager.sendRequestWithGeneration(
+        file,
+        'callHierarchy/incomingCalls',
+        { item: { data: 'version one' } },
+        {
+          expectedGeneration: prepared!.serverGeneration,
+          expectedDocumentRevision: prepared!.documentRevision,
+        },
+      ),
+    ).rejects.toThrow('changed document revision')
+  })
+
+  test('generation-bound requests preserve an explicit close as terminal', async () => {
+    const { manager, controls } = await createManager()
+    const server = controls.get('typescript')!
+    const file = '/repo/src/closed-call-hierarchy.ts'
+    const fileUri = getLspDocumentIdentity(file).fileUri
+    await manager.openFile(file, 'version one')
+
+    const prepared = await manager.sendRequestWithGeneration<unknown>(
+      file,
+      'textDocument/prepareCallHierarchy',
+      {},
+    )
+    expect(prepared).toBeDefined()
+    await manager.closeFile(file)
+
+    await expect(
+      manager.sendRequestWithGeneration(
+        file,
+        'callHierarchy/incomingCalls',
+        { item: { data: 'version one' } },
+        {
+          expectedGeneration: prepared!.serverGeneration,
+          expectedDocumentRevision: prepared!.documentRevision,
+          expectedDocumentCloseEpoch: prepared!.documentCloseEpoch,
+        },
+      ),
+    ).rejects.toMatchObject({ code: 'LSP_DOCUMENT_CLOSED' })
+    expect(
+      documentVersions(server.events, fileUri).filter(
+        event => event.method === 'textDocument/didOpen',
+      ),
+    ).toHaveLength(1)
+    expect(
+      server.events.filter(event => event.kind === 'request'),
+    ).toHaveLength(1)
   })
 
   test('different documents await one shared lazy server initialization', async () => {
@@ -704,6 +1251,8 @@ describe('LSP request concurrency', () => {
 
 describe('LSP document identity and diagnostics activity', () => {
   test('keeps POSIX document identity canonical and case-sensitive', () => {
+    if (process.platform === 'win32') return
+
     const mixedCase = getLspDocumentIdentity('/repo/Source File.ts')
     const lowerCase = getLspDocumentIdentity('/repo/source file.ts')
 
@@ -746,6 +1295,14 @@ describe('LSP document identity and diagnostics activity', () => {
       fileURLToPath(firstIdentity.fileUri),
       fileURLToPath(firstIdentity.fileUri),
     ])
+  })
+
+  test('case-folds Unicode Windows aliases before URI encoding', () => {
+    const upper = getLspDocumentIdentity('C:\\Repo\\Ä.ts')
+    const lower = getLspDocumentIdentity('c:/repo/ä.ts')
+
+    expect(upper.fileUri).not.toBe(lower.fileUri)
+    expect(upper.stateKey).toBe(lower.stateKey)
   })
 
   test('reuses the opened Windows URI for requests through a case alias', async () => {

--- a/src/services/lsp/LSPServerManager.ts
+++ b/src/services/lsp/LSPServerManager.ts
@@ -24,6 +24,26 @@ type OpenLspDocumentState = {
   activityPath: string
 }
 
+export type LspGenerationRequestResult<T> = {
+  result: T
+  serverGeneration: number
+}
+
+const LSP_SERVER_GENERATION_CHANGED = 'LSP_SERVER_GENERATION_CHANGED'
+
+function generationChangedError(
+  serverName: string,
+  expectedGeneration: number,
+  actualGeneration: number,
+): Error & { code: typeof LSP_SERVER_GENERATION_CHANGED } {
+  return Object.assign(
+    new Error(
+      `LSP server '${serverName}' changed generation from ${expectedGeneration} to ${actualGeneration}`,
+    ),
+    { code: LSP_SERVER_GENERATION_CHANGED },
+  ) as Error & { code: typeof LSP_SERVER_GENERATION_CHANGED }
+}
+
 export type LSPServerManagerDependencies = {
   loadServerConfigs: typeof getAllLspServers
   createServerInstance: (
@@ -62,6 +82,13 @@ export type LSPServerManager = {
     method: string,
     params: unknown,
   ): Promise<T | undefined>
+  /** Send a request and atomically report which server generation produced it. */
+  sendRequestWithGeneration<T>(
+    filePath: string,
+    method: string,
+    params: unknown,
+    options?: { expectedGeneration?: number },
+  ): Promise<LspGenerationRequestResult<T> | undefined>
   /** Get all running server instances */
   getAllServers(): Map<string, LSPServerInstance>
   /** Synchronize file open to LSP server (sends didOpen notification) */
@@ -394,48 +421,91 @@ export function createLSPServerManager(
   }
 
   /** Synchronize the current generation, then send the request under the document lock. */
-  async function sendRequest<T>(
+  async function sendRequestWithGeneration<T>(
     filePath: string,
     method: string,
     params: unknown,
-  ): Promise<T | undefined> {
+    options: { expectedGeneration?: number } = {},
+  ): Promise<LspGenerationRequestResult<T> | undefined> {
     const identity = getLspDocumentIdentity(filePath)
     return withDocumentLock(identity.stateKey, async () => {
       try {
         for (let generationRetry = 0; generationRetry <= 1; generationRetry++) {
           const server = await ensureServerStarted(filePath)
           if (!server) return undefined
-
-          if (!getCurrentDocumentState(identity, server)) {
-            const content = await dependencies.readDocument(identity.resolvedPath)
-            dependencies.recordFileActivity(identity.activityPath)
-            await synchronizeOpenUnlocked(
-              filePath,
-              content,
-              identity,
-              server,
+          const expectedGeneration = options.expectedGeneration
+          if (
+            expectedGeneration !== undefined &&
+            server.generation !== expectedGeneration
+          ) {
+            throw generationChangedError(
+              server.name,
+              expectedGeneration,
+              server.generation,
             )
           }
 
-          const state = getCurrentDocumentState(identity, server)
-          if (!state) {
-            throw new Error(
-              `LSP document ${filePath} is not synchronized to server generation ${server.generation}`,
-            )
-          }
-
+          let requestGeneration = server.generation
           try {
-            return await server.sendRequest<T>(
+            if (!getCurrentDocumentState(identity, server)) {
+              const content = await dependencies.readDocument(
+                identity.resolvedPath,
+              )
+              dependencies.recordFileActivity(identity.activityPath)
+              await synchronizeOpenUnlocked(
+                filePath,
+                content,
+                identity,
+                server,
+              )
+            }
+
+            const state = getCurrentDocumentState(identity, server)
+            if (!state) {
+              throw new Error(
+                `LSP document ${filePath} is not synchronized to server generation ${server.generation}`,
+              )
+            }
+            requestGeneration = state.serverGeneration
+            if (
+              expectedGeneration !== undefined &&
+              state.serverGeneration !== expectedGeneration
+            ) {
+              throw generationChangedError(
+                server.name,
+                expectedGeneration,
+                state.serverGeneration,
+              )
+            }
+
+            const result = await server.sendRequest<T>(
               method,
               useDocumentUri(params, state.fileUri),
             )
+            return {
+              result,
+              serverGeneration: state.serverGeneration,
+            }
           } catch (error) {
+            if (
+              (error as { code?: unknown }).code ===
+              LSP_SERVER_GENERATION_CHANGED
+            ) {
+              throw error
+            }
             const generationChanged =
-              server.generation !== state.serverGeneration ||
+              server.generation !== requestGeneration ||
               server.state !== 'running'
-            if (generationChanged && generationRetry === 0) {
+            if (generationChanged) {
               openedDocuments.delete(identity.stateKey)
-              continue
+              if (options.expectedGeneration !== undefined) {
+                throw generationChangedError(
+                  server.name,
+                  options.expectedGeneration,
+                  server.generation,
+                )
+              }
+              if (generationRetry === 0) continue
             }
             throw error
           }
@@ -454,6 +524,15 @@ export function createLSPServerManager(
         throw error
       }
     })
+  }
+
+  async function sendRequest<T>(
+    filePath: string,
+    method: string,
+    params: unknown,
+  ): Promise<T | undefined> {
+    return (await sendRequestWithGeneration<T>(filePath, method, params))
+      ?.result
   }
 
   function getAllServers(): Map<string, LSPServerInstance> {
@@ -536,8 +615,10 @@ export function createLSPServerManager(
       const server = getServerForFile(filePath)
       if (!server || server.state !== 'running') return
       const state = getCurrentDocumentState(identity, server)
+      dependencies.recordFileActivity(
+        state?.activityPath ?? identity.activityPath,
+      )
       if (!state) return
-      dependencies.recordFileActivity(state.activityPath)
 
       // Best-effort by design: didSave carries no version or content, so a
       // dropped notification cannot desynchronize the document version space.
@@ -598,6 +679,7 @@ export function createLSPServerManager(
     getServerForFile,
     ensureServerStarted,
     sendRequest,
+    sendRequestWithGeneration,
     getAllServers,
     openFile,
     changeFile,

--- a/src/services/lsp/LSPServerManager.ts
+++ b/src/services/lsp/LSPServerManager.ts
@@ -21,6 +21,7 @@ type OpenLspDocumentState = {
   serverGeneration: number
   version: number
   fileUri: string
+  activityPath: string
 }
 
 export type LSPServerManagerDependencies = {
@@ -229,6 +230,7 @@ export function createLSPServerManager(
       serverGeneration: targetGeneration,
       version: 1,
       fileUri: identity.fileUri,
+      activityPath: identity.activityPath,
     })
     logForDebugging(
       `LSP: Sent didOpen for ${filePath} (languageId: ${languageId}, generation: ${targetGeneration})`,
@@ -463,7 +465,10 @@ export function createLSPServerManager(
     await withDocumentLock(identity.stateKey, async () => {
       const server = await ensureServerStarted(filePath)
       if (!server) return
-      dependencies.recordFileActivity(identity.activityPath)
+      const state = getCurrentDocumentState(identity, server)
+      dependencies.recordFileActivity(
+        state?.activityPath ?? identity.activityPath,
+      )
       await synchronizeOpenUnlocked(filePath, content, identity, server)
     })
   }
@@ -473,9 +478,11 @@ export function createLSPServerManager(
     await withDocumentLock(identity.stateKey, async () => {
       const server = await ensureServerStarted(filePath)
       if (!server) return
-      dependencies.recordFileActivity(identity.activityPath)
 
       const state = getCurrentDocumentState(identity, server)
+      dependencies.recordFileActivity(
+        state?.activityPath ?? identity.activityPath,
+      )
       if (!state) {
         await synchronizeOpenUnlocked(filePath, content, identity, server)
         return
@@ -528,9 +535,9 @@ export function createLSPServerManager(
     await withDocumentLock(identity.stateKey, async () => {
       const server = getServerForFile(filePath)
       if (!server || server.state !== 'running') return
-      dependencies.recordFileActivity(identity.activityPath)
       const state = getCurrentDocumentState(identity, server)
       if (!state) return
+      dependencies.recordFileActivity(state.activityPath)
 
       // Best-effort by design: didSave carries no version or content, so a
       // dropped notification cannot desynchronize the document version space.

--- a/src/services/lsp/LSPServerManager.ts
+++ b/src/services/lsp/LSPServerManager.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path'
 import { logForDebugging } from '../../utils/debug.js'
 import { errorMessage } from '../../utils/errors.js'
 import { logError } from '../../utils/log.js'
+import { withTimeout } from '../../utils/sleep.js'
 import { getAllLspServers } from './config.js'
 import {
   getLspDocumentIdentity,
@@ -19,17 +20,44 @@ import type { ScopedLspServerConfig } from './types.js'
 type OpenLspDocumentState = {
   serverName: string
   serverGeneration: number
+  revision: number
+  closeEpoch: number
   version: number
   fileUri: string
   activityPath: string
 }
 
+type PendingOpenLspDocumentState = Omit<
+  OpenLspDocumentState,
+  'revision' | 'closeEpoch'
+>
+
 export type LspGenerationRequestResult<T> = {
   result: T
   serverGeneration: number
+  documentRevision: number
+  documentCloseEpoch: number
 }
 
-const LSP_SERVER_GENERATION_CHANGED = 'LSP_SERVER_GENERATION_CHANGED'
+export const LSP_SERVER_GENERATION_CHANGED = 'LSP_SERVER_GENERATION_CHANGED'
+export const LSP_DOCUMENT_REVISION_CHANGED = 'LSP_DOCUMENT_REVISION_CHANGED'
+export const LSP_DOCUMENT_CLOSED = 'LSP_DOCUMENT_CLOSED'
+
+export function isLspServerGenerationChanged(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: unknown }).code === LSP_SERVER_GENERATION_CHANGED
+  )
+}
+
+export function isLspDocumentRevisionChanged(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as { code?: unknown }).code === LSP_DOCUMENT_REVISION_CHANGED
+  )
+}
 
 function generationChangedError(
   serverName: string,
@@ -44,6 +72,38 @@ function generationChangedError(
   ) as Error & { code: typeof LSP_SERVER_GENERATION_CHANGED }
 }
 
+function documentRevisionChangedError(
+  filePath: string,
+  expectedRevision: number,
+  actualRevision: number | undefined,
+): Error & { code: typeof LSP_DOCUMENT_REVISION_CHANGED } {
+  return Object.assign(
+    new Error(
+      `LSP document '${filePath}' changed document revision from ${expectedRevision} to ${actualRevision ?? 'closed'}`,
+    ),
+    { code: LSP_DOCUMENT_REVISION_CHANGED },
+  ) as Error & { code: typeof LSP_DOCUMENT_REVISION_CHANGED }
+}
+
+function documentClosedError(
+  filePath: string,
+  expectedCloseEpoch: number,
+  actualCloseEpoch: number,
+): Error & { code: typeof LSP_DOCUMENT_CLOSED } {
+  return Object.assign(
+    new Error(
+      `LSP document '${filePath}' was explicitly closed (close epoch changed from ${expectedCloseEpoch} to ${actualCloseEpoch})`,
+    ),
+    { code: LSP_DOCUMENT_CLOSED },
+  ) as Error & { code: typeof LSP_DOCUMENT_CLOSED }
+}
+
+export type LspGenerationRequestOptions = {
+  expectedGeneration?: number
+  expectedDocumentRevision?: number
+  expectedDocumentCloseEpoch?: number
+}
+
 export type LSPServerManagerDependencies = {
   loadServerConfigs: typeof getAllLspServers
   createServerInstance: (
@@ -53,7 +113,10 @@ export type LSPServerManagerDependencies = {
   ) => LSPServerInstance
   readDocument: (filePath: string) => Promise<string>
   recordFileActivity: (filePath: string) => void
+  lifecycleNotificationTimeoutMs: number
 }
+
+const DEFAULT_LSP_LIFECYCLE_NOTIFICATION_TIMEOUT_MS = 2_000
 
 const DEFAULT_DEPENDENCIES: LSPServerManagerDependencies = {
   loadServerConfigs: getAllLspServers,
@@ -61,6 +124,8 @@ const DEFAULT_DEPENDENCIES: LSPServerManagerDependencies = {
     createLSPServerInstance(name, config, options),
   readDocument: readLspDocumentContents,
   recordFileActivity: recordLSPDiagnosticFileActivity,
+  lifecycleNotificationTimeoutMs:
+    DEFAULT_LSP_LIFECYCLE_NOTIFICATION_TIMEOUT_MS,
 }
 
 /**
@@ -82,12 +147,12 @@ export type LSPServerManager = {
     method: string,
     params: unknown,
   ): Promise<T | undefined>
-  /** Send a request and atomically report which server generation produced it. */
+  /** Send a request and report its server generation and document revision. */
   sendRequestWithGeneration<T>(
     filePath: string,
     method: string,
     params: unknown,
-    options?: { expectedGeneration?: number },
+    options?: LspGenerationRequestOptions,
   ): Promise<LspGenerationRequestResult<T> | undefined>
   /** Get all running server instances */
   getAllServers(): Map<string, LSPServerInstance>
@@ -113,10 +178,18 @@ export type LSPServerManager = {
 export function createLSPServerManager(
   dependencyOverrides: Partial<LSPServerManagerDependencies> = {},
 ): LSPServerManager {
-  const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependencyOverrides }
+  const dependencies = {
+    ...DEFAULT_DEPENDENCIES,
+    ...dependencyOverrides,
+    lifecycleNotificationTimeoutMs:
+      dependencyOverrides.lifecycleNotificationTimeoutMs ??
+      DEFAULT_LSP_LIFECYCLE_NOTIFICATION_TIMEOUT_MS,
+  }
   const servers = new Map<string, LSPServerInstance>()
   const extensionMap = new Map<string, string[]>()
   const openedDocuments = new Map<string, OpenLspDocumentState>()
+  const documentRevisions = new Map<string, number>()
+  const documentCloseEpochs = new Map<string, number>()
   const documentOperations = new Map<string, Promise<void>>()
   let shuttingDown = false
 
@@ -132,6 +205,16 @@ export function createLSPServerManager(
         openedDocuments.delete(documentKey)
       }
     }
+  }
+
+  function getDocumentCloseEpoch(documentKey: string): number {
+    return documentCloseEpochs.get(documentKey) ?? 0
+  }
+
+  function advanceDocumentRevision(documentKey: string): number {
+    const revision = (documentRevisions.get(documentKey) ?? 0) + 1
+    documentRevisions.set(documentKey, revision)
+    return revision
   }
 
   async function withDocumentLock<T>(
@@ -204,6 +287,73 @@ export function createLSPServerManager(
     }
   }
 
+  async function notifyAndCommit(
+    server: LSPServerInstance,
+    identity: LspDocumentIdentity,
+    description: string,
+    method: string,
+    params: unknown,
+    nextState: (targetGeneration: number) => PendingOpenLspDocumentState,
+  ): Promise<number> {
+    const targetGeneration = server.generation
+    try {
+      await sendStrictLifecycleNotification(
+        server,
+        targetGeneration,
+        method,
+        params,
+      )
+    } catch (error) {
+      openedDocuments.delete(identity.stateKey)
+      const syncError = new Error(`${description}: ${errorMessage(error)}`)
+      logError(syncError)
+      throw syncError
+    }
+
+    if (
+      server.state !== 'running' ||
+      server.generation !== targetGeneration
+    ) {
+      openedDocuments.delete(identity.stateKey)
+      const syncError = new Error(
+        `${description}: LSP server generation changed during notification`,
+      )
+      logError(syncError)
+      throw syncError
+    }
+
+    openedDocuments.set(identity.stateKey, {
+      ...nextState(targetGeneration),
+      revision: advanceDocumentRevision(identity.stateKey),
+      closeEpoch: getDocumentCloseEpoch(identity.stateKey),
+    })
+    return targetGeneration
+  }
+
+  async function sendStrictLifecycleNotification(
+    server: LSPServerInstance,
+    targetGeneration: number,
+    method: string,
+    params: unknown,
+  ): Promise<void> {
+    try {
+      await withTimeout(
+        server.sendNotificationStrict(method, params),
+        dependencies.lifecycleNotificationTimeoutMs,
+        `LSP lifecycle notification '${method}' timed out after ${dependencies.lifecycleNotificationTimeoutMs}ms`,
+      )
+    } catch (error) {
+      if (server.generation === targetGeneration) {
+        await server.stop().catch(stopError => {
+          logForDebugging(
+            `Failed to stop LSP server '${server.name}' after notification failure: ${errorMessage(stopError)}`,
+          )
+        })
+      }
+      throw error
+    }
+  }
+
   async function synchronizeOpenUnlocked(
     filePath: string,
     content: string,
@@ -220,45 +370,27 @@ export function createLSPServerManager(
     const extension = path.extname(filePath).toLowerCase()
     const languageId =
       server.config.extensionToLanguage[extension] || 'plaintext'
-    const targetGeneration = server.generation
-
-    try {
-      await server.sendNotificationStrict('textDocument/didOpen', {
+    const targetGeneration = await notifyAndCommit(
+      server,
+      identity,
+      `Failed to sync file open ${filePath}`,
+      'textDocument/didOpen',
+      {
         textDocument: {
           uri: identity.fileUri,
           languageId,
           version: 1,
           text: content,
         },
-      })
-    } catch (error) {
-      openedDocuments.delete(identity.stateKey)
-      const syncError = new Error(
-        `Failed to sync file open ${filePath}: ${errorMessage(error)}`,
-      )
-      logError(syncError)
-      throw syncError
-    }
-
-    if (
-      server.state !== 'running' ||
-      server.generation !== targetGeneration
-    ) {
-      openedDocuments.delete(identity.stateKey)
-      const syncError = new Error(
-        `Failed to sync file open ${filePath}: LSP server generation changed during notification`,
-      )
-      logError(syncError)
-      throw syncError
-    }
-
-    openedDocuments.set(identity.stateKey, {
-      serverName: server.name,
-      serverGeneration: targetGeneration,
-      version: 1,
-      fileUri: identity.fileUri,
-      activityPath: identity.activityPath,
-    })
+      },
+      generation => ({
+        serverName: server.name,
+        serverGeneration: generation,
+        version: 1,
+        fileUri: identity.fileUri,
+        activityPath: identity.activityPath,
+      }),
+    )
     logForDebugging(
       `LSP: Sent didOpen for ${filePath} (languageId: ${languageId}, generation: ${targetGeneration})`,
     )
@@ -353,6 +485,8 @@ export function createLSPServerManager(
     servers.clear()
     extensionMap.clear()
     openedDocuments.clear()
+    documentRevisions.clear()
+    documentCloseEpochs.clear()
     documentOperations.clear()
 
     const errors = results
@@ -420,110 +554,207 @@ export function createLSPServerManager(
     return server
   }
 
-  /** Synchronize the current generation, then send the request under the document lock. */
+  /** Synchronize under the document lock, then send without blocking later edits. */
   async function sendRequestWithGeneration<T>(
     filePath: string,
     method: string,
     params: unknown,
-    options: { expectedGeneration?: number } = {},
+    options: LspGenerationRequestOptions = {},
   ): Promise<LspGenerationRequestResult<T> | undefined> {
     const identity = getLspDocumentIdentity(filePath)
-    return withDocumentLock(identity.stateKey, async () => {
-      try {
-        for (let generationRetry = 0; generationRetry <= 1; generationRetry++) {
-          const server = await ensureServerStarted(filePath)
-          if (!server) return undefined
-          const expectedGeneration = options.expectedGeneration
-          if (
-            expectedGeneration !== undefined &&
-            server.generation !== expectedGeneration
-          ) {
-            throw generationChangedError(
-              server.name,
-              expectedGeneration,
-              server.generation,
-            )
-          }
+    const requestCloseEpoch =
+      options.expectedDocumentCloseEpoch ??
+      getDocumentCloseEpoch(identity.stateKey)
+    try {
+      for (let generationRetry = 0; generationRetry <= 1; generationRetry++) {
+        let server: LSPServerInstance | undefined
+        let requestState: OpenLspDocumentState | undefined
+        let requestGeneration = 0
+        try {
+          const context = await withDocumentLock(
+            identity.stateKey,
+            async () => {
+              const currentDocumentCloseEpoch = getDocumentCloseEpoch(
+                identity.stateKey,
+              )
+              if (
+                currentDocumentCloseEpoch !== requestCloseEpoch
+              ) {
+                throw documentClosedError(
+                  filePath,
+                  requestCloseEpoch,
+                  currentDocumentCloseEpoch,
+                )
+              }
 
-          let requestGeneration = server.generation
-          try {
-            if (!getCurrentDocumentState(identity, server)) {
-              const content = await dependencies.readDocument(
-                identity.resolvedPath,
-              )
-              dependencies.recordFileActivity(identity.activityPath)
-              await synchronizeOpenUnlocked(
-                filePath,
-                content,
-                identity,
-                server,
-              )
-            }
-
-            const state = getCurrentDocumentState(identity, server)
-            if (!state) {
-              throw new Error(
-                `LSP document ${filePath} is not synchronized to server generation ${server.generation}`,
-              )
-            }
-            requestGeneration = state.serverGeneration
-            if (
-              expectedGeneration !== undefined &&
-              state.serverGeneration !== expectedGeneration
-            ) {
-              throw generationChangedError(
-                server.name,
-                expectedGeneration,
-                state.serverGeneration,
-              )
-            }
-
-            const result = await server.sendRequest<T>(
-              method,
-              useDocumentUri(params, state.fileUri),
-            )
-            return {
-              result,
-              serverGeneration: state.serverGeneration,
-            }
-          } catch (error) {
-            if (
-              (error as { code?: unknown }).code ===
-              LSP_SERVER_GENERATION_CHANGED
-            ) {
-              throw error
-            }
-            const generationChanged =
-              server.generation !== requestGeneration ||
-              server.state !== 'running'
-            if (generationChanged) {
-              openedDocuments.delete(identity.stateKey)
-              if (options.expectedGeneration !== undefined) {
+              server = await ensureServerStarted(filePath)
+              if (!server) return undefined
+              requestGeneration = server.generation
+              const expectedGeneration = options.expectedGeneration
+              if (
+                expectedGeneration !== undefined &&
+                server.generation !== expectedGeneration
+              ) {
                 throw generationChangedError(
                   server.name,
-                  options.expectedGeneration,
+                  expectedGeneration,
                   server.generation,
                 )
               }
-              if (generationRetry === 0) continue
+
+              if (!getCurrentDocumentState(identity, server)) {
+                const content = await dependencies.readDocument(
+                  identity.resolvedPath,
+                )
+                dependencies.recordFileActivity(identity.activityPath)
+                await synchronizeOpenUnlocked(
+                  filePath,
+                  content,
+                  identity,
+                  server,
+                )
+              }
+
+              const state = getCurrentDocumentState(identity, server)
+              if (!state) {
+                throw new Error(
+                  `LSP document ${filePath} is not synchronized to server generation ${server.generation}`,
+                )
+              }
+              requestGeneration = state.serverGeneration
+              if (
+                expectedGeneration !== undefined &&
+                state.serverGeneration !== expectedGeneration
+              ) {
+                throw generationChangedError(
+                  server.name,
+                  expectedGeneration,
+                  state.serverGeneration,
+                )
+              }
+              const expectedDocumentRevision =
+                options.expectedDocumentRevision
+              if (
+                expectedDocumentRevision !== undefined &&
+                state.revision !== expectedDocumentRevision
+              ) {
+                throw documentRevisionChangedError(
+                  filePath,
+                  expectedDocumentRevision,
+                  state.revision,
+                )
+              }
+              requestState = state
+              return { server, state }
+            },
+          )
+          if (!context) return undefined
+
+          const result = await context.server.sendRequest<T>(
+            method,
+            useDocumentUri(params, context.state.fileUri),
+          )
+          return await withDocumentLock(identity.stateKey, async () => {
+            const currentDocumentCloseEpoch = getDocumentCloseEpoch(
+              identity.stateKey,
+            )
+            if (currentDocumentCloseEpoch !== requestCloseEpoch) {
+              throw documentClosedError(
+                filePath,
+                requestCloseEpoch,
+                currentDocumentCloseEpoch,
+              )
             }
+            if (
+              context.server.state !== 'running' ||
+              context.server.generation !== context.state.serverGeneration
+            ) {
+              throw new Error(
+                `LSP request '${method}' aborted because server '${context.server.name}' changed generation or became unavailable`,
+              )
+            }
+            if (openedDocuments.get(identity.stateKey) !== context.state) {
+              throw new Error(
+                `LSP request '${method}' aborted because document ${filePath} changed while the request was pending`,
+              )
+            }
+            return {
+              result,
+              serverGeneration: context.state.serverGeneration,
+              documentRevision: context.state.revision,
+              documentCloseEpoch: context.state.closeEpoch,
+            }
+          })
+        } catch (error) {
+          const currentDocumentCloseEpoch = getDocumentCloseEpoch(
+            identity.stateKey,
+          )
+          if (currentDocumentCloseEpoch !== requestCloseEpoch) {
+            throw documentClosedError(
+              filePath,
+              requestCloseEpoch,
+              currentDocumentCloseEpoch,
+            )
+          }
+          if (
+            isLspServerGenerationChanged(error) ||
+            isLspDocumentRevisionChanged(error)
+          ) {
             throw error
           }
+          if (
+            server &&
+            (server.generation !== requestGeneration ||
+              server.state !== 'running')
+          ) {
+            if (openedDocuments.get(identity.stateKey) === requestState) {
+              openedDocuments.delete(identity.stateKey)
+            }
+            if (options.expectedGeneration !== undefined) {
+              throw generationChangedError(
+                server.name,
+                options.expectedGeneration,
+                server.generation,
+              )
+            }
+            if (generationRetry === 0) continue
+          } else if (requestState) {
+            const currentState = openedDocuments.get(identity.stateKey)
+            if (
+              options.expectedDocumentRevision !== undefined &&
+              currentState !== requestState
+            ) {
+              throw documentRevisionChangedError(
+                filePath,
+                options.expectedDocumentRevision,
+                currentState?.revision,
+              )
+            }
+            if (
+              currentState !== undefined &&
+              currentState !== requestState &&
+              options.expectedGeneration === undefined &&
+              generationRetry === 0
+            ) {
+              continue
+            }
+          }
+          throw error
         }
-
-        throw new Error(
-          `LSP request failed for file ${filePath}: server generation kept changing`,
-        )
-      } catch (error) {
-        const err = error as Error
-        logError(
-          new Error(
-            `LSP request failed for file ${filePath}, method '${method}': ${err.message}`,
-          ),
-        )
-        throw error
       }
-    })
+
+      throw new Error(
+        `LSP request failed for file ${filePath}: server generation or document state kept changing`,
+      )
+    } catch (error) {
+      const err = error as Error
+      logError(
+        new Error(
+          `LSP request failed for file ${filePath}, method '${method}': ${err.message}`,
+        ),
+      )
+      throw error
+    }
   }
 
   async function sendRequest<T>(
@@ -568,40 +799,23 @@ export function createLSPServerManager(
       }
 
       const nextVersion = state.version + 1
-      const targetGeneration = server.generation
-      try {
-        await server.sendNotificationStrict('textDocument/didChange', {
+      await notifyAndCommit(
+        server,
+        identity,
+        `Failed to sync file change ${filePath}`,
+        'textDocument/didChange',
+        {
           textDocument: {
             uri: state.fileUri,
             version: nextVersion,
           },
           contentChanges: [{ text: content }],
-        })
-      } catch (error) {
-        openedDocuments.delete(identity.stateKey)
-        const syncError = new Error(
-          `Failed to sync file change ${filePath}: ${errorMessage(error)}`,
-        )
-        logError(syncError)
-        throw syncError
-      }
-
-      if (
-        server.state !== 'running' ||
-        server.generation !== targetGeneration
-      ) {
-        openedDocuments.delete(identity.stateKey)
-        const syncError = new Error(
-          `Failed to sync file change ${filePath}: LSP server generation changed during notification`,
-        )
-        logError(syncError)
-        throw syncError
-      }
-
-      openedDocuments.set(identity.stateKey, {
-        ...state,
-        version: nextVersion,
-      })
+        },
+        () => ({
+          ...state,
+          version: nextVersion,
+        }),
+      )
       logForDebugging(
         `LSP: Sent didChange for ${filePath} (version: ${nextVersion})`,
       )
@@ -622,18 +836,32 @@ export function createLSPServerManager(
 
       // Best-effort by design: didSave carries no version or content, so a
       // dropped notification cannot desynchronize the document version space.
-      await server.sendNotification('textDocument/didSave', {
-        textDocument: {
-          uri: state.fileUri,
-        },
-      })
-      logForDebugging(`LSP: Sent didSave for ${filePath}`)
+      try {
+        await withTimeout(
+          server.sendNotification('textDocument/didSave', {
+            textDocument: {
+              uri: state.fileUri,
+            },
+          }),
+          dependencies.lifecycleNotificationTimeoutMs,
+          `LSP lifecycle notification 'textDocument/didSave' timed out after ${dependencies.lifecycleNotificationTimeoutMs}ms`,
+        )
+        logForDebugging(`LSP: Sent didSave for ${filePath}`)
+      } catch (error) {
+        logForDebugging(
+          `LSP: Best-effort didSave failed for ${filePath}: ${errorMessage(error)}`,
+        )
+      }
     })
   }
 
   /** Close the current document lifecycle, forgetting local state on every outcome. */
   async function closeFile(filePath: string): Promise<void> {
     const identity = getLspDocumentIdentity(filePath)
+    documentCloseEpochs.set(
+      identity.stateKey,
+      getDocumentCloseEpoch(identity.stateKey) + 1,
+    )
     await withDocumentLock(identity.stateKey, async () => {
       const state = openedDocuments.get(identity.stateKey)
       if (!state) return
@@ -649,9 +877,14 @@ export function createLSPServerManager(
       }
 
       try {
-        await server.sendNotificationStrict('textDocument/didClose', {
-          textDocument: { uri: state.fileUri },
-        })
+        await sendStrictLifecycleNotification(
+          server,
+          state.serverGeneration,
+          'textDocument/didClose',
+          {
+            textDocument: { uri: state.fileUri },
+          },
+        )
         logForDebugging(`LSP: Sent didClose for ${filePath}`)
       } catch (error) {
         const syncError = new Error(

--- a/src/services/lsp/LSPServerManager.ts
+++ b/src/services/lsp/LSPServerManager.ts
@@ -90,6 +90,7 @@ export function createLSPServerManager(
   const extensionMap = new Map<string, string[]>()
   const openedDocuments = new Map<string, OpenLspDocumentState>()
   const documentOperations = new Map<string, Promise<void>>()
+  let shuttingDown = false
 
   function invalidateServerDocuments(
     serverName: string,
@@ -109,6 +110,9 @@ export function createLSPServerManager(
     documentKey: string,
     operation: () => Promise<T>,
   ): Promise<T> {
+    if (shuttingDown) {
+      throw new Error('LSP server manager is shutting down')
+    }
     const previous = documentOperations.get(documentKey) ?? Promise.resolve()
     let release!: () => void
     const gate = new Promise<void>(resolve => {
@@ -148,6 +152,28 @@ export function createLSPServerManager(
     if (isCurrentDocumentState(state, server)) return state
     if (state) openedDocuments.delete(identity.stateKey)
     return undefined
+  }
+
+  function useDocumentUri(params: unknown, fileUri: string): unknown {
+    if (!params || typeof params !== 'object' || Array.isArray(params)) {
+      return params
+    }
+    const requestParams = params as Record<string, unknown>
+    const textDocument = requestParams.textDocument
+    if (
+      !textDocument ||
+      typeof textDocument !== 'object' ||
+      Array.isArray(textDocument)
+    ) {
+      return params
+    }
+    return {
+      ...requestParams,
+      textDocument: {
+        ...(textDocument as Record<string, unknown>),
+        uri: fileUri,
+      },
+    }
   }
 
   async function synchronizeOpenUnlocked(
@@ -211,6 +237,7 @@ export function createLSPServerManager(
 
   /** Initialize the manager by loading configured server definitions. */
   async function initialize(): Promise<void> {
+    shuttingDown = false
     let serverConfigs: Record<string, ScopedLspServerConfig>
 
     try {
@@ -284,13 +311,15 @@ export function createLSPServerManager(
 
   /** Stop every server and clear manager-owned state. */
   async function shutdown(): Promise<void> {
+    shuttingDown = true
+    const operations = Array.from(documentOperations.values())
     const toStop = Array.from(servers.entries()).filter(
-      ([, server]) =>
-        server.state === 'running' || server.state === 'error',
+      ([, server]) => server.state !== 'stopped',
     )
     const results = await Promise.allSettled(
       toStop.map(([, server]) => server.stop()),
     )
+    await Promise.allSettled(operations)
 
     servers.clear()
     extensionMap.clear()
@@ -325,6 +354,9 @@ export function createLSPServerManager(
   async function ensureServerStarted(
     filePath: string,
   ): Promise<LSPServerInstance | undefined> {
+    if (shuttingDown) {
+      throw new Error('LSP server manager is shutting down')
+    }
     const server = getServerForFile(filePath)
     if (!server) return undefined
 
@@ -346,6 +378,10 @@ export function createLSPServerManager(
       }
     }
 
+    if (shuttingDown) {
+      throw new Error('LSP server manager is shutting down')
+    }
+
     if (server.state !== 'running') {
       throw new Error(
         `LSP server '${server.name}' is not ready for file ${filePath}: server is ${server.state}`,
@@ -364,27 +400,48 @@ export function createLSPServerManager(
     const identity = getLspDocumentIdentity(filePath)
     return withDocumentLock(identity.stateKey, async () => {
       try {
-        const server = await ensureServerStarted(filePath)
-        if (!server) return undefined
+        for (let generationRetry = 0; generationRetry <= 1; generationRetry++) {
+          const server = await ensureServerStarted(filePath)
+          if (!server) return undefined
 
-        if (!getCurrentDocumentState(identity, server)) {
-          const content = await dependencies.readDocument(identity.resolvedPath)
-          dependencies.recordFileActivity(identity.activityPath)
-          await synchronizeOpenUnlocked(
-            filePath,
-            content,
-            identity,
-            server,
-          )
+          if (!getCurrentDocumentState(identity, server)) {
+            const content = await dependencies.readDocument(identity.resolvedPath)
+            dependencies.recordFileActivity(identity.activityPath)
+            await synchronizeOpenUnlocked(
+              filePath,
+              content,
+              identity,
+              server,
+            )
+          }
+
+          const state = getCurrentDocumentState(identity, server)
+          if (!state) {
+            throw new Error(
+              `LSP document ${filePath} is not synchronized to server generation ${server.generation}`,
+            )
+          }
+
+          try {
+            return await server.sendRequest<T>(
+              method,
+              useDocumentUri(params, state.fileUri),
+            )
+          } catch (error) {
+            const generationChanged =
+              server.generation !== state.serverGeneration ||
+              server.state !== 'running'
+            if (generationChanged && generationRetry === 0) {
+              openedDocuments.delete(identity.stateKey)
+              continue
+            }
+            throw error
+          }
         }
 
-        if (!getCurrentDocumentState(identity, server)) {
-          throw new Error(
-            `LSP document ${filePath} is not synchronized to server generation ${server.generation}`,
-          )
-        }
-
-        return await server.sendRequest<T>(method, params)
+        throw new Error(
+          `LSP request failed for file ${filePath}: server generation kept changing`,
+        )
       } catch (error) {
         const err = error as Error
         logError(
@@ -475,20 +532,14 @@ export function createLSPServerManager(
       const state = getCurrentDocumentState(identity, server)
       if (!state) return
 
-      try {
-        await server.sendNotification('textDocument/didSave', {
-          textDocument: {
-            uri: state.fileUri,
-          },
-        })
-        logForDebugging(`LSP: Sent didSave for ${filePath}`)
-      } catch (error) {
-        const syncError = new Error(
-          `Failed to sync file save ${filePath}: ${errorMessage(error)}`,
-        )
-        logError(syncError)
-        throw syncError
-      }
+      // Best-effort by design: didSave carries no version or content, so a
+      // dropped notification cannot desynchronize the document version space.
+      await server.sendNotification('textDocument/didSave', {
+        textDocument: {
+          uri: state.fileUri,
+        },
+      })
+      logForDebugging(`LSP: Sent didSave for ${filePath}`)
     })
   }
 

--- a/src/services/lsp/LSPServerManager.ts
+++ b/src/services/lsp/LSPServerManager.ts
@@ -1,15 +1,47 @@
-import * as path from 'path'
-import { pathToFileURL } from 'url'
+import * as path from 'node:path'
 import { logForDebugging } from '../../utils/debug.js'
 import { errorMessage } from '../../utils/errors.js'
 import { logError } from '../../utils/log.js'
 import { getAllLspServers } from './config.js'
+import {
+  getLspDocumentIdentity,
+  readLspDocumentContents,
+  type LspDocumentIdentity,
+} from './documentIdentity.js'
 import { recordLSPDiagnosticFileActivity } from './LSPDiagnosticRegistry.js'
 import {
   createLSPServerInstance,
   type LSPServerInstance,
+  type LSPServerInstanceOptions,
 } from './LSPServerInstance.js'
 import type { ScopedLspServerConfig } from './types.js'
+
+type OpenLspDocumentState = {
+  serverName: string
+  serverGeneration: number
+  version: number
+  fileUri: string
+}
+
+export type LSPServerManagerDependencies = {
+  loadServerConfigs: typeof getAllLspServers
+  createServerInstance: (
+    name: string,
+    config: ScopedLspServerConfig,
+    options: LSPServerInstanceOptions,
+  ) => LSPServerInstance
+  readDocument: (filePath: string) => Promise<string>
+  recordFileActivity: (filePath: string) => void
+}
+
+const DEFAULT_DEPENDENCIES: LSPServerManagerDependencies = {
+  loadServerConfigs: getAllLspServers,
+  createServerInstance: (name, config, options) =>
+    createLSPServerInstance(name, config, options),
+  readDocument: readLspDocumentContents,
+  recordFileActivity: recordLSPDiagnosticFileActivity,
+}
+
 /**
  * LSP Server Manager interface returned by createLSPServerManager.
  * Manages multiple LSP server instances and routes requests based on file extensions.
@@ -23,7 +55,7 @@ export type LSPServerManager = {
   getServerForFile(filePath: string): LSPServerInstance | undefined
   /** Ensure the appropriate LSP server is started for the given file */
   ensureServerStarted(filePath: string): Promise<LSPServerInstance | undefined>
-  /** Send a request to the appropriate LSP server for the given file */
+  /** Send a request after synchronizing the document to the current server generation */
   sendRequest<T>(
     filePath: string,
     method: string,
@@ -39,41 +71,150 @@ export type LSPServerManager = {
   saveFile(filePath: string): Promise<void>
   /** Synchronize file close to LSP server (sends didClose notification) */
   closeFile(filePath: string): Promise<void>
-  /** Check if a file is already open on a compatible LSP server */
+  /** Check if a file is open on its current compatible LSP server generation */
   isFileOpen(filePath: string): boolean
 }
 
 /**
  * Creates an LSP server manager instance.
  *
- * Manages multiple LSP server instances and routes requests based on file extensions.
- * Uses factory function pattern with closures for state encapsulation (avoiding classes).
- *
- * @returns LSP server manager instance
- *
- * @example
- * const manager = createLSPServerManager()
- * await manager.initialize()
- * const result = await manager.sendRequest('/path/to/file.ts', 'textDocument/definition', params)
- * await manager.shutdown()
+ * Server processes remain lazy-started. Document lifecycle operations are
+ * serialized per canonical document key, while unrelated documents remain
+ * independent after sharing any in-flight server initialization.
  */
-export function createLSPServerManager(): LSPServerManager {
-  // Private state managed via closures
-  const servers: Map<string, LSPServerInstance> = new Map()
-  const extensionMap: Map<string, string[]> = new Map()
-  // Track which files have been opened on which servers (URI -> server name)
-  const openedFiles: Map<string, string> = new Map()
+export function createLSPServerManager(
+  dependencyOverrides: Partial<LSPServerManagerDependencies> = {},
+): LSPServerManager {
+  const dependencies = { ...DEFAULT_DEPENDENCIES, ...dependencyOverrides }
+  const servers = new Map<string, LSPServerInstance>()
+  const extensionMap = new Map<string, string[]>()
+  const openedDocuments = new Map<string, OpenLspDocumentState>()
+  const documentOperations = new Map<string, Promise<void>>()
 
-  /**
-   * Initialize the manager by loading all configured LSP servers.
-   *
-   * @throws {Error} If configuration loading fails
-   */
+  function invalidateServerDocuments(
+    serverName: string,
+    serverGeneration: number,
+  ): void {
+    for (const [documentKey, state] of openedDocuments) {
+      if (
+        state.serverName === serverName &&
+        state.serverGeneration === serverGeneration
+      ) {
+        openedDocuments.delete(documentKey)
+      }
+    }
+  }
+
+  async function withDocumentLock<T>(
+    documentKey: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = documentOperations.get(documentKey) ?? Promise.resolve()
+    let release!: () => void
+    const gate = new Promise<void>(resolve => {
+      release = resolve
+    })
+    const tail = previous.catch(() => {}).then(() => gate)
+    documentOperations.set(documentKey, tail)
+
+    await previous.catch(() => {})
+    try {
+      return await operation()
+    } finally {
+      release()
+      if (documentOperations.get(documentKey) === tail) {
+        documentOperations.delete(documentKey)
+      }
+    }
+  }
+
+  function isCurrentDocumentState(
+    state: OpenLspDocumentState | undefined,
+    server: LSPServerInstance,
+  ): state is OpenLspDocumentState {
+    return (
+      state !== undefined &&
+      state.serverName === server.name &&
+      state.serverGeneration === server.generation &&
+      server.state === 'running'
+    )
+  }
+
+  function getCurrentDocumentState(
+    identity: LspDocumentIdentity,
+    server: LSPServerInstance,
+  ): OpenLspDocumentState | undefined {
+    const state = openedDocuments.get(identity.stateKey)
+    if (isCurrentDocumentState(state, server)) return state
+    if (state) openedDocuments.delete(identity.stateKey)
+    return undefined
+  }
+
+  async function synchronizeOpenUnlocked(
+    filePath: string,
+    content: string,
+    identity: LspDocumentIdentity,
+    server: LSPServerInstance,
+  ): Promise<void> {
+    if (getCurrentDocumentState(identity, server)) {
+      logForDebugging(
+        `LSP: File already open, skipping didOpen for ${filePath}`,
+      )
+      return
+    }
+
+    const extension = path.extname(filePath).toLowerCase()
+    const languageId =
+      server.config.extensionToLanguage[extension] || 'plaintext'
+    const targetGeneration = server.generation
+
+    try {
+      await server.sendNotificationStrict('textDocument/didOpen', {
+        textDocument: {
+          uri: identity.fileUri,
+          languageId,
+          version: 1,
+          text: content,
+        },
+      })
+    } catch (error) {
+      openedDocuments.delete(identity.stateKey)
+      const syncError = new Error(
+        `Failed to sync file open ${filePath}: ${errorMessage(error)}`,
+      )
+      logError(syncError)
+      throw syncError
+    }
+
+    if (
+      server.state !== 'running' ||
+      server.generation !== targetGeneration
+    ) {
+      openedDocuments.delete(identity.stateKey)
+      const syncError = new Error(
+        `Failed to sync file open ${filePath}: LSP server generation changed during notification`,
+      )
+      logError(syncError)
+      throw syncError
+    }
+
+    openedDocuments.set(identity.stateKey, {
+      serverName: server.name,
+      serverGeneration: targetGeneration,
+      version: 1,
+      fileUri: identity.fileUri,
+    })
+    logForDebugging(
+      `LSP: Sent didOpen for ${filePath} (languageId: ${languageId}, generation: ${targetGeneration})`,
+    )
+  }
+
+  /** Initialize the manager by loading configured server definitions. */
   async function initialize(): Promise<void> {
     let serverConfigs: Record<string, ScopedLspServerConfig>
 
     try {
-      const result = await getAllLspServers()
+      const result = await dependencies.loadServerConfigs()
       serverConfigs = result.servers
       logForDebugging(
         `[LSP SERVER MANAGER] getAllLspServers returned ${Object.keys(serverConfigs).length} server(s)`,
@@ -86,10 +227,8 @@ export function createLSPServerManager(): LSPServerManager {
       throw error
     }
 
-    // Build extension → server mapping
     for (const [serverName, config] of Object.entries(serverConfigs)) {
       try {
-        // Validate config before using it
         if (!config.command) {
           throw new Error(
             `Server ${serverName} missing required 'command' field`,
@@ -104,33 +243,29 @@ export function createLSPServerManager(): LSPServerManager {
           )
         }
 
-        // Map file extensions to this server (derive from extensionToLanguage)
-        const fileExtensions = Object.keys(config.extensionToLanguage)
-        for (const ext of fileExtensions) {
-          const normalized = ext.toLowerCase()
-          if (!extensionMap.has(normalized)) {
-            extensionMap.set(normalized, [])
-          }
-          const serverList = extensionMap.get(normalized)
-          if (serverList) {
-            serverList.push(serverName)
-          }
+        for (const extension of Object.keys(config.extensionToLanguage)) {
+          const normalized = extension.toLowerCase()
+          const serverNames = extensionMap.get(normalized) ?? []
+          serverNames.push(serverName)
+          extensionMap.set(normalized, serverNames)
         }
 
-        // Create server instance
-        const instance = createLSPServerInstance(serverName, config)
+        const instance = dependencies.createServerInstance(
+          serverName,
+          config,
+          {
+            onUnavailable: generation =>
+              invalidateServerDocuments(serverName, generation),
+          },
+        )
         servers.set(serverName, instance)
 
-        // Register handler for workspace/configuration requests from the server
-        // Some servers (like TypeScript) send these even when we say we don't support them
         instance.onRequest(
           'workspace/configuration',
           (params: { items: Array<{ section?: string }> }) => {
             logForDebugging(
               `LSP: Received workspace/configuration request from ${serverName}`,
             )
-            // Return empty/null config for each requested item
-            // This satisfies the protocol without providing actual configuration
             return params.items.map(() => null)
           },
         )
@@ -141,85 +276,63 @@ export function createLSPServerManager(): LSPServerManager {
             `Failed to initialize LSP server ${serverName}: ${err.message}`,
           ),
         )
-        // Continue with other servers - don't fail entire initialization
       }
     }
 
     logForDebugging(`LSP manager initialized with ${servers.size} servers`)
   }
 
-  /**
-   * Shutdown all running servers and clear state.
-   * Only servers in 'running' state are explicitly stopped;
-   * servers in other states are cleared without shutdown.
-   *
-   * @throws {Error} If one or more servers fail to stop
-   */
+  /** Stop every server and clear manager-owned state. */
   async function shutdown(): Promise<void> {
     const toStop = Array.from(servers.entries()).filter(
-      ([, s]) => s.state === 'running' || s.state === 'error',
+      ([, server]) =>
+        server.state === 'running' || server.state === 'error',
     )
-
     const results = await Promise.allSettled(
       toStop.map(([, server]) => server.stop()),
     )
 
     servers.clear()
     extensionMap.clear()
-    openedFiles.clear()
+    openedDocuments.clear()
+    documentOperations.clear()
 
     const errors = results
-      .map((r, i) =>
-        r.status === 'rejected'
-          ? `${toStop[i]![0]}: ${errorMessage(r.reason)}`
+      .map((result, index) =>
+        result.status === 'rejected'
+          ? `${toStop[index]![0]}: ${errorMessage(result.reason)}`
           : null,
       )
-      .filter((e): e is string => e !== null)
+      .filter((error): error is string => error !== null)
 
     if (errors.length > 0) {
-      const err = new Error(
+      const shutdownError = new Error(
         `Failed to stop ${errors.length} LSP server(s): ${errors.join('; ')}`,
       )
-      logError(err)
-      throw err
+      logError(shutdownError)
+      throw shutdownError
     }
   }
 
-  /**
-   * Get the LSP server instance for a given file path.
-   * If multiple servers handle the same extension, returns the first registered server.
-   * Returns undefined if no server handles this file type.
-   */
+  /** Return the first configured server for the file extension. */
   function getServerForFile(filePath: string): LSPServerInstance | undefined {
-    const ext = path.extname(filePath).toLowerCase()
-    const serverNames = extensionMap.get(ext)
-
-    if (!serverNames || serverNames.length === 0) {
-      return undefined
-    }
-
-    // Use first server (can add priority later)
-    const serverName = serverNames[0]
-    if (!serverName) {
-      return undefined
-    }
-
-    return servers.get(serverName)
+    const extension = path.extname(filePath).toLowerCase()
+    const serverName = extensionMap.get(extension)?.[0]
+    return serverName ? servers.get(serverName) : undefined
   }
 
-  /**
-   * Ensure the appropriate LSP server is started for the given file.
-   * Returns undefined if no server handles this file type.
-   *
-   * @throws {Error} If server fails to start
-   */
+  /** Lazily start or await the server selected for this file. */
   async function ensureServerStarted(
     filePath: string,
   ): Promise<LSPServerInstance | undefined> {
     const server = getServerForFile(filePath)
     if (!server) return undefined
 
-    if (server.state === 'stopped' || server.state === 'error') {
+    if (
+      server.state === 'stopped' ||
+      server.state === 'error' ||
+      server.state === 'starting'
+    ) {
       try {
         await server.start()
       } catch (error) {
@@ -233,184 +346,192 @@ export function createLSPServerManager(): LSPServerManager {
       }
     }
 
+    if (server.state !== 'running') {
+      throw new Error(
+        `LSP server '${server.name}' is not ready for file ${filePath}: server is ${server.state}`,
+      )
+    }
+
     return server
   }
 
-  /**
-   * Send a request to the appropriate LSP server for the given file.
-   * Returns undefined if no server handles this file type.
-   *
-   * @throws {Error} If server fails to start or request fails
-   */
+  /** Synchronize the current generation, then send the request under the document lock. */
   async function sendRequest<T>(
     filePath: string,
     method: string,
     params: unknown,
   ): Promise<T | undefined> {
-    const server = await ensureServerStarted(filePath)
-    if (!server) return undefined
+    const identity = getLspDocumentIdentity(filePath)
+    return withDocumentLock(identity.stateKey, async () => {
+      try {
+        const server = await ensureServerStarted(filePath)
+        if (!server) return undefined
 
-    try {
-      return await server.sendRequest<T>(method, params)
-    } catch (error) {
-      const err = error as Error
-      logError(
-        new Error(
-          `LSP request failed for file ${filePath}, method '${method}': ${err.message}`,
-        ),
-      )
-      throw error
-    }
+        if (!getCurrentDocumentState(identity, server)) {
+          const content = await dependencies.readDocument(identity.resolvedPath)
+          dependencies.recordFileActivity(identity.activityPath)
+          await synchronizeOpenUnlocked(
+            filePath,
+            content,
+            identity,
+            server,
+          )
+        }
+
+        if (!getCurrentDocumentState(identity, server)) {
+          throw new Error(
+            `LSP document ${filePath} is not synchronized to server generation ${server.generation}`,
+          )
+        }
+
+        return await server.sendRequest<T>(method, params)
+      } catch (error) {
+        const err = error as Error
+        logError(
+          new Error(
+            `LSP request failed for file ${filePath}, method '${method}': ${err.message}`,
+          ),
+        )
+        throw error
+      }
+    })
   }
 
-  // Return public interface
   function getAllServers(): Map<string, LSPServerInstance> {
     return servers
   }
 
   async function openFile(filePath: string, content: string): Promise<void> {
-    const server = await ensureServerStarted(filePath)
-    if (!server) return
-
-    const resolvedFilePath = path.resolve(filePath)
-    const fileUri = pathToFileURL(resolvedFilePath).href
-    recordLSPDiagnosticFileActivity(resolvedFilePath)
-
-    // Skip if already opened on this server
-    if (openedFiles.get(fileUri) === server.name) {
-      logForDebugging(
-        `LSP: File already open, skipping didOpen for ${filePath}`,
-      )
-      return
-    }
-
-    // Get language ID from server's extensionToLanguage mapping
-    const ext = path.extname(filePath).toLowerCase()
-    const languageId = server.config.extensionToLanguage[ext] || 'plaintext'
-
-    try {
-      await server.sendNotification('textDocument/didOpen', {
-        textDocument: {
-          uri: fileUri,
-          languageId,
-          version: 1,
-          text: content,
-        },
-      })
-      // Track that this file is now open on this server
-      openedFiles.set(fileUri, server.name)
-      logForDebugging(
-        `LSP: Sent didOpen for ${filePath} (languageId: ${languageId})`,
-      )
-    } catch (error) {
-      const err = new Error(
-        `Failed to sync file open ${filePath}: ${errorMessage(error)}`,
-      )
-      logError(err)
-      // Re-throw to propagate error to caller
-      throw err
-    }
+    const identity = getLspDocumentIdentity(filePath)
+    await withDocumentLock(identity.stateKey, async () => {
+      const server = await ensureServerStarted(filePath)
+      if (!server) return
+      dependencies.recordFileActivity(identity.activityPath)
+      await synchronizeOpenUnlocked(filePath, content, identity, server)
+    })
   }
 
   async function changeFile(filePath: string, content: string): Promise<void> {
-    const server = getServerForFile(filePath)
-    if (!server || server.state !== 'running') {
-      return openFile(filePath, content)
-    }
+    const identity = getLspDocumentIdentity(filePath)
+    await withDocumentLock(identity.stateKey, async () => {
+      const server = await ensureServerStarted(filePath)
+      if (!server) return
+      dependencies.recordFileActivity(identity.activityPath)
 
-    const resolvedFilePath = path.resolve(filePath)
-    const fileUri = pathToFileURL(resolvedFilePath).href
+      const state = getCurrentDocumentState(identity, server)
+      if (!state) {
+        await synchronizeOpenUnlocked(filePath, content, identity, server)
+        return
+      }
 
-    // If file hasn't been opened on this server yet, open it first
-    // LSP servers require didOpen before didChange
-    if (openedFiles.get(fileUri) !== server.name) {
-      return openFile(filePath, content)
-    }
+      const nextVersion = state.version + 1
+      const targetGeneration = server.generation
+      try {
+        await server.sendNotificationStrict('textDocument/didChange', {
+          textDocument: {
+            uri: state.fileUri,
+            version: nextVersion,
+          },
+          contentChanges: [{ text: content }],
+        })
+      } catch (error) {
+        openedDocuments.delete(identity.stateKey)
+        const syncError = new Error(
+          `Failed to sync file change ${filePath}: ${errorMessage(error)}`,
+        )
+        logError(syncError)
+        throw syncError
+      }
 
-    recordLSPDiagnosticFileActivity(resolvedFilePath)
+      if (
+        server.state !== 'running' ||
+        server.generation !== targetGeneration
+      ) {
+        openedDocuments.delete(identity.stateKey)
+        const syncError = new Error(
+          `Failed to sync file change ${filePath}: LSP server generation changed during notification`,
+        )
+        logError(syncError)
+        throw syncError
+      }
 
-    try {
-      await server.sendNotification('textDocument/didChange', {
-        textDocument: {
-          uri: fileUri,
-          version: 1,
-        },
-        contentChanges: [{ text: content }],
+      openedDocuments.set(identity.stateKey, {
+        ...state,
+        version: nextVersion,
       })
-      logForDebugging(`LSP: Sent didChange for ${filePath}`)
-    } catch (error) {
-      const err = new Error(
-        `Failed to sync file change ${filePath}: ${errorMessage(error)}`,
+      logForDebugging(
+        `LSP: Sent didChange for ${filePath} (version: ${nextVersion})`,
       )
-      logError(err)
-      // Re-throw to propagate error to caller
-      throw err
-    }
+    })
   }
 
-  /**
-   * Save a file in LSP servers (sends didSave notification)
-   * Called after file is written to disk to trigger diagnostics
-   */
+  /** Send didSave after earlier same-document lifecycle operations settle. */
   async function saveFile(filePath: string): Promise<void> {
-    const server = getServerForFile(filePath)
-    if (!server || server.state !== 'running') return
+    const identity = getLspDocumentIdentity(filePath)
+    await withDocumentLock(identity.stateKey, async () => {
+      const server = getServerForFile(filePath)
+      if (!server || server.state !== 'running') return
+      dependencies.recordFileActivity(identity.activityPath)
+      const state = getCurrentDocumentState(identity, server)
+      if (!state) return
 
-    const resolvedFilePath = path.resolve(filePath)
-    recordLSPDiagnosticFileActivity(resolvedFilePath)
-
-    try {
-      await server.sendNotification('textDocument/didSave', {
-        textDocument: {
-          uri: pathToFileURL(resolvedFilePath).href,
-        },
-      })
-      logForDebugging(`LSP: Sent didSave for ${filePath}`)
-    } catch (error) {
-      const err = new Error(
-        `Failed to sync file save ${filePath}: ${errorMessage(error)}`,
-      )
-      logError(err)
-      // Re-throw to propagate error to caller
-      throw err
-    }
+      try {
+        await server.sendNotification('textDocument/didSave', {
+          textDocument: {
+            uri: state.fileUri,
+          },
+        })
+        logForDebugging(`LSP: Sent didSave for ${filePath}`)
+      } catch (error) {
+        const syncError = new Error(
+          `Failed to sync file save ${filePath}: ${errorMessage(error)}`,
+        )
+        logError(syncError)
+        throw syncError
+      }
+    })
   }
 
-  /**
-   * Close a file in LSP servers (sends didClose notification)
-   *
-   * NOTE: Currently available but not yet integrated with compact flow.
-   * TODO: Integrate with compact - call closeFile() when compact removes files from context
-   * This will notify LSP servers that files are no longer in active use.
-   */
+  /** Close the current document lifecycle, forgetting local state on every outcome. */
   async function closeFile(filePath: string): Promise<void> {
-    const server = getServerForFile(filePath)
-    if (!server || server.state !== 'running') return
+    const identity = getLspDocumentIdentity(filePath)
+    await withDocumentLock(identity.stateKey, async () => {
+      const state = openedDocuments.get(identity.stateKey)
+      if (!state) return
+      openedDocuments.delete(identity.stateKey)
 
-    const fileUri = pathToFileURL(path.resolve(filePath)).href
+      const server = servers.get(state.serverName)
+      if (
+        !server ||
+        server.state !== 'running' ||
+        server.generation !== state.serverGeneration
+      ) {
+        return
+      }
 
-    try {
-      await server.sendNotification('textDocument/didClose', {
-        textDocument: {
-          uri: fileUri,
-        },
-      })
-      // Remove from tracking so file can be reopened later
-      openedFiles.delete(fileUri)
-      logForDebugging(`LSP: Sent didClose for ${filePath}`)
-    } catch (error) {
-      const err = new Error(
-        `Failed to sync file close ${filePath}: ${errorMessage(error)}`,
-      )
-      logError(err)
-      // Re-throw to propagate error to caller
-      throw err
-    }
+      try {
+        await server.sendNotificationStrict('textDocument/didClose', {
+          textDocument: { uri: state.fileUri },
+        })
+        logForDebugging(`LSP: Sent didClose for ${filePath}`)
+      } catch (error) {
+        const syncError = new Error(
+          `Failed to sync file close ${filePath}: ${errorMessage(error)}`,
+        )
+        logError(syncError)
+        throw syncError
+      }
+    })
   }
 
   function isFileOpen(filePath: string): boolean {
-    const fileUri = pathToFileURL(path.resolve(filePath)).href
-    return openedFiles.has(fileUri)
+    const identity = getLspDocumentIdentity(filePath)
+    const state = openedDocuments.get(identity.stateKey)
+    if (!state) return false
+    const server = servers.get(state.serverName)
+    if (server && isCurrentDocumentState(state, server)) return true
+    openedDocuments.delete(identity.stateKey)
+    return false
   }
 
   return {

--- a/src/services/lsp/documentIdentity.ts
+++ b/src/services/lsp/documentIdentity.ts
@@ -1,0 +1,119 @@
+import { constants } from 'node:fs'
+import { open } from 'node:fs/promises'
+import * as path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+export const MAX_LSP_FILE_SIZE_BYTES = 10_000_000
+
+export class LspDocumentTooLargeError extends Error {
+  readonly sizeBytes: number
+
+  constructor(sizeBytes: number) {
+    super(
+      `File too large for LSP analysis (${Math.ceil(sizeBytes / 1_000_000)}MB exceeds 10MB limit)`,
+    )
+    this.name = 'LspDocumentTooLargeError'
+    this.sizeBytes = sizeBytes
+  }
+}
+
+export type LspDocumentIdentity = {
+  resolvedPath: string
+  fileUri: string
+  stateKey: string
+  activityPath: string
+}
+
+const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
+
+function encodeWindowsFileUri(filePath: string): string {
+  const normalized = filePath.replaceAll('\\', '/').toLowerCase()
+  const [drive, ...segments] = normalized.split('/')
+  const encodedSegments = segments.map(segment =>
+    encodeURIComponent(segment).replace(/[!'()*]/g, character =>
+      `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+    ),
+  )
+  return `file:///${drive?.toLowerCase()}/${encodedSegments.join('/')}`
+}
+
+/**
+ * Resolve the filesystem path and stable URI/key used for one LSP document.
+ * Windows document identity is case-insensitive; POSIX identity is not.
+ */
+export function getLspDocumentIdentity(
+  filePath: string,
+): LspDocumentIdentity {
+  if (process.platform === 'win32' || WINDOWS_DRIVE_PATH.test(filePath)) {
+    const resolvedPath = path.win32.resolve(filePath)
+    if (WINDOWS_DRIVE_PATH.test(resolvedPath)) {
+      const fileUri = encodeWindowsFileUri(resolvedPath)
+      return {
+        resolvedPath,
+        fileUri,
+        stateKey: fileUri,
+        activityPath: fileURLToPath(fileUri),
+      }
+    }
+
+    const fileUri = pathToFileURL(resolvedPath).href
+    return {
+      resolvedPath,
+      fileUri,
+      stateKey: fileUri.toLowerCase(),
+      activityPath: fileURLToPath(fileUri),
+    }
+  }
+
+  const resolvedPath = path.resolve(filePath)
+  const fileUri = pathToFileURL(resolvedPath).href
+  return {
+    resolvedPath,
+    fileUri,
+    stateKey: fileUri,
+    activityPath: resolvedPath,
+  }
+}
+
+/** Read a complete LSP document without bypassing the tool's size policy. */
+export async function readLspDocumentContents(
+  filePath: string,
+): Promise<string> {
+  const handle = await open(
+    filePath,
+    constants.O_RDONLY | constants.O_NONBLOCK,
+  )
+  try {
+    const stats = await handle.stat()
+    if (!stats.isFile()) {
+      throw new Error(`LSP document is not a regular file: ${filePath}`)
+    }
+    if (stats.size > MAX_LSP_FILE_SIZE_BYTES) {
+      throw new LspDocumentTooLargeError(stats.size)
+    }
+
+    const chunks: Buffer[] = []
+    let totalBytes = 0
+    while (totalBytes <= MAX_LSP_FILE_SIZE_BYTES) {
+      const bytesRemaining = MAX_LSP_FILE_SIZE_BYTES + 1 - totalBytes
+      const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, bytesRemaining))
+      const { bytesRead } = await handle.read(
+        buffer,
+        0,
+        buffer.length,
+        null,
+      )
+      if (bytesRead === 0) break
+
+      totalBytes += bytesRead
+      if (totalBytes > MAX_LSP_FILE_SIZE_BYTES) {
+        throw new LspDocumentTooLargeError(totalBytes)
+      }
+      chunks.push(buffer.subarray(0, bytesRead))
+    }
+
+    return Buffer.concat(chunks, totalBytes).toString('utf-8')
+  } finally {
+    await handle.close()
+  }
+}

--- a/src/services/lsp/documentIdentity.ts
+++ b/src/services/lsp/documentIdentity.ts
@@ -27,7 +27,7 @@ export type LspDocumentIdentity = {
 const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[\\/]/
 
 function encodeWindowsFileUri(filePath: string): string {
-  const normalized = filePath.replaceAll('\\', '/').toLowerCase()
+  const normalized = filePath.replaceAll('\\', '/')
   const [drive, ...segments] = normalized.split('/')
   const encodedSegments = segments.map(segment =>
     encodeURIComponent(segment).replace(/[!'()*]/g, character =>
@@ -51,7 +51,7 @@ export function getLspDocumentIdentity(
       return {
         resolvedPath,
         fileUri,
-        stateKey: fileUri,
+        stateKey: fileUri.toLowerCase(),
         activityPath: fileURLToPath(fileUri),
       }
     }

--- a/src/services/lsp/documentIdentity.ts
+++ b/src/services/lsp/documentIdentity.ts
@@ -51,7 +51,7 @@ export function getLspDocumentIdentity(
       return {
         resolvedPath,
         fileUri,
-        stateKey: fileUri.toLowerCase(),
+        stateKey: encodeWindowsFileUri(resolvedPath.toLowerCase()),
         activityPath: fileURLToPath(fileUri),
       }
     }
@@ -60,7 +60,7 @@ export function getLspDocumentIdentity(
     return {
       resolvedPath,
       fileUri,
-      stateKey: fileUri.toLowerCase(),
+      stateKey: pathToFileURL(resolvedPath.toLowerCase()).href,
       activityPath: fileURLToPath(fileUri),
     }
   }

--- a/src/services/lsp/manager.availability.test.ts
+++ b/src/services/lsp/manager.availability.test.ts
@@ -3,33 +3,101 @@ import { expect, test } from 'bun:test'
 
 // Keep a pristine Bun module graph: tools.lsp.test.ts installs a process-wide
 // mock for manager.js, so in-process behavior would depend on test-file order.
-test('reports restartable servers but hides exhausted servers in every state', () => {
+test('bounds failed starts before advertising server availability', () => {
   const managerModuleUrl = new URL('./manager.ts', import.meta.url).href
+  const instanceModuleUrl = new URL(
+    './LSPServerInstance.ts',
+    import.meta.url,
+  ).href
   const output = execFileSync(
     process.execPath,
     [
       '-e',
       `
+        const manager = await import(${JSON.stringify(managerModuleUrl)})
+        const { createLSPServerInstance } = await import(${JSON.stringify(instanceModuleUrl)})
         const {
           _resetLspManagerForTesting,
           _setLspManagerForTesting,
           isLspConnected,
-        } = await import(${JSON.stringify(managerModuleUrl)})
+        } = manager
 
-        const install = (state, isCrashRecoveryExhausted) => {
-          const server = { state, isCrashRecoveryExhausted }
-          _setLspManagerForTesting({
-            getAllServers: () => new Map([['typescript', server]]),
-          })
+        const config = {
+          command: 'test-lsp',
+          extensionToLanguage: { '.ts': 'typescript' },
+          maxRestarts: 1,
+          scope: 'project',
+          source: 'test',
         }
 
-        const results = [isLspConnected()]
-        install('error', false)
-        results.push(isLspConnected())
-        install('error', true)
-        results.push(isLspConnected())
-        install('stopped', true)
-        results.push(isLspConnected())
+        const runScenario = async failurePhase => {
+          let failureEnabled = true
+          let initialized = false
+          let startCalls = 0
+          let initializeCalls = 0
+          const client = {
+            get capabilities() { return {} },
+            get isInitialized() { return initialized },
+            async start() {
+              startCalls++
+              if (failureEnabled && failurePhase === 'spawn') {
+                throw new Error('spawn failed')
+              }
+            },
+            async initialize() {
+              initializeCalls++
+              if (failureEnabled && failurePhase === 'initialize-timeout') {
+                return await new Promise(() => {})
+              }
+              initialized = true
+              return { capabilities: {} }
+            },
+            async sendRequest() {},
+            async sendNotification() {},
+            async sendNotificationStrict() {},
+            onNotification() {},
+            onRequest() {},
+            async stop() { initialized = false },
+          }
+          const instance = createLSPServerInstance(
+            'typescript',
+            config,
+            {
+              createClient: () => client,
+              defaultStartupTimeoutMs: 0,
+            },
+          )
+          _setLspManagerForTesting({
+            getAllServers: () => new Map([['typescript', instance]]),
+          })
+
+          const availability = [isLspConnected()]
+          const errors = []
+          for (let attempt = 0; attempt < 2; attempt++) {
+            await instance.start().catch(error => errors.push(error.message))
+            availability.push(isLspConnected())
+          }
+          await instance.start().catch(error => errors.push(error.message))
+          availability.push(isLspConnected())
+
+          failureEnabled = false
+          await instance.restart()
+          availability.push(isLspConnected())
+
+          return {
+            availability,
+            errors,
+            generation: instance.generation,
+            initializeCalls,
+            startCalls,
+          }
+        }
+
+        const results = {
+          initiallyAvailable: isLspConnected(),
+          spawn: await runScenario('spawn'),
+          timeout: await runScenario('initialize-timeout'),
+        }
         _resetLspManagerForTesting()
         process.stdout.write(JSON.stringify(results))
       `,
@@ -37,5 +105,29 @@ test('reports restartable servers but hides exhausted servers in every state', (
     { encoding: 'utf8' },
   )
 
-  expect(JSON.parse(output)).toEqual([false, true, false, false])
+  expect(JSON.parse(output)).toEqual({
+    initiallyAvailable: false,
+    spawn: {
+      availability: [true, true, false, false, true],
+      errors: [
+        'spawn failed',
+        'spawn failed',
+        "LSP server 'typescript' exceeded max automatic recovery attempts (1)",
+      ],
+      generation: 1,
+      initializeCalls: 1,
+      startCalls: 3,
+    },
+    timeout: {
+      availability: [true, true, false, false, true],
+      errors: [
+        "LSP server 'typescript' timed out after 0ms during initialization",
+        "LSP server 'typescript' timed out after 0ms during initialization",
+        "LSP server 'typescript' exceeded max automatic recovery attempts (1)",
+      ],
+      generation: 1,
+      initializeCalls: 3,
+      startCalls: 3,
+    },
+  })
 })

--- a/src/services/lsp/manager.availability.test.ts
+++ b/src/services/lsp/manager.availability.test.ts
@@ -102,7 +102,7 @@ test('bounds failed starts before advertising server availability', () => {
         process.stdout.write(JSON.stringify(results))
       `,
     ],
-    { encoding: 'utf8' },
+    { encoding: 'utf8', timeout: 30_000 },
   )
 
   expect(JSON.parse(output)).toEqual({

--- a/src/services/lsp/manager.availability.test.ts
+++ b/src/services/lsp/manager.availability.test.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from 'node:child_process'
+import { expect, test } from 'bun:test'
+
+test('reports restartable servers but hides exhausted servers in every state', () => {
+  const managerModuleUrl = new URL('./manager.ts', import.meta.url).href
+  const output = execFileSync(
+    process.execPath,
+    [
+      '-e',
+      `
+        const {
+          _resetLspManagerForTesting,
+          _setLspManagerForTesting,
+          isLspConnected,
+        } = await import(${JSON.stringify(managerModuleUrl)})
+
+        const install = (state, isCrashRecoveryExhausted) => {
+          const server = { state, isCrashRecoveryExhausted }
+          _setLspManagerForTesting({
+            getAllServers: () => new Map([['typescript', server]]),
+          })
+        }
+
+        const results = [isLspConnected()]
+        install('error', false)
+        results.push(isLspConnected())
+        install('error', true)
+        results.push(isLspConnected())
+        install('stopped', true)
+        results.push(isLspConnected())
+        _resetLspManagerForTesting()
+        process.stdout.write(JSON.stringify(results))
+      `,
+    ],
+    { encoding: 'utf8' },
+  )
+
+  expect(JSON.parse(output)).toEqual([false, true, false, false])
+})

--- a/src/services/lsp/manager.availability.test.ts
+++ b/src/services/lsp/manager.availability.test.ts
@@ -1,6 +1,8 @@
 import { execFileSync } from 'node:child_process'
 import { expect, test } from 'bun:test'
 
+// Keep a pristine Bun module graph: tools.lsp.test.ts installs a process-wide
+// mock for manager.js, so in-process behavior would depend on test-file order.
 test('reports restartable servers but hides exhausted servers in every state', () => {
   const managerModuleUrl = new URL('./manager.ts', import.meta.url).href
   const output = execFileSync(

--- a/src/services/lsp/manager.ts
+++ b/src/services/lsp/manager.ts
@@ -46,7 +46,19 @@ let initializationPromise: Promise<void> | undefined
  * tests on the same shard.
  */
 export function _resetLspManagerForTesting(): void {
+  lspManagerInstance = undefined
   initializationState = 'not-started'
+  initializationError = undefined
+  initializationPromise = undefined
+  initializationGeneration++
+}
+
+/** Install a complete manager double without mutating the module graph. */
+export function _setLspManagerForTesting(
+  manager: LSPServerManager | undefined,
+): void {
+  lspManagerInstance = manager
+  initializationState = manager ? 'success' : 'not-started'
   initializationError = undefined
   initializationPromise = undefined
   initializationGeneration++
@@ -94,17 +106,15 @@ export function getInitializationStatus():
 }
 
 /**
- * Check whether at least one language server is connected and healthy.
- * Backs LSPTool.isEnabled().
+ * Check whether at least one language server is configured and can be started
+ * or restarted lazily. Backs LSPTool.isEnabled().
  */
 export function isLspConnected(): boolean {
   if (initializationState === 'failed') return false
   const manager = getLspServerManager()
   if (!manager) return false
-  const servers = manager.getAllServers()
-  if (servers.size === 0) return false
-  for (const server of servers.values()) {
-    if (server.state !== 'error') return true
+  for (const server of manager.getAllServers().values()) {
+    if (!server.isCrashRecoveryExhausted) return true
   }
   return false
 }

--- a/src/services/lsp/types.ts
+++ b/src/services/lsp/types.ts
@@ -22,7 +22,7 @@ export type LspServerConfig = {
   settings?: unknown
   /** Workspace folder path to use for the server */
   workspaceFolder?: string
-  /** Maximum time to wait for server startup (ms) */
+  /** Maximum time to wait for each server startup phase (default: 30000 ms) */
   startupTimeout?: number
   /** Maximum time to wait for graceful shutdown (ms) */
   shutdownTimeout?: number

--- a/src/tools.lsp.test.ts
+++ b/src/tools.lsp.test.ts
@@ -9,6 +9,7 @@ import { join } from 'node:path'
 import { execFileSync } from 'node:child_process'
 import { afterAll, beforeEach, expect, mock, test } from 'bun:test'
 import { MAX_LSP_FILE_SIZE_BYTES } from './services/lsp/documentIdentity.js'
+import type { LSPServerManager } from './services/lsp/LSPServerManager.js'
 import { getEmptyToolPermissionContext } from './Tool.js'
 import {
   acquireSharedMutationLock,
@@ -16,7 +17,48 @@ import {
 } from './test/sharedMutationLock.js'
 
 let lspConnected = false
-let lspManager: Record<string, unknown> | undefined
+let lspManager: LSPServerManager | undefined
+
+function createLspManagerDouble(
+  overrides: Partial<LSPServerManager> = {},
+): LSPServerManager {
+  return {
+    async initialize() {},
+    async shutdown() {},
+    getServerForFile: () => undefined,
+    ensureServerStarted: async () => undefined,
+    async sendRequest<T>() {
+      return undefined as T | undefined
+    },
+    async sendRequestWithGeneration<T>() {
+      return undefined as
+        | { result: T; serverGeneration: number }
+        | undefined
+    },
+    getAllServers: () => new Map(),
+    async openFile() {},
+    async changeFile() {},
+    async saveFile() {},
+    async closeFile() {},
+    isFileOpen: () => false,
+    ...overrides,
+  }
+}
+
+function createSendRequestDouble(): {
+  sendRequest: LSPServerManager['sendRequest']
+  calls: ReturnType<typeof mock>
+} {
+  const calls = mock(
+    async (_filePath: string, _method: string, _params: unknown) => null,
+  )
+  const sendRequest: LSPServerManager['sendRequest'] = async <T>(
+    filePath: string,
+    method: string,
+    params: unknown,
+  ) => (await calls(filePath, method, params)) as T
+  return { sendRequest, calls }
+}
 const HOOK_EVENTS = [
   'PreToolUse',
   'PostToolUse',
@@ -97,15 +139,15 @@ test('LSPTool keeps the 10 MB guard ahead of open and request', async () => {
   const directory = mkdtempSync(join(tmpdir(), 'openclaude-lsp-tool-size-'))
   const filePath = join(directory, 'large.ts')
   const openFile = mock(async () => {})
-  const sendRequest = mock(async () => null)
+  const { sendRequest, calls: sendRequestCalls } = createSendRequestDouble()
   try {
     writeFileSync(filePath, '')
     truncateSync(filePath, MAX_LSP_FILE_SIZE_BYTES + 1)
-    lspManager = {
+    lspManager = createLspManagerDouble({
       isFileOpen: () => false,
       openFile,
       sendRequest,
-    }
+    })
 
     const result = await LSPTool.call(
       { operation: 'hover', filePath, line: 1, character: 1 },
@@ -114,7 +156,7 @@ test('LSPTool keeps the 10 MB guard ahead of open and request', async () => {
 
     expect(result.data.result).toContain('exceeds 10MB limit')
     expect(openFile).not.toHaveBeenCalled()
-    expect(sendRequest).not.toHaveBeenCalled()
+    expect(sendRequestCalls).not.toHaveBeenCalled()
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }
@@ -126,14 +168,14 @@ test('LSPTool opens FIFO recovery paths nonblocking before validation', async ()
   const directory = mkdtempSync(join(tmpdir(), 'openclaude-lsp-tool-fifo-'))
   const filePath = join(directory, 'stream.ts')
   const openFile = mock(async () => {})
-  const sendRequest = mock(async () => null)
+  const { sendRequest, calls: sendRequestCalls } = createSendRequestDouble()
   try {
     execFileSync('mkfifo', [filePath])
-    lspManager = {
+    lspManager = createLspManagerDouble({
       isFileOpen: () => false,
       openFile,
       sendRequest,
-    }
+    })
 
     const result = await LSPTool.call(
       { operation: 'hover', filePath, line: 1, character: 1 },
@@ -142,7 +184,7 @@ test('LSPTool opens FIFO recovery paths nonblocking before validation', async ()
 
     expect(result.data.result).toContain('not a regular file')
     expect(openFile).not.toHaveBeenCalled()
-    expect(sendRequest).not.toHaveBeenCalled()
+    expect(sendRequestCalls).not.toHaveBeenCalled()
   } finally {
     rmSync(directory, { recursive: true, force: true })
   }
@@ -150,12 +192,12 @@ test('LSPTool opens FIFO recovery paths nonblocking before validation', async ()
 
 test('LSPTool does not redundantly open a current document', async () => {
   const openFile = mock(async () => {})
-  const sendRequest = mock(async () => null)
-  lspManager = {
+  const { sendRequest, calls: sendRequestCalls } = createSendRequestDouble()
+  lspManager = createLspManagerDouble({
     isFileOpen: () => true,
     openFile,
     sendRequest,
-  }
+  })
 
   await LSPTool.call(
     {
@@ -168,16 +210,16 @@ test('LSPTool does not redundantly open a current document', async () => {
   )
 
   expect(openFile).not.toHaveBeenCalled()
-  expect(sendRequest).toHaveBeenCalledTimes(1)
+  expect(sendRequestCalls).toHaveBeenCalledTimes(1)
 })
 
 test('LSPTool request params use the shared canonical document URI', async () => {
-  const sendRequest = mock(async () => null)
-  lspManager = {
+  const { sendRequest, calls: sendRequestCalls } = createSendRequestDouble()
+  lspManager = createLspManagerDouble({
     isFileOpen: () => true,
     openFile: mock(async () => {}),
     sendRequest,
-  }
+  })
 
   await LSPTool.call(
     {
@@ -189,7 +231,7 @@ test('LSPTool request params use the shared canonical document URI', async () =>
     {} as never,
   )
 
-  expect(sendRequest).toHaveBeenCalledWith(
+  expect(sendRequestCalls).toHaveBeenCalledWith(
     '/repo/Source File.ts',
     'textDocument/hover',
     {
@@ -197,4 +239,101 @@ test('LSPTool request params use the shared canonical document URI', async () =>
       position: { line: 0, character: 0 },
     },
   )
+})
+
+test('LSPTool retries both call-hierarchy requests on one replacement generation', async () => {
+  const requests: Array<{
+    method: string
+    expectedGeneration: number | undefined
+    itemGeneration: number | undefined
+  }> = []
+  let prepareGeneration = 0
+  const sendRequestWithGeneration: LSPServerManager['sendRequestWithGeneration'] =
+    async <T>(
+      _filePath: string,
+      method: string,
+      params: unknown,
+      options?: { expectedGeneration?: number },
+    ) => {
+      const itemGeneration = (
+        params as { item?: { data?: { generation?: number } } }
+      ).item?.data?.generation
+      requests.push({
+        method,
+        expectedGeneration: options?.expectedGeneration,
+        itemGeneration,
+      })
+
+      if (method === 'textDocument/prepareCallHierarchy') {
+        prepareGeneration++
+        return {
+          result: [
+            {
+              name: 'target',
+              kind: 12,
+              uri: 'file:///repo/src/current.ts',
+              range: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 6 },
+              },
+              selectionRange: {
+                start: { line: 0, character: 0 },
+                end: { line: 0, character: 6 },
+              },
+              data: { generation: prepareGeneration },
+            },
+          ] as T,
+          serverGeneration: prepareGeneration,
+        }
+      }
+
+      if (options?.expectedGeneration === 1) {
+        throw Object.assign(new Error('server generation changed'), {
+          code: 'LSP_SERVER_GENERATION_CHANGED',
+        })
+      }
+
+      return {
+        result: [] as T,
+        serverGeneration: options?.expectedGeneration ?? 0,
+      }
+    }
+
+  lspManager = createLspManagerDouble({
+    isFileOpen: () => true,
+    sendRequestWithGeneration,
+  })
+
+  await LSPTool.call(
+    {
+      operation: 'incomingCalls',
+      filePath: '/repo/src/current.ts',
+      line: 1,
+      character: 1,
+    },
+    {} as never,
+  )
+
+  expect(requests).toEqual([
+    {
+      method: 'textDocument/prepareCallHierarchy',
+      expectedGeneration: undefined,
+      itemGeneration: undefined,
+    },
+    {
+      method: 'callHierarchy/incomingCalls',
+      expectedGeneration: 1,
+      itemGeneration: 1,
+    },
+    {
+      method: 'textDocument/prepareCallHierarchy',
+      expectedGeneration: undefined,
+      itemGeneration: undefined,
+    },
+    {
+      method: 'callHierarchy/incomingCalls',
+      expectedGeneration: 2,
+      itemGeneration: 2,
+    },
+  ])
 })

--- a/src/tools.lsp.test.ts
+++ b/src/tools.lsp.test.ts
@@ -1,3 +1,15 @@
+import {
+  closeSync,
+  constants,
+  mkdtempSync,
+  openSync,
+  rmSync,
+  truncateSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { execFileSync, spawn } from 'node:child_process'
 import { afterAll, beforeEach, expect, mock, test } from 'bun:test'
 import { getEmptyToolPermissionContext } from './Tool.js'
 import {
@@ -6,6 +18,7 @@ import {
 } from './test/sharedMutationLock.js'
 
 let lspConnected = false
+let lspManager: Record<string, unknown> | undefined
 const HOOK_EVENTS = [
   'PreToolUse',
   'PostToolUse',
@@ -43,7 +56,7 @@ mock.module('src/entrypoints/agentSdkTypes.js', () => ({ HOOK_EVENTS }))
 
 mock.module('./services/lsp/manager.js', () => ({
   getInitializationStatus: () => ({ status: 'success' }),
-  getLspServerManager: () => undefined,
+  getLspServerManager: () => lspManager,
   initializeLspServerManager: async () => {},
   isLspConnected: () => lspConnected,
   reinitializeLspServerManager: () => {},
@@ -53,6 +66,7 @@ mock.module('./services/lsp/manager.js', () => ({
 }))
 
 const { getAllBaseTools, getTools } = await import('./tools.js')
+const { LSPTool } = await import('./tools/LSPTool/LSPTool.js')
 
 afterAll(() => {
   try {
@@ -64,6 +78,7 @@ afterAll(() => {
 
 beforeEach(() => {
   lspConnected = false
+  lspManager = undefined
 })
 
 test('LSPTool is part of the base tool pool', () => {
@@ -78,4 +93,156 @@ test('LSPTool is filtered from usable tools until a server is connected', () => 
   lspConnected = true
 
   expect(getTools(permissionContext).map(tool => tool.name)).toContain('LSP')
+})
+
+test('LSPTool keeps the 10 MB guard ahead of open and request', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'openclaude-lsp-tool-size-'))
+  const filePath = join(directory, 'large.ts')
+  const openFile = mock(async () => {})
+  const sendRequest = mock(async () => null)
+  try {
+    writeFileSync(filePath, '')
+    truncateSync(filePath, 10_000_001)
+    lspManager = {
+      isFileOpen: () => false,
+      openFile,
+      sendRequest,
+    }
+
+    const result = await LSPTool.call(
+      { operation: 'hover', filePath, line: 1, character: 1 },
+      {} as never,
+    )
+
+    expect(result.data.result).toContain('exceeds 10MB limit')
+    expect(openFile).not.toHaveBeenCalled()
+    expect(sendRequest).not.toHaveBeenCalled()
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('LSPTool rejects non-regular documents without reading their stream', async () => {
+  if (process.platform === 'win32') return
+
+  const directory = mkdtempSync(join(tmpdir(), 'openclaude-lsp-tool-fifo-'))
+  const filePath = join(directory, 'stream.ts')
+  const openFile = mock(async () => {})
+  const sendRequest = mock(async () => null)
+  let keeper: number | undefined
+  try {
+    execFileSync('mkfifo', [filePath])
+    keeper = openSync(
+      filePath,
+      constants.O_RDONLY | constants.O_NONBLOCK,
+    )
+    const writer = spawn(
+      'dd',
+      ['if=/dev/zero', `of=${filePath}`, 'bs=10000001', 'count=1', 'status=none'],
+      { stdio: 'ignore' },
+    )
+    const writerDone = new Promise<void>((resolve, reject) => {
+      writer.once('error', reject)
+      writer.once('exit', () => resolve())
+    })
+    lspManager = {
+      isFileOpen: () => false,
+      openFile,
+      sendRequest,
+    }
+
+    const result = await LSPTool.call(
+      { operation: 'hover', filePath, line: 1, character: 1 },
+      {} as never,
+    )
+    closeSync(keeper)
+    keeper = undefined
+    await writerDone
+
+    expect(result.data.result).toContain('not a regular file')
+    expect(openFile).not.toHaveBeenCalled()
+    expect(sendRequest).not.toHaveBeenCalled()
+  } finally {
+    if (keeper !== undefined) closeSync(keeper)
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('LSPTool opens FIFO recovery paths nonblocking before validation', async () => {
+  if (process.platform === 'win32') return
+
+  const directory = mkdtempSync(join(tmpdir(), 'openclaude-lsp-tool-fifo-'))
+  const filePath = join(directory, 'stream.ts')
+  const openFile = mock(async () => {})
+  const sendRequest = mock(async () => null)
+  try {
+    execFileSync('mkfifo', [filePath])
+    lspManager = {
+      isFileOpen: () => false,
+      openFile,
+      sendRequest,
+    }
+
+    const result = await LSPTool.call(
+      { operation: 'hover', filePath, line: 1, character: 1 },
+      {} as never,
+    )
+
+    expect(result.data.result).toContain('not a regular file')
+    expect(openFile).not.toHaveBeenCalled()
+    expect(sendRequest).not.toHaveBeenCalled()
+  } finally {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test('LSPTool does not redundantly open a current document', async () => {
+  const openFile = mock(async () => {})
+  const sendRequest = mock(async () => null)
+  lspManager = {
+    isFileOpen: () => true,
+    openFile,
+    sendRequest,
+  }
+
+  await LSPTool.call(
+    {
+      operation: 'hover',
+      filePath: '/repo/src/current.ts',
+      line: 1,
+      character: 1,
+    },
+    {} as never,
+  )
+
+  expect(openFile).not.toHaveBeenCalled()
+  expect(sendRequest).toHaveBeenCalledTimes(1)
+})
+
+test('LSPTool request params use the shared canonical document URI', async () => {
+  const sendRequest = mock(async () => null)
+  lspManager = {
+    isFileOpen: () => true,
+    openFile: mock(async () => {}),
+    sendRequest,
+  }
+
+  await LSPTool.call(
+    {
+      operation: 'hover',
+      filePath: '/repo/Source File.ts',
+      line: 1,
+      character: 1,
+    },
+    {} as never,
+  )
+
+  expect(sendRequest).toHaveBeenCalledWith(
+    '/repo/Source File.ts',
+    'textDocument/hover',
+    {
+      textDocument: { uri: 'file:///repo/Source%20File.ts' },
+      position: { line: 0, character: 0 },
+    },
+  )
 })

--- a/src/tools.lsp.test.ts
+++ b/src/tools.lsp.test.ts
@@ -1,15 +1,16 @@
-import {
-  mkdtempSync,
-  rmSync,
-  truncateSync,
-  writeFileSync,
-} from 'node:fs'
+import { mkdtempSync, rmSync, truncateSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { execFileSync } from 'node:child_process'
 import { afterAll, beforeEach, expect, mock, test } from 'bun:test'
-import { MAX_LSP_FILE_SIZE_BYTES } from './services/lsp/documentIdentity.js'
-import type { LSPServerManager } from './services/lsp/LSPServerManager.js'
+import {
+  getLspDocumentIdentity,
+  MAX_LSP_FILE_SIZE_BYTES,
+} from './services/lsp/documentIdentity.js'
+import {
+  LSP_SERVER_GENERATION_CHANGED,
+  type LSPServerManager,
+} from './services/lsp/LSPServerManager.js'
 import { getEmptyToolPermissionContext } from './Tool.js'
 import {
   acquireSharedMutationLock,
@@ -32,7 +33,12 @@ function createLspManagerDouble(
     },
     async sendRequestWithGeneration<T>() {
       return undefined as
-        | { result: T; serverGeneration: number }
+        | {
+            result: T
+            serverGeneration: number
+            documentRevision: number
+            documentCloseEpoch: number
+          }
         | undefined
     },
     getAllServers: () => new Map(),
@@ -122,17 +128,19 @@ beforeEach(() => {
 })
 
 test('LSPTool is part of the base tool pool', () => {
-  expect(getAllBaseTools().map(tool => tool.name)).toContain('LSP')
+  expect(getAllBaseTools().map((tool) => tool.name)).toContain('LSP')
 })
 
 test('LSPTool is filtered from usable tools until a server is connected', () => {
   const permissionContext = getEmptyToolPermissionContext()
 
-  expect(getTools(permissionContext).map(tool => tool.name)).not.toContain('LSP')
+  expect(getTools(permissionContext).map((tool) => tool.name)).not.toContain(
+    'LSP',
+  )
 
   lspConnected = true
 
-  expect(getTools(permissionContext).map(tool => tool.name)).toContain('LSP')
+  expect(getTools(permissionContext).map((tool) => tool.name)).toContain('LSP')
 })
 
 test('LSPTool keeps the 10 MB guard ahead of open and request', async () => {
@@ -235,105 +243,139 @@ test('LSPTool request params use the shared canonical document URI', async () =>
     '/repo/Source File.ts',
     'textDocument/hover',
     {
-      textDocument: { uri: 'file:///repo/Source%20File.ts' },
+      textDocument: {
+        uri: getLspDocumentIdentity('/repo/Source File.ts').fileUri,
+      },
       position: { line: 0, character: 0 },
     },
   )
 })
 
-test('LSPTool retries both call-hierarchy requests on one replacement generation', async () => {
-  const requests: Array<{
-    method: string
-    expectedGeneration: number | undefined
-    itemGeneration: number | undefined
-  }> = []
-  let prepareGeneration = 0
-  const sendRequestWithGeneration: LSPServerManager['sendRequestWithGeneration'] =
-    async <T>(
-      _filePath: string,
-      method: string,
-      params: unknown,
-      options?: { expectedGeneration?: number },
-    ) => {
-      const itemGeneration = (
-        params as { item?: { data?: { generation?: number } } }
-      ).item?.data?.generation
-      requests.push({
-        method,
-        expectedGeneration: options?.expectedGeneration,
-        itemGeneration,
+for (const [contextName, contextCode] of [
+  ['replacement generation', LSP_SERVER_GENERATION_CHANGED],
+  ['document revision change', 'LSP_DOCUMENT_REVISION_CHANGED'],
+] as const) {
+  for (const operation of ['incomingCalls', 'outgoingCalls'] as const) {
+    test(`LSPTool retries ${operation} after one ${contextName}`, async () => {
+      const requests: Array<{
+        method: string
+        expectedGeneration: number | undefined
+        expectedDocumentRevision: number | undefined
+        expectedDocumentCloseEpoch: number | undefined
+        itemGeneration: number | undefined
+      }> = []
+      let prepareGeneration = 0
+      const sendRequestWithGeneration: LSPServerManager['sendRequestWithGeneration'] =
+        async <T>(
+          _filePath: string,
+          method: string,
+          params: unknown,
+          options?: {
+            expectedGeneration?: number
+            expectedDocumentRevision?: number
+            expectedDocumentCloseEpoch?: number
+          },
+        ) => {
+          const itemGeneration = (
+            params as { item?: { data?: { generation?: number } } }
+          ).item?.data?.generation
+          requests.push({
+            method,
+            expectedGeneration: options?.expectedGeneration,
+            expectedDocumentRevision: options?.expectedDocumentRevision,
+            expectedDocumentCloseEpoch:
+              options?.expectedDocumentCloseEpoch,
+            itemGeneration,
+          })
+
+          if (method === 'textDocument/prepareCallHierarchy') {
+            prepareGeneration++
+            return {
+              result: [
+                {
+                  name: 'target',
+                  kind: 12,
+                  uri: 'file:///repo/src/current.ts',
+                  range: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 6 },
+                  },
+                  selectionRange: {
+                    start: { line: 0, character: 0 },
+                    end: { line: 0, character: 6 },
+                  },
+                  data: { generation: prepareGeneration },
+                },
+              ] as T,
+              serverGeneration: prepareGeneration,
+              documentRevision: prepareGeneration,
+              documentCloseEpoch: prepareGeneration,
+            }
+          }
+
+          if (options?.expectedGeneration === 1) {
+            throw Object.assign(new Error('request context changed'), {
+              code: contextCode,
+            })
+          }
+
+          return {
+            result: [] as T,
+            serverGeneration: options?.expectedGeneration ?? 0,
+            documentRevision: options?.expectedDocumentRevision ?? 0,
+            documentCloseEpoch: options?.expectedDocumentCloseEpoch ?? 0,
+          }
+        }
+
+      lspManager = createLspManagerDouble({
+        isFileOpen: () => true,
+        sendRequestWithGeneration,
       })
 
-      if (method === 'textDocument/prepareCallHierarchy') {
-        prepareGeneration++
-        return {
-          result: [
-            {
-              name: 'target',
-              kind: 12,
-              uri: 'file:///repo/src/current.ts',
-              range: {
-                start: { line: 0, character: 0 },
-                end: { line: 0, character: 6 },
-              },
-              selectionRange: {
-                start: { line: 0, character: 0 },
-                end: { line: 0, character: 6 },
-              },
-              data: { generation: prepareGeneration },
-            },
-          ] as T,
-          serverGeneration: prepareGeneration,
-        }
-      }
+      await LSPTool.call(
+        {
+          operation,
+          filePath: '/repo/src/current.ts',
+          line: 1,
+          character: 1,
+        },
+        {} as never,
+      )
 
-      if (options?.expectedGeneration === 1) {
-        throw Object.assign(new Error('server generation changed'), {
-          code: 'LSP_SERVER_GENERATION_CHANGED',
-        })
-      }
-
-      return {
-        result: [] as T,
-        serverGeneration: options?.expectedGeneration ?? 0,
-      }
-    }
-
-  lspManager = createLspManagerDouble({
-    isFileOpen: () => true,
-    sendRequestWithGeneration,
-  })
-
-  await LSPTool.call(
-    {
-      operation: 'incomingCalls',
-      filePath: '/repo/src/current.ts',
-      line: 1,
-      character: 1,
-    },
-    {} as never,
-  )
-
-  expect(requests).toEqual([
-    {
-      method: 'textDocument/prepareCallHierarchy',
-      expectedGeneration: undefined,
-      itemGeneration: undefined,
-    },
-    {
-      method: 'callHierarchy/incomingCalls',
-      expectedGeneration: 1,
-      itemGeneration: 1,
-    },
-    {
-      method: 'textDocument/prepareCallHierarchy',
-      expectedGeneration: undefined,
-      itemGeneration: undefined,
-    },
-    {
-      method: 'callHierarchy/incomingCalls',
-      expectedGeneration: 2,
-      itemGeneration: 2,
-    },
-  ])
-})
+      const callMethod =
+        operation === 'incomingCalls'
+          ? 'callHierarchy/incomingCalls'
+          : 'callHierarchy/outgoingCalls'
+      expect(requests).toEqual([
+        {
+          method: 'textDocument/prepareCallHierarchy',
+          expectedGeneration: undefined,
+          expectedDocumentRevision: undefined,
+          expectedDocumentCloseEpoch: undefined,
+          itemGeneration: undefined,
+        },
+        {
+          method: callMethod,
+          expectedGeneration: 1,
+          expectedDocumentRevision: 1,
+          expectedDocumentCloseEpoch: 1,
+          itemGeneration: 1,
+        },
+        {
+          method: 'textDocument/prepareCallHierarchy',
+          expectedGeneration: undefined,
+          expectedDocumentRevision: undefined,
+          expectedDocumentCloseEpoch: undefined,
+          itemGeneration: undefined,
+        },
+        {
+          method: callMethod,
+          expectedGeneration: 2,
+          expectedDocumentRevision: 2,
+          expectedDocumentCloseEpoch: 2,
+          itemGeneration: 2,
+        },
+      ])
+    })
+  }
+}

--- a/src/tools.lsp.test.ts
+++ b/src/tools.lsp.test.ts
@@ -8,6 +8,7 @@ import {
   MAX_LSP_FILE_SIZE_BYTES,
 } from './services/lsp/documentIdentity.js'
 import {
+  LSP_DOCUMENT_REVISION_CHANGED,
   LSP_SERVER_GENERATION_CHANGED,
   type LSPServerManager,
 } from './services/lsp/LSPServerManager.js'
@@ -162,7 +163,9 @@ test('LSPTool keeps the 10 MB guard ahead of open and request', async () => {
       {} as never,
     )
 
-    expect(result.data.result).toContain('exceeds 10MB limit')
+    expect(result.data.result).toBe(
+      'File too large for LSP analysis (11MB exceeds 10MB limit)',
+    )
     expect(openFile).not.toHaveBeenCalled()
     expect(sendRequestCalls).not.toHaveBeenCalled()
   } finally {
@@ -253,7 +256,7 @@ test('LSPTool request params use the shared canonical document URI', async () =>
 
 for (const [contextName, contextCode] of [
   ['replacement generation', LSP_SERVER_GENERATION_CHANGED],
-  ['document revision change', 'LSP_DOCUMENT_REVISION_CHANGED'],
+  ['document revision change', LSP_DOCUMENT_REVISION_CHANGED],
 ] as const) {
   for (const operation of ['incomingCalls', 'outgoingCalls'] as const) {
     test(`LSPTool retries ${operation} after one ${contextName}`, async () => {

--- a/src/tools.lsp.test.ts
+++ b/src/tools.lsp.test.ts
@@ -1,16 +1,14 @@
 import {
-  closeSync,
-  constants,
   mkdtempSync,
-  openSync,
   rmSync,
   truncateSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { execFileSync, spawn } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { afterAll, beforeEach, expect, mock, test } from 'bun:test'
+import { MAX_LSP_FILE_SIZE_BYTES } from './services/lsp/documentIdentity.js'
 import { getEmptyToolPermissionContext } from './Tool.js'
 import {
   acquireSharedMutationLock,
@@ -102,7 +100,7 @@ test('LSPTool keeps the 10 MB guard ahead of open and request', async () => {
   const sendRequest = mock(async () => null)
   try {
     writeFileSync(filePath, '')
-    truncateSync(filePath, 10_000_001)
+    truncateSync(filePath, MAX_LSP_FILE_SIZE_BYTES + 1)
     lspManager = {
       isFileOpen: () => false,
       openFile,
@@ -118,52 +116,6 @@ test('LSPTool keeps the 10 MB guard ahead of open and request', async () => {
     expect(openFile).not.toHaveBeenCalled()
     expect(sendRequest).not.toHaveBeenCalled()
   } finally {
-    rmSync(directory, { recursive: true, force: true })
-  }
-})
-
-test('LSPTool rejects non-regular documents without reading their stream', async () => {
-  if (process.platform === 'win32') return
-
-  const directory = mkdtempSync(join(tmpdir(), 'openclaude-lsp-tool-fifo-'))
-  const filePath = join(directory, 'stream.ts')
-  const openFile = mock(async () => {})
-  const sendRequest = mock(async () => null)
-  let keeper: number | undefined
-  try {
-    execFileSync('mkfifo', [filePath])
-    keeper = openSync(
-      filePath,
-      constants.O_RDONLY | constants.O_NONBLOCK,
-    )
-    const writer = spawn(
-      'dd',
-      ['if=/dev/zero', `of=${filePath}`, 'bs=10000001', 'count=1', 'status=none'],
-      { stdio: 'ignore' },
-    )
-    const writerDone = new Promise<void>((resolve, reject) => {
-      writer.once('error', reject)
-      writer.once('exit', () => resolve())
-    })
-    lspManager = {
-      isFileOpen: () => false,
-      openFile,
-      sendRequest,
-    }
-
-    const result = await LSPTool.call(
-      { operation: 'hover', filePath, line: 1, character: 1 },
-      {} as never,
-    )
-    closeSync(keeper)
-    keeper = undefined
-    await writerDone
-
-    expect(result.data.result).toContain('not a regular file')
-    expect(openFile).not.toHaveBeenCalled()
-    expect(sendRequest).not.toHaveBeenCalled()
-  } finally {
-    if (keeper !== undefined) closeSync(keeper)
     rmSync(directory, { recursive: true, force: true })
   }
 })

--- a/src/tools/LSPTool/LSPTool.ts
+++ b/src/tools/LSPTool/LSPTool.ts
@@ -17,6 +17,11 @@ import {
   waitForInitialization,
 } from '../../services/lsp/manager.js'
 import {
+  isLspDocumentRevisionChanged,
+  isLspServerGenerationChanged,
+  type LSPServerManager,
+} from '../../services/lsp/LSPServerManager.js'
+import {
   getLspDocumentIdentity,
   LspDocumentTooLargeError,
   readLspDocumentContents,
@@ -125,12 +130,72 @@ type OutputSchema = ReturnType<typeof outputSchema>
 export type Output = z.infer<OutputSchema>
 export type Input = z.infer<InputSchema>
 
-const LSP_SERVER_GENERATION_CHANGED = 'LSP_SERVER_GENERATION_CHANGED'
+type CallHierarchyFlowResult =
+  | { kind: 'result'; result: unknown }
+  | { kind: 'output'; output: Output }
 
-function isLspServerGenerationChanged(error: unknown): boolean {
-  return (
-    (error as { code?: unknown }).code === LSP_SERVER_GENERATION_CHANGED
-  )
+async function runCallHierarchyFlow(
+  manager: LSPServerManager,
+  input: Input,
+  absolutePath: string,
+  method: string,
+  params: unknown,
+): Promise<CallHierarchyFlowResult> {
+  const callMethod =
+    input.operation === 'incomingCalls'
+      ? 'callHierarchy/incomingCalls'
+      : 'callHierarchy/outgoingCalls'
+
+  for (let generationRetry = 0; generationRetry <= 1; generationRetry++) {
+    const prepared = await manager.sendRequestWithGeneration<
+      CallHierarchyItem[]
+    >(absolutePath, method, params)
+    if (!prepared) return { kind: 'result', result: undefined }
+
+    const callItems = prepared.result
+    if (!callItems || callItems.length === 0) {
+      return {
+        kind: 'output',
+        output: {
+          operation: input.operation,
+          result: 'No call hierarchy item found at this position',
+          filePath: input.filePath,
+          resultCount: 0,
+          fileCount: 0,
+        },
+      }
+    }
+
+    try {
+      const calls = await manager.sendRequestWithGeneration(
+        absolutePath,
+        callMethod,
+        { item: callItems[0] },
+        {
+          expectedGeneration: prepared.serverGeneration,
+          expectedDocumentRevision: prepared.documentRevision,
+          expectedDocumentCloseEpoch: prepared.documentCloseEpoch,
+        },
+      )
+      if (!calls) {
+        logForDebugging(
+          `LSP server returned undefined for ${callMethod} on ${input.filePath}`,
+        )
+      }
+      return { kind: 'result', result: calls?.result ?? null }
+    } catch (error) {
+      if (
+        generationRetry === 0 &&
+        (isLspServerGenerationChanged(error) ||
+          isLspDocumentRevisionChanged(error))
+      ) {
+        continue
+      }
+      throw error
+    }
+  }
+
+  return { kind: 'result', result: undefined }
 }
 
 export const LSPTool = buildTool({
@@ -280,56 +345,17 @@ export const LSPTool = buildTool({
         input.operation === 'incomingCalls' ||
         input.operation === 'outgoingCalls'
       ) {
-        for (let generationRetry = 0; generationRetry <= 1; generationRetry++) {
-          const prepared = await manager.sendRequestWithGeneration<
-            CallHierarchyItem[]
-          >(absolutePath, method, params)
-          if (!prepared) {
-            result = undefined
-            break
-          }
-
-          const callItems = prepared.result
-          if (!callItems || callItems.length === 0) {
-            const output: Output = {
-              operation: input.operation,
-              result: 'No call hierarchy item found at this position',
-              filePath: input.filePath,
-              resultCount: 0,
-              fileCount: 0,
-            }
-            return { data: output }
-          }
-
-          const callMethod =
-            input.operation === 'incomingCalls'
-              ? 'callHierarchy/incomingCalls'
-              : 'callHierarchy/outgoingCalls'
-
-          try {
-            const calls = await manager.sendRequestWithGeneration(
-              absolutePath,
-              callMethod,
-              { item: callItems[0] },
-              { expectedGeneration: prepared.serverGeneration },
-            )
-            if (!calls) {
-              logForDebugging(
-                `LSP server returned undefined for ${callMethod} on ${input.filePath}`,
-              )
-            }
-            result = calls?.result ?? null
-            break
-          } catch (error) {
-            if (
-              generationRetry === 0 &&
-              isLspServerGenerationChanged(error)
-            ) {
-              continue
-            }
-            throw error
-          }
+        const callHierarchy = await runCallHierarchyFlow(
+          manager,
+          input,
+          absolutePath,
+          method,
+          params,
+        )
+        if (callHierarchy.kind === 'output') {
+          return { data: callHierarchy.output }
         }
+        result = callHierarchy.result
       } else {
         result = await manager.sendRequest(absolutePath, method, params)
       }

--- a/src/tools/LSPTool/LSPTool.ts
+++ b/src/tools/LSPTool/LSPTool.ts
@@ -125,6 +125,14 @@ type OutputSchema = ReturnType<typeof outputSchema>
 export type Output = z.infer<OutputSchema>
 export type Input = z.infer<InputSchema>
 
+const LSP_SERVER_GENERATION_CHANGED = 'LSP_SERVER_GENERATION_CHANGED'
+
+function isLspServerGenerationChanged(error: unknown): boolean {
+  return (
+    (error as { code?: unknown }).code === LSP_SERVER_GENERATION_CHANGED
+  )
+}
+
 export const LSPTool = buildTool({
   name: LSP_TOOL_NAME,
   searchHint: 'code intelligence (definitions, references, symbols, hover)',
@@ -264,8 +272,67 @@ export const LSPTool = buildTool({
         await manager.openFile(absolutePath, fileContent)
       }
 
-      // Send request to LSP server
-      let result = await manager.sendRequest(absolutePath, method, params)
+      let result: unknown
+
+      // Call hierarchy items may contain opaque, process-owned data. Keep the
+      // prepare result and its follow-up request on one server generation.
+      if (
+        input.operation === 'incomingCalls' ||
+        input.operation === 'outgoingCalls'
+      ) {
+        for (let generationRetry = 0; generationRetry <= 1; generationRetry++) {
+          const prepared = await manager.sendRequestWithGeneration<
+            CallHierarchyItem[]
+          >(absolutePath, method, params)
+          if (!prepared) {
+            result = undefined
+            break
+          }
+
+          const callItems = prepared.result
+          if (!callItems || callItems.length === 0) {
+            const output: Output = {
+              operation: input.operation,
+              result: 'No call hierarchy item found at this position',
+              filePath: input.filePath,
+              resultCount: 0,
+              fileCount: 0,
+            }
+            return { data: output }
+          }
+
+          const callMethod =
+            input.operation === 'incomingCalls'
+              ? 'callHierarchy/incomingCalls'
+              : 'callHierarchy/outgoingCalls'
+
+          try {
+            const calls = await manager.sendRequestWithGeneration(
+              absolutePath,
+              callMethod,
+              { item: callItems[0] },
+              { expectedGeneration: prepared.serverGeneration },
+            )
+            if (!calls) {
+              logForDebugging(
+                `LSP server returned undefined for ${callMethod} on ${input.filePath}`,
+              )
+            }
+            result = calls?.result ?? null
+            break
+          } catch (error) {
+            if (
+              generationRetry === 0 &&
+              isLspServerGenerationChanged(error)
+            ) {
+              continue
+            }
+            throw error
+          }
+        }
+      } else {
+        result = await manager.sendRequest(absolutePath, method, params)
+      }
 
       if (result === undefined) {
         // Log for diagnostic purposes - helps track usage patterns and potential bugs
@@ -280,43 +347,6 @@ export const LSPTool = buildTool({
         }
         return {
           data: output,
-        }
-      }
-
-      // For incomingCalls and outgoingCalls, we need a two-step process:
-      // 1. First get CallHierarchyItem(s) from prepareCallHierarchy
-      // 2. Then request the actual calls using that item
-      if (
-        input.operation === 'incomingCalls' ||
-        input.operation === 'outgoingCalls'
-      ) {
-        const callItems = result as CallHierarchyItem[]
-        if (!callItems || callItems.length === 0) {
-          const output: Output = {
-            operation: input.operation,
-            result: 'No call hierarchy item found at this position',
-            filePath: input.filePath,
-            resultCount: 0,
-            fileCount: 0,
-          }
-          return { data: output }
-        }
-
-        // Use the first call hierarchy item to request calls
-        const callMethod =
-          input.operation === 'incomingCalls'
-            ? 'callHierarchy/incomingCalls'
-            : 'callHierarchy/outgoingCalls'
-
-        result = await manager.sendRequest(absolutePath, callMethod, {
-          item: callItems[0],
-        })
-
-        if (result === undefined) {
-          logForDebugging(
-            `LSP server returned undefined for ${callMethod} on ${input.filePath}`,
-          )
-          // Continue to formatter which will handle empty/null gracefully
         }
       }
 

--- a/src/tools/LSPTool/LSPTool.ts
+++ b/src/tools/LSPTool/LSPTool.ts
@@ -1,6 +1,4 @@
-import { open } from 'fs/promises'
 import * as path from 'path'
-import { pathToFileURL } from 'url'
 import type {
   CallHierarchyIncomingCall,
   CallHierarchyItem,
@@ -18,6 +16,11 @@ import {
   isLspConnected,
   waitForInitialization,
 } from '../../services/lsp/manager.js'
+import {
+  getLspDocumentIdentity,
+  LspDocumentTooLargeError,
+  readLspDocumentContents,
+} from '../../services/lsp/documentIdentity.js'
 import type { ValidationResult } from '../../Tool.js'
 import { buildTool, type ToolDef } from '../../Tool.js'
 import { uniq } from '../../utils/array.js'
@@ -49,8 +52,6 @@ import {
   renderToolUseMessage,
   userFacingName,
 } from './UI.js'
-
-const MAX_LSP_FILE_SIZE_BYTES = 10_000_000
 
 /**
  * Tool-compatible input schema (regular ZodObject instead of discriminated union)
@@ -259,22 +260,8 @@ export const LSPTool = buildTool({
       // Most LSP servers require textDocument/didOpen before operations
       // Only read the file if it's not already open to avoid unnecessary I/O
       if (!manager.isFileOpen(absolutePath)) {
-        const handle = await open(absolutePath, 'r')
-        try {
-          const stats = await handle.stat()
-          if (stats.size > MAX_LSP_FILE_SIZE_BYTES) {
-            const output: Output = {
-              operation: input.operation,
-              result: `File too large for LSP analysis (${Math.ceil(stats.size / 1_000_000)}MB exceeds 10MB limit)`,
-              filePath: input.filePath,
-            }
-            return { data: output }
-          }
-          const fileContent = await handle.readFile({ encoding: 'utf-8' })
-          await manager.openFile(absolutePath, fileContent)
-        } finally {
-          await handle.close()
-        }
+        const fileContent = await readLspDocumentContents(absolutePath)
+        await manager.openFile(absolutePath, fileContent)
       }
 
       // Send request to LSP server
@@ -395,6 +382,16 @@ export const LSPTool = buildTool({
       const err = toError(error)
       const errorMessage = err.message
 
+      if (err instanceof LspDocumentTooLargeError) {
+        return {
+          data: {
+            operation: input.operation,
+            result: errorMessage,
+            filePath: input.filePath,
+          },
+        }
+      }
+
       // Log error for tracking
       logError(
         new Error(
@@ -428,7 +425,7 @@ function getMethodAndParams(
   input: Input,
   absolutePath: string,
 ): { method: string; params: unknown } {
-  const uri = pathToFileURL(absolutePath).href
+  const uri = getLspDocumentIdentity(absolutePath).fileUri
   // Convert from 1-based (user-friendly) to 0-based (LSP protocol)
   const position = {
     line: input.line - 1,

--- a/src/utils/plugins/schemas.ts
+++ b/src/utils/plugins/schemas.ts
@@ -803,7 +803,9 @@ export const LspServerConfigSchema = lazySchema(() =>
       .int()
       .positive()
       .optional()
-      .describe('Maximum time to wait for server startup (milliseconds)'),
+      .describe(
+        'Maximum time to wait for each server startup phase (default: 30000 milliseconds)',
+      ),
     shutdownTimeout: z
       .number()
       .int()


### PR DESCRIPTION
## Summary
- track open LSP documents by server generation and the last successfully delivered version
- resynchronize full document contents before requests after a language-server replacement
- keep lifecycle state truthful when `didOpen`, `didChange`, or `didClose` delivery fails
- serialize synchronization per document without adding a global LSP request lock

This fixes protocol-invalid version reuse and stale open-document markers that could make definitions, references, hover results, and diagnostics use outdated contents.

## Impact
- user-facing impact: LSP operations now use current document contents across edits and process restarts while preserving lazy server startup
- developer/maintainer impact: adds generation-aware document state, a strict lifecycle-notification seam, canonical document identity handling, and focused regression coverage

## Testing
- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check`
- [x] focused tests: `bun test src/services/lsp/LSPClient.test.ts src/services/lsp/LSPServerInstance.test.ts src/services/lsp/LSPServerManager.protocol.test.ts src/services/lsp/LSPServerManager.test.ts src/tools.lsp.test.ts src/services/lsp/LSPDiagnosticRegistry.test.ts src/commands/lsp/lsp.test.ts src/utils/plugins/lspRecommendation.test.ts` (87 passed)
- [x] `bun run typecheck`
- [x] `bun run typecheck:type-tests`
- [x] `bun run test:provider`
- [x] `npm run test:provider-recommendation`
- [x] `bun run --cwd web typecheck`
- [x] `bun run --cwd web build`
- [x] `bun run doctor:runtime`
- [x] `bun run security:pr-scan -- --base upstream/main --head HEAD`

## Notes
- reviewed `CONTRIBUTING.md` and `AGENTS.md`: yes
- reviewer focus: generation mismatch handling and lifecycle state commits in `LSPServerManager.ts`
- provider/model path tested: not applicable
- screenshots attached (if UI changed): not applicable
- follow-up work or known limitations: crash-rate policy and restart backoff remain intentionally out of scope for a separate recovery change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language-server reliability during restarts, crashes, connection failures, and timeouts.
  * Prevented stale document data and resynchronized open files after server recovery.
  * Improved cross-platform file path handling, including Windows.
  * Rejected unsupported files and documents larger than 10 MB.
  * Improved language-server availability reporting and recovery after failed startup.

* **Improvements**
  * Document changes, saves, and closes now maintain consistent versions.
  * Concurrent requests and lifecycle operations are handled more reliably.
  * Improved notification delivery and recovery from failed document operations.
  * Call-hierarchy requests now retry safely when the server restarts.
  * Clarified language-server startup timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Risk assessment

- Subprocess/background execution: this change coordinates the existing lazy LSP process lifecycle; it does not add restart backoff, circuit-breaker policy, or new background execution.
- File-read permissions: LSP reads remain behind the existing tool permission checks and bounded regular-file validation; no additional paths or permissions are introduced.
- Merge blocker assessment: no new trust-boundary blocker is introduced by these changes.