### PR TITLE
fix(settings): preserve concurrent updates

### DIFF
--- a/src/services/settingsSync/index.ts
+++ b/src/services/settingsSync/index.ts
@@ -33,9 +33,8 @@ import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
 } from '../../utils/model/providers.js'
-import { markInternalWrite } from '../../utils/settings/internalWrites.js'
 import { getSettingsFilePathForSource } from '../../utils/settings/settings.js'
-import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import { replaceSettingsFileSync } from '../../utils/settings/settingsFileTransaction.js'
 import { sleep } from '../../utils/sleep.js'
 import { getClaudeCodeUserAgent } from '../../utils/userAgent.js'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../analytics/growthbook.js'
@@ -477,6 +476,20 @@ async function writeFileForSync(
   }
 }
 
+function writeSettingsFileForSync(
+  filePath: string,
+  content: string,
+): boolean {
+  try {
+    replaceSettingsFileSync(filePath, content)
+    logForDiagnosticsNoPII('info', 'settings_sync_file_written')
+    return true
+  } catch {
+    logForDiagnosticsNoPII('warn', 'settings_sync_file_write_failed')
+    return false
+  }
+}
+
 /**
  * Apply remote entries to local files (CCR pull pattern).
  * Only writes files that match expected keys.
@@ -488,10 +501,14 @@ async function writeFileForSync(
 async function applyRemoteEntriesToLocal(
   entries: Record<string, string>,
   projectId: string | null,
-): Promise<void> {
+): Promise<{
+  appliedCount: number
+  settingsFilesWritten: number
+  memoryFilesWritten: number
+}> {
   let appliedCount = 0
-  let settingsWritten = false
-  let memoryWritten = false
+  let settingsFilesWritten = 0
+  let memoryFilesWritten = 0
 
   // Helper to check size limit (defense-in-depth, matches backend limit)
   const exceedsSizeLimit = (content: string, _path: string): boolean => {
@@ -514,11 +531,9 @@ async function applyRemoteEntriesToLocal(
       userSettingsPath &&
       !exceedsSizeLimit(userSettingsContent, userSettingsPath)
     ) {
-      // Mark as internal write to prevent spurious change detection
-      markInternalWrite(userSettingsPath)
-      if (await writeFileForSync(userSettingsPath, userSettingsContent)) {
+      if (writeSettingsFileForSync(userSettingsPath, userSettingsContent)) {
         appliedCount++
-        settingsWritten = true
+        settingsFilesWritten++
       }
     }
   }
@@ -530,7 +545,7 @@ async function applyRemoteEntriesToLocal(
     if (!exceedsSizeLimit(userMemoryContent, userMemoryPath)) {
       if (await writeFileForSync(userMemoryPath, userMemoryContent)) {
         appliedCount++
-        memoryWritten = true
+        memoryFilesWritten++
       }
     }
   }
@@ -545,11 +560,11 @@ async function applyRemoteEntriesToLocal(
         localSettingsPath &&
         !exceedsSizeLimit(projectSettingsContent, localSettingsPath)
       ) {
-        // Mark as internal write to prevent spurious change detection
-        markInternalWrite(localSettingsPath)
-        if (await writeFileForSync(localSettingsPath, projectSettingsContent)) {
+        if (
+          writeSettingsFileForSync(localSettingsPath, projectSettingsContent)
+        ) {
           appliedCount++
-          settingsWritten = true
+          settingsFilesWritten++
         }
       }
     }
@@ -561,21 +576,31 @@ async function applyRemoteEntriesToLocal(
       if (!exceedsSizeLimit(projectMemoryContent, localMemoryPath)) {
         if (await writeFileForSync(localMemoryPath, projectMemoryContent)) {
           appliedCount++
-          memoryWritten = true
+          memoryFilesWritten++
         }
       }
     }
   }
 
   // Invalidate caches so subsequent reads pick up new content
-  if (settingsWritten) {
-    resetSettingsCache()
-  }
-  if (memoryWritten) {
+  if (memoryFilesWritten > 0) {
     clearMemoryFileCaches()
   }
 
   logForDiagnosticsNoPII('info', 'settings_sync_applied', {
     appliedCount,
   })
+  return { appliedCount, settingsFilesWritten, memoryFilesWritten }
+}
+
+/** @internal Direct apply seam for focused settings-file transaction tests. */
+export function _applyRemoteEntriesToLocalForTesting(
+  entries: Record<string, string>,
+  projectId: string | null,
+): Promise<{
+  appliedCount: number
+  settingsFilesWritten: number
+  memoryFilesWritten: number
+}> {
+  return applyRemoteEntriesToLocal(entries, projectId)
 }

--- a/src/services/settingsSync/index.ts
+++ b/src/services/settingsSync/index.ts
@@ -520,11 +520,13 @@ async function applyRemoteEntriesToLocal(
   appliedCount: number
   settingsFilesWritten: number
   settingsFilesFailed: number
+  settingsFilesRejected: number
   memoryFilesWritten: number
 }> {
   let appliedCount = 0
   let settingsFilesWritten = 0
   let settingsFilesFailed = 0
+  let settingsFilesRejected = 0
   let memoryFilesWritten = 0
 
   // Helper to check size limit (defense-in-depth, matches backend limit)
@@ -555,7 +557,7 @@ async function applyRemoteEntriesToLocal(
         settingsFilesFailed++
       }
     } else {
-      settingsFilesFailed++
+      settingsFilesRejected++
     }
   }
 
@@ -590,7 +592,7 @@ async function applyRemoteEntriesToLocal(
           settingsFilesFailed++
         }
       } else {
-        settingsFilesFailed++
+        settingsFilesRejected++
       }
     }
 
@@ -616,12 +618,14 @@ async function applyRemoteEntriesToLocal(
     appliedCount,
     settingsFilesWritten,
     settingsFilesFailed,
+    settingsFilesRejected,
     memoryFilesWritten,
   })
   return {
     appliedCount,
     settingsFilesWritten,
     settingsFilesFailed,
+    settingsFilesRejected,
     memoryFilesWritten,
   }
 }
@@ -659,6 +663,7 @@ export function _applyRemoteEntriesToLocalForTesting(
   appliedCount: number
   settingsFilesWritten: number
   settingsFilesFailed: number
+  settingsFilesRejected: number
   memoryFilesWritten: number
 }> {
   return applyRemoteEntriesToLocal(entries, projectId)

--- a/src/services/settingsSync/index.ts
+++ b/src/services/settingsSync/index.ts
@@ -112,9 +112,24 @@ export async function uploadUserSettingsInBackground(): Promise<void> {
 // Cached so the fire-and-forget at runHeadless entry and the await in
 // installPluginsAndApplyMcpInBackground share one fetch.
 let downloadPromise: Promise<boolean> | null = null
+let downloadedEntriesForTesting: {
+  entries: Record<string, string>
+  projectId: string | null
+} | null = null
 
 /** Test-only: clear the cached download promise between tests. */
 export function _resetDownloadPromiseForTesting(): void {
+  downloadPromise = null
+}
+
+/** Test-only: bypass eligibility and HTTP while retaining public download flow. */
+export function _setDownloadedEntriesForTesting(
+  value: {
+    entries: Record<string, string>
+    projectId: string | null
+  } | null,
+): void {
+  downloadedEntriesForTesting = value
   downloadPromise = null
 }
 
@@ -156,6 +171,12 @@ export function redownloadUserSettings(): Promise<boolean> {
 async function doDownloadUserSettings(
   maxRetries = DEFAULT_MAX_RETRIES,
 ): Promise<boolean> {
+  if (downloadedEntriesForTesting) {
+    return applyDownloadedEntries(
+      downloadedEntriesForTesting.entries,
+      downloadedEntriesForTesting.projectId,
+    )
+  }
   if (feature('DOWNLOAD_USER_SETTINGS')) {
     try {
       if (
@@ -183,13 +204,7 @@ async function doDownloadUserSettings(
 
       const entries = result.data!.content.entries
       const projectId = await getRepoRemoteHash()
-      const entryCount = Object.keys(entries).length
-      logForDiagnosticsNoPII('info', 'settings_sync_download_applying', {
-        entryCount,
-      })
-      await applyRemoteEntriesToLocal(entries, projectId)
-      logEvent('tengu_settings_sync_download_success', { entryCount })
-      return true
+      return applyDownloadedEntries(entries, projectId)
     } catch {
       // Fail-open: log error but don't block CCR startup
       logForDiagnosticsNoPII('error', 'settings_sync_download_error')
@@ -504,10 +519,12 @@ async function applyRemoteEntriesToLocal(
 ): Promise<{
   appliedCount: number
   settingsFilesWritten: number
+  settingsFilesFailed: number
   memoryFilesWritten: number
 }> {
   let appliedCount = 0
   let settingsFilesWritten = 0
+  let settingsFilesFailed = 0
   let memoryFilesWritten = 0
 
   // Helper to check size limit (defense-in-depth, matches backend limit)
@@ -534,7 +551,11 @@ async function applyRemoteEntriesToLocal(
       if (writeSettingsFileForSync(userSettingsPath, userSettingsContent)) {
         appliedCount++
         settingsFilesWritten++
+      } else {
+        settingsFilesFailed++
       }
+    } else {
+      settingsFilesFailed++
     }
   }
 
@@ -565,7 +586,11 @@ async function applyRemoteEntriesToLocal(
         ) {
           appliedCount++
           settingsFilesWritten++
+        } else {
+          settingsFilesFailed++
         }
+      } else {
+        settingsFilesFailed++
       }
     }
 
@@ -590,9 +615,40 @@ async function applyRemoteEntriesToLocal(
   logForDiagnosticsNoPII('info', 'settings_sync_applied', {
     appliedCount,
     settingsFilesWritten,
+    settingsFilesFailed,
     memoryFilesWritten,
   })
-  return { appliedCount, settingsFilesWritten, memoryFilesWritten }
+  return {
+    appliedCount,
+    settingsFilesWritten,
+    settingsFilesFailed,
+    memoryFilesWritten,
+  }
+}
+
+async function applyDownloadedEntries(
+  entries: Record<string, string>,
+  projectId: string | null,
+): Promise<boolean> {
+  const entryCount = Object.keys(entries).length
+  logForDiagnosticsNoPII('info', 'settings_sync_download_applying', {
+    entryCount,
+  })
+  const result = await applyRemoteEntriesToLocal(entries, projectId)
+  if (result.settingsFilesFailed > 0) {
+    logForDiagnosticsNoPII('warn', 'settings_sync_download_apply_failed', {
+      entryCount,
+      settingsFilesFailed: result.settingsFilesFailed,
+    })
+    logEvent('tengu_settings_sync_download_apply_failed', {
+      entryCount,
+      settingsFilesFailed: result.settingsFilesFailed,
+    })
+    return false
+  }
+
+  logEvent('tengu_settings_sync_download_success', { entryCount })
+  return true
 }
 
 /** @internal Direct apply seam for focused settings-file transaction tests. */
@@ -602,6 +658,7 @@ export function _applyRemoteEntriesToLocalForTesting(
 ): Promise<{
   appliedCount: number
   settingsFilesWritten: number
+  settingsFilesFailed: number
   memoryFilesWritten: number
 }> {
   return applyRemoteEntriesToLocal(entries, projectId)

--- a/src/services/settingsSync/index.ts
+++ b/src/services/settingsSync/index.ts
@@ -589,6 +589,8 @@ async function applyRemoteEntriesToLocal(
 
   logForDiagnosticsNoPII('info', 'settings_sync_applied', {
     appliedCount,
+    settingsFilesWritten,
+    memoryFilesWritten,
   })
   return { appliedCount, settingsFilesWritten, memoryFilesWritten }
 }

--- a/src/services/settingsSync/settings.transaction.test.ts
+++ b/src/services/settingsSync/settings.transaction.test.ts
@@ -17,7 +17,12 @@ import {
   setClaudeConfigHomeDirForTesting,
 } from '../../utils/envUtils.js'
 import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
-import { _applyRemoteEntriesToLocalForTesting } from './index.js'
+import {
+  _applyRemoteEntriesToLocalForTesting,
+  _setDownloadedEntriesForTesting,
+  downloadUserSettings,
+  redownloadUserSettings,
+} from './index.js'
 import { SYNC_KEYS } from './types.js'
 
 const fixturePath = resolve(
@@ -185,6 +190,7 @@ test(
         expect(result).toEqual({
           appliedCount: 1,
           settingsFilesWritten: 1,
+          settingsFilesFailed: 0,
           memoryFilesWritten: 0,
         })
         expect(elapsedMs).toBeGreaterThanOrEqual(500)
@@ -223,6 +229,7 @@ test(
         expect(result).toEqual({
           appliedCount: 1,
           settingsFilesWritten: 1,
+          settingsFilesFailed: 0,
           memoryFilesWritten: 0,
         })
         expect(JSON.parse(readFileSync(localSettings, 'utf8')).env).toEqual({
@@ -259,6 +266,7 @@ test(
         expect(result).toEqual({
           appliedCount: 1,
           settingsFilesWritten: 0,
+          settingsFilesFailed: 1,
           memoryFilesWritten: 1,
         })
         expect(JSON.parse(readFileSync(userSettings, 'utf8')).env).toEqual({
@@ -277,6 +285,7 @@ test(
         ).toEqual({
           appliedCount: 1,
           settingsFilesWritten: 1,
+          settingsFilesFailed: 0,
           memoryFilesWritten: 0,
         })
         expect(JSON.parse(readFileSync(userSettings, 'utf8')).env).toEqual({
@@ -284,6 +293,44 @@ test(
         })
         expect(existsSync(`${userSettings}.lock`)).toBe(false)
       } finally {
+        await terminateHolder(holder)
+      }
+    })
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'startup and reload downloads return false after a timed-out settings apply',
+  async () => {
+    await withSyncEnvironment(async ({ root, userMemory, userSettings }) => {
+      writeFileSync(userSettings, '{"env":{"ORIGINAL":"yes"}}\n')
+      const entered = join(root, 'download-holder-entered')
+      const completed = join(root, 'download-holder-completed')
+      const holder = startHolder(userSettings, 5_000, entered, completed)
+      try {
+        await waitForHolder(entered, holder)
+        _setDownloadedEntriesForTesting({
+          entries: {
+            [SYNC_KEYS.USER_SETTINGS]: '{"env":{"REPLACED":"no"}}\n',
+            [SYNC_KEYS.USER_MEMORY]: 'best-effort memory\n',
+          },
+          projectId: null,
+        })
+
+        const startupDownload = downloadUserSettings()
+        expect(downloadUserSettings()).toBe(startupDownload)
+        expect(await startupDownload).toBe(false)
+        expect(await redownloadUserSettings()).toBe(false)
+
+        expect(JSON.parse(readFileSync(userSettings, 'utf8')).env).toEqual({
+          ORIGINAL: 'yes',
+        })
+        expect(readFileSync(userMemory, 'utf8')).toBe('best-effort memory\n')
+        await finishHolder(holder)
+        expect(existsSync(`${userSettings}.lock`)).toBe(false)
+      } finally {
+        _setDownloadedEntriesForTesting(null)
         await terminateHolder(holder)
       }
     })

--- a/src/services/settingsSync/settings.transaction.test.ts
+++ b/src/services/settingsSync/settings.transaction.test.ts
@@ -188,7 +188,6 @@ test(
           memoryFilesWritten: 0,
         })
         expect(elapsedMs).toBeGreaterThanOrEqual(500)
-        expect(elapsedMs).toBeLessThan(1_800)
         expect(JSON.parse(readFileSync(userSettings, 'utf8')).env).toEqual({
           SYNCED: 'yes',
         })

--- a/src/services/settingsSync/settings.transaction.test.ts
+++ b/src/services/settingsSync/settings.transaction.test.ts
@@ -1,0 +1,293 @@
+import { spawn, type ChildProcessByStdio } from 'node:child_process'
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import type { Readable } from 'node:stream'
+import { expect, test } from 'bun:test'
+import { getOriginalCwd, setOriginalCwd } from '../../bootstrap/state.js'
+import {
+  getClaudeConfigHomeDirOverrideForTesting,
+  setClaudeConfigHomeDirForTesting,
+} from '../../utils/envUtils.js'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import { _applyRemoteEntriesToLocalForTesting } from './index.js'
+import { SYNC_KEYS } from './types.js'
+
+const fixturePath = resolve(
+  import.meta.dir,
+  '../../test/fixtures/settingsTransactionWriter.fixture.ts',
+)
+const CHILD_TIMEOUT_MS = 15_000
+const TEST_TIMEOUT_MS = CHILD_TIMEOUT_MS + 5_000
+
+type Holder = {
+  process: ChildProcessByStdio<null, Readable, Readable>
+  exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>
+  output: () => { stdout: string; stderr: string }
+}
+
+function startHolder(
+  targetPath: string,
+  holdMs: number,
+  enteredMarker: string,
+  completedMarker: string,
+): Holder {
+  const child = spawn(
+    process.execPath,
+    [
+      fixturePath,
+      'hold-path-for',
+      targetPath,
+      'unused',
+      String(holdMs),
+      enteredMarker,
+      completedMarker,
+    ],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, FORCE_COLOR: '0' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  )
+  let stdout = ''
+  let stderr = ''
+  child.stdout.setEncoding('utf8')
+  child.stderr.setEncoding('utf8')
+  child.stdout.on('data', chunk => {
+    stdout += chunk
+  })
+  child.stderr.on('data', chunk => {
+    stderr += chunk
+  })
+  return {
+    process: child,
+    exited: new Promise(resolveExit => {
+      child.once('exit', (code, signal) => resolveExit({ code, signal }))
+    }),
+    output: () => ({ stdout, stderr }),
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolveDelay => setTimeout(resolveDelay, ms))
+}
+
+async function waitForHolder(marker: string, holder: Holder): Promise<void> {
+  const deadline = performance.now() + CHILD_TIMEOUT_MS
+  while (!existsSync(marker)) {
+    if (
+      holder.process.exitCode !== null ||
+      holder.process.signalCode !== null
+    ) {
+      const { stdout, stderr } = holder.output()
+      throw new Error(
+        `Holder exited before acquiring the lock\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+      )
+    }
+    if (performance.now() >= deadline) {
+      throw new Error('Timed out waiting for holder to acquire the lock')
+    }
+    await delay(10)
+  }
+}
+
+async function finishHolder(holder: Holder): Promise<void> {
+  const outcome = await Promise.race([
+    holder.exited,
+    delay(CHILD_TIMEOUT_MS).then(() => {
+      throw new Error('Holder did not exit')
+    }),
+  ])
+  const { stdout, stderr } = holder.output()
+  if (outcome.code !== 0) {
+    throw new Error(
+      `Holder exited with code ${outcome.code ?? 'null'} and signal ${outcome.signal ?? 'none'}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+    )
+  }
+}
+
+async function terminateHolder(holder: Holder | undefined): Promise<void> {
+  if (
+    !holder ||
+    holder.process.exitCode !== null ||
+    holder.process.signalCode !== null
+  ) {
+    return
+  }
+  holder.process.kill('SIGTERM')
+  await Promise.race([holder.exited, delay(500)])
+  if (
+    holder.process.exitCode === null &&
+    holder.process.signalCode === null
+  ) {
+    holder.process.kill('SIGKILL')
+    await holder.exited
+  }
+}
+
+async function withSyncEnvironment(
+  run: (paths: {
+    root: string
+    userSettings: string
+    userMemory: string
+    localSettings: string
+  }) => Promise<void>,
+): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-sync-'))
+  const project = join(root, 'project')
+  const previousConfig = getClaudeConfigHomeDirOverrideForTesting()
+  const previousCwd = getOriginalCwd()
+  mkdirSync(project)
+  setClaudeConfigHomeDirForTesting(root)
+  setOriginalCwd(project)
+  resetSettingsCache()
+  try {
+    await run({
+      root,
+      userSettings: join(root, 'settings.json'),
+      userMemory: join(root, 'CLAUDE.md'),
+      localSettings: join(project, '.openclaude', 'settings.local.json'),
+    })
+  } finally {
+    setClaudeConfigHomeDirForTesting(previousConfig)
+    setOriginalCwd(previousCwd)
+    resetSettingsCache()
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test(
+  'user settings sync waits for the shared transaction lock and succeeds',
+  async () => {
+    await withSyncEnvironment(async ({ root, userSettings }) => {
+      writeFileSync(userSettings, '{}\n')
+      const entered = join(root, 'user-holder-entered')
+      const completed = join(root, 'user-holder-completed')
+      const holder = startHolder(userSettings, 1_000, entered, completed)
+      try {
+        await waitForHolder(entered, holder)
+        const startedAt = performance.now()
+        const result = await _applyRemoteEntriesToLocalForTesting(
+          {
+            [SYNC_KEYS.USER_SETTINGS]: '{"env":{"SYNCED":"yes"}}\n',
+          },
+          null,
+        )
+        const elapsedMs = performance.now() - startedAt
+
+        expect(result).toEqual({
+          appliedCount: 1,
+          settingsFilesWritten: 1,
+          memoryFilesWritten: 0,
+        })
+        expect(elapsedMs).toBeGreaterThanOrEqual(500)
+        expect(elapsedMs).toBeLessThan(1_800)
+        expect(JSON.parse(readFileSync(userSettings, 'utf8')).env).toEqual({
+          SYNCED: 'yes',
+        })
+        await finishHolder(holder)
+        expect(existsSync(`${userSettings}.lock`)).toBe(false)
+      } finally {
+        await terminateHolder(holder)
+      }
+    })
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'local settings sync uses the same physical-target lock',
+  async () => {
+    await withSyncEnvironment(async ({ root, localSettings }) => {
+      mkdirSync(dirname(localSettings), { recursive: true })
+      writeFileSync(localSettings, '{}\n')
+      const entered = join(root, 'local-holder-entered')
+      const completed = join(root, 'local-holder-completed')
+      const holder = startHolder(localSettings, 1_000, entered, completed)
+      try {
+        await waitForHolder(entered, holder)
+        const result = await _applyRemoteEntriesToLocalForTesting(
+          {
+            [SYNC_KEYS.projectSettings('project-id')]:
+              '{"env":{"LOCAL_SYNCED":"yes"}}\n',
+          },
+          'project-id',
+        )
+
+        expect(result).toEqual({
+          appliedCount: 1,
+          settingsFilesWritten: 1,
+          memoryFilesWritten: 0,
+        })
+        expect(JSON.parse(readFileSync(localSettings, 'utf8')).env).toEqual({
+          LOCAL_SYNCED: 'yes',
+        })
+        await finishHolder(holder)
+        expect(existsSync(`${localSettings}.lock`)).toBe(false)
+      } finally {
+        await terminateHolder(holder)
+      }
+    })
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'a timed-out settings entry is not reported applied and memory still syncs',
+  async () => {
+    await withSyncEnvironment(async ({ root, userMemory, userSettings }) => {
+      writeFileSync(userSettings, '{"env":{"ORIGINAL":"yes"}}\n')
+      const entered = join(root, 'timeout-holder-entered')
+      const completed = join(root, 'timeout-holder-completed')
+      const holder = startHolder(userSettings, 4_500, entered, completed)
+      try {
+        await waitForHolder(entered, holder)
+        const result = await _applyRemoteEntriesToLocalForTesting(
+          {
+            [SYNC_KEYS.USER_SETTINGS]: '{"env":{"REPLACED":"no"}}\n',
+            [SYNC_KEYS.USER_MEMORY]: 'synced memory\n',
+          },
+          null,
+        )
+
+        expect(result).toEqual({
+          appliedCount: 1,
+          settingsFilesWritten: 0,
+          memoryFilesWritten: 1,
+        })
+        expect(JSON.parse(readFileSync(userSettings, 'utf8')).env).toEqual({
+          ORIGINAL: 'yes',
+        })
+        expect(readFileSync(userMemory, 'utf8')).toBe('synced memory\n')
+        await finishHolder(holder)
+
+        expect(
+          await _applyRemoteEntriesToLocalForTesting(
+            {
+              [SYNC_KEYS.USER_SETTINGS]: '{"env":{"LATER":"yes"}}\n',
+            },
+            null,
+          ),
+        ).toEqual({
+          appliedCount: 1,
+          settingsFilesWritten: 1,
+          memoryFilesWritten: 0,
+        })
+        expect(JSON.parse(readFileSync(userSettings, 'utf8')).env).toEqual({
+          LATER: 'yes',
+        })
+        expect(existsSync(`${userSettings}.lock`)).toBe(false)
+      } finally {
+        await terminateHolder(holder)
+      }
+    })
+  },
+  TEST_TIMEOUT_MS,
+)

--- a/src/services/settingsSync/settings.transaction.test.ts
+++ b/src/services/settingsSync/settings.transaction.test.ts
@@ -191,6 +191,7 @@ test(
           appliedCount: 1,
           settingsFilesWritten: 1,
           settingsFilesFailed: 0,
+          settingsFilesRejected: 0,
           memoryFilesWritten: 0,
         })
         expect(elapsedMs).toBeGreaterThanOrEqual(500)
@@ -230,6 +231,7 @@ test(
           appliedCount: 1,
           settingsFilesWritten: 1,
           settingsFilesFailed: 0,
+          settingsFilesRejected: 0,
           memoryFilesWritten: 0,
         })
         expect(JSON.parse(readFileSync(localSettings, 'utf8')).env).toEqual({
@@ -267,6 +269,7 @@ test(
           appliedCount: 1,
           settingsFilesWritten: 0,
           settingsFilesFailed: 1,
+          settingsFilesRejected: 0,
           memoryFilesWritten: 1,
         })
         expect(JSON.parse(readFileSync(userSettings, 'utf8')).env).toEqual({
@@ -286,6 +289,7 @@ test(
           appliedCount: 1,
           settingsFilesWritten: 1,
           settingsFilesFailed: 0,
+          settingsFilesRejected: 0,
           memoryFilesWritten: 0,
         })
         expect(JSON.parse(readFileSync(userSettings, 'utf8')).env).toEqual({
@@ -300,6 +304,34 @@ test(
   TEST_TIMEOUT_MS,
 )
 
+test('permanent settings rejections are reported without retry failure', async () => {
+  await withSyncEnvironment(async ({ userSettings }) => {
+    const oversizedSettings = 'x'.repeat(500 * 1024 + 1)
+    const entries = {
+      [SYNC_KEYS.USER_SETTINGS]: oversizedSettings,
+      [SYNC_KEYS.projectSettings('project-id')]: oversizedSettings,
+    }
+
+    expect(
+      await _applyRemoteEntriesToLocalForTesting(entries, 'project-id'),
+    ).toEqual({
+      appliedCount: 0,
+      settingsFilesWritten: 0,
+      settingsFilesFailed: 0,
+      settingsFilesRejected: 2,
+      memoryFilesWritten: 0,
+    })
+    expect(existsSync(userSettings)).toBe(false)
+
+    try {
+      _setDownloadedEntriesForTesting({ entries, projectId: 'project-id' })
+      expect(await redownloadUserSettings()).toBe(true)
+    } finally {
+      _setDownloadedEntriesForTesting(null)
+    }
+  })
+})
+
 test(
   'startup and reload downloads return false after a timed-out settings apply',
   async () => {
@@ -307,7 +339,7 @@ test(
       writeFileSync(userSettings, '{"env":{"ORIGINAL":"yes"}}\n')
       const entered = join(root, 'download-holder-entered')
       const completed = join(root, 'download-holder-completed')
-      const holder = startHolder(userSettings, 5_000, entered, completed)
+      const holder = startHolder(userSettings, 9_000, entered, completed)
       try {
         await waitForHolder(entered, holder)
         _setDownloadedEntriesForTesting({

--- a/src/test/fixtures/settingsTransactionWriter.fixture.ts
+++ b/src/test/fixtures/settingsTransactionWriter.fixture.ts
@@ -1,5 +1,5 @@
 import { existsSync, realpathSync, writeFileSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { basename, dirname, join, resolve } from 'node:path'
 import {
   getFsImplementation,
   setFsImplementation,
@@ -7,7 +7,7 @@ import {
 
 const [
   role,
-  configDir,
+  target,
   key,
   value,
   enteredMarker,
@@ -16,9 +16,19 @@ const [
   releaseMarker,
 ] = process.argv.slice(2)
 
+const supportedRoles: ReadonlySet<string> = new Set([
+  'normal',
+  'hold-lock',
+  'hold-path-for',
+  'pause-after-read',
+])
+
+if (!role || !supportedRoles.has(role)) {
+  throw new Error(`Invalid settings transaction fixture role: ${role}`)
+}
+
 if (
-  !role ||
-  !configDir ||
+  !target ||
   !key ||
   !value ||
   !enteredMarker ||
@@ -27,14 +37,19 @@ if (
   throw new Error('Missing settings transaction fixture arguments')
 }
 
-process.env.OPENCLAUDE_CONFIG_DIR = configDir
+if (role !== 'hold-path-for') {
+  process.env.OPENCLAUDE_CONFIG_DIR = target
+}
 const settingsPath =
   role === 'hold-path-for'
-    ? resolve(configDir)
-    : resolve(configDir, 'settings.json')
+    ? resolve(target)
+    : resolve(target, 'settings.json')
+const settingsParentPath = dirname(settingsPath)
 const settingsReadPath = existsSync(settingsPath)
   ? realpathSync(settingsPath)
-  : settingsPath
+  : existsSync(settingsParentPath)
+    ? join(realpathSync(settingsParentPath), basename(settingsPath))
+    : settingsPath
 const waitBuffer = new Int32Array(new SharedArrayBuffer(4))
 
 function waitForMarker(marker: string): void {

--- a/src/test/fixtures/settingsTransactionWriter.fixture.ts
+++ b/src/test/fixtures/settingsTransactionWriter.fixture.ts
@@ -22,6 +22,7 @@ const supportedRoles: ReadonlySet<string> = new Set([
   'hold-lock',
   'hold-path-for',
   'pause-after-read',
+  'pause-before-lock-owner',
 ])
 
 if (!role || !supportedRoles.has(role)) {
@@ -39,7 +40,11 @@ if (
 }
 
 const expectedArgumentCount =
-  role === 'hold-lock' || role === 'pause-after-read' ? 8 : 6
+  role === 'hold-lock' ||
+  role === 'pause-after-read' ||
+  role === 'pause-before-lock-owner'
+    ? 8
+    : 6
 if (fixtureArgs.length !== expectedArgumentCount) {
   throw new Error(
     `Invalid argument count for ${role}: expected ${expectedArgumentCount}, received ${fixtureArgs.length}`,
@@ -52,6 +57,12 @@ if (role === 'hold-lock' && !releaseMarker) {
 
 if (role === 'pause-after-read' && (!readMarker || !releaseMarker)) {
   throw new Error('Pause-after-read fixture requires read and release markers')
+}
+
+if (role === 'pause-before-lock-owner' && (!readMarker || !releaseMarker)) {
+  throw new Error(
+    'Pause-before-lock-owner fixture requires pause and release markers',
+  )
 }
 
 const holdMs = role === 'hold-path-for' ? Number(value) : undefined
@@ -100,6 +111,30 @@ if (role === 'pause-after-read') {
         waitForMarker(releaseMarker)
       }
       return content
+    },
+  })
+}
+
+if (role === 'pause-before-lock-owner') {
+  const originalFs = getFsImplementation()
+  let paused = false
+  setFsImplementation({
+    ...originalFs,
+    readlinkSync(path) {
+      const ownerPath = resolve(path)
+      const lockPath = `${settingsReadPath}.lock`
+      const ownerDirectory = dirname(ownerPath)
+      if (
+        !paused &&
+        basename(ownerPath) === 'owner.json' &&
+        (ownerDirectory === lockPath ||
+          ownerDirectory.startsWith(`${lockPath}.pending.`))
+      ) {
+        paused = true
+        writeFileSync(readMarker, '')
+        waitForMarker(releaseMarker)
+      }
+      return originalFs.readlinkSync(path)
     },
   })
 }

--- a/src/test/fixtures/settingsTransactionWriter.fixture.ts
+++ b/src/test/fixtures/settingsTransactionWriter.fixture.ts
@@ -5,6 +5,7 @@ import {
   setFsImplementation,
 } from '../../utils/fsOperations.js'
 
+const fixtureArgs = process.argv.slice(2)
 const [
   role,
   target,
@@ -14,7 +15,7 @@ const [
   completedMarker,
   readMarker,
   releaseMarker,
-] = process.argv.slice(2)
+] = fixtureArgs
 
 const supportedRoles: ReadonlySet<string> = new Set([
   'normal',
@@ -35,6 +36,30 @@ if (
   !completedMarker
 ) {
   throw new Error('Missing settings transaction fixture arguments')
+}
+
+const expectedArgumentCount =
+  role === 'hold-lock' || role === 'pause-after-read' ? 8 : 6
+if (fixtureArgs.length !== expectedArgumentCount) {
+  throw new Error(
+    `Invalid argument count for ${role}: expected ${expectedArgumentCount}, received ${fixtureArgs.length}`,
+  )
+}
+
+if (role === 'hold-lock' && !releaseMarker) {
+  throw new Error('Hold-lock fixture requires a release marker')
+}
+
+if (role === 'pause-after-read' && (!readMarker || !releaseMarker)) {
+  throw new Error('Pause-after-read fixture requires read and release markers')
+}
+
+const holdMs = role === 'hold-path-for' ? Number(value) : undefined
+if (
+  role === 'hold-path-for' &&
+  (!Number.isFinite(holdMs) || (holdMs ?? -1) < 0)
+) {
+  throw new Error(`Invalid hold duration: ${value}`)
 }
 
 if (role !== 'hold-path-for') {
@@ -63,9 +88,6 @@ function waitForMarker(marker: string): void {
 }
 
 if (role === 'pause-after-read') {
-  if (!readMarker || !releaseMarker) {
-    throw new Error('Pause-after-read fixture requires read and release markers')
-  }
   const originalFs = getFsImplementation()
   let paused = false
   setFsImplementation({
@@ -89,15 +111,8 @@ if (role === 'hold-lock' || role === 'hold-path-for') {
   withSettingsFileTransactionSync(settingsPath, () => {
     writeFileSync(enteredMarker, '')
     if (role === 'hold-path-for') {
-      const holdMs = Number(value)
-      if (!Number.isFinite(holdMs) || holdMs < 0) {
-        throw new Error(`Invalid hold duration: ${value}`)
-      }
-      Atomics.wait(waitBuffer, 0, 0, holdMs)
+      Atomics.wait(waitBuffer, 0, 0, holdMs!)
     } else {
-      if (!releaseMarker) {
-        throw new Error('Hold-lock fixture requires a release marker')
-      }
       waitForMarker(releaseMarker)
     }
   })

--- a/src/test/fixtures/settingsTransactionWriter.fixture.ts
+++ b/src/test/fixtures/settingsTransactionWriter.fixture.ts
@@ -1,0 +1,106 @@
+import { existsSync, realpathSync, writeFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  getFsImplementation,
+  setFsImplementation,
+} from '../../utils/fsOperations.js'
+
+const [
+  role,
+  configDir,
+  key,
+  value,
+  enteredMarker,
+  completedMarker,
+  readMarker,
+  releaseMarker,
+] = process.argv.slice(2)
+
+if (
+  !role ||
+  !configDir ||
+  !key ||
+  !value ||
+  !enteredMarker ||
+  !completedMarker
+) {
+  throw new Error('Missing settings transaction fixture arguments')
+}
+
+process.env.OPENCLAUDE_CONFIG_DIR = configDir
+const settingsPath =
+  role === 'hold-path-for'
+    ? resolve(configDir)
+    : resolve(configDir, 'settings.json')
+const settingsReadPath = existsSync(settingsPath)
+  ? realpathSync(settingsPath)
+  : settingsPath
+const waitBuffer = new Int32Array(new SharedArrayBuffer(4))
+
+function waitForMarker(marker: string): void {
+  const deadline = performance.now() + 15_000
+  while (!existsSync(marker)) {
+    if (performance.now() >= deadline) {
+      throw new Error(`Timed out waiting for fixture marker: ${marker}`)
+    }
+    Atomics.wait(waitBuffer, 0, 0, 10)
+  }
+}
+
+if (role === 'pause-after-read') {
+  if (!readMarker || !releaseMarker) {
+    throw new Error('Pause-after-read fixture requires read and release markers')
+  }
+  const originalFs = getFsImplementation()
+  let paused = false
+  setFsImplementation({
+    ...originalFs,
+    readFileSync(path, options) {
+      const content = originalFs.readFileSync(path, options)
+      if (!paused && resolve(path) === settingsReadPath) {
+        paused = true
+        writeFileSync(readMarker, '')
+        waitForMarker(releaseMarker)
+      }
+      return content
+    },
+  })
+}
+
+if (role === 'hold-lock' || role === 'hold-path-for') {
+  const { withSettingsFileTransactionSync } = await import(
+    '../../utils/settings/settingsFileTransaction.js'
+  )
+  withSettingsFileTransactionSync(settingsPath, () => {
+    writeFileSync(enteredMarker, '')
+    if (role === 'hold-path-for') {
+      const holdMs = Number(value)
+      if (!Number.isFinite(holdMs) || holdMs < 0) {
+        throw new Error(`Invalid hold duration: ${value}`)
+      }
+      Atomics.wait(waitBuffer, 0, 0, holdMs)
+    } else {
+      if (!releaseMarker) {
+        throw new Error('Hold-lock fixture requires a release marker')
+      }
+      waitForMarker(releaseMarker)
+    }
+  })
+  writeFileSync(completedMarker, '')
+  process.stdout.write(`${JSON.stringify({ ok: true })}\n`)
+} else {
+  const { updateSettingsForSource } = await import(
+    '../../utils/settings/settings.js'
+  )
+  writeFileSync(enteredMarker, '')
+  const result = updateSettingsForSource('userSettings', {
+    env: { [key]: value },
+  })
+  writeFileSync(completedMarker, '')
+  process.stdout.write(
+    `${JSON.stringify({
+      ok: result.error === null,
+      error: result.error?.message,
+    })}\n`,
+  )
+}

--- a/src/utils/settings/settings.transaction.test.ts
+++ b/src/utils/settings/settings.transaction.test.ts
@@ -367,6 +367,40 @@ test('a malformed document is untouched and does not strand the lock', async () 
   })
 })
 
+test('an array document is rejected without dropping the requested update', async () => {
+  await withIsolatedUserSettings((_root, settingsPath) => {
+    const invalidSettings = '[]\n'
+    writeFileSync(settingsPath, invalidSettings)
+
+    const result = updateSettingsForSource('userSettings', {
+      env: { NEVER_WRITTEN: 'yes' },
+    })
+
+    expect(result.error?.message).toBe(
+      `Invalid settings document at ${settingsPath}: expected a JSON object`,
+    )
+    expect(readFileSync(settingsPath, 'utf8')).toBe(invalidSettings)
+    expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+  })
+})
+
+test('JSON null is reported as an invalid settings document', async () => {
+  await withIsolatedUserSettings((_root, settingsPath) => {
+    const invalidSettings = 'null\n'
+    writeFileSync(settingsPath, invalidSettings)
+
+    const result = updateSettingsForSource('userSettings', {
+      env: { NEVER_WRITTEN: 'yes' },
+    })
+
+    expect(result.error?.message).toBe(
+      `Invalid settings document at ${settingsPath}: expected a JSON object`,
+    )
+    expect(readFileSync(settingsPath, 'utf8')).toBe(invalidSettings)
+    expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+  })
+})
+
 test('does not retry unrelated filesystem errors', async () => {
   const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-fs-error-'))
   const nonDirectory = join(root, 'not-a-directory')

--- a/src/utils/settings/settings.transaction.test.ts
+++ b/src/utils/settings/settings.transaction.test.ts
@@ -709,6 +709,68 @@ test(
 )
 
 test(
+  'retries when the owner releases after a pending publish loses its race',
+  async () => {
+    await withIsolatedUserSettings(async (root, settingsPath) => {
+      const holderEntered = join(root, 'holder-entered')
+      const holderCompleted = join(root, 'holder-completed')
+      const releaseHolder = join(root, 'release-holder')
+      const originalFs = getFsImplementation()
+      const children: CapturedChild[] = []
+      let removedContendedLock = false
+      try {
+        writeFileSync(settingsPath, '{}\n')
+        const holder = startWriter([
+          'hold-lock',
+          root,
+          'unused',
+          'unused',
+          holderEntered,
+          holderCompleted,
+          'unused',
+          releaseHolder,
+        ])
+        children.push(holder)
+        await waitForMarker(holderEntered, holder, 'holder')
+
+        setFsImplementation({
+          ...originalFs,
+          lstatSync(path) {
+            if (
+              !removedContendedLock &&
+              resolve(path) === resolve(`${settingsPath}.lock`)
+            ) {
+              removedContendedLock = true
+              holder.process.kill('SIGKILL')
+              rmSync(`${settingsPath}.lock`, {
+                recursive: true,
+                force: true,
+              })
+            }
+            return originalFs.lstatSync(path)
+          },
+        })
+
+        expect(
+          updateSettingsForSource('userSettings', {
+            env: { RETRIED_AFTER_RELEASE: 'yes' },
+          }),
+        ).toEqual({ error: null })
+        expect(removedContendedLock).toBe(true)
+        expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+          RETRIED_AFTER_RELEASE: 'yes',
+        })
+        expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+      } finally {
+        setFsImplementation(originalFs)
+        await Promise.all(children.map(terminateChild))
+      }
+    })
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
   'does not expire a live synchronous owner when its lock entry is old',
   async () => {
     const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-live-owner-'))
@@ -769,7 +831,7 @@ test(
 )
 
 test(
-  'a waiting process can exit without leaving lock identity files',
+  'a waiting process can exit without blocking a later writer',
   async () => {
     const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-dead-waiter-'))
     const settingsPath = join(root, 'settings.json')
@@ -778,6 +840,8 @@ test(
     const releaseHolder = join(root, 'release-holder')
     const writerEntered = join(root, 'writer-entered')
     const writerCompleted = join(root, 'writer-completed')
+    const laterEntered = join(root, 'later-entered')
+    const laterCompleted = join(root, 'later-completed')
     const children: CapturedChild[] = []
     try {
       writeFileSync(settingsPath, '{}\n')
@@ -810,9 +874,23 @@ test(
 
       writeFileSync(releaseHolder, '')
       expect(await finishWriter(holder, 'holder')).toEqual({ ok: true })
-      expect(
-        readdirSync(root).filter(name => name.startsWith('settings.json.lock')),
-      ).toEqual([])
+
+      const laterWriter = startWriter([
+        'normal',
+        root,
+        'AFTER_KILLED_WAITER',
+        'yes',
+        laterEntered,
+        laterCompleted,
+      ])
+      children.push(laterWriter)
+      expect(await finishWriter(laterWriter, 'later writer')).toEqual({
+        ok: true,
+      })
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+        AFTER_KILLED_WAITER: 'yes',
+      })
+      expect(existsSync(`${settingsPath}.lock`)).toBe(false)
     } finally {
       await Promise.all(children.map(terminateChild))
       rmSync(root, { recursive: true, force: true })
@@ -883,6 +961,64 @@ test(
         name.startsWith('settings.json.lock.recovered.'),
       )
       expect(recoveryGuards).toHaveLength(1)
+    } finally {
+      await Promise.all(children.map(terminateChild))
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'recovers after a process exits before publishing its lock owner',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-lock-claim-'))
+    const settingsPath = join(root, 'settings.json')
+    const interruptedEntered = join(root, 'interrupted-entered')
+    const interruptedCompleted = join(root, 'interrupted-completed')
+    const claimCreated = join(root, 'claim-created')
+    const releaseInterrupted = join(root, 'release-interrupted')
+    const writerEntered = join(root, 'writer-entered')
+    const writerCompleted = join(root, 'writer-completed')
+    const children: CapturedChild[] = []
+    try {
+      writeFileSync(settingsPath, '{}\n')
+      const interrupted = startWriter([
+        'pause-before-lock-owner',
+        root,
+        'MUST_NOT_APPLY',
+        'no',
+        interruptedEntered,
+        interruptedCompleted,
+        claimCreated,
+        releaseInterrupted,
+      ])
+      children.push(interrupted)
+      await waitForMarker(claimCreated, interrupted, 'interrupted claimant')
+      interrupted.process.kill('SIGKILL')
+      await interrupted.exited
+
+      const writer = startWriter([
+        'normal',
+        root,
+        'RECOVERED_AFTER_INCOMPLETE_CLAIM',
+        'yes',
+        writerEntered,
+        writerCompleted,
+      ])
+      children.push(writer)
+      expect(await finishWriter(writer, 'recovery writer')).toEqual({
+        ok: true,
+      })
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+        RECOVERED_AFTER_INCOMPLETE_CLAIM: 'yes',
+      })
+      expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+      expect(
+        readdirSync(root).filter(name =>
+          name.startsWith('settings.json.lock.pending.'),
+        ),
+      ).toHaveLength(1)
     } finally {
       await Promise.all(children.map(terminateChild))
       rmSync(root, { recursive: true, force: true })

--- a/src/utils/settings/settings.transaction.test.ts
+++ b/src/utils/settings/settings.transaction.test.ts
@@ -11,7 +11,7 @@ import {
   utimesSync,
   writeFileSync,
 } from 'node:fs'
-import { tmpdir } from 'node:os'
+import { hostname, tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import type { Readable } from 'node:stream'
 import { expect, spyOn, test } from 'bun:test'
@@ -965,6 +965,110 @@ test(
       await Promise.all(children.map(terminateChild))
       rmSync(root, { recursive: true, force: true })
     }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'persists process incarnation identity for real lock owners',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-owner-id-'))
+    const settingsPath = join(root, 'settings.json')
+    const holderEntered = join(root, 'holder-entered')
+    const holderCompleted = join(root, 'holder-completed')
+    const releaseHolder = join(root, 'release-holder')
+    const children: CapturedChild[] = []
+    try {
+      writeFileSync(settingsPath, '{}\n')
+      const holder = startWriter([
+        'hold-lock',
+        root,
+        'unused',
+        'unused',
+        holderEntered,
+        holderCompleted,
+        'unused',
+        releaseHolder,
+      ])
+      children.push(holder)
+      await waitForMarker(holderEntered, holder, 'holder')
+
+      const owner = JSON.parse(
+        readFileSync(join(`${settingsPath}.lock`, 'owner.json'), 'utf8'),
+      ) as Record<string, unknown>
+      expect(owner.version).toBe(2)
+      expect(owner.pid).toBe(holder.process.pid)
+      expect(owner.processStartId).toBeString()
+      expect(owner.processStartId).toMatch(/^(linux|posix|windows):/)
+
+      writeFileSync(releaseHolder, '')
+      expect(await finishWriter(holder, 'holder')).toEqual({ ok: true })
+    } finally {
+      await Promise.all(children.map(terminateChild))
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'recovers when a live process has reused the recorded owner PID',
+  async () => {
+    await withIsolatedUserSettings((_root, settingsPath) => {
+      const lockPath = `${settingsPath}.lock`
+      const staleToken = '00000000-0000-4000-8000-000000000001'
+      mkdirSync(lockPath)
+      writeFileSync(
+        join(lockPath, 'owner.json'),
+        JSON.stringify({
+          version: 2,
+          host: hostname(),
+          pid: process.pid,
+          token: staleToken,
+          processStartId: 'test:previous-process-instance',
+        }),
+      )
+
+      expect(
+        updateSettingsForSource('userSettings', {
+          env: { RECOVERED_AFTER_PID_REUSE: 'yes' },
+        }),
+      ).toEqual({ error: null })
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+        RECOVERED_AFTER_PID_REUSE: 'yes',
+      })
+      expect(existsSync(lockPath)).toBe(false)
+      expect(
+        existsSync(`${lockPath}.recovered.${process.pid}.${staleToken}`),
+      ).toBe(true)
+    })
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'keeps a live legacy owner record protected',
+  async () => {
+    await withIsolatedUserSettings((_root, settingsPath) => {
+      const lockPath = `${settingsPath}.lock`
+      mkdirSync(lockPath)
+      writeFileSync(
+        join(lockPath, 'owner.json'),
+        JSON.stringify({
+          version: 1,
+          host: hostname(),
+          pid: process.pid,
+          token: '00000000-0000-4000-8000-000000000002',
+        }),
+      )
+
+      const result = updateSettingsForSource('userSettings', {
+        env: { MUST_NOT_RECLAIM_LIVE_V1: 'no' },
+      })
+      expect(result.error?.message).toContain('Timed out after 2000ms')
+      expect(existsSync(lockPath)).toBe(true)
+      expect(existsSync(settingsPath)).toBe(false)
+    })
   },
   TEST_TIMEOUT_MS,
 )

--- a/src/utils/settings/settings.transaction.test.ts
+++ b/src/utils/settings/settings.transaction.test.ts
@@ -520,6 +520,8 @@ test.each([
 test('keeps an operation error primary when lock release also fails', async () => {
   const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-release-error-'))
   const settingsPath = join(root, 'settings.json')
+  const originalFs = getFsImplementation()
+  let releaseOwnerRead = false
   try {
     const { withSettingsFileTransactionSync } = await import(
       './settingsFileTransaction.js'
@@ -529,9 +531,39 @@ test('keeps an operation error primary when lock release also fails', async () =
         const lockPath = `${targetPath}.lock`
         rmSync(lockPath, { recursive: true, force: true })
         mkdirSync(lockPath)
+        const ownerPath = join(lockPath, 'owner.json')
+        setFsImplementation({
+          ...originalFs,
+          readFileSync(path, options) {
+            if (resolve(path) === resolve(ownerPath)) releaseOwnerRead = true
+            return originalFs.readFileSync(path, options)
+          },
+        })
         throw new Error('primary operation failure')
       }),
     ).toThrow('primary operation failure')
+    expect(releaseOwnerRead).toBe(true)
+  } finally {
+    setFsImplementation(originalFs)
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('propagates a release error after the operation succeeds', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-release-error-'))
+  const settingsPath = join(root, 'settings.json')
+  try {
+    const { withSettingsFileTransactionSync } = await import(
+      './settingsFileTransaction.js'
+    )
+    expect(() =>
+      withSettingsFileTransactionSync(settingsPath, targetPath => {
+        const lockPath = `${targetPath}.lock`
+        rmSync(lockPath, { recursive: true, force: true })
+        mkdirSync(lockPath)
+        return 'operation result'
+      }),
+    ).toThrow('Settings file lock ownership changed before release')
   } finally {
     rmSync(root, { recursive: true, force: true })
   }

--- a/src/utils/settings/settings.transaction.test.ts
+++ b/src/utils/settings/settings.transaction.test.ts
@@ -388,6 +388,19 @@ test('does not retry unrelated filesystem errors', async () => {
   }
 })
 
+test('reports transaction failures with operation-neutral context', async () => {
+  await withIsolatedUserSettings((_root, settingsPath) => {
+    mkdirSync(settingsPath)
+    const result = updateSettingsForSource('userSettings', {
+      env: { NEVER_WRITTEN: 'yes' },
+    })
+    expect(result.error?.message).toContain(
+      `Failed to update settings at ${settingsPath}:`,
+    )
+    expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+  })
+})
+
 test(
   'waits for a short holder and succeeds before the contention deadline',
   async () => {

--- a/src/utils/settings/settings.transaction.test.ts
+++ b/src/utils/settings/settings.transaction.test.ts
@@ -1,0 +1,649 @@
+import { spawn, type ChildProcessByStdio } from 'node:child_process'
+import {
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import type { Readable } from 'node:stream'
+import { expect, spyOn, test } from 'bun:test'
+import { getOriginalCwd, setOriginalCwd } from '../../bootstrap/state.js'
+import {
+  getClaudeConfigHomeDirOverrideForTesting,
+  setClaudeConfigHomeDirForTesting,
+} from '../envUtils.js'
+import * as gitignore from '../git/gitignore.js'
+import {
+  getSettingsForSource,
+  updateSettingsForSource,
+} from './settings.js'
+import {
+  clearInternalWrites,
+  consumeInternalWrite,
+} from './internalWrites.js'
+import { resetSettingsCache } from './settingsCache.js'
+import type { SettingsJson } from './types.js'
+
+const fixturePath = resolve(
+  import.meta.dir,
+  '../../test/fixtures/settingsTransactionWriter.fixture.ts',
+)
+const CHILD_TIMEOUT_MS = 20_000
+const TEST_TIMEOUT_MS = CHILD_TIMEOUT_MS + 10_000
+
+type CapturedChild = {
+  process: ChildProcessByStdio<null, Readable, Readable>
+  exited: Promise<{ code: number | null; signal: NodeJS.Signals | null }>
+  output: () => { stdout: string; stderr: string }
+}
+
+function startWriter(args: string[]): CapturedChild {
+  const child = spawn(process.execPath, [fixturePath, ...args], {
+    cwd: process.cwd(),
+    env: { ...process.env, FORCE_COLOR: '0' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  })
+  let stdout = ''
+  let stderr = ''
+  child.stdout.setEncoding('utf8')
+  child.stderr.setEncoding('utf8')
+  child.stdout.on('data', chunk => {
+    stdout += chunk
+  })
+  child.stderr.on('data', chunk => {
+    stderr += chunk
+  })
+
+  return {
+    process: child,
+    exited: new Promise(resolveExit => {
+      child.once('exit', (code, signal) => resolveExit({ code, signal }))
+    }),
+    output: () => ({ stdout, stderr }),
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolveDelay => setTimeout(resolveDelay, ms))
+}
+
+async function waitForMarker(
+  marker: string,
+  child: CapturedChild,
+  label: string,
+): Promise<void> {
+  const deadline = performance.now() + CHILD_TIMEOUT_MS
+  while (!existsSync(marker)) {
+    if (
+      child.process.exitCode !== null ||
+      child.process.signalCode !== null
+    ) {
+      const { stdout, stderr } = child.output()
+      throw new Error(
+        `${label} exited before creating its marker\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+      )
+    }
+    if (performance.now() >= deadline) {
+      const { stdout, stderr } = child.output()
+      throw new Error(
+        `${label} timed out before creating its marker\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+      )
+    }
+    await delay(10)
+  }
+}
+
+async function markerAppearsWithin(
+  marker: string,
+  child: CapturedChild,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadline = performance.now() + timeoutMs
+  while (!existsSync(marker)) {
+    if (
+      child.process.exitCode !== null ||
+      child.process.signalCode !== null ||
+      performance.now() >= deadline
+    ) {
+      return existsSync(marker)
+    }
+    await delay(10)
+  }
+  return true
+}
+
+async function finishWriter(
+  child: CapturedChild,
+  label: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const outcome = await Promise.race([
+    child.exited,
+    delay(CHILD_TIMEOUT_MS).then(() => {
+      throw new Error(`${label} did not exit within ${CHILD_TIMEOUT_MS}ms`)
+    }),
+  ])
+  const { stdout, stderr } = child.output()
+  if (outcome.code !== 0) {
+    throw new Error(
+      `${label} exited with code ${outcome.code ?? 'null'} and signal ${outcome.signal ?? 'none'}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+    )
+  }
+  const lastLine = stdout.trim().split(/\r?\n/).at(-1)
+  if (!lastLine) {
+    throw new Error(`${label} emitted no JSON\nstderr:\n${stderr}`)
+  }
+  try {
+    return JSON.parse(lastLine) as { ok: boolean; error?: string }
+  } catch (error) {
+    throw new Error(
+      `${label} emitted invalid JSON: ${error}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+    )
+  }
+}
+
+async function terminateChild(child: CapturedChild): Promise<void> {
+  if (
+    child.process.exitCode !== null ||
+    child.process.signalCode !== null
+  ) {
+    return
+  }
+  child.process.kill('SIGTERM')
+  await Promise.race([child.exited, delay(500)])
+  if (
+    child.process.exitCode === null &&
+    child.process.signalCode === null
+  ) {
+    child.process.kill('SIGKILL')
+    await child.exited
+  }
+}
+
+async function runConcurrentWriters(
+  markerRoot: string,
+  configDirA: string,
+  configDirB: string,
+  settingsPath: string,
+): Promise<{
+  resultA: { ok: boolean; error?: string }
+  resultB: { ok: boolean; error?: string }
+  finalSettings: { env?: Record<string, string> }
+}> {
+  const writerAEntered = join(markerRoot, 'writer-a-entered')
+  const writerACompleted = join(markerRoot, 'writer-a-completed')
+  const writerARead = join(markerRoot, 'writer-a-read')
+  const releaseWriterA = join(markerRoot, 'release-writer-a')
+  const writerBEntered = join(markerRoot, 'writer-b-entered')
+  const writerBCompleted = join(markerRoot, 'writer-b-completed')
+  const children: CapturedChild[] = []
+
+  try {
+    const writerA = startWriter([
+      'pause-after-read',
+      configDirA,
+      'WRITER_A',
+      'a',
+      writerAEntered,
+      writerACompleted,
+      writerARead,
+      releaseWriterA,
+    ])
+    children.push(writerA)
+    await waitForMarker(writerARead, writerA, 'writer A')
+
+    const writerB = startWriter([
+      'normal',
+      configDirB,
+      'WRITER_B',
+      'b',
+      writerBEntered,
+      writerBCompleted,
+    ])
+    children.push(writerB)
+    await waitForMarker(writerBEntered, writerB, 'writer B')
+
+    // On unfixed main, B completes against the same old document. With the
+    // transaction lock, B remains pending behind A. Either observation is
+    // enough to release A without building a barrier that deadlocks the fix.
+    await markerAppearsWithin(writerBCompleted, writerB, 500)
+    writeFileSync(releaseWriterA, '')
+
+    const [resultA, resultB] = await Promise.all([
+      finishWriter(writerA, 'writer A'),
+      finishWriter(writerB, 'writer B'),
+    ])
+    return {
+      resultA,
+      resultB,
+      finalSettings: JSON.parse(readFileSync(settingsPath, 'utf8')) as {
+        env?: Record<string, string>
+      },
+    }
+  } finally {
+    await Promise.all(children.map(terminateChild))
+  }
+}
+
+async function withIsolatedUserSettings(
+  run: (root: string, settingsPath: string) => void | Promise<void>,
+): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-unit-'))
+  const previousOverride = getClaudeConfigHomeDirOverrideForTesting()
+  setClaudeConfigHomeDirForTesting(root)
+  resetSettingsCache()
+  try {
+    await run(root, join(root, 'settings.json'))
+  } finally {
+    setClaudeConfigHomeDirForTesting(previousOverride)
+    resetSettingsCache()
+    rmSync(root, { recursive: true, force: true })
+  }
+}
+
+test(
+  'two processes preserve disjoint settings patches during contention',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-race-'))
+    const settingsPath = join(root, 'settings.json')
+
+    try {
+      writeFileSync(
+        settingsPath,
+        `${JSON.stringify({ env: { BASE: 'base' } }, null, 2)}\n`,
+      )
+
+      const { resultA, resultB, finalSettings } =
+        await runConcurrentWriters(root, root, root, settingsPath)
+      expect(resultA).toEqual({ ok: true })
+      expect(resultB).toEqual({ ok: true })
+      expect(finalSettings.env).toEqual({
+        BASE: 'base',
+        WRITER_A: 'a',
+        WRITER_B: 'b',
+      })
+      expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test('reads the merge base from disk after ownership, not from warm caches', async () => {
+  await withIsolatedUserSettings((_root, settingsPath) => {
+    writeFileSync(
+      settingsPath,
+      `${JSON.stringify({ env: { CACHED: 'yes' } }, null, 2)}\n`,
+    )
+    expect(getSettingsForSource('userSettings')?.env).toEqual({
+      CACHED: 'yes',
+    })
+
+    writeFileSync(
+      settingsPath,
+      `${JSON.stringify({ env: { CACHED: 'yes', EXTERNAL: 'yes' } }, null, 2)}\n`,
+    )
+    expect(
+      updateSettingsForSource('userSettings', {
+        env: { LOCAL: 'yes' },
+      }),
+    ).toEqual({ error: null })
+
+    expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+      CACHED: 'yes',
+      EXTERNAL: 'yes',
+      LOCAL: 'yes',
+    })
+  })
+})
+
+test('creates a missing settings file without weakening the synchronous result', async () => {
+  await withIsolatedUserSettings((_root, settingsPath) => {
+    expect(existsSync(settingsPath)).toBe(false)
+    expect(
+      updateSettingsForSource('userSettings', { env: { CREATED: 'yes' } }),
+    ).toEqual({ error: null })
+    expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+      CREATED: 'yes',
+    })
+    expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+  })
+})
+
+test('preserves deletion, array replacement, and ordinary success semantics', async () => {
+  await withIsolatedUserSettings((_root, settingsPath) => {
+    writeFileSync(
+      settingsPath,
+      `${JSON.stringify(
+        {
+          env: { KEEP: 'yes', REMOVE: 'yes' },
+          permissions: { allow: ['Bash(one)'] },
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    const patch = {
+      env: { REMOVE: undefined },
+      permissions: { allow: ['Bash(two)'] },
+    } as unknown as SettingsJson
+    expect(updateSettingsForSource('userSettings', patch)).toEqual({
+      error: null,
+    })
+
+    expect(JSON.parse(readFileSync(settingsPath, 'utf8'))).toMatchObject({
+      env: { KEEP: 'yes' },
+      permissions: { allow: ['Bash(two)'] },
+    })
+  })
+})
+
+test('a malformed document is untouched and does not strand the lock', async () => {
+  await withIsolatedUserSettings((_root, settingsPath) => {
+    const malformed = '{"env":'
+    writeFileSync(settingsPath, malformed)
+    const failed = updateSettingsForSource('userSettings', {
+      env: { FIRST: 'no' },
+    })
+    expect(failed.error?.message).toBe(
+      `Invalid JSON syntax in settings file at ${settingsPath}`,
+    )
+    expect(readFileSync(settingsPath, 'utf8')).toBe(malformed)
+    expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+
+    writeFileSync(settingsPath, '{}\n')
+    expect(
+      updateSettingsForSource('userSettings', { env: { SECOND: 'yes' } }),
+    ).toEqual({ error: null })
+    expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+      SECOND: 'yes',
+    })
+  })
+})
+
+test('does not retry unrelated filesystem errors', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-fs-error-'))
+  const nonDirectory = join(root, 'not-a-directory')
+  writeFileSync(nonDirectory, '')
+  try {
+    const { withSettingsFileTransactionSync } = await import(
+      './settingsFileTransaction.js'
+    )
+    const startedAt = performance.now()
+    expect(() =>
+      withSettingsFileTransactionSync(
+        join(nonDirectory, 'settings.json'),
+        () => undefined,
+      ),
+    ).toThrow()
+    expect(performance.now() - startedAt).toBeLessThan(500)
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test(
+  'waits for a short holder and succeeds before the contention deadline',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-wait-'))
+    const settingsPath = join(root, 'settings.json')
+    const holderEntered = join(root, 'holder-entered')
+    const holderCompleted = join(root, 'holder-completed')
+    const releaseHolder = join(root, 'release-holder')
+    const writerEntered = join(root, 'writer-entered')
+    const writerCompleted = join(root, 'writer-completed')
+    const children: CapturedChild[] = []
+    try {
+      writeFileSync(settingsPath, '{}\n')
+      const holder = startWriter([
+        'hold-lock',
+        root,
+        'unused',
+        'unused',
+        holderEntered,
+        holderCompleted,
+        'unused',
+        releaseHolder,
+      ])
+      children.push(holder)
+      await waitForMarker(holderEntered, holder, 'holder')
+
+      const writer = startWriter([
+        'normal',
+        root,
+        'WAITED',
+        'yes',
+        writerEntered,
+        writerCompleted,
+      ])
+      children.push(writer)
+      await waitForMarker(writerEntered, writer, 'waiting writer')
+      expect(await markerAppearsWithin(writerCompleted, writer, 200)).toBe(false)
+
+      writeFileSync(releaseHolder, '')
+      expect(await finishWriter(holder, 'holder')).toEqual({ ok: true })
+      expect(await finishWriter(writer, 'waiting writer')).toEqual({ ok: true })
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+        WAITED: 'yes',
+      })
+      expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+    } finally {
+      await Promise.all(children.map(terminateChild))
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'times out a long-held lock clearly and allows a later update',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-timeout-'))
+    const settingsPath = join(root, 'settings.json')
+    const holderEntered = join(root, 'holder-entered')
+    const holderCompleted = join(root, 'holder-completed')
+    const releaseHolder = join(root, 'release-holder')
+    const timedEntered = join(root, 'timed-entered')
+    const timedCompleted = join(root, 'timed-completed')
+    const laterEntered = join(root, 'later-entered')
+    const laterCompleted = join(root, 'later-completed')
+    const children: CapturedChild[] = []
+    try {
+      writeFileSync(settingsPath, '{}\n')
+      const holder = startWriter([
+        'hold-lock',
+        root,
+        'unused',
+        'unused',
+        holderEntered,
+        holderCompleted,
+        'unused',
+        releaseHolder,
+      ])
+      children.push(holder)
+      await waitForMarker(holderEntered, holder, 'holder')
+
+      const timedWriter = startWriter([
+        'normal',
+        root,
+        'TIMED_OUT',
+        'no',
+        timedEntered,
+        timedCompleted,
+      ])
+      children.push(timedWriter)
+      await waitForMarker(timedEntered, timedWriter, 'timed writer')
+      const startedAt = performance.now()
+      const timedResult = await finishWriter(timedWriter, 'timed writer')
+      const elapsedMs = performance.now() - startedAt
+      expect(timedResult.ok).toBe(false)
+      expect(timedResult.error).toContain('Timed out after 2000ms')
+      expect(elapsedMs).toBeGreaterThanOrEqual(1_800)
+      expect(elapsedMs).toBeLessThan(3_500)
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8'))).toEqual({})
+
+      writeFileSync(releaseHolder, '')
+      expect(await finishWriter(holder, 'holder')).toEqual({ ok: true })
+
+      const laterWriter = startWriter([
+        'normal',
+        root,
+        'LATER',
+        'yes',
+        laterEntered,
+        laterCompleted,
+      ])
+      children.push(laterWriter)
+      expect(await finishWriter(laterWriter, 'later writer')).toEqual({
+        ok: true,
+      })
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+        LATER: 'yes',
+      })
+      expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+    } finally {
+      await Promise.all(children.map(terminateChild))
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'symlinked parent and direct-file aliases share a lock and preserve the links',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-alias-'))
+    const realConfig = join(root, 'real-config')
+    const parentAlias = join(root, 'parent-alias')
+    const directAliasConfig = join(root, 'direct-alias-config')
+    const settingsPath = join(realConfig, 'settings.json')
+    const directSettingsAlias = join(directAliasConfig, 'settings.json')
+    try {
+      mkdirSync(realConfig)
+      mkdirSync(directAliasConfig)
+      writeFileSync(
+        settingsPath,
+        `${JSON.stringify({ env: { BASE: 'base' } }, null, 2)}\n`,
+      )
+      try {
+        symlinkSync(
+          realConfig,
+          parentAlias,
+          process.platform === 'win32' ? 'junction' : 'dir',
+        )
+        symlinkSync(settingsPath, directSettingsAlias, 'file')
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code
+        if (
+          process.platform === 'win32' &&
+          (code === 'EPERM' || code === 'EACCES')
+        ) {
+          return
+        }
+        throw error
+      }
+
+      const { resultA, resultB, finalSettings } = await runConcurrentWriters(
+        root,
+        parentAlias,
+        directAliasConfig,
+        settingsPath,
+      )
+      expect(resultA).toEqual({ ok: true })
+      expect(resultB).toEqual({ ok: true })
+      expect(finalSettings.env).toEqual({
+        BASE: 'base',
+        WRITER_A: 'a',
+        WRITER_B: 'b',
+      })
+      expect(lstatSync(parentAlias).isSymbolicLink()).toBe(true)
+      expect(lstatSync(directSettingsAlias).isSymbolicLink()).toBe(true)
+      expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test('marks the requested logical alias after publishing to its physical target', () => {
+  const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-mark-'))
+  const realConfig = join(root, 'real-config')
+  const configAlias = join(root, 'config-alias')
+  const logicalSettingsPath = join(configAlias, 'settings.json')
+  const previousOverride = getClaudeConfigHomeDirOverrideForTesting()
+  try {
+    mkdirSync(realConfig)
+    try {
+      symlinkSync(
+        realConfig,
+        configAlias,
+        process.platform === 'win32' ? 'junction' : 'dir',
+      )
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (
+        process.platform === 'win32' &&
+        (code === 'EPERM' || code === 'EACCES')
+      ) {
+        return
+      }
+      throw error
+    }
+
+    setClaudeConfigHomeDirForTesting(configAlias)
+    resetSettingsCache()
+    clearInternalWrites()
+    expect(
+      updateSettingsForSource('userSettings', { env: { MARKED: 'yes' } }),
+    ).toEqual({ error: null })
+    expect(consumeInternalWrite(logicalSettingsPath, 5_000)).toBe(true)
+    expect(
+      consumeInternalWrite(join(realConfig, 'settings.json'), 5_000),
+    ).toBe(false)
+  } finally {
+    setClaudeConfigHomeDirForTesting(previousOverride)
+    resetSettingsCache()
+    clearInternalWrites()
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test('local settings still arrange the existing global gitignore rule', () => {
+  const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-gitignore-'))
+  const project = join(root, 'project')
+  const previousOriginalCwd = getOriginalCwd()
+  const previousOverride = getClaudeConfigHomeDirOverrideForTesting()
+  const addRule = spyOn(
+    gitignore,
+    'addFileGlobRuleToGitignore',
+  ).mockResolvedValue(undefined)
+  try {
+    mkdirSync(project)
+    setOriginalCwd(project)
+    setClaudeConfigHomeDirForTesting(join(root, 'config'))
+    resetSettingsCache()
+
+    expect(
+      updateSettingsForSource('localSettings', {
+        env: { LOCAL: 'yes' },
+      }),
+    ).toEqual({ error: null })
+    expect(addRule).toHaveBeenCalledWith(
+      '.openclaude/settings.local.json',
+      project,
+    )
+  } finally {
+    addRule.mockRestore()
+    setOriginalCwd(previousOriginalCwd)
+    setClaudeConfigHomeDirForTesting(previousOverride)
+    resetSettingsCache()
+    rmSync(root, { recursive: true, force: true })
+  }
+})

--- a/src/utils/settings/settings.transaction.test.ts
+++ b/src/utils/settings/settings.transaction.test.ts
@@ -4,9 +4,11 @@ import {
   lstatSync,
   mkdtempSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -18,6 +20,10 @@ import {
   getClaudeConfigHomeDirOverrideForTesting,
   setClaudeConfigHomeDirForTesting,
 } from '../envUtils.js'
+import {
+  getFsImplementation,
+  setFsImplementation,
+} from '../fsOperations.js'
 import * as gitignore from '../git/gitignore.js'
 import {
   getSettingsForSource,
@@ -422,6 +428,32 @@ test('does not retry unrelated filesystem errors', async () => {
   }
 })
 
+test('does not require hard-link support from the settings filesystem', async () => {
+  await withIsolatedUserSettings((_root, settingsPath) => {
+    const originalFs = getFsImplementation()
+    setFsImplementation({
+      ...originalFs,
+      linkSync() {
+        throw Object.assign(new Error('Hard links are unavailable'), {
+          code: 'ENOTSUP',
+        })
+      },
+    })
+    try {
+      expect(
+        updateSettingsForSource('userSettings', {
+          env: { NO_HARD_LINK: 'yes' },
+        }),
+      ).toEqual({ error: null })
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+        NO_HARD_LINK: 'yes',
+      })
+    } finally {
+      setFsImplementation(originalFs)
+    }
+  })
+})
+
 test('reports transaction failures with operation-neutral context', async () => {
   await withIsolatedUserSettings((_root, settingsPath) => {
     mkdirSync(settingsPath)
@@ -563,6 +595,189 @@ test(
 )
 
 test(
+  'does not expire a live synchronous owner when its lock entry is old',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-live-owner-'))
+    const settingsPath = join(root, 'settings.json')
+    const holderEntered = join(root, 'holder-entered')
+    const holderCompleted = join(root, 'holder-completed')
+    const releaseHolder = join(root, 'release-holder')
+    const writerEntered = join(root, 'writer-entered')
+    const writerCompleted = join(root, 'writer-completed')
+    const children: CapturedChild[] = []
+    try {
+      writeFileSync(settingsPath, '{}\n')
+      const holder = startWriter([
+        'hold-lock',
+        root,
+        'unused',
+        'unused',
+        holderEntered,
+        holderCompleted,
+        'unused',
+        releaseHolder,
+      ])
+      children.push(holder)
+      await waitForMarker(holderEntered, holder, 'holder')
+
+      const olderThanPreviousLease = new Date(Date.now() - 31_000)
+      utimesSync(
+        `${settingsPath}.lock`,
+        olderThanPreviousLease,
+        olderThanPreviousLease,
+      )
+
+      const writer = startWriter([
+        'normal',
+        root,
+        'MUST_NOT_APPLY',
+        'no',
+        writerEntered,
+        writerCompleted,
+      ])
+      children.push(writer)
+      await waitForMarker(writerEntered, writer, 'waiting writer')
+      const writerResult = await finishWriter(writer, 'waiting writer')
+
+      expect(writerResult.ok).toBe(false)
+      expect(writerResult.error).toContain('Timed out after 2000ms')
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8'))).toEqual({})
+
+      writeFileSync(releaseHolder, '')
+      expect(await finishWriter(holder, 'holder')).toEqual({ ok: true })
+      expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+    } finally {
+      await Promise.all(children.map(terminateChild))
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'a waiting process can exit without leaving lock identity files',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-dead-waiter-'))
+    const settingsPath = join(root, 'settings.json')
+    const holderEntered = join(root, 'holder-entered')
+    const holderCompleted = join(root, 'holder-completed')
+    const releaseHolder = join(root, 'release-holder')
+    const writerEntered = join(root, 'writer-entered')
+    const writerCompleted = join(root, 'writer-completed')
+    const children: CapturedChild[] = []
+    try {
+      writeFileSync(settingsPath, '{}\n')
+      const holder = startWriter([
+        'hold-lock',
+        root,
+        'unused',
+        'unused',
+        holderEntered,
+        holderCompleted,
+        'unused',
+        releaseHolder,
+      ])
+      children.push(holder)
+      await waitForMarker(holderEntered, holder, 'holder')
+
+      const writer = startWriter([
+        'normal',
+        root,
+        'MUST_NOT_APPLY',
+        'no',
+        writerEntered,
+        writerCompleted,
+      ])
+      children.push(writer)
+      await waitForMarker(writerEntered, writer, 'waiting writer')
+      expect(await markerAppearsWithin(writerCompleted, writer, 200)).toBe(false)
+      writer.process.kill('SIGKILL')
+      await writer.exited
+
+      writeFileSync(releaseHolder, '')
+      expect(await finishWriter(holder, 'holder')).toEqual({ ok: true })
+      expect(
+        readdirSync(root).filter(name => name.startsWith('settings.json.lock')),
+      ).toEqual([])
+    } finally {
+      await Promise.all(children.map(terminateChild))
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
+  'serializes competing recoveries after the recorded holder process exits',
+  async () => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-dead-owner-'))
+    const settingsPath = join(root, 'settings.json')
+    const holderEntered = join(root, 'holder-entered')
+    const holderCompleted = join(root, 'holder-completed')
+    const releaseHolder = join(root, 'release-holder')
+    const writerAEntered = join(root, 'writer-a-entered')
+    const writerACompleted = join(root, 'writer-a-completed')
+    const writerBEntered = join(root, 'writer-b-entered')
+    const writerBCompleted = join(root, 'writer-b-completed')
+    const children: CapturedChild[] = []
+    try {
+      writeFileSync(settingsPath, '{}\n')
+      const holder = startWriter([
+        'hold-lock',
+        root,
+        'unused',
+        'unused',
+        holderEntered,
+        holderCompleted,
+        'unused',
+        releaseHolder,
+      ])
+      children.push(holder)
+      await waitForMarker(holderEntered, holder, 'holder')
+      holder.process.kill('SIGKILL')
+      await holder.exited
+
+      const writerA = startWriter([
+        'normal',
+        root,
+        'RECOVERED_A',
+        'a',
+        writerAEntered,
+        writerACompleted,
+      ])
+      const writerB = startWriter([
+        'normal',
+        root,
+        'RECOVERED_B',
+        'b',
+        writerBEntered,
+        writerBCompleted,
+      ])
+      children.push(writerA, writerB)
+      expect(
+        await Promise.all([
+          finishWriter(writerA, 'recovery writer A'),
+          finishWriter(writerB, 'recovery writer B'),
+        ]),
+      ).toEqual([{ ok: true }, { ok: true }])
+      expect(JSON.parse(readFileSync(settingsPath, 'utf8')).env).toEqual({
+        RECOVERED_A: 'a',
+        RECOVERED_B: 'b',
+      })
+      expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+      const recoveryGuards = readdirSync(root).filter(name =>
+        name.startsWith('settings.json.lock.recovered.'),
+      )
+      expect(recoveryGuards).toHaveLength(1)
+    } finally {
+      await Promise.all(children.map(terminateChild))
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test(
   'symlinked parent and direct-file aliases share a lock and preserve the links',
   async () => {
     const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-alias-'))
@@ -684,6 +899,10 @@ test('local settings still arrange the existing global gitignore rule', () => {
     ).toEqual({ error: null })
     expect(addRule).toHaveBeenCalledWith(
       '.openclaude/settings.local.json',
+      project,
+    )
+    expect(addRule).toHaveBeenCalledWith(
+      '.openclaude/settings.local.json.lock*',
       project,
     )
   } finally {

--- a/src/utils/settings/settings.transaction.test.ts
+++ b/src/utils/settings/settings.transaction.test.ts
@@ -454,6 +454,89 @@ test('does not require hard-link support from the settings filesystem', async ()
   })
 })
 
+test.each([
+  [
+    'an invalid hold-lock argument count',
+    (root: string, entered: string, completed: string) => [
+      'hold-lock',
+      root,
+      'unused',
+      'unused',
+      entered,
+      completed,
+    ],
+    'Invalid argument count for hold-lock',
+  ],
+  [
+    'a missing hold-lock release marker',
+    (root: string, entered: string, completed: string) => [
+      'hold-lock',
+      root,
+      'unused',
+      'unused',
+      entered,
+      completed,
+      'unused',
+      '',
+    ],
+    'Hold-lock fixture requires a release marker',
+  ],
+  [
+    'a missing pause-after-read marker',
+    (root: string, entered: string, completed: string) => [
+      'pause-after-read',
+      root,
+      'unused',
+      'unused',
+      entered,
+      completed,
+      '',
+      'unused',
+    ],
+    'Pause-after-read fixture requires read and release markers',
+  ],
+] as const)(
+  'fixture rejects %s before acquiring',
+  async (_label, buildArgs, expectedError) => {
+    const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-fixture-args-'))
+    const entered = join(root, 'entered')
+    const completed = join(root, 'completed')
+    const child = startWriter(buildArgs(root, entered, completed))
+    try {
+      const outcome = await child.exited
+      const { stderr } = child.output()
+      expect(outcome.code).not.toBe(0)
+      expect(stderr).toContain(expectedError)
+      expect(existsSync(entered)).toBe(false)
+      expect(existsSync(join(root, 'settings.json.lock'))).toBe(false)
+    } finally {
+      await terminateChild(child)
+      rmSync(root, { recursive: true, force: true })
+    }
+  },
+  TEST_TIMEOUT_MS,
+)
+
+test('keeps an operation error primary when lock release also fails', async () => {
+  const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-release-error-'))
+  const settingsPath = join(root, 'settings.json')
+  try {
+    const { withSettingsFileTransactionSync } = await import(
+      './settingsFileTransaction.js'
+    )
+    expect(() =>
+      withSettingsFileTransactionSync(settingsPath, targetPath => {
+        const lockPath = `${targetPath}.lock`
+        rmSync(lockPath, { recursive: true, force: true })
+        mkdirSync(lockPath)
+        throw new Error('primary operation failure')
+      }),
+    ).toThrow('primary operation failure')
+  } finally {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
 test('reports transaction failures with operation-neutral context', async () => {
   await withIsolatedUserSettings((_root, settingsPath) => {
     mkdirSync(settingsPath)
@@ -564,7 +647,6 @@ test(
       expect(timedResult.ok).toBe(false)
       expect(timedResult.error).toContain('Timed out after 2000ms')
       expect(elapsedMs).toBeGreaterThanOrEqual(1_800)
-      expect(elapsedMs).toBeLessThan(3_500)
       expect(JSON.parse(readFileSync(settingsPath, 'utf8'))).toEqual({})
 
       writeFileSync(releaseHolder, '')
@@ -877,7 +959,7 @@ test('marks the requested logical alias after publishing to its physical target'
   }
 })
 
-test('local settings still arrange the existing global gitignore rule', () => {
+test('repository settings sources arrange their global gitignore rules', () => {
   const root = mkdtempSync(join(tmpdir(), 'openclaude-settings-gitignore-'))
   const project = join(root, 'project')
   const previousOriginalCwd = getOriginalCwd()
@@ -897,12 +979,21 @@ test('local settings still arrange the existing global gitignore rule', () => {
         env: { LOCAL: 'yes' },
       }),
     ).toEqual({ error: null })
+    expect(
+      updateSettingsForSource('projectSettings', {
+        env: { PROJECT: 'yes' },
+      }),
+    ).toEqual({ error: null })
     expect(addRule).toHaveBeenCalledWith(
       '.openclaude/settings.local.json',
       project,
     )
     expect(addRule).toHaveBeenCalledWith(
       '.openclaude/settings.local.json.lock*',
+      project,
+    )
+    expect(addRule).toHaveBeenCalledWith(
+      '.openclaude/settings.json.lock*',
       project,
     )
   } finally {

--- a/src/utils/settings/settings.transaction.test.ts
+++ b/src/utils/settings/settings.transaction.test.ts
@@ -1014,6 +1014,7 @@ test(
         RECOVERED_AFTER_INCOMPLETE_CLAIM: 'yes',
       })
       expect(existsSync(`${settingsPath}.lock`)).toBe(false)
+      // Pin the abandoned claim: reaping pending paths could race a paused creator.
       expect(
         readdirSync(root).filter(name =>
           name.startsWith('settings.json.lock.pending.'),

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -44,6 +44,7 @@ import {
   setCachedSettingsForSource,
   setSessionSettingsCache,
 } from './settingsCache.js'
+import { withSettingsFileTransactionSync } from './settingsFileTransaction.js'
 import { type SettingsJson, SettingsSchema } from './types.js'
 import {
   filterInvalidModelPricing,
@@ -439,79 +440,72 @@ export function updateSettingsForSource(
   }
 
   try {
-    getFsImplementation().mkdirSync(dirname(filePath))
+    const validationError = withSettingsFileTransactionSync(
+      filePath,
+      targetPath => {
+        // The transaction merge base must bypass both process-local settings
+        // caches so a peer's completed update cannot be overwritten.
+        let existingSettings = parseSettingsFileUncached(targetPath).settings
 
-    // Try to get existing settings with validation. Bypass the per-source
-    // cache — mergeWith below mutates its target (including nested refs),
-    // and mutating the cached object would leak unpersisted state if the
-    // write fails before resetSettingsCache().
-    let existingSettings = getSettingsForSourceUncached(source)
-
-    // If validation failed, check if file exists with a JSON syntax error
-    if (!existingSettings) {
-      let content: string | null = null
-      try {
-        content = readFileSync(filePath)
-      } catch (e) {
-        if (!isENOENT(e)) {
-          throw e
-        }
-        // File doesn't exist — fall through to merge with empty settings
-      }
-      if (content !== null) {
-        const rawData = safeParseJSON(content)
-        if (rawData === null) {
-          // JSON syntax error - return validation error instead of overwriting
-          // safeParseJSON will already log the error, so we'll just return the error here
-          return {
-            error: new Error(
-              `Invalid JSON syntax in settings file at ${filePath}`,
-            ),
+        // If validation failed, check if the physical file has a JSON syntax error.
+        if (!existingSettings) {
+          let content: string | null = null
+          try {
+            content = readFileSync(targetPath)
+          } catch (e) {
+            if (!isENOENT(e)) throw e
+            // File doesn't exist — fall through to merge with empty settings.
+          }
+          if (content !== null) {
+            const rawData = safeParseJSON(content)
+            if (rawData === null) {
+              return new Error(
+                `Invalid JSON syntax in settings file at ${filePath}`,
+              )
+            }
+            if (rawData && typeof rawData === 'object') {
+              existingSettings = rawData as SettingsJson
+              logForDebugging(
+                `Using raw settings from ${filePath} due to validation failure`,
+              )
+            }
           }
         }
-        if (rawData && typeof rawData === 'object') {
-          existingSettings = rawData as SettingsJson
-          logForDebugging(
-            `Using raw settings from ${filePath} due to validation failure`,
-          )
-        }
-      }
-    }
 
-    const updatedSettings = mergeWith(
-      existingSettings || {},
-      settings,
-      (
-        _objValue: unknown,
-        srcValue: unknown,
-        key: string | number | symbol,
-        object: Record<string | number | symbol, unknown>,
-      ) => {
-        // Handle undefined as deletion
-        if (srcValue === undefined && object && typeof key === 'string') {
-          delete object[key]
-          return undefined
-        }
-        // For arrays, always replace with the provided array
-        // This puts the responsibility on the caller to compute the desired final state
-        if (Array.isArray(srcValue)) {
-          return srcValue
-        }
-        // For non-arrays, let lodash handle the default merge behavior
-        return undefined
+        const updatedSettings = mergeWith(
+          existingSettings || {},
+          settings,
+          (
+            _objValue: unknown,
+            srcValue: unknown,
+            key: string | number | symbol,
+            object: Record<string | number | symbol, unknown>,
+          ) => {
+            // Handle undefined as deletion
+            if (srcValue === undefined && object && typeof key === 'string') {
+              delete object[key]
+              return undefined
+            }
+            // For arrays, always replace with the provided array
+            // This puts the responsibility on the caller to compute the desired final state
+            if (Array.isArray(srcValue)) {
+              return srcValue
+            }
+            // For non-arrays, let lodash handle the default merge behavior
+            return undefined
+          },
+        )
+
+        writeFileSyncAndFlush_DEPRECATED(
+          targetPath,
+          jsonStringify(updatedSettings, null, 2) + '\n',
+        )
+        markInternalWrite(filePath)
+        resetSettingsCache()
+        return null
       },
     )
-
-    // Mark this as an internal write before writing the file
-    markInternalWrite(filePath)
-
-    writeFileSyncAndFlush_DEPRECATED(
-      filePath,
-      jsonStringify(updatedSettings, null, 2) + '\n',
-    )
-
-    // Invalidate the session cache since settings have been updated
-    resetSettingsCache()
+    if (validationError) return { error: validationError }
 
     if (source === 'localSettings') {
       // Okay to add to gitignore async without awaiting

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -515,9 +515,7 @@ export function updateSettingsForSource(
       )
     }
   } catch (e) {
-    const error = new Error(
-      `Failed to read raw settings from ${filePath}: ${e}`,
-    )
+    const error = new Error(`Failed to update settings at ${filePath}: ${e}`)
     logError(error)
     return { error }
   }

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -521,8 +521,11 @@ export function updateSettingsForSource(
 
     if (source === 'localSettings') {
       // Okay to add to gitignore async without awaiting
+      const relativePath =
+        getRelativeSettingsFilePathForSource('localSettings')
+      void addFileGlobRuleToGitignore(relativePath, getOriginalCwd())
       void addFileGlobRuleToGitignore(
-        getRelativeSettingsFilePathForSource('localSettings'),
+        `${relativePath}.lock*`,
         getOriginalCwd(),
       )
     }

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -519,11 +519,12 @@ export function updateSettingsForSource(
     )
     if (validationError) return { error: validationError }
 
-    if (source === 'localSettings') {
+    if (source === 'localSettings' || source === 'projectSettings') {
       // Okay to add to gitignore async without awaiting
-      const relativePath =
-        getRelativeSettingsFilePathForSource('localSettings')
-      void addFileGlobRuleToGitignore(relativePath, getOriginalCwd())
+      const relativePath = getRelativeSettingsFilePathForSource(source)
+      if (source === 'localSettings') {
+        void addFileGlobRuleToGitignore(relativePath, getOriginalCwd())
+      }
       void addFileGlobRuleToGitignore(
         `${relativePath}.lock*`,
         getOriginalCwd(),

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -19,9 +19,10 @@ import { readFileSync } from '../fileRead.js'
 import { getFsImplementation, safeResolvePath } from '../fsOperations.js'
 import { addFileGlobRuleToGitignore } from '../git/gitignore.js'
 import { safeParseJSON } from '../json.js'
+import { stripBOM } from '../jsonRead.js'
 import { logError } from '../log.js'
 import { getPlatform } from '../platform.js'
-import { clone, jsonStringify } from '../slowOperations.js'
+import { clone, jsonParse, jsonStringify } from '../slowOperations.js'
 import { profileCheckpoint } from '../startupProfiler.js'
 import {
   type EditableSettingSource,
@@ -447,7 +448,8 @@ export function updateSettingsForSource(
         // caches so a peer's completed update cannot be overwritten.
         let existingSettings = parseSettingsFileUncached(targetPath).settings
 
-        // If validation failed, check if the physical file has a JSON syntax error.
+        // If validation failed, distinguish syntax errors from schema-invalid
+        // objects whose unknown fields still need to survive the merge.
         if (!existingSettings) {
           let content: string | null = null
           try {
@@ -457,18 +459,28 @@ export function updateSettingsForSource(
             // File doesn't exist — fall through to merge with empty settings.
           }
           if (content !== null) {
-            const rawData = safeParseJSON(content)
-            if (rawData === null) {
+            let rawData: unknown
+            try {
+              rawData = jsonParse(stripBOM(content))
+            } catch (parseError) {
+              logError(parseError)
               return new Error(
                 `Invalid JSON syntax in settings file at ${filePath}`,
               )
             }
-            if (rawData && typeof rawData === 'object') {
-              existingSettings = rawData as SettingsJson
-              logForDebugging(
-                `Using raw settings from ${filePath} due to validation failure`,
+            if (
+              rawData === null ||
+              typeof rawData !== 'object' ||
+              Array.isArray(rawData)
+            ) {
+              return new Error(
+                `Invalid settings document at ${filePath}: expected a JSON object`,
               )
             }
+            existingSettings = rawData as SettingsJson
+            logForDebugging(
+              `Using raw settings from ${filePath} due to validation failure`,
+            )
           }
         }
 

--- a/src/utils/settings/settingsFileTransaction.ts
+++ b/src/utils/settings/settingsFileTransaction.ts
@@ -298,22 +298,21 @@ export function withSettingsFileTransactionSync<T>(
   const targetPath = resolveSettingsMutationTarget(requestedPath)
   getFsImplementation().mkdirSync(dirname(targetPath))
   const release = acquireSettingsLock(targetPath)
-  let operationFailed = false
+  let result: T
   try {
-    return operation(targetPath)
-  } catch (error) {
-    operationFailed = true
-    throw error
-  } finally {
+    result = operation(targetPath)
+  } catch (operationError) {
     try {
       release()
     } catch (releaseError) {
-      if (!operationFailed) throw releaseError
       logForDebugging(`Settings lock release failed: ${releaseError}`, {
         level: 'error',
       })
     }
+    throw operationError
   }
+  release()
+  return result
 }
 
 /** Replace a complete settings document using the shared transaction identity. */

--- a/src/utils/settings/settingsFileTransaction.ts
+++ b/src/utils/settings/settingsFileTransaction.ts
@@ -1,4 +1,11 @@
-import { dirname, resolve } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import {
+  mkdirSync as mkdirExclusiveSync,
+  renameSync as renameLockSync,
+  rmSync as removeLockSync,
+} from 'node:fs'
+import { hostname } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
 import { logForDebugging } from '../debug.js'
 import { getErrnoCode } from '../errors.js'
 import { writeFileSyncAndFlush_DEPRECATED } from '../file.js'
@@ -6,16 +13,226 @@ import {
   getFsImplementation,
   resolveDeepestExistingAncestorSync,
 } from '../fsOperations.js'
-import * as lockfile from '../lockfile.js'
 import { markInternalWrite } from './internalWrites.js'
 import { resetSettingsCache } from './settingsCache.js'
 
 const SETTINGS_LOCK_RETRY_MS = 25
 const SETTINGS_LOCK_CONTENTION_LOG_MS = 100
 const SETTINGS_LOCK_WAIT_MS = 2_000
-const SETTINGS_LOCK_STALE_MS = 30_000
-const SETTINGS_LOCK_UPDATE_MS = 5_000
+const SETTINGS_LOCK_HOST = hostname()
+const SETTINGS_LOCK_OWNER_FILE = 'owner.json'
 const waitBuffer = new Int32Array(new SharedArrayBuffer(4))
+
+type SettingsLockIdentity = {
+  version: 1
+  host: string
+  pid: number
+  token: string
+}
+
+type SettingsLockIdentityRead =
+  | { state: 'missing' }
+  | { state: 'invalid' }
+  | { state: 'valid'; identity: SettingsLockIdentity }
+
+function sameIdentity(
+  left: SettingsLockIdentity,
+  right: SettingsLockIdentity,
+): boolean {
+  return (
+    left.version === right.version &&
+    left.host === right.host &&
+    left.pid === right.pid &&
+    left.token === right.token
+  )
+}
+
+function readLockIdentity(lockPath: string): SettingsLockIdentityRead {
+  let raw: string
+  try {
+    raw = getFsImplementation().readFileSync(
+      join(lockPath, SETTINGS_LOCK_OWNER_FILE),
+      { encoding: 'utf8' },
+    )
+  } catch (error) {
+    if (getErrnoCode(error) !== 'ENOENT') return { state: 'invalid' }
+    try {
+      getFsImplementation().lstatSync(lockPath)
+      return { state: 'invalid' }
+    } catch (lockError) {
+      return getErrnoCode(lockError) === 'ENOENT'
+        ? { state: 'missing' }
+        : { state: 'invalid' }
+    }
+  }
+
+  try {
+    const candidate = JSON.parse(raw) as Partial<SettingsLockIdentity>
+    if (
+      candidate.version !== 1 ||
+      typeof candidate.host !== 'string' ||
+      candidate.host.length === 0 ||
+      candidate.host.length > 255 ||
+      !Number.isSafeInteger(candidate.pid) ||
+      (candidate.pid ?? 0) <= 0 ||
+      typeof candidate.token !== 'string' ||
+      !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+        candidate.token,
+      )
+    ) {
+      return { state: 'invalid' }
+    }
+    return {
+      state: 'valid',
+      identity: candidate as SettingsLockIdentity,
+    }
+  } catch {
+    return { state: 'invalid' }
+  }
+}
+
+function createLockIdentity(): SettingsLockIdentity {
+  return {
+    version: 1,
+    host: SETTINGS_LOCK_HOST,
+    pid: process.pid,
+    token: randomUUID(),
+  }
+}
+
+function isIdentityOwnerAlive(identity: SettingsLockIdentity): boolean {
+  // A different host may share this filesystem, but its process namespace is
+  // not observable here. Never reclaim that ownership on local PID evidence.
+  if (identity.host !== SETTINGS_LOCK_HOST) return true
+  try {
+    process.kill(identity.pid, 0)
+    return true
+  } catch (error) {
+    return getErrnoCode(error) !== 'ESRCH'
+  }
+}
+
+function tryCreateOwnedLock(
+  lockPath: string,
+  owner: SettingsLockIdentity,
+): boolean {
+  try {
+    mkdirExclusiveSync(lockPath, { mode: 0o700 })
+  } catch (error) {
+    if (getErrnoCode(error) === 'EEXIST') return false
+    try {
+      getFsImplementation().lstatSync(lockPath)
+      return false
+    } catch (statError) {
+      if (getErrnoCode(statError) !== 'ENOENT') throw statError
+      throw error
+    }
+  }
+
+  try {
+    writeFileSyncAndFlush_DEPRECATED(
+      join(lockPath, SETTINGS_LOCK_OWNER_FILE),
+      JSON.stringify(owner),
+      { encoding: 'utf8', mode: 0o600 },
+    )
+    return true
+  } catch (error) {
+    removeLockSync(lockPath, { recursive: true, force: true })
+    throw error
+  }
+}
+
+function recoveredLockPath(
+  lockPath: string,
+  owner: SettingsLockIdentity,
+): string {
+  return `${lockPath}.recovered.${owner.pid}.${owner.token}`
+}
+
+function tryRecoverDeadLock(
+  lockPath: string,
+  expectedOwner: SettingsLockIdentity,
+): boolean {
+  const recoveredPath = recoveredLockPath(lockPath, expectedOwner)
+  try {
+    renameLockSync(lockPath, recoveredPath)
+  } catch (error) {
+    const code = getErrnoCode(error)
+    if (code === 'ENOENT' || code === 'EEXIST' || code === 'ENOTEMPTY') {
+      return false
+    }
+    if (code === 'EPERM') {
+      try {
+        getFsImplementation().lstatSync(recoveredPath)
+        return false
+      } catch (statError) {
+        if (getErrnoCode(statError) !== 'ENOENT') throw statError
+      }
+    }
+    throw error
+  }
+
+  const recoveredOwner = readLockIdentity(recoveredPath)
+  if (
+    recoveredOwner.state !== 'valid' ||
+    !sameIdentity(recoveredOwner.identity, expectedOwner)
+  ) {
+    throw Object.assign(
+      new Error('Settings file lock changed during dead-owner recovery'),
+      { code: 'ECOMPROMISED' },
+    )
+  }
+
+  // Keep the deterministic non-empty tombstone. A contender that read this
+  // dead owner before the rename can only target the same path, so rename will
+  // refuse to replace the tombstone instead of moving a successor's live lock.
+  logForDebugging(
+    `Recovered settings file lock from exited process ${expectedOwner.pid}`,
+    { level: 'warn' },
+  )
+  return true
+}
+
+function tryAcquireSettingsLock(
+  lockPath: string,
+  owner: SettingsLockIdentity,
+): boolean {
+  if (tryCreateOwnedLock(lockPath, owner)) return true
+
+  const currentOwner = readLockIdentity(lockPath)
+  if (
+    currentOwner.state !== 'valid' ||
+    isIdentityOwnerAlive(currentOwner.identity)
+  ) {
+    return false
+  }
+
+  if (!tryRecoverDeadLock(lockPath, currentOwner.identity)) return false
+  return tryCreateOwnedLock(lockPath, owner)
+}
+
+function releaseOwnedLock(
+  lockPath: string,
+  owner: SettingsLockIdentity,
+): void {
+  const currentOwner = readLockIdentity(lockPath)
+  if (
+    currentOwner.state !== 'valid' ||
+    !sameIdentity(currentOwner.identity, owner)
+  ) {
+    throw Object.assign(
+      new Error('Settings file lock ownership changed before release'),
+      { code: 'ECOMPROMISED' },
+    )
+  }
+  removeLockSync(lockPath, { recursive: true })
+}
+
+function describeCurrentOwner(lockPath: string): string {
+  const currentOwner = readLockIdentity(lockPath)
+  if (currentOwner.state !== 'valid') return 'an unknown owner'
+  return `${currentOwner.identity.host} process ${currentOwner.identity.pid}`
+}
 
 function resolveSettingsMutationTarget(requestedPath: string): string {
   const fs = getFsImplementation()
@@ -31,56 +248,41 @@ function resolveSettingsMutationTarget(requestedPath: string): string {
 }
 
 function acquireSettingsLock(targetPath: string): () => void {
+  const lockPath = `${targetPath}.lock`
+  const owner = createLockIdentity()
   const startedAt = performance.now()
   const deadline = startedAt + SETTINGS_LOCK_WAIT_MS
   let reportedContention = false
+
   while (true) {
-    try {
-      return lockfile.lockSync(targetPath, {
-        lockfilePath: `${targetPath}.lock`,
-        realpath: false,
-        stale: SETTINGS_LOCK_STALE_MS,
-        update: SETTINGS_LOCK_UPDATE_MS,
-        onCompromised: error => {
-          // The compromise callback runs from an asynchronous heartbeat and
-          // cannot interrupt this helper's synchronous operation. Throwing here
-          // would become an unhandled exception, so log deliberately; a local
-          // filesystem operation exceeding the stale window is out of contract.
-          logForDebugging(`Settings file lock compromised: ${error}`, {
-            level: 'error',
-          })
-        },
-      })
-    } catch (error) {
-      if (getErrnoCode(error) !== 'ELOCKED') throw error
-      const now = performance.now()
-      const elapsed = now - startedAt
-      if (
-        !reportedContention &&
-        elapsed >= SETTINGS_LOCK_CONTENTION_LOG_MS
-      ) {
-        reportedContention = true
-        logForDebugging(
-          `Settings file lock contention has lasted ${Math.round(elapsed)}ms`,
-          { level: 'warn' },
-        )
-      }
-      const remaining = deadline - now
-      if (remaining <= 0) {
-        throw Object.assign(
-          new Error(
-            `Timed out after ${SETTINGS_LOCK_WAIT_MS}ms waiting for the settings file lock`,
-          ),
-          { code: 'ELOCKED' },
-        )
-      }
-      Atomics.wait(
-        waitBuffer,
-        0,
-        0,
-        Math.min(SETTINGS_LOCK_RETRY_MS, remaining),
+    if (tryAcquireSettingsLock(lockPath, owner)) {
+      return () => releaseOwnedLock(lockPath, owner)
+    }
+
+    const now = performance.now()
+    const elapsed = now - startedAt
+    if (!reportedContention && elapsed >= SETTINGS_LOCK_CONTENTION_LOG_MS) {
+      reportedContention = true
+      logForDebugging(
+        `Settings file lock contention has lasted ${Math.round(elapsed)}ms`,
+        { level: 'warn' },
       )
     }
+    const remaining = deadline - now
+    if (remaining <= 0) {
+      throw Object.assign(
+        new Error(
+          `Timed out after ${SETTINGS_LOCK_WAIT_MS}ms waiting for settings lock ${lockPath}, held by ${describeCurrentOwner(lockPath)}. If that process is known to have exited, remove the lock directory before retrying.`,
+        ),
+        { code: 'ELOCKED' },
+      )
+    }
+    Atomics.wait(
+      waitBuffer,
+      0,
+      0,
+      Math.min(SETTINGS_LOCK_RETRY_MS, remaining),
+    )
   }
 }
 

--- a/src/utils/settings/settingsFileTransaction.ts
+++ b/src/utils/settings/settingsFileTransaction.ts
@@ -1,0 +1,93 @@
+import { dirname, resolve } from 'node:path'
+import { logForDebugging } from '../debug.js'
+import { getErrnoCode } from '../errors.js'
+import { writeFileSyncAndFlush_DEPRECATED } from '../file.js'
+import {
+  getFsImplementation,
+  resolveDeepestExistingAncestorSync,
+} from '../fsOperations.js'
+import * as lockfile from '../lockfile.js'
+import { markInternalWrite } from './internalWrites.js'
+import { resetSettingsCache } from './settingsCache.js'
+
+const SETTINGS_LOCK_RETRY_MS = 25
+const SETTINGS_LOCK_WAIT_MS = 2_000
+const SETTINGS_LOCK_STALE_MS = 30_000
+const SETTINGS_LOCK_UPDATE_MS = 5_000
+const waitBuffer = new Int32Array(new SharedArrayBuffer(4))
+
+function resolveSettingsMutationTarget(requestedPath: string): string {
+  const fs = getFsImplementation()
+  const absolutePath = resolve(requestedPath)
+  try {
+    return fs.realpathSync(absolutePath)
+  } catch (error) {
+    if (getErrnoCode(error) !== 'ENOENT') throw error
+    return (
+      resolveDeepestExistingAncestorSync(fs, absolutePath) ?? absolutePath
+    )
+  }
+}
+
+function acquireSettingsLock(targetPath: string): () => void {
+  const deadline = performance.now() + SETTINGS_LOCK_WAIT_MS
+  while (true) {
+    try {
+      return lockfile.lockSync(targetPath, {
+        lockfilePath: `${targetPath}.lock`,
+        realpath: false,
+        stale: SETTINGS_LOCK_STALE_MS,
+        update: SETTINGS_LOCK_UPDATE_MS,
+        onCompromised: error => {
+          logForDebugging(`Settings file lock compromised: ${error}`, {
+            level: 'error',
+          })
+        },
+      })
+    } catch (error) {
+      if (getErrnoCode(error) !== 'ELOCKED') throw error
+      const remaining = deadline - performance.now()
+      if (remaining <= 0) {
+        throw Object.assign(
+          new Error(
+            `Timed out after ${SETTINGS_LOCK_WAIT_MS}ms waiting for the settings file lock`,
+          ),
+          { code: 'ELOCKED' },
+        )
+      }
+      Atomics.wait(
+        waitBuffer,
+        0,
+        0,
+        Math.min(SETTINGS_LOCK_RETRY_MS, remaining),
+      )
+    }
+  }
+}
+
+/** Run one synchronous settings-file operation under its physical-target lock. */
+export function withSettingsFileTransactionSync<T>(
+  requestedPath: string,
+  operation: (targetPath: string) => T,
+): T {
+  const targetPath = resolveSettingsMutationTarget(requestedPath)
+  getFsImplementation().mkdirSync(dirname(targetPath))
+  const release = acquireSettingsLock(targetPath)
+  try {
+    return operation(targetPath)
+  } finally {
+    release()
+  }
+}
+
+/** Replace a complete settings document using the shared transaction identity. */
+export function replaceSettingsFileSync(
+  requestedPath: string,
+  content: string,
+): void {
+  withSettingsFileTransactionSync(requestedPath, targetPath => {
+    writeFileSyncAndFlush_DEPRECATED(targetPath, content)
+    markInternalWrite(requestedPath)
+    resetSettingsCache()
+  })
+}

--- a/src/utils/settings/settingsFileTransaction.ts
+++ b/src/utils/settings/settingsFileTransaction.ts
@@ -11,6 +11,7 @@ import { markInternalWrite } from './internalWrites.js'
 import { resetSettingsCache } from './settingsCache.js'
 
 const SETTINGS_LOCK_RETRY_MS = 25
+const SETTINGS_LOCK_CONTENTION_LOG_MS = 100
 const SETTINGS_LOCK_WAIT_MS = 2_000
 const SETTINGS_LOCK_STALE_MS = 30_000
 const SETTINGS_LOCK_UPDATE_MS = 5_000
@@ -30,7 +31,9 @@ function resolveSettingsMutationTarget(requestedPath: string): string {
 }
 
 function acquireSettingsLock(targetPath: string): () => void {
-  const deadline = performance.now() + SETTINGS_LOCK_WAIT_MS
+  const startedAt = performance.now()
+  const deadline = startedAt + SETTINGS_LOCK_WAIT_MS
+  let reportedContention = false
   while (true) {
     try {
       return lockfile.lockSync(targetPath, {
@@ -39,6 +42,10 @@ function acquireSettingsLock(targetPath: string): () => void {
         stale: SETTINGS_LOCK_STALE_MS,
         update: SETTINGS_LOCK_UPDATE_MS,
         onCompromised: error => {
+          // The compromise callback runs from an asynchronous heartbeat and
+          // cannot interrupt this helper's synchronous operation. Throwing here
+          // would become an unhandled exception, so log deliberately; a local
+          // filesystem operation exceeding the stale window is out of contract.
           logForDebugging(`Settings file lock compromised: ${error}`, {
             level: 'error',
           })
@@ -46,7 +53,19 @@ function acquireSettingsLock(targetPath: string): () => void {
       })
     } catch (error) {
       if (getErrnoCode(error) !== 'ELOCKED') throw error
-      const remaining = deadline - performance.now()
+      const now = performance.now()
+      const elapsed = now - startedAt
+      if (
+        !reportedContention &&
+        elapsed >= SETTINGS_LOCK_CONTENTION_LOG_MS
+      ) {
+        reportedContention = true
+        logForDebugging(
+          `Settings file lock contention has lasted ${Math.round(elapsed)}ms`,
+          { level: 'warn' },
+        )
+      }
+      const remaining = deadline - now
       if (remaining <= 0) {
         throw Object.assign(
           new Error(
@@ -65,7 +84,11 @@ function acquireSettingsLock(targetPath: string): () => void {
   }
 }
 
-/** Run one synchronous settings-file operation under its physical-target lock. */
+/**
+ * Run one synchronous settings-file operation under its physical-target lock.
+ * Calls for the same target must not be nested; contention remains bounded by
+ * the normal acquisition deadline.
+ */
 export function withSettingsFileTransactionSync<T>(
   requestedPath: string,
   operation: (targetPath: string) => T,

--- a/src/utils/settings/settingsFileTransaction.ts
+++ b/src/utils/settings/settingsFileTransaction.ts
@@ -1,6 +1,8 @@
 import { randomUUID } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
 import {
   mkdirSync as mkdirExclusiveSync,
+  readFileSync as readProcessFileSync,
   renameSync as renameLockSync,
   rmSync as removeLockSync,
 } from 'node:fs'
@@ -22,13 +24,24 @@ const SETTINGS_LOCK_WAIT_MS = 2_000
 const SETTINGS_LOCK_HOST = hostname()
 const SETTINGS_LOCK_OWNER_FILE = 'owner.json'
 const waitBuffer = new Int32Array(new SharedArrayBuffer(4))
+let settingsLockProcessStartId: string | undefined
 
-type SettingsLockIdentity = {
+type SettingsLockIdentityV1 = {
   version: 1
   host: string
   pid: number
   token: string
 }
+
+type SettingsLockIdentityV2 = {
+  version: 2
+  host: string
+  pid: number
+  token: string
+  processStartId: string
+}
+
+type SettingsLockIdentity = SettingsLockIdentityV1 | SettingsLockIdentityV2
 
 type SettingsLockIdentityRead =
   | { state: 'missing' }
@@ -39,12 +52,19 @@ function sameIdentity(
   left: SettingsLockIdentity,
   right: SettingsLockIdentity,
 ): boolean {
-  return (
+  if (
     left.version === right.version &&
     left.host === right.host &&
     left.pid === right.pid &&
     left.token === right.token
-  )
+  ) {
+    return (
+      left.version === 1 ||
+      (right.version === 2 &&
+        left.processStartId === right.processStartId)
+    )
+  }
+  return false
 }
 
 function readLockIdentity(lockPath: string): SettingsLockIdentityRead {
@@ -67,14 +87,15 @@ function readLockIdentity(lockPath: string): SettingsLockIdentityRead {
   }
 
   try {
-    const candidate = JSON.parse(raw) as Partial<SettingsLockIdentity>
+    const candidate = JSON.parse(raw) as Record<string, unknown>
     if (
-      candidate.version !== 1 ||
+      (candidate.version !== 1 && candidate.version !== 2) ||
       typeof candidate.host !== 'string' ||
       candidate.host.length === 0 ||
       candidate.host.length > 255 ||
+      typeof candidate.pid !== 'number' ||
       !Number.isSafeInteger(candidate.pid) ||
-      (candidate.pid ?? 0) <= 0 ||
+      candidate.pid <= 0 ||
       typeof candidate.token !== 'string' ||
       !/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
         candidate.token,
@@ -82,34 +103,159 @@ function readLockIdentity(lockPath: string): SettingsLockIdentityRead {
     ) {
       return { state: 'invalid' }
     }
+    if (
+      candidate.version === 2 &&
+      (typeof candidate.processStartId !== 'string' ||
+        candidate.processStartId.length === 0 ||
+        candidate.processStartId.length > 512)
+    ) {
+      return { state: 'invalid' }
+    }
     return {
       state: 'valid',
-      identity: candidate as SettingsLockIdentity,
+      identity:
+        candidate.version === 1
+          ? {
+              version: 1,
+              host: candidate.host,
+              pid: candidate.pid,
+              token: candidate.token,
+            }
+          : {
+              version: 2,
+              host: candidate.host,
+              pid: candidate.pid,
+              token: candidate.token,
+              processStartId: candidate.processStartId as string,
+            },
     }
   } catch {
     return { state: 'invalid' }
   }
 }
 
+function readLinuxProcessStartId(pid: number): string | null {
+  try {
+    const bootId = readProcessFileSync(
+      '/proc/sys/kernel/random/boot_id',
+      'utf8',
+    ).trim()
+    const stat = readProcessFileSync(`/proc/${pid}/stat`, 'utf8')
+    const commandEnd = stat.lastIndexOf(')')
+    if (commandEnd < 0) return null
+    const fields = stat.slice(commandEnd + 1).trim().split(/\s+/)
+    const startTicks = fields[19]
+    if (
+      !/^[0-9a-f-]{36}$/i.test(bootId) ||
+      startTicks === undefined ||
+      !/^\d+$/.test(startTicks)
+    ) {
+      return null
+    }
+    return `linux:${bootId}:${startTicks}`
+  } catch {
+    return null
+  }
+}
+
+function readCommandProcessStartId(
+  command: string,
+  args: string[],
+  prefix: string,
+): string | null {
+  try {
+    const result = spawnSync(command, args, {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        LANG: 'C',
+        LC_ALL: 'C',
+        TZ: 'UTC',
+      },
+      timeout: 1_000,
+      windowsHide: true,
+    })
+    if (result.error || result.status !== 0) return null
+    const value = result.stdout.trim().replace(/\s+/g, ' ')
+    return value.length > 0 && value.length <= 480
+      ? `${prefix}:${value}`
+      : null
+  } catch {
+    return null
+  }
+}
+
+function readProcessStartId(pid: number): string | null {
+  if (process.platform === 'linux') return readLinuxProcessStartId(pid)
+  if (process.platform === 'win32') {
+    return readCommandProcessStartId(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `(Get-Process -Id ${pid} -ErrorAction Stop).StartTime.ToUniversalTime().Ticks`,
+      ],
+      'windows',
+    )
+  }
+  return readCommandProcessStartId(
+    'ps',
+    ['-p', String(pid), '-o', 'lstart='],
+    'posix',
+  )
+}
+
+function currentProcessStartId(): string | null {
+  if (settingsLockProcessStartId !== undefined) {
+    return settingsLockProcessStartId
+  }
+  const processStartId = readProcessStartId(process.pid)
+  if (processStartId !== null) settingsLockProcessStartId = processStartId
+  return processStartId
+}
+
 function createLockIdentity(): SettingsLockIdentity {
-  return {
-    version: 1,
+  const common = {
     host: SETTINGS_LOCK_HOST,
     pid: process.pid,
     token: randomUUID(),
   }
+  const processStartId = currentProcessStartId()
+  if (processStartId === null) {
+    throw Object.assign(
+      new Error('Unable to determine process identity for settings lock'),
+      { code: 'EIDENTITY' },
+    )
+  }
+  return { version: 2, ...common, processStartId }
 }
 
-function isIdentityOwnerAlive(identity: SettingsLockIdentity): boolean {
+function isIdentityOwnerAlive(
+  identity: SettingsLockIdentity,
+  processStartIds: Map<string, string | null>,
+): boolean {
   // A different host may share this filesystem, but its process namespace is
   // not observable here. Never reclaim that ownership on local PID evidence.
   if (identity.host !== SETTINGS_LOCK_HOST) return true
   try {
     process.kill(identity.pid, 0)
-    return true
   } catch (error) {
-    return getErrnoCode(error) !== 'ESRCH'
+    if (getErrnoCode(error) === 'ESRCH') return false
   }
+  if (identity.version === 1) return true
+  const cacheKey = `${identity.host}:${identity.pid}:${identity.token}:${identity.processStartId}`
+  let currentProcessStartId: string | null
+  if (processStartIds.has(cacheKey)) {
+    currentProcessStartId = processStartIds.get(cacheKey) ?? null
+  } else {
+    currentProcessStartId = readProcessStartId(identity.pid)
+    processStartIds.set(cacheKey, currentProcessStartId)
+  }
+  return (
+    currentProcessStartId === null ||
+    currentProcessStartId === identity.processStartId
+  )
 }
 
 function pendingLockPath(
@@ -229,13 +375,14 @@ function tryRecoverDeadLock(
 function tryAcquireSettingsLock(
   lockPath: string,
   pendingPath: string,
+  processStartIds: Map<string, string | null>,
 ): boolean {
   if (tryPublishPendingLock(pendingPath, lockPath)) return true
 
   const currentOwner = readLockIdentity(lockPath)
   if (
     currentOwner.state !== 'valid' ||
-    isIdentityOwnerAlive(currentOwner.identity)
+    isIdentityOwnerAlive(currentOwner.identity, processStartIds)
   ) {
     return false
   }
@@ -288,10 +435,11 @@ function acquireSettingsLock(targetPath: string): () => void {
   const deadline = startedAt + SETTINGS_LOCK_WAIT_MS
   let reportedContention = false
   let acquired = false
+  const processStartIds = new Map<string, string | null>()
 
   try {
     while (true) {
-      if (tryAcquireSettingsLock(lockPath, pendingPath)) {
+      if (tryAcquireSettingsLock(lockPath, pendingPath, processStartIds)) {
         acquired = true
         return () => releaseOwnedLock(lockPath, owner)
       }

--- a/src/utils/settings/settingsFileTransaction.ts
+++ b/src/utils/settings/settingsFileTransaction.ts
@@ -112,32 +112,65 @@ function isIdentityOwnerAlive(identity: SettingsLockIdentity): boolean {
   }
 }
 
-function tryCreateOwnedLock(
+function pendingLockPath(
   lockPath: string,
   owner: SettingsLockIdentity,
-): boolean {
-  try {
-    mkdirExclusiveSync(lockPath, { mode: 0o700 })
-  } catch (error) {
-    if (getErrnoCode(error) === 'EEXIST') return false
-    try {
-      getFsImplementation().lstatSync(lockPath)
-      return false
-    } catch (statError) {
-      if (getErrnoCode(statError) !== 'ENOENT') throw statError
-      throw error
-    }
-  }
+): string {
+  return `${lockPath}.pending.${owner.pid}.${owner.token}`
+}
 
+function removePendingLock(pendingPath: string): void {
+  try {
+    removeLockSync(pendingPath, { recursive: true, force: true })
+  } catch (error) {
+    logForDebugging(`Pending settings lock cleanup failed: ${error}`, {
+      level: 'error',
+    })
+  }
+}
+
+function preparePendingLock(
+  lockPath: string,
+  owner: SettingsLockIdentity,
+): string {
+  // A crash can leave this private path behind. Its UUID cannot block another
+  // claimant, and removing it later could race a creator paused before publish.
+  const pendingPath = pendingLockPath(lockPath, owner)
+  mkdirExclusiveSync(pendingPath, { mode: 0o700 })
   try {
     writeFileSyncAndFlush_DEPRECATED(
-      join(lockPath, SETTINGS_LOCK_OWNER_FILE),
+      join(pendingPath, SETTINGS_LOCK_OWNER_FILE),
       JSON.stringify(owner),
       { encoding: 'utf8', mode: 0o600 },
     )
+  } catch (error) {
+    removePendingLock(pendingPath)
+    throw error
+  }
+  return pendingPath
+}
+
+function tryPublishPendingLock(
+  pendingPath: string,
+  lockPath: string,
+): boolean {
+  try {
+    renameLockSync(pendingPath, lockPath)
     return true
   } catch (error) {
-    removeLockSync(lockPath, { recursive: true, force: true })
+    const code = getErrnoCode(error)
+    if (code === 'EEXIST' || code === 'ENOTEMPTY' || code === 'EPERM') {
+      try {
+        getFsImplementation().lstatSync(lockPath)
+        return false
+      } catch (statError) {
+        if (getErrnoCode(statError) === 'ENOENT') {
+          // The observed owner released between rename and confirmation.
+          return false
+        }
+        throw statError
+      }
+    }
     throw error
   }
 }
@@ -195,9 +228,9 @@ function tryRecoverDeadLock(
 
 function tryAcquireSettingsLock(
   lockPath: string,
-  owner: SettingsLockIdentity,
+  pendingPath: string,
 ): boolean {
-  if (tryCreateOwnedLock(lockPath, owner)) return true
+  if (tryPublishPendingLock(pendingPath, lockPath)) return true
 
   const currentOwner = readLockIdentity(lockPath)
   if (
@@ -208,7 +241,7 @@ function tryAcquireSettingsLock(
   }
 
   if (!tryRecoverDeadLock(lockPath, currentOwner.identity)) return false
-  return tryCreateOwnedLock(lockPath, owner)
+  return tryPublishPendingLock(pendingPath, lockPath)
 }
 
 function releaseOwnedLock(
@@ -250,39 +283,46 @@ function resolveSettingsMutationTarget(requestedPath: string): string {
 function acquireSettingsLock(targetPath: string): () => void {
   const lockPath = `${targetPath}.lock`
   const owner = createLockIdentity()
+  const pendingPath = preparePendingLock(lockPath, owner)
   const startedAt = performance.now()
   const deadline = startedAt + SETTINGS_LOCK_WAIT_MS
   let reportedContention = false
+  let acquired = false
 
-  while (true) {
-    if (tryAcquireSettingsLock(lockPath, owner)) {
-      return () => releaseOwnedLock(lockPath, owner)
-    }
+  try {
+    while (true) {
+      if (tryAcquireSettingsLock(lockPath, pendingPath)) {
+        acquired = true
+        return () => releaseOwnedLock(lockPath, owner)
+      }
 
-    const now = performance.now()
-    const elapsed = now - startedAt
-    if (!reportedContention && elapsed >= SETTINGS_LOCK_CONTENTION_LOG_MS) {
-      reportedContention = true
-      logForDebugging(
-        `Settings file lock contention has lasted ${Math.round(elapsed)}ms`,
-        { level: 'warn' },
+      const now = performance.now()
+      const elapsed = now - startedAt
+      if (!reportedContention && elapsed >= SETTINGS_LOCK_CONTENTION_LOG_MS) {
+        reportedContention = true
+        logForDebugging(
+          `Settings file lock contention has lasted ${Math.round(elapsed)}ms`,
+          { level: 'warn' },
+        )
+      }
+      const remaining = deadline - now
+      if (remaining <= 0) {
+        throw Object.assign(
+          new Error(
+            `Timed out after ${SETTINGS_LOCK_WAIT_MS}ms waiting for settings lock ${lockPath}, held by ${describeCurrentOwner(lockPath)}. If that process is known to have exited, remove the lock directory before retrying.`,
+          ),
+          { code: 'ELOCKED' },
+        )
+      }
+      Atomics.wait(
+        waitBuffer,
+        0,
+        0,
+        Math.min(SETTINGS_LOCK_RETRY_MS, remaining),
       )
     }
-    const remaining = deadline - now
-    if (remaining <= 0) {
-      throw Object.assign(
-        new Error(
-          `Timed out after ${SETTINGS_LOCK_WAIT_MS}ms waiting for settings lock ${lockPath}, held by ${describeCurrentOwner(lockPath)}. If that process is known to have exited, remove the lock directory before retrying.`,
-        ),
-        { code: 'ELOCKED' },
-      )
-    }
-    Atomics.wait(
-      waitBuffer,
-      0,
-      0,
-      Math.min(SETTINGS_LOCK_RETRY_MS, remaining),
-    )
+  } finally {
+    if (!acquired) removePendingLock(pendingPath)
   }
 }
 

--- a/src/utils/settings/settingsFileTransaction.ts
+++ b/src/utils/settings/settingsFileTransaction.ts
@@ -298,10 +298,21 @@ export function withSettingsFileTransactionSync<T>(
   const targetPath = resolveSettingsMutationTarget(requestedPath)
   getFsImplementation().mkdirSync(dirname(targetPath))
   const release = acquireSettingsLock(targetPath)
+  let operationFailed = false
   try {
     return operation(targetPath)
+  } catch (error) {
+    operationFailed = true
+    throw error
   } finally {
-    release()
+    try {
+      release()
+    } catch (releaseError) {
+      if (!operationFailed) throw releaseError
+      logForDebugging(`Settings lock release failed: ${releaseError}`, {
+        level: 'error',
+      })
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- Serialize the complete settings read-merge-write transaction under one physical-target lock.
- Preserve the synchronous settings API with a bounded contention wait, a fresh post-acquisition read, and symlink-safe publication.
- Route direct user and local settings-sync replacements through the same lock and count only successful settings writes as applied.

## Root cause

Atomic file replacement protected readers from partial output, but it did not serialize the read and merge that preceded publication. Two processes could therefore read the same old settings document, both return success, and have the later publication erase the other process's disjoint patch.

## Reproduction

The regression was reproduced on untouched upstream base `108a4134931b02985e5baa828b5d406ab392a0f8` with:

```bash
bun test src/utils/settings/settings.transaction.test.ts --test-name-pattern "two processes preserve disjoint settings patches during contention"
```

Both subprocess updates reported success, but the final document contained `BASE` and `WRITER_A` while the disjoint `WRITER_B` update was missing. The same test passes with this change.

## Design decision

The implementation considered a fail-fast sync lock, broad async API conversion, and a custom owner/recovery protocol. Fail-fast does not preserve the required ordinary-contention outcome, async conversion would broaden the caller surface, and custom ownership is unnecessary for this focused race.

`proper-lockfile` does not support built-in retries through its synchronous adapter, so the selected design uses a small outer loop that retries only explicit `ELOCKED` contention. It waits in 25 ms intervals with a monotonic two-second deadline; timeout returns a clear settings error, while unrelated filesystem errors propagate immediately.

The helper canonicalizes the physical settings target before acquiring its sibling lock, then performs the fresh disk read, merge, atomic publication, cache invalidation, and release as one synchronous transaction. Publication targets the physical file while internal-write tracking retains the logical settings path, so live parent and direct-file symlink aliases converge on one lock without replacing the symlink.

## Settings sync

Direct user and local settings-file replacements use the same physical-target transaction helper. A failed or timed-out settings replacement is not counted as applied; memory-file processing and later entries retain their existing behavior.

## Scope

This PR does not change:

- provider or model state;
- plugins or marketplaces;
- permissions or sandboxing;
- migrations;
- general UI persistence;
- caller-wide rollback;
- settings-download orchestration;
- read-dependent array or list callers outside the settings layer.

Supersedes #2095 with a clean implementation limited to the original settings transaction race and direct settings-sync integration.

## Testing

- `bun test src/utils/settings/settings.transaction.test.ts` — 11 passed, 0 failed.
- `bun test src/services/settingsSync/settings.transaction.test.ts` — 3 passed, 0 failed.
- Primary two-process regression repeated 20 consecutive times — 20 passed, 0 failed.
- `bun run typecheck` — passed.
- `bun run typecheck:type-tests` — passed; 10 focused type-test files checked.
- `bun run check` — passed.
- `bun run security:pr-scan` — passed; no suspicious additions found.
- `git diff --check upstream/main...HEAD` — passed.

## Process

- `CONTRIBUTING.md` reviewed.
- `AGENTS.md` reviewed.
- No dependency changes.
- No UI changes.
- Screenshots are not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved settings synchronization reliability during concurrent updates.
  - Applied settings updates atomically while keeping cached values consistent.
  - Prevented timed-out, oversized, malformed, or failed writes from being reported as successful.
  - Preserved valid settings and unknown fields when validation fails.
  - Improved handling of file locks, symbolic links, deletions, and array replacements.
  - Reported failed and rejected settings-file writes accurately during synchronization.
  - Added lock files to settings-related ignore rules.

- **Tests**
  - Added comprehensive coverage for concurrent updates, lock contention, file changes, and error recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->