### PR TITLE
fix(query): use monotonic watchdog deadlines

### DIFF
--- a/src/utils/QueryGuard.test.ts
+++ b/src/utils/QueryGuard.test.ts
@@ -242,6 +242,56 @@ describe('QueryGuard', () => {
     expect(guard.isActive).toBe(false)
   })
 
+  test('forward wall-clock jumps do not trigger an immediate timeout', () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const baseline = new Date('2026-08-10T00:00:00.000Z').getTime()
+    let nowMs = baseline
+    vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+    const guard = new QueryGuard({
+      idleTimeoutMs: 100,
+      hardMaxQueryMs: 1_000,
+    })
+    const onTimeout = vi.fn()
+    guard.setTimeoutHandler(onTimeout)
+    const generation = guard.tryStart()!
+
+    nowMs = baseline + 60 * 60 * 1_000
+    guard.registerActivity('clock-jump-probe', generation)
+    vi.advanceTimersByTime(99)
+
+    expect(onTimeout).not.toHaveBeenCalled()
+    expect(guard.isActive).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(onTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'idle', elapsedMs: 100 }),
+    )
+  })
+
+  test('backward wall-clock jumps do not delay the scheduled timeout', () => {
+    vi.useFakeTimers()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const baseline = new Date('2026-08-10T00:00:00.000Z').getTime()
+    let nowMs = baseline
+    vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+    const guard = new QueryGuard({
+      idleTimeoutMs: 100,
+      hardMaxQueryMs: 1_000,
+    })
+    const onTimeout = vi.fn()
+    guard.setTimeoutHandler(onTimeout)
+    guard.tryStart()
+
+    nowMs = baseline - 60 * 60 * 1_000
+    vi.advanceTimersByTime(100)
+
+    expect(onTimeout).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: 'idle', elapsedMs: 100 }),
+    )
+    expect(guard.isActive).toBe(false)
+  })
+
   test('active bounded lease is not aborted merely because idle timeout elapses', () => {
     vi.useFakeTimers()
     vi.spyOn(console, 'error').mockImplementation(() => {})

--- a/src/utils/QueryGuard.ts
+++ b/src/utils/QueryGuard.ts
@@ -119,6 +119,8 @@ export class QueryGuard {
   private _changed = createSignal()
   private _timeoutId: ReturnType<typeof setTimeout> | null = null
   private _timeoutHandler: QueryTimeoutHandler | null = null
+  // Deadline arithmetic is monotonic so NTP/manual wall-clock jumps cannot
+  // manufacture an immediate timeout or postpone an already-scheduled one.
   private _queryStartedAt = 0
   private _lastActivityAt = 0
   private _suspendCount = 0
@@ -187,7 +189,7 @@ export class QueryGuard {
     this._suspendedAt = 0
     this._totalSuspendedMs = 0
     this._lastContext = null
-    this._queryStartedAt = Date.now()
+    this._queryStartedAt = performance.now()
     this._lastActivityAt = this._queryStartedAt
     this._context = this._createContext(metadata)
     this._getActiveOperations = metadata?.getActiveOperations ?? null
@@ -258,7 +260,7 @@ export class QueryGuard {
     void reason
     if (this._status !== 'running') return
     if (generation !== undefined && generation !== this._generation) return
-    this._lastActivityAt = Date.now()
+    this._lastActivityAt = performance.now()
     this._scheduleTimeout()
   }
 
@@ -279,7 +281,7 @@ export class QueryGuard {
       }
     }
 
-    const now = Date.now()
+    const now = performance.now()
     const leaseTimeoutMs =
       typeof input.timeoutMs === 'number' &&
       Number.isFinite(input.timeoutMs) &&
@@ -347,7 +349,7 @@ export class QueryGuard {
       return () => {}
     }
     if (this._suspendCount === 0) {
-      this._suspendedAt = Date.now()
+      this._suspendedAt = performance.now()
     }
     this._suspendCount++
     this._scheduleTimeout()
@@ -373,7 +375,7 @@ export class QueryGuard {
    */
   private _resumeAfterInteraction(): void {
     if (this._status !== 'running') return
-    const now = Date.now()
+    const now = performance.now()
     const suspendedStartedAt = this._suspendedAt
     const suspendedMs = Math.max(0, now - suspendedStartedAt)
     this._suspendedAt = 0
@@ -493,7 +495,7 @@ export class QueryGuard {
     this._clearTimeout()
     if (this._status !== 'running') return
 
-    const now = Date.now()
+    const now = performance.now()
     const reason = this._getTimeoutReason(now)
     if (reason) {
       this._timeoutId = setTimeout(() => this._handleTimeout(), 0)
@@ -512,7 +514,7 @@ export class QueryGuard {
     this._timeoutId = null
     if (this._status !== 'running') return
 
-    const now = Date.now()
+    const now = performance.now()
     const reason = this._getTimeoutReason(now)
     if (!reason) {
       this._scheduleTimeout()
@@ -528,7 +530,7 @@ export class QueryGuard {
       generation: this._generation,
       reason,
       timeoutMs: this._getTimeoutMsForReason(reason, now),
-      elapsedMs: now - context.startedAt,
+      elapsedMs: now - this._queryStartedAt,
       context,
       activeOperations: this._snapshotActiveOperations(),
     }

--- a/src/utils/queryLifecycle.ts
+++ b/src/utils/queryLifecycle.ts
@@ -63,6 +63,7 @@ export type QueryGuardTimeoutInfo = {
   generation: number
   reason: QueryGuardTimeoutReason
   timeoutMs: number
+  /** Monotonic milliseconds since query start; do not compare with context.startedAt. */
   elapsedMs: number
   context: QueryLifecycleContext
   activeOperations: QueryActiveOperationSnapshot


### PR DESCRIPTION
## Summary

- move QueryGuard deadline arithmetic from wall time to a monotonic clock
- keep lifecycle context timestamps in wall time while reporting monotonic elapsed duration
- add red/green regressions for forward and backward system-clock corrections

## Impact

- user-facing impact: system-clock corrections can no longer manufacture an immediate query timeout or postpone an already-scheduled one
- developer/maintainer impact: timeout defaults, lease policy, lifecycle shapes, and provider behavior are unchanged

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check`
- [x] focused tests: `bun test src/utils/QueryGuard.test.ts` — 33 pass, 0 fail, 94 assertions
- [x] `bun run typecheck`
- [x] `bun run typecheck:type-tests`
- [x] `bun run security:pr-scan`
- [x] both clock-jump tests fail against `main` for the intended behavior and pass on this branch

## Notes

- provider/model path tested: not applicable; this changes the provider-independent query lifecycle guard
- screenshots attached (if UI changed): not applicable
- follow-up work or known limitations: this hardens one current timeout trigger but does not identify the reporter's original initiating condition

Refs #1830


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watchdog timeout reliability when the system clock moves forward or backward.
  * Timeout scheduling and elapsed-time reporting now remain consistent despite wall-clock changes.

* **Documentation**
  * Clarified the meaning of reported timeout elapsed time and how it should be interpreted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->