### PR TITLE
fix(api): resolve swarm-field tool names by own-property, not the prototype chain

### DIFF
--- a/src/utils/api.swarmFields.test.ts
+++ b/src/utils/api.swarmFields.test.ts
@@ -1,0 +1,46 @@
+import { expect, test } from 'bun:test'
+import type Anthropic from '@anthropic-ai/sdk'
+
+import { AGENT_TOOL_NAME } from '../tools/AgentTool/constants.js'
+import { filterSwarmFieldsFromSchema } from './api.js'
+
+const schema: Anthropic.Tool.InputSchema = {
+  type: 'object',
+  properties: {
+    name: { type: 'string' },
+    team_name: { type: 'string' },
+    mode: { type: 'string' },
+    prompt: { type: 'string' },
+  },
+  required: ['name', 'prompt'],
+}
+
+// `filterSwarmFieldsFromSchema` looks the tool name up in a plain-object map.
+// A name that collides with an Object.prototype member (`constructor`,
+// `hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable`) resolves the
+// inherited function — truthy with `.length === 1` — which slips past the
+// `!fieldsToRemove || length === 0` guard and then throws in the `for...of`.
+for (const name of [
+  'constructor',
+  'hasOwnProperty',
+  'isPrototypeOf',
+  'propertyIsEnumerable',
+]) {
+  test(`prototype-named tool "${name}" is treated as unmapped, not crashed`, () => {
+    expect(() => filterSwarmFieldsFromSchema(name, schema)).not.toThrow()
+    // Unmapped tool → schema returned unchanged (same reference).
+    expect(filterSwarmFieldsFromSchema(name, schema)).toBe(schema)
+  })
+}
+
+test('a genuinely mapped tool still has its swarm fields removed', () => {
+  const filtered = filterSwarmFieldsFromSchema(AGENT_TOOL_NAME, schema)
+  expect(Object.keys(filtered.properties ?? {})).toEqual(['prompt'])
+  expect(filtered.required).toEqual(['prompt'])
+})
+
+test('an ordinary unmapped tool is returned unchanged', () => {
+  expect(filterSwarmFieldsFromSchema('mcp__server__do_thing', schema)).toBe(
+    schema,
+  )
+})

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -94,11 +94,20 @@ const SWARM_FIELDS_BY_TOOL: Record<string, string[]> = {
  * Filter swarm-related fields from a tool's input schema.
  * Called at runtime when isAgentSwarmsEnabled() returns false.
  */
-function filterSwarmFieldsFromSchema(
+export function filterSwarmFieldsFromSchema(
   toolName: string,
   schema: Anthropic.Tool.InputSchema,
 ): Anthropic.Tool.InputSchema {
-  const fieldsToRemove = SWARM_FIELDS_BY_TOOL[toolName]
+  // Guard with Object.hasOwn: a bare `SWARM_FIELDS_BY_TOOL[toolName]` lookup
+  // resolves inherited Object.prototype members for names like `constructor` or
+  // `hasOwnProperty` to their functions. Those are truthy with `.length === 1`,
+  // so the guard below is bypassed and the `for...of` on line ~111 throws
+  // "is not iterable", breaking schema construction for the whole request.
+  // Mirrors the own-key guard already used for provider-supplied tool names in
+  // services/api/toolArgumentNormalization.ts.
+  const fieldsToRemove = Object.hasOwn(SWARM_FIELDS_BY_TOOL, toolName)
+    ? SWARM_FIELDS_BY_TOOL[toolName]
+    : undefined
   if (!fieldsToRemove || fieldsToRemove.length === 0) {
     return schema
   }


### PR DESCRIPTION
## What

`filterSwarmFieldsFromSchema()` in `src/utils/api.ts` looks the tool name up in a plain-object map with a bare `SWARM_FIELDS_BY_TOOL[toolName]`. When a tool's name collides with an `Object.prototype` member — `constructor`, `hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable` — the lookup resolves the inherited **function** instead of `undefined`.

Those functions are truthy and have `.length === 1`, so the `!fieldsToRemove || fieldsToRemove.length === 0` guard is bypassed. Execution then reaches:

```ts
for (const field of fieldsToRemove) {
  delete filteredProps[field]
}
```

Iterating a function throws `TypeError: <fn> is not iterable`. This runs inside per-request tool-schema construction (`toolToAPISchema`, on the default non-EAP path where `isAgentSwarmsEnabled()` is false), so a single tool whose name is a prototype member breaks schema building for the whole request.

Quick repro of the guard bypass:

```js
const M = { exit_plan_mode_v2: ['a'], Agent: ['b'] }
M['constructor']            // => [Function: Object]
M['constructor'].length     // => 1  (truthy, guard slips)
for (const x of M['constructor']) {}  // TypeError: ... is not iterable
// valueOf / toString have length 0 and hit the safe early-return
```

## Fix

Guard the lookup with `Object.hasOwn` so a prototype-named tool is treated as unmapped (return the schema unchanged) rather than crashing. This mirrors the own-key guard already applied to provider-supplied tool names in `src/services/api/toolArgumentNormalization.ts`, which handles the identical map-lookup pattern for the same reason.

## Test

`src/utils/api.swarmFields.test.ts` — the four prototype-named tools return the schema unchanged instead of throwing; a genuinely mapped tool still has its swarm fields (and matching `required` entries) removed; an ordinary unmapped tool is returned unchanged. Verified fails-on-bug (all four prototype cases throw when the guard is reverted).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool schema filtering for names that overlap with built-in object properties.
  * Prevented errors when processing tool fields that are not configured for mapping.

* **Tests**
  * Added coverage for prototype-name collisions, mapped-tool field removal, and unchanged schemas for ordinary tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->