### PR TITLE
fix(api): scope Anthropic attribution to compatible request paths

### DIFF
--- a/src/constants/system.ts
+++ b/src/constants/system.ts
@@ -2,6 +2,7 @@
 
 import { feature } from 'bun:bundle'
 import { getFeatureValue_CACHED_MAY_BE_STALE } from '../services/analytics/growthbook.js'
+import type { AnthropicAttributionPolicy } from '../utils/anthropicAttribution.js'
 import { logForDebugging } from '../utils/debug.js'
 import { isEnvDefinedFalsy } from '../utils/envUtils.js'
 import { getAPIProvider } from '../utils/model/providers.js'
@@ -50,10 +51,10 @@ export function getCLISyspromptPrefix(options?: {
 }
 
 /**
- * Check if attribution header is enabled.
- * Enabled by default, can be disabled via env var or GrowthBook killswitch.
+ * Read the configured attribution preference. Provider and auth policy may
+ * override this when a route requires or forbids the billing block.
  */
-function isAttributionHeaderEnabled(): boolean {
+export function isAttributionHeaderEnabled(): boolean {
   if (isEnvDefinedFalsy(process.env.CLAUDE_CODE_ATTRIBUTION_HEADER)) {
     return false
   }
@@ -63,7 +64,8 @@ function isAttributionHeaderEnabled(): boolean {
 /**
  * Get attribution header for API requests.
  * Returns a header string with cc_version (including fingerprint) and cc_entrypoint.
- * Enabled by default, can be disabled via env var or GrowthBook killswitch.
+ * The caller must resolve provider and auth policy for the effective request
+ * route before calling this function.
  *
  * When NATIVE_CLIENT_ATTESTATION is enabled, includes a `cch=00000` placeholder.
  * Before the request is sent, Bun's native HTTP stack finds this placeholder
@@ -74,8 +76,11 @@ function isAttributionHeaderEnabled(): boolean {
  * We use a placeholder (instead of injecting from Zig) because same-length
  * replacement avoids Content-Length changes and buffer reallocation.
  */
-export function getAttributionHeader(fingerprint: string): string {
-  if (!isAttributionHeaderEnabled()) {
+export function getAttributionHeader(
+  fingerprint: string,
+  policy: AnthropicAttributionPolicy,
+): string {
+  if (!policy.generate) {
     return ''
   }
 
@@ -94,6 +99,6 @@ export function getAttributionHeader(fingerprint: string): string {
   const workloadPair = workload ? ` cc_workload=${workload};` : ''
   const header = `x-anthropic-billing-header: cc_version=${version}; cc_entrypoint=${entrypoint};${cch}${workloadPair}`
 
-  logForDebugging(`attribution header ${header}`)
+  logForDebugging(`attribution header generated: ${policy.reason}`)
   return header
 }

--- a/src/services/api/authRouting.attribution.test.ts
+++ b/src/services/api/authRouting.attribution.test.ts
@@ -91,12 +91,54 @@ describeAttribution('current Anthropic attribution route resolution', () => {
         resolveAnthropicAttributionAuthFromSources({
           apiKeySource,
           authTokenSource: 'CLAUDE_CODE_OAUTH_TOKEN',
+          bareMode: false,
           isSubscriber: true,
           managedOAuthContext: true,
         }),
       ).toBe('oauth_subscription')
     })
   }
+
+  for (const [apiKeySource, authTokenSource] of [
+    ['ANTHROPIC_API_KEY', 'none'],
+    ['apiKeyHelper', 'apiKeyHelper'],
+  ] as const) {
+    test(`preserves bare-mode ${apiKeySource} in a managed context`, () => {
+      expect(
+        resolveAnthropicAttributionAuthFromSources({
+          apiKeySource,
+          authTokenSource,
+          bareMode: true,
+          isSubscriber: false,
+          managedOAuthContext: true,
+        }),
+      ).toBe('api_key')
+    })
+  }
+
+  test('preserves a managed API key when managed OAuth is not effective', () => {
+    expect(
+      resolveAnthropicAttributionAuthFromSources({
+        apiKeySource: '/login managed key',
+        authTokenSource: 'none',
+        bareMode: false,
+        isSubscriber: false,
+        managedOAuthContext: true,
+      }),
+    ).toBe('api_key')
+  })
+
+  test('does not force managed OAuth past an explicit non-subscriber result', () => {
+    expect(
+      resolveAnthropicAttributionAuthFromSources({
+        apiKeySource: 'none',
+        authTokenSource: 'CLAUDE_CODE_OAUTH_TOKEN',
+        bareMode: false,
+        isSubscriber: false,
+        managedOAuthContext: true,
+      }),
+    ).toBe('unknown')
+  })
 
   for (const [label, envKey, envValue] of [
     ['remote', 'CLAUDE_CODE_REMOTE', '1'],

--- a/src/services/api/authRouting.attribution.test.ts
+++ b/src/services/api/authRouting.attribution.test.ts
@@ -1,13 +1,43 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
 import { applyAnthropicAttributionPolicy } from '../../utils/anthropicAttribution.js'
-import { resolveCurrentAnthropicAttributionPolicy } from './authRouting.js'
+import {
+  providerModuleIsMocked,
+  REAL_PROVIDER_TEST_CHILD_ENV,
+  REAL_PROVIDER_TEST_TIMEOUT_MS,
+  runTestFileWithRealProviders,
+} from '../../test/providerModuleIsolation.js'
+
+// Bun keeps mock.module() registrations process-global across test files.
+// Bind request modules only when the canonical provider module is real. When a
+// prior file replaced it, run this file in a clean child process instead.
+const _realProvidersModule = await import(
+  `../../utils/model/providers.js?attributionReal=${Date.now()}-${Math.random()}`
+)
+const _loadedProvidersModule = await import('src/utils/model/providers.js')
+const runInProviderIsolatedChild =
+  process.env[REAL_PROVIDER_TEST_CHILD_ENV] !== '1' &&
+  providerModuleIsMocked(_loadedProvidersModule, _realProvidersModule)
+type AuthRoutingModule = typeof import('./authRouting.js')
+let resolveAnthropicAttributionAuthFromSources!: AuthRoutingModule['resolveAnthropicAttributionAuthFromSources']
+let resolveCurrentAnthropicAttributionPolicy!: AuthRoutingModule['resolveCurrentAnthropicAttributionPolicy']
+if (!runInProviderIsolatedChild) {
+  ;({
+    resolveAnthropicAttributionAuthFromSources,
+    resolveCurrentAnthropicAttributionPolicy,
+  } = await import(
+    `./authRouting.js?attributionReal=${Date.now()}-${Math.random()}`
+  ))
+}
 
 const routeEnvKeys = [
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_AUTH_TOKEN',
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_MODEL',
+  'CLAUDE_CODE_ENTRYPOINT',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'CLAUDE_CODE_REMOTE',
   'CLAUDE_CODE_USE_BEDROCK',
   'CLAUDE_CODE_USE_FOUNDRY',
   'CLAUDE_CODE_USE_GEMINI',
@@ -41,7 +71,53 @@ afterEach(() => {
   }
 })
 
-describe('current Anthropic attribution route resolution', () => {
+if (runInProviderIsolatedChild) {
+  test('runs attribution route cases with the real provider module', async () => {
+    await runTestFileWithRealProviders(import.meta.path)
+  }, { timeout: REAL_PROVIDER_TEST_TIMEOUT_MS + 5_000 })
+}
+
+const describeAttribution = runInProviderIsolatedChild
+  ? describe.skip
+  : describe
+
+describeAttribution('current Anthropic attribution route resolution', () => {
+  for (const apiKeySource of [
+    'ANTHROPIC_API_KEY',
+    'apiKeyHelper',
+  ] as const) {
+    test(`ignores ${apiKeySource} when managed OAuth is effective`, () => {
+      expect(
+        resolveAnthropicAttributionAuthFromSources({
+          apiKeySource,
+          authTokenSource: 'CLAUDE_CODE_OAUTH_TOKEN',
+          isSubscriber: true,
+          managedOAuthContext: true,
+        }),
+      ).toBe('oauth_subscription')
+    })
+  }
+
+  for (const [label, envKey, envValue] of [
+    ['remote', 'CLAUDE_CODE_REMOTE', '1'],
+    ['Claude Desktop', 'CLAUDE_CODE_ENTRYPOINT', 'claude-desktop'],
+  ] as const) {
+    test(`uses the effective OAuth credential for ${label} sessions`, () => {
+      process.env[envKey] = envValue
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-test-token'
+
+      expect(
+        resolveCurrentAnthropicAttributionPolicy({
+          attributionEnabled: false,
+        }),
+      ).toEqual({
+        generate: true,
+        retain: true,
+        reason: 'official_oauth_required',
+      })
+    })
+  }
+
   for (const [label, envKey] of [
     ['Bedrock', 'CLAUDE_CODE_USE_BEDROCK'],
     ['Vertex', 'CLAUDE_CODE_USE_VERTEX'],

--- a/src/services/api/authRouting.attribution.test.ts
+++ b/src/services/api/authRouting.attribution.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
+import { resolveCurrentAnthropicAttributionPolicy } from './authRouting.js'
+
+const routeEnvKeys = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_MODEL',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_GITHUB',
+  'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_OPENAI',
+  'CLAUDE_CODE_USE_VERTEX',
+  'MINIMAX_API_KEY',
+  'OPENAI_BASE_URL',
+  'OPENAI_MODEL',
+] as const
+const originalEnv = { ...process.env }
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('authRouting.attribution.test.ts')
+  for (const key of routeEnvKeys) delete process.env[key]
+  process.env.ANTHROPIC_API_KEY = 'sk-test-attribution-routing'
+})
+
+afterEach(() => {
+  try {
+    for (const key of routeEnvKeys) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = originalEnv[key]
+      }
+    }
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+describe('current Anthropic attribution route resolution', () => {
+  for (const [label, envKey] of [
+    ['Bedrock', 'CLAUDE_CODE_USE_BEDROCK'],
+    ['Vertex', 'CLAUDE_CODE_USE_VERTEX'],
+    ['Foundry', 'CLAUDE_CODE_USE_FOUNDRY'],
+  ] as const) {
+    test(`does not emit first-party metadata on ${label}`, () => {
+      process.env[envKey] = '1'
+
+      expect(
+        resolveCurrentAnthropicAttributionPolicy({
+          attributionEnabled: true,
+        }),
+      ).toEqual({
+        generate: false,
+        retain: false,
+        reason: 'non_official_route',
+      })
+    })
+  }
+
+  test('does not emit through a provider override', () => {
+    expect(
+      resolveCurrentAnthropicAttributionPolicy({
+        attributionEnabled: true,
+        providerOverride: {
+          model: 'third-party-model',
+          baseURL: 'https://provider.example/v1',
+          apiKey: 'provider-test-key',
+        },
+      }),
+    ).toMatchObject({ generate: false, retain: false })
+  })
+
+  test('treats a custom Anthropic Messages route as non-official', () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://messages.example/v1'
+    process.env.ANTHROPIC_MODEL = 'claude-compatible'
+
+    expect(
+      resolveCurrentAnthropicAttributionPolicy({
+        attributionEnabled: true,
+      }),
+    ).toMatchObject({ generate: false, retain: false })
+  })
+})

--- a/src/services/api/authRouting.attribution.test.ts
+++ b/src/services/api/authRouting.attribution.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../../test/sharedMutationLock.js'
+import { applyAnthropicAttributionPolicy } from '../../utils/anthropicAttribution.js'
 import { resolveCurrentAnthropicAttributionPolicy } from './authRouting.js'
 
 const routeEnvKeys = [
@@ -49,29 +50,41 @@ describe('current Anthropic attribution route resolution', () => {
     test(`does not emit first-party metadata on ${label}`, () => {
       process.env[envKey] = '1'
 
-      expect(
-        resolveCurrentAnthropicAttributionPolicy({
-          attributionEnabled: true,
-        }),
-      ).toEqual({
+      const policy = resolveCurrentAnthropicAttributionPolicy({
+        attributionEnabled: true,
+      })
+
+      expect(policy).toEqual({
         generate: false,
         retain: false,
         reason: 'non_official_route',
       })
+      expect(
+        applyAnthropicAttributionPolicy(
+          ['x-anthropic-billing-header: stale', 'stable route prompt'],
+          policy,
+        ),
+      ).toEqual(['stable route prompt'])
     })
   }
 
   test('does not emit through a provider override', () => {
+    const policy = resolveCurrentAnthropicAttributionPolicy({
+      attributionEnabled: true,
+      providerOverride: {
+        model: 'third-party-model',
+        baseURL: 'https://provider.example/v1',
+        apiKey: 'provider-test-key',
+      },
+    })
+
+    expect(policy).toMatchObject({ generate: false, retain: false })
     expect(
-      resolveCurrentAnthropicAttributionPolicy({
-        attributionEnabled: true,
-        providerOverride: {
-          model: 'third-party-model',
-          baseURL: 'https://provider.example/v1',
-          apiKey: 'provider-test-key',
-        },
-      }),
-    ).toMatchObject({ generate: false, retain: false })
+      applyAnthropicAttributionPolicy(
+        ['x-anthropic-billing-header: stale', 'stable route prompt'],
+        policy,
+      ),
+    ).toEqual(['stable route prompt'])
   })
 
   test('treats a custom Anthropic Messages route as non-official', () => {

--- a/src/services/api/authRouting.ts
+++ b/src/services/api/authRouting.ts
@@ -3,8 +3,122 @@ import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
 } from 'src/utils/model/providers.js'
+import {
+  getAnthropicApiKeyWithSource,
+  getAuthTokenSource,
+  isClaudeAISubscriber,
+} from 'src/utils/auth.js'
+import {
+  getTransportKindForRoute,
+  resolveActiveRouteIdFromEnv,
+} from '../../integrations/routeMetadata.js'
+import {
+  type AnthropicAttributionAuth,
+  type AnthropicAttributionPolicy,
+  type AnthropicAttributionRoute,
+  getAnthropicAttributionDiagnostic,
+  resolveAnthropicAttributionAuth,
+  resolveAnthropicAttributionPolicy,
+} from '../../utils/anthropicAttribution.js'
+import { logForDebugging } from '../../utils/debug.js'
 
 export type ProviderOverride = { model: string; baseURL: string; apiKey: string }
+
+function resolveCurrentAnthropicAttributionAuth(): AnthropicAttributionAuth {
+  let apiKeySource: ReturnType<
+    typeof getAnthropicApiKeyWithSource
+  >['source'] = 'none'
+  try {
+    ;({ source: apiKeySource } = getAnthropicApiKeyWithSource({
+      skipRetrievingKeyFromApiKeyHelper: true,
+    }))
+  } catch {
+    // Missing credentials are an ambiguous state, not an error for policy.
+  }
+
+  let authTokenSource: ReturnType<typeof getAuthTokenSource>['source'] = 'none'
+  try {
+    ;({ source: authTokenSource } = getAuthTokenSource())
+  } catch {
+    return 'unknown'
+  }
+
+  const apiKey =
+    apiKeySource === 'ANTHROPIC_API_KEY' || apiKeySource === 'apiKeyHelper'
+      ? 'external'
+      : apiKeySource === '/login managed key'
+        ? 'managed'
+        : 'none'
+  const authToken =
+    authTokenSource === 'ANTHROPIC_AUTH_TOKEN' ||
+    authTokenSource === 'apiKeyHelper'
+      ? 'api_key'
+      : authTokenSource === 'CLAUDE_CODE_OAUTH_TOKEN' ||
+          authTokenSource === 'CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR' ||
+          authTokenSource === 'CCR_OAUTH_TOKEN_FILE' ||
+          authTokenSource === 'claude.ai'
+        ? 'oauth'
+        : 'none'
+  const hasOAuthToken = authToken === 'oauth'
+  let isSubscriber = false
+  if (hasOAuthToken) {
+    try {
+      isSubscriber = isClaudeAISubscriber()
+    } catch {
+      return 'unknown'
+    }
+  }
+
+  return resolveAnthropicAttributionAuth({
+    apiKey,
+    authToken,
+    isSubscriber,
+  })
+}
+
+function resolveAnthropicAttributionRoute(
+  providerOverride?: ProviderOverride,
+): AnthropicAttributionRoute {
+  if (providerOverride) return 'non_official'
+
+  try {
+    const routeId = resolveActiveRouteIdFromEnv(process.env)
+    if (
+      routeId === 'anthropic' &&
+      getAPIProvider() === 'firstParty' &&
+      isFirstPartyAnthropicBaseUrl()
+    ) {
+      return 'official_anthropic'
+    }
+    if (routeId && getTransportKindForRoute(routeId) !== null) {
+      return 'non_official'
+    }
+    return 'unknown'
+  } catch {
+    return 'unknown'
+  }
+}
+
+export function resolveCurrentAnthropicAttributionPolicy({
+  attributionEnabled,
+  providerOverride,
+}: {
+  attributionEnabled: boolean
+  providerOverride?: ProviderOverride
+}): AnthropicAttributionPolicy {
+  const route = resolveAnthropicAttributionRoute(providerOverride)
+  const policy = resolveAnthropicAttributionPolicy({
+    route,
+    auth:
+      route === 'official_anthropic'
+        ? resolveCurrentAnthropicAttributionAuth()
+        : 'unknown',
+    attributionEnabled,
+  })
+  const diagnostic = getAnthropicAttributionDiagnostic(policy)
+  if (diagnostic) logForDebugging(diagnostic)
+  return policy
+}
 
 export function shouldUseFirstPartyAnthropicAuthForProvider({
   providerOverride,

--- a/src/services/api/authRouting.ts
+++ b/src/services/api/authRouting.ts
@@ -7,6 +7,7 @@ import {
   getAnthropicApiKeyWithSource,
   getAuthTokenSource,
   isClaudeAISubscriber,
+  isManagedOAuthContext,
 } from 'src/utils/auth.js'
 import {
   getTransportKindForRoute,
@@ -23,6 +24,67 @@ import {
 import { logForDebugging } from '../../utils/debug.js'
 
 export type ProviderOverride = { model: string; baseURL: string; apiKey: string }
+
+function resolveAnthropicAttributionAuthTokenSource(
+  authTokenSource: ReturnType<typeof getAuthTokenSource>['source'],
+  managedOAuthContext: boolean,
+): 'oauth' | 'api_key' | 'none' {
+  if (
+    managedOAuthContext &&
+    (authTokenSource === 'ANTHROPIC_AUTH_TOKEN' ||
+      authTokenSource === 'apiKeyHelper')
+  ) {
+    return 'none'
+  }
+  if (
+    authTokenSource === 'ANTHROPIC_AUTH_TOKEN' ||
+    authTokenSource === 'apiKeyHelper'
+  ) {
+    return 'api_key'
+  }
+  if (
+    authTokenSource === 'CLAUDE_CODE_OAUTH_TOKEN' ||
+    authTokenSource === 'CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR' ||
+    authTokenSource === 'CCR_OAUTH_TOKEN_FILE' ||
+    authTokenSource === 'claude.ai'
+  ) {
+    return 'oauth'
+  }
+  return 'none'
+}
+
+export function resolveAnthropicAttributionAuthFromSources({
+  apiKeySource,
+  authTokenSource,
+  isSubscriber,
+  managedOAuthContext,
+}: {
+  apiKeySource: ReturnType<typeof getAnthropicApiKeyWithSource>['source']
+  authTokenSource: ReturnType<typeof getAuthTokenSource>['source']
+  isSubscriber: boolean
+  managedOAuthContext: boolean
+}): AnthropicAttributionAuth {
+  // Match getAnthropicClient: managed remote and Desktop sessions send OAuth
+  // and ignore inherited API-key settings, so those settings cannot win the
+  // attribution credential precedence either.
+  const apiKey = managedOAuthContext
+    ? 'none'
+    : apiKeySource === 'ANTHROPIC_API_KEY' || apiKeySource === 'apiKeyHelper'
+      ? 'external'
+      : apiKeySource === '/login managed key'
+        ? 'managed'
+        : 'none'
+  const authToken = resolveAnthropicAttributionAuthTokenSource(
+    authTokenSource,
+    managedOAuthContext,
+  )
+
+  return resolveAnthropicAttributionAuth({
+    apiKey,
+    authToken,
+    isSubscriber,
+  })
+}
 
 function resolveCurrentAnthropicAttributionAuth(): AnthropicAttributionAuth {
   let apiKeySource: ReturnType<
@@ -43,23 +105,12 @@ function resolveCurrentAnthropicAttributionAuth(): AnthropicAttributionAuth {
     return 'unknown'
   }
 
-  const apiKey =
-    apiKeySource === 'ANTHROPIC_API_KEY' || apiKeySource === 'apiKeyHelper'
-      ? 'external'
-      : apiKeySource === '/login managed key'
-        ? 'managed'
-        : 'none'
-  const authToken =
-    authTokenSource === 'ANTHROPIC_AUTH_TOKEN' ||
-    authTokenSource === 'apiKeyHelper'
-      ? 'api_key'
-      : authTokenSource === 'CLAUDE_CODE_OAUTH_TOKEN' ||
-          authTokenSource === 'CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR' ||
-          authTokenSource === 'CCR_OAUTH_TOKEN_FILE' ||
-          authTokenSource === 'claude.ai'
-        ? 'oauth'
-        : 'none'
-  const hasOAuthToken = authToken === 'oauth'
+  const managedOAuthContext = isManagedOAuthContext()
+  const hasOAuthToken =
+    resolveAnthropicAttributionAuthTokenSource(
+      authTokenSource,
+      managedOAuthContext,
+    ) === 'oauth'
   let isSubscriber = false
   if (hasOAuthToken) {
     try {
@@ -69,10 +120,11 @@ function resolveCurrentAnthropicAttributionAuth(): AnthropicAttributionAuth {
     }
   }
 
-  return resolveAnthropicAttributionAuth({
-    apiKey,
-    authToken,
+  return resolveAnthropicAttributionAuthFromSources({
+    apiKeySource,
+    authTokenSource,
     isSubscriber,
+    managedOAuthContext,
   })
 }
 

--- a/src/services/api/authRouting.ts
+++ b/src/services/api/authRouting.ts
@@ -6,6 +6,7 @@ import {
 import {
   getAnthropicApiKeyWithSource,
   getAuthTokenSource,
+  getSubscriptionType,
   isClaudeAISubscriber,
   isManagedOAuthContext,
 } from 'src/utils/auth.js'
@@ -22,6 +23,7 @@ import {
   resolveAnthropicAttributionPolicy,
 } from '../../utils/anthropicAttribution.js'
 import { logForDebugging } from '../../utils/debug.js'
+import { isBareMode } from '../../utils/envUtils.js'
 
 export type ProviderOverride = { model: string; baseURL: string; apiKey: string }
 
@@ -53,21 +55,41 @@ function resolveAnthropicAttributionAuthTokenSource(
   return 'none'
 }
 
+function isManagedOAuthEffective(
+  authTokenSource: ReturnType<typeof getAuthTokenSource>['source'],
+  managedOAuthContext: boolean,
+  bareMode: boolean,
+): boolean {
+  return (
+    managedOAuthContext &&
+    !bareMode &&
+    resolveAnthropicAttributionAuthTokenSource(authTokenSource, false) ===
+      'oauth'
+  )
+}
+
 export function resolveAnthropicAttributionAuthFromSources({
   apiKeySource,
   authTokenSource,
+  bareMode,
   isSubscriber,
   managedOAuthContext,
 }: {
   apiKeySource: ReturnType<typeof getAnthropicApiKeyWithSource>['source']
   authTokenSource: ReturnType<typeof getAuthTokenSource>['source']
+  bareMode: boolean
   isSubscriber: boolean
   managedOAuthContext: boolean
 }): AnthropicAttributionAuth {
-  // Match getAnthropicClient: managed remote and Desktop sessions send OAuth
-  // and ignore inherited API-key settings, so those settings cannot win the
-  // attribution credential precedence either.
-  const apiKey = managedOAuthContext
+  // Match getAnthropicClient: managed remote and Desktop sessions ignore
+  // inherited API-key settings only when OAuth is actually effective. Bare
+  // mode remains API-key-only even if a managed-context marker is present.
+  const managedOAuthIsEffective = isManagedOAuthEffective(
+    authTokenSource,
+    managedOAuthContext,
+    bareMode,
+  )
+  const apiKey = managedOAuthIsEffective
     ? 'none'
     : apiKeySource === 'ANTHROPIC_API_KEY' || apiKeySource === 'apiKeyHelper'
       ? 'external'
@@ -76,7 +98,7 @@ export function resolveAnthropicAttributionAuthFromSources({
         : 'none'
   const authToken = resolveAnthropicAttributionAuthTokenSource(
     authTokenSource,
-    managedOAuthContext,
+    managedOAuthIsEffective,
   )
 
   return resolveAnthropicAttributionAuth({
@@ -105,16 +127,27 @@ function resolveCurrentAnthropicAttributionAuth(): AnthropicAttributionAuth {
     return 'unknown'
   }
 
+  const bareMode = isBareMode()
   const managedOAuthContext = isManagedOAuthContext()
+  const managedOAuthIsEffective = isManagedOAuthEffective(
+    authTokenSource,
+    managedOAuthContext,
+    bareMode,
+  )
   const hasOAuthToken =
     resolveAnthropicAttributionAuthTokenSource(
       authTokenSource,
-      managedOAuthContext,
+      managedOAuthIsEffective,
     ) === 'oauth'
   let isSubscriber = false
   if (hasOAuthToken) {
     try {
-      isSubscriber = isClaudeAISubscriber()
+      // Managed launchers establish the subscription OAuth path independently
+      // of machine-local token discovery, but an explicit trusted free-plan
+      // override still makes the client send API-key auth.
+      isSubscriber = managedOAuthIsEffective
+        ? getSubscriptionType() !== 'free'
+        : isClaudeAISubscriber()
     } catch {
       return 'unknown'
     }
@@ -123,6 +156,7 @@ function resolveCurrentAnthropicAttributionAuth(): AnthropicAttributionAuth {
   return resolveAnthropicAttributionAuthFromSources({
     apiKeySource,
     authTokenSource,
+    bareMode,
     isSubscriber,
     managedOAuthContext,
   })

--- a/src/services/api/claude.lifecycle.test.ts
+++ b/src/services/api/claude.lifecycle.test.ts
@@ -7,6 +7,11 @@ import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
+  setAllowedSettingSources,
+  setFlagSettingsInline,
+  setFlagSettingsPath,
+} from '../../bootstrap/state.js'
+import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
 } from '../../test/sharedMutationLock.js'
@@ -20,13 +25,38 @@ import {
 } from '../../utils/interruptionTrace.js'
 import { asSystemPrompt } from '../../utils/systemPromptType.js'
 import { getClaudeAIOAuthTokens } from '../../utils/auth.js'
-import {
-  executeNonStreamingRequest,
-  type Options,
-  queryHaiku,
-  queryModelWithStreaming,
-} from './claude.js'
+import { enableConfigs } from '../../utils/config.js'
+import { SETTING_SOURCES } from '../../utils/settings/constants.js'
+import { resetSettingsCache } from '../../utils/settings/settingsCache.js'
+import { type Options } from './claude.js'
 import { EMPTY_USAGE } from './emptyUsage.js'
+import {
+  providerModuleIsMocked,
+  REAL_PROVIDER_TEST_CHILD_ENV,
+  REAL_PROVIDER_TEST_TIMEOUT_MS,
+  runTestFileWithRealProviders,
+} from '../../test/providerModuleIsolation.js'
+
+// Bun keeps mock.module() registrations process-global across test files.
+// Bind request modules only when the canonical provider module is real. When a
+// prior file replaced it, run this file in a clean child process instead.
+const _realProvidersModule = await import(
+  `../../utils/model/providers.js?attributionReal=${Date.now()}-${Math.random()}`
+)
+const _loadedProvidersModule = await import('src/utils/model/providers.js')
+const runInProviderIsolatedChild =
+  process.env[REAL_PROVIDER_TEST_CHILD_ENV] !== '1' &&
+  providerModuleIsMocked(_loadedProvidersModule, _realProvidersModule)
+type ClaudeModule = typeof import('./claude.js')
+let executeNonStreamingRequest!: ClaudeModule['executeNonStreamingRequest']
+let queryHaiku!: ClaudeModule['queryHaiku']
+let queryModelWithStreaming!: ClaudeModule['queryModelWithStreaming']
+if (!runInProviderIsolatedChild) {
+  ;({ executeNonStreamingRequest, queryHaiku, queryModelWithStreaming } =
+    await import(
+      `./claude.js?attributionReal=${Date.now()}-${Math.random()}`
+    ))
+}
 
 const envKeys = [
   'AIMLAPI_API_KEY',
@@ -38,7 +68,9 @@ const envKeys = [
   'ANTHROPIC_SMALL_FAST_MODEL',
   'CLAUDE_CODE_ALWAYS_ENABLE_EFFORT',
   'CLAUDE_CODE_ATTRIBUTION_HEADER',
+  'CLAUDE_CODE_ENTRYPOINT',
   'CLAUDE_CODE_OAUTH_TOKEN',
+  'CLAUDE_CODE_REMOTE',
   'CLAUDE_CODE_TEST_FIXTURES_ROOT',
   'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
   'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID',
@@ -69,6 +101,7 @@ const originalEnv = { ...process.env }
 const originalFetch = globalThis.fetch
 const hadSavedMacro = Object.hasOwn(globalThis, 'MACRO')
 const savedMacro = (globalThis as Record<string, unknown>).MACRO
+const originalNodeEnv = process.env.NODE_ENV
 let fixturesRoot: string | undefined
 
 type FetchOverride = NonNullable<Options['fetchOverride']>
@@ -359,17 +392,19 @@ function makeOptions(
   }
 }
 
-async function capturePrimarySystemBlocks({
+async function capturePrimaryRequest({
   model = 'claude-lifecycle-test',
   systemPrompt = asSystemPrompt(['stable system prompt']),
 }: {
   model?: string
   systemPrompt?: ReturnType<typeof asSystemPrompt>
-} = {}): Promise<unknown[]> {
+} = {}): Promise<{ system: unknown[]; headers: Headers }> {
   const queryLifecycle = new QueryLifecycleOperationTracker()
   let requestBody: Record<string, unknown> | undefined
+  let requestHeaders: Headers | undefined
   const fetchOverride: FetchOverride = async (_input, init) => {
     requestBody = parseRequestBody(init)
+    requestHeaders = new Headers(init?.headers)
     return makeErrorResponse(400, 'captured request')
   }
 
@@ -399,7 +434,17 @@ async function capturePrimarySystemBlocks({
   if (!Array.isArray(requestBody?.system)) {
     throw new Error('expected captured Anthropic system blocks')
   }
-  return requestBody.system
+  if (!requestHeaders) {
+    throw new Error('expected captured Anthropic request headers')
+  }
+  return { system: requestBody.system, headers: requestHeaders }
+}
+
+async function capturePrimarySystemBlocks(options: {
+  model?: string
+  systemPrompt?: ReturnType<typeof asSystemPrompt>
+} = {}): Promise<unknown[]> {
+  return (await capturePrimaryRequest(options)).system
 }
 
 function systemBlockTexts(blocks: unknown[]): string[] {
@@ -444,8 +489,22 @@ function setClientTestEnv(): void {
   resetGrowthBook()
 }
 
+function setIgnoredApiKeyHelper(): void {
+  delete process.env.ANTHROPIC_API_KEY
+  setFlagSettingsPath(undefined)
+  setFlagSettingsInline({ apiKeyHelper: 'ignored-test-helper' })
+  setAllowedSettingSources(['flagSettings'])
+  resetSettingsCache()
+  enableConfigs()
+  process.env.NODE_ENV = 'development'
+}
+
 beforeEach(async () => {
   await acquireSharedMutationLock('claude.lifecycle.test.ts')
+  setFlagSettingsPath(undefined)
+  setFlagSettingsInline(null)
+  setAllowedSettingSources([...SETTING_SOURCES])
+  resetSettingsCache()
   getClaudeAIOAuthTokens.cache?.clear?.()
 })
 
@@ -464,6 +523,11 @@ afterEach(() => {
       delete (globalThis as Record<string, unknown>).MACRO
     }
     globalThis.fetch = originalFetch
+    process.env.NODE_ENV = originalNodeEnv
+    setFlagSettingsPath(undefined)
+    setFlagSettingsInline(null)
+    setAllowedSettingSources([...SETTING_SOURCES])
+    resetSettingsCache()
     getClaudeAIOAuthTokens.cache?.clear?.()
     resetGrowthBook()
     if (fixturesRoot) {
@@ -475,7 +539,48 @@ afterEach(() => {
   }
 })
 
-describe('Claude API lifecycle tracking', () => {
+if (runInProviderIsolatedChild) {
+  test('runs Claude lifecycle cases with the real provider module', async () => {
+    await runTestFileWithRealProviders(import.meta.path)
+  }, { timeout: REAL_PROVIDER_TEST_TIMEOUT_MS + 5_000 })
+}
+
+const describeLifecycle = runInProviderIsolatedChild
+  ? describe.skip
+  : describe
+
+describeLifecycle('Claude API lifecycle tracking', () => {
+  for (const [label, envKey, envValue, ambientAuth] of [
+    ['remote', 'CLAUDE_CODE_REMOTE', '1', 'api-key'],
+    [
+      'Claude Desktop',
+      'CLAUDE_CODE_ENTRYPOINT',
+      'claude-desktop',
+      'api-key-helper',
+    ],
+  ] as const) {
+    test(`uses OAuth headers and attribution in managed ${label} sessions`, async () => {
+      setClientTestEnv()
+      process.env[envKey] = envValue
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-test-token'
+      process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+      process.env.OPENCLAUDE_MAX_RETRIES = '0'
+      if (ambientAuth === 'api-key-helper') setIgnoredApiKeyHelper()
+      getClaudeAIOAuthTokens.cache?.clear?.()
+
+      const request = await capturePrimaryRequest()
+      const texts = systemBlockTexts(request.system)
+
+      expect(
+        texts.some(text => text.startsWith('x-anthropic-billing-header')),
+      ).toBe(true)
+      expect(request.headers.get('authorization')).toBe(
+        'Bearer oauth-test-token',
+      )
+      expect(request.headers.has('x-api-key')).toBe(false)
+    })
+  }
+
   test('Haiku side queries omit effort from native Anthropic requests when force enabled', async () => {
     setClientTestEnv()
     process.env.CLAUDE_CODE_ALWAYS_ENABLE_EFFORT = '1'

--- a/src/services/api/claude.lifecycle.test.ts
+++ b/src/services/api/claude.lifecycle.test.ts
@@ -3,7 +3,7 @@ import type {
   BetaMessage,
   BetaMessageStreamParams,
 } from '@anthropic-ai/sdk/resources/beta/messages/messages.mjs'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -523,7 +523,11 @@ afterEach(() => {
       delete (globalThis as Record<string, unknown>).MACRO
     }
     globalThis.fetch = originalFetch
-    process.env.NODE_ENV = originalNodeEnv
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = originalNodeEnv
+    }
     setFlagSettingsPath(undefined)
     setFlagSettingsInline(null)
     setAllowedSettingSources([...SETTING_SOURCES])
@@ -616,6 +620,29 @@ describeLifecycle('Claude API lifecycle tracking', () => {
     expect(requestBody).not.toHaveProperty('reasoning_effort')
     expect(requestBody).not.toHaveProperty('effort')
     expect(requestHeaders?.get('anthropic-beta')).not.toContain('effort')
+  })
+
+  test('honors a trusted free-plan override in a managed OAuth context', async () => {
+    setClientTestEnv()
+    writeFileSync(
+      join(fixturesRoot!, 'settings.json'),
+      JSON.stringify({ subscriptionType: 'free' }),
+    )
+    resetSettingsCache()
+    process.env.CLAUDE_CODE_REMOTE = '1'
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-test-token'
+    process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+    getClaudeAIOAuthTokens.cache?.clear?.()
+
+    const request = await capturePrimaryRequest()
+    const texts = systemBlockTexts(request.system)
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+    expect(request.headers.get('x-api-key')).toBe('sk-test-lifecycle')
+    expect(request.headers.has('authorization')).toBe(false)
   })
 
   test('strips Anthropic billing attribution from a custom native endpoint', async () => {

--- a/src/services/api/claude.lifecycle.test.ts
+++ b/src/services/api/claude.lifecycle.test.ts
@@ -19,6 +19,7 @@ import {
   __resetInterruptionTraceForTests,
 } from '../../utils/interruptionTrace.js'
 import { asSystemPrompt } from '../../utils/systemPromptType.js'
+import { getClaudeAIOAuthTokens } from '../../utils/auth.js'
 import {
   executeNonStreamingRequest,
   type Options,
@@ -32,9 +33,12 @@ const envKeys = [
   'ANTHROPIC_AUTH_TOKEN',
   'ANTHROPIC_API_KEY',
   'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_FIRST_PARTY_PROXY_HOSTS',
   'ANTHROPIC_MODEL',
   'ANTHROPIC_SMALL_FAST_MODEL',
   'CLAUDE_CODE_ALWAYS_ENABLE_EFFORT',
+  'CLAUDE_CODE_ATTRIBUTION_HEADER',
+  'CLAUDE_CODE_OAUTH_TOKEN',
   'CLAUDE_CODE_TEST_FIXTURES_ROOT',
   'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED',
   'CLAUDE_CODE_PROVIDER_PROFILE_ENV_APPLIED_ID',
@@ -50,10 +54,13 @@ const envKeys = [
   'CLAUDE_FEATURE_FLAGS_FILE',
   'CLAUDE_STREAM_IDLE_TIMEOUT_MS',
   'GEMINI_API_KEY',
+  'GITHUB_TOKEN',
   'LONGCAT_API_KEY',
+  'MINIMAX_API_KEY',
   'OPENAI_API_KEY',
   'OPENAI_BASE_URL',
   'OPENAI_MODEL',
+  'OPENCLAUDE_CONFIG_DIR',
   'OPENCLAUDE_INTERRUPT_TRACE',
   'OPENCLAUDE_MAX_RETRIES',
   'VCR_RECORD',
@@ -352,6 +359,62 @@ function makeOptions(
   }
 }
 
+async function capturePrimarySystemBlocks({
+  model = 'claude-lifecycle-test',
+  systemPrompt = asSystemPrompt(['stable system prompt']),
+}: {
+  model?: string
+  systemPrompt?: ReturnType<typeof asSystemPrompt>
+} = {}): Promise<unknown[]> {
+  const queryLifecycle = new QueryLifecycleOperationTracker()
+  let requestBody: Record<string, unknown> | undefined
+  const fetchOverride: FetchOverride = async (_input, init) => {
+    requestBody = parseRequestBody(init)
+    return makeErrorResponse(400, 'captured request')
+  }
+
+  const generator = queryModelWithStreaming({
+    messages: [
+      {
+        type: 'user',
+        uuid: '00000000-0000-0000-0000-000000000009',
+        timestamp: '2026-08-21T00:00:00.000Z',
+        message: { role: 'user', content: 'hello' },
+      } as Message,
+    ],
+    systemPrompt,
+    thinkingConfig: { type: 'disabled' },
+    tools: [],
+    signal: new AbortController().signal,
+    options: {
+      ...makeOptions(queryLifecycle),
+      model,
+      fetchOverride,
+    },
+  })
+
+  await generator.next()
+  await generator.return(undefined)
+
+  if (!Array.isArray(requestBody?.system)) {
+    throw new Error('expected captured Anthropic system blocks')
+  }
+  return requestBody.system
+}
+
+function systemBlockTexts(blocks: unknown[]): string[] {
+  return blocks.flatMap(block => {
+    if (
+      typeof block === 'object' &&
+      block !== null &&
+      typeof (block as { text?: unknown }).text === 'string'
+    ) {
+      return [(block as { text: string }).text]
+    }
+    return []
+  })
+}
+
 function setTestMacro(): void {
   ;(globalThis as Record<string, unknown>).MACRO = {
     VERSION: '0.0.0-test',
@@ -370,17 +433,20 @@ function setClientTestEnv(): void {
     delete process.env[key]
   }
   process.env.ANTHROPIC_API_KEY = 'sk-test-lifecycle'
+  process.env.OPENCLAUDE_CONFIG_DIR = fixturesRoot
   process.env.CLAUDE_CODE_TEST_FIXTURES_ROOT = fixturesRoot
   process.env.CLAUDE_FEATURE_FLAGS_FILE = join(
     fixturesRoot,
     'feature-flags.json',
   )
   process.env.VCR_RECORD = '1'
+  getClaudeAIOAuthTokens.cache?.clear?.()
   resetGrowthBook()
 }
 
 beforeEach(async () => {
   await acquireSharedMutationLock('claude.lifecycle.test.ts')
+  getClaudeAIOAuthTokens.cache?.clear?.()
 })
 
 afterEach(() => {
@@ -398,6 +464,7 @@ afterEach(() => {
       delete (globalThis as Record<string, unknown>).MACRO
     }
     globalThis.fetch = originalFetch
+    getClaudeAIOAuthTokens.cache?.clear?.()
     resetGrowthBook()
     if (fixturesRoot) {
       rmSync(fixturesRoot, { force: true, recursive: true })
@@ -444,6 +511,134 @@ describe('Claude API lifecycle tracking', () => {
     expect(requestBody).not.toHaveProperty('reasoning_effort')
     expect(requestBody).not.toHaveProperty('effort')
     expect(requestHeaders?.get('anthropic-beta')).not.toContain('effort')
+  })
+
+  test('strips Anthropic billing attribution from a custom native endpoint', async () => {
+    setClientTestEnv()
+    process.env.ANTHROPIC_BASE_URL = 'https://custom-anthropic.example/v1'
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+
+    const texts = systemBlockTexts(await capturePrimarySystemBlocks())
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+    expect(texts).toContain('stable system prompt')
+  })
+
+  test('keeps required billing attribution for official OAuth when globally disabled', async () => {
+    setClientTestEnv()
+    delete process.env.ANTHROPIC_API_KEY
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-test-token'
+    process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+    getClaudeAIOAuthTokens.cache?.clear?.()
+
+    const texts = systemBlockTexts(await capturePrimarySystemBlocks())
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(true)
+    expect(texts).toContain('stable system prompt')
+  })
+
+  test('preserves the disable setting for an official API key', async () => {
+    setClientTestEnv()
+    process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+
+    const texts = systemBlockTexts(await capturePrimarySystemBlocks())
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+  })
+
+  test('does not trust an Anthropic lookalike host with leftover OAuth state', async () => {
+    setClientTestEnv()
+    delete process.env.ANTHROPIC_API_KEY
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-test-token'
+    process.env.ANTHROPIC_BASE_URL =
+      'https://api.anthropic.com.attacker.example/secret/path'
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+
+    const texts = systemBlockTexts(await capturePrimarySystemBlocks())
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+  })
+
+  test('keeps OAuth attribution through an approved loopback first-party proxy', async () => {
+    setClientTestEnv()
+    delete process.env.ANTHROPIC_API_KEY
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-test-token'
+    process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+    process.env.ANTHROPIC_BASE_URL = 'http://127.0.0.1:47821'
+    process.env.ANTHROPIC_FIRST_PARTY_PROXY_HOSTS = '127.0.0.1:47821'
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+    getClaudeAIOAuthTokens.cache?.clear?.()
+
+    const texts = systemBlockTexts(await capturePrimarySystemBlocks())
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(true)
+  })
+
+  test('uses the normalized MiniMax native route before building attribution', async () => {
+    setClientTestEnv()
+    process.env.MINIMAX_API_KEY = 'minimax-test-key'
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+
+    const texts = systemBlockTexts(
+      await capturePrimarySystemBlocks({ model: 'MiniMax-M2.7' }),
+    )
+
+    expect(process.env.ANTHROPIC_BASE_URL).toBe(
+      'https://api.minimax.io/anthropic',
+    )
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+  })
+
+  test('strips attribution from GitHub native Anthropic transport', async () => {
+    setClientTestEnv()
+    process.env.CLAUDE_CODE_USE_GITHUB = '1'
+    process.env.GITHUB_TOKEN = 'github-test-token'
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+
+    const texts = systemBlockTexts(
+      await capturePrimarySystemBlocks({ model: 'claude-sonnet-4-6' }),
+    )
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+  })
+
+  test('keeps the generated block first and drops later stale copies', async () => {
+    setClientTestEnv()
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+
+    const texts = systemBlockTexts(
+      await capturePrimarySystemBlocks({
+        systemPrompt: asSystemPrompt([
+          'stable system prompt',
+          'x-anthropic-billing-header: stale',
+          'second stable prompt',
+        ]),
+      }),
+    )
+
+    const attribution = texts.filter(text =>
+      text.startsWith('x-anthropic-billing-header'),
+    )
+    expect(attribution).toHaveLength(1)
+    expect(attribution[0]).not.toBe('x-anthropic-billing-header: stale')
+    expect(texts[1]).toStartWith('You are OpenClaude')
+    expect(texts[2]).toBe('stable system prompt\n\nsecond stable prompt')
   })
 
   test('uses the original codexplan selection for custom-gateway defaults', async () => {

--- a/src/services/api/claude.lifecycle.test.ts
+++ b/src/services/api/claude.lifecycle.test.ts
@@ -67,6 +67,7 @@ const envKeys = [
   'ANTHROPIC_MODEL',
   'ANTHROPIC_SMALL_FAST_MODEL',
   'CLAUDE_CODE_ALWAYS_ENABLE_EFFORT',
+  'ANTHROPIC_UNIX_SOCKET',
   'CLAUDE_CODE_ATTRIBUTION_HEADER',
   'CLAUDE_CODE_ENTRYPOINT',
   'CLAUDE_CODE_OAUTH_TOKEN',
@@ -562,6 +563,12 @@ describeLifecycle('Claude API lifecycle tracking', () => {
       'claude-desktop',
       'api-key-helper',
     ],
+    [
+      'Unix-socket OAuth proxy',
+      'ANTHROPIC_UNIX_SOCKET',
+      '/tmp/openclaude-auth-test.sock',
+      'auth-token',
+    ],
   ] as const) {
     test(`uses OAuth headers and attribution in managed ${label} sessions`, async () => {
       setClientTestEnv()
@@ -570,6 +577,9 @@ describeLifecycle('Claude API lifecycle tracking', () => {
       process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
       process.env.OPENCLAUDE_MAX_RETRIES = '0'
       if (ambientAuth === 'api-key-helper') setIgnoredApiKeyHelper()
+      if (ambientAuth === 'auth-token') {
+        process.env.ANTHROPIC_AUTH_TOKEN = 'ignored-test-auth-token'
+      }
       getClaudeAIOAuthTokens.cache?.clear?.()
 
       const request = await capturePrimaryRequest()
@@ -620,6 +630,36 @@ describeLifecycle('Claude API lifecycle tracking', () => {
     expect(requestBody).not.toHaveProperty('reasoning_effort')
     expect(requestBody).not.toHaveProperty('effort')
     expect(requestHeaders?.get('anthropic-beta')).not.toContain('effort')
+  })
+
+  test('keeps Unix-socket API-key auth when the OAuth placeholder is absent', async () => {
+    setClientTestEnv()
+    writeFileSync(
+      join(fixturesRoot!, '.credentials.json'),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'stored-test-oauth-token',
+          refreshToken: null,
+          expiresAt: null,
+          scopes: ['user:inference'],
+          subscriptionType: null,
+          rateLimitTier: null,
+        },
+      }),
+    )
+    process.env.ANTHROPIC_UNIX_SOCKET = '/tmp/openclaude-auth-test.sock'
+    process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+    process.env.OPENCLAUDE_MAX_RETRIES = '0'
+    getClaudeAIOAuthTokens.cache?.clear?.()
+
+    const request = await capturePrimaryRequest()
+    const texts = systemBlockTexts(request.system)
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+    expect(request.headers.get('x-api-key')).toBe('sk-test-lifecycle')
+    expect(request.headers.has('authorization')).toBe(false)
   })
 
   test('honors a trusted free-plan override in a managed OAuth context', async () => {

--- a/src/services/api/claude.ts
+++ b/src/services/api/claude.ts
@@ -28,6 +28,7 @@ import {
 import {
   getAttributionHeader,
   getCLISyspromptPrefix,
+  isAttributionHeaderEnabled,
 } from '../../constants/system.js'
 import {
   getEmptyToolPermissionContext,
@@ -163,6 +164,7 @@ import {
   modelSupportsAdvisor,
 } from 'src/utils/advisor.js'
 import { getAgentContext } from 'src/utils/agentContext.js'
+import { applyAnthropicAttributionPolicy } from 'src/utils/anthropicAttribution.js'
 import { isClaudeAISubscriber } from 'src/utils/auth.js'
 import {
   getToolSearchBetaHeader,
@@ -240,6 +242,7 @@ import {
 import { getInitializationStatus } from '../lsp/manager.js'
 import { isToolFromMcpServer } from '../mcp/utils.js'
 import { withStreamingVCR, withVCR } from '../vcr.js'
+import { resolveCurrentAnthropicAttributionPolicy } from './authRouting.js'
 import { CLIENT_REQUEST_ID_HEADER, getAnthropicClient } from './client.js'
 import {
   API_ERROR_MESSAGE_PREFIX,
@@ -1564,10 +1567,12 @@ async function* queryModel(
   const injectChromeHere =
     useToolSearch && hasChromeTools && !isMcpInstructionsDeltaEnabled()
 
-  // filter(Boolean) works by converting each element to a boolean - empty strings become false and are filtered out.
+  const attributionEnabled = isAttributionHeaderEnabled()
+
+  // Build the stable prompt here, but delay attribution and request blocks
+  // until client creation has normalized the effective provider route.
   systemPrompt = asSystemPrompt(
     [
-      getAttributionHeader(fingerprint),
       getCLISyspromptPrefix({
         isNonInteractive: options.isNonInteractiveSession,
         hasAppendSystemPrompt: options.hasAppendSystemPrompt,
@@ -1577,16 +1582,6 @@ async function* queryModel(
       ...(injectChromeHere ? [CHROME_TOOL_SEARCH_INSTRUCTIONS] : []),
     ].filter(Boolean),
   )
-
-  // Prepend system prompt block for easy API identification
-  logAPIPrefix(systemPrompt)
-
-  const enablePromptCaching =
-    options.enablePromptCaching ?? getPromptCachingEnabled(options.model)
-  const system = buildSystemPromptBlocks(systemPrompt, enablePromptCaching, {
-    skipGlobalCacheForSystemPrompt: needsToolBasedCacheMarker,
-    querySource: options.querySource,
-  })
   const useBetas = betas.length > 0
 
   const extraToolSchemas = [...(options.extraToolSchemas ?? [])]
@@ -1669,34 +1664,6 @@ async function* queryModel(
 
   const effort = resolveAppliedEffort(options.model, options.effortValue)
 
-  if (feature('PROMPT_CACHE_BREAK_DETECTION')) {
-    // Exclude defer_loading tools from the hash -- the API strips them from the
-    // prompt, so they never affect the actual cache key. Including them creates
-    // false-positive "tool schemas changed" breaks when tools are discovered or
-    // MCP servers reconnect.
-    const toolsForCacheDetection = allTools.filter(
-      t => !('defer_loading' in t && t.defer_loading),
-    )
-    // Capture everything that could affect the server-side cache key.
-    // Pass latched header values (not live state) so break detection
-    // reflects what we actually send, not what the user toggled.
-    recordPromptState({
-      system,
-      toolSchemas: toolsForCacheDetection,
-      querySource: options.querySource,
-      model: options.model,
-      agentId: options.agentId,
-      fastMode: fastModeHeaderLatched,
-      globalCacheStrategy,
-      betas,
-      autoModeActive: afkHeaderLatched,
-      isUsingOverage: currentLimits.isUsingOverage ?? false,
-      cachedMCEnabled: cacheEditingHeaderLatched,
-      effortValue: effort,
-      extraBodyParams: getExtraBodyParams(),
-    })
-  }
-
   const startIncludingRetries = Date.now()
   let start = Date.now()
   let attemptNumber = 0
@@ -1744,6 +1711,8 @@ async function* queryModel(
   // Capture the betas sent in the last API request, including the ones that
   // were dynamically added, so we can log and send it to telemetry.
   let lastRequestBetas: string[] | undefined
+  let apiPrefixLogged = false
+  let promptStateRecorded = false
 
   const paramsFromContext = (retryContext: RetryContext) => {
     const betasParams = [...betas]
@@ -1844,6 +1813,54 @@ async function* queryModel(
 
     const enablePromptCaching =
       options.enablePromptCaching ?? getPromptCachingEnabled(retryContext.model)
+    const attributionPolicy = resolveCurrentAnthropicAttributionPolicy({
+      attributionEnabled,
+      providerOverride: options.providerOverride,
+    })
+    const requestSystemPrompt = asSystemPrompt(
+      applyAnthropicAttributionPolicy(
+        [
+          getAttributionHeader(fingerprint, attributionPolicy),
+          ...systemPrompt,
+        ].filter(Boolean),
+        attributionPolicy,
+      ),
+    )
+    const system = buildSystemPromptBlocks(
+      requestSystemPrompt,
+      enablePromptCaching,
+      {
+        skipGlobalCacheForSystemPrompt: needsToolBasedCacheMarker,
+        querySource: options.querySource,
+      },
+    )
+    if (!apiPrefixLogged) {
+      apiPrefixLogged = true
+      logAPIPrefix(requestSystemPrompt)
+    }
+    if (feature('PROMPT_CACHE_BREAK_DETECTION') && !promptStateRecorded) {
+      promptStateRecorded = true
+      // Exclude defer_loading tools from the hash. The API strips them from
+      // the prompt, so they never affect the actual cache key.
+      const toolsForCacheDetection = allTools.filter(
+        t => !('defer_loading' in t && t.defer_loading),
+      )
+      recordPromptState({
+        system,
+        toolSchemas: toolsForCacheDetection,
+        querySource: options.querySource,
+        model: options.model,
+        agentId: options.agentId,
+        fastMode: fastModeHeaderLatched,
+        globalCacheStrategy,
+        betas,
+        autoModeActive: afkHeaderLatched,
+        isUsingOverage: currentLimits.isUsingOverage ?? false,
+        cachedMCEnabled: cacheEditingHeaderLatched,
+        effortValue: effort,
+        extraBodyParams: getExtraBodyParams(),
+      })
+    }
 
     // Fast mode: header is latched session-stable (cache-safe), but
     // `speed='fast'` stays dynamic so cooldown still suppresses the actual

--- a/src/test/providerModuleIsolation.ts
+++ b/src/test/providerModuleIsolation.ts
@@ -1,0 +1,60 @@
+export const REAL_PROVIDER_TEST_CHILD_ENV =
+  'OPENCLAUDE_REAL_PROVIDER_TEST_CHILD'
+export const REAL_PROVIDER_TEST_TIMEOUT_MS = 30_000
+
+type ProviderModule = Pick<
+  typeof import('../utils/model/providers.js'),
+  | 'getAPIProvider'
+  | 'usesAnthropicAccountFlow'
+  | 'isFirstPartyAnthropicProvider'
+  | 'isCustomAnthropicProvider'
+  | 'isGithubNativeAnthropicMode'
+  | 'getAPIProviderForStatsig'
+  | 'isFirstPartyAnthropicBaseUrl'
+>
+
+const PROVIDER_FUNCTIONS = [
+  'getAPIProvider',
+  'usesAnthropicAccountFlow',
+  'isFirstPartyAnthropicProvider',
+  'isCustomAnthropicProvider',
+  'isGithubNativeAnthropicMode',
+  'getAPIProviderForStatsig',
+  'isFirstPartyAnthropicBaseUrl',
+] as const satisfies readonly (keyof ProviderModule)[]
+
+export function providerModuleIsMocked(
+  loaded: ProviderModule,
+  cacheBustedReal: ProviderModule,
+): boolean {
+  return PROVIDER_FUNCTIONS.some(
+    name => String(loaded[name]) !== String(cacheBustedReal[name]),
+  )
+}
+
+export async function runTestFileWithRealProviders(
+  testFile: string,
+): Promise<void> {
+  const child = Bun.spawn({
+    cmd: [process.execPath, 'test', testFile],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      [REAL_PROVIDER_TEST_CHILD_ENV]: '1',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+    timeout: REAL_PROVIDER_TEST_TIMEOUT_MS,
+    killSignal: process.platform === 'win32' ? undefined : 'SIGKILL',
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  if (exitCode !== 0) {
+    throw new Error(
+      `provider-isolated test process failed for ${testFile} (${exitCode})\n${stdout}\n${stderr}`,
+    )
+  }
+}

--- a/src/utils/anthropicAttribution.test.ts
+++ b/src/utils/anthropicAttribution.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { resetGrowthBook } from '../services/analytics/growthbook.js'
+import { isAttributionHeaderEnabled } from '../constants/system.js'
+import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
+import { getSystemPromptTelemetryBlock } from './api.js'
+import {
+  applyAnthropicAttributionPolicy,
+  getAnthropicAttributionDiagnostic,
+  resolveAnthropicAttributionAuth,
+  resolveAnthropicAttributionPolicy,
+} from './anthropicAttribution.js'
+import { asSystemPrompt } from './systemPromptType.js'
+
+const originalAttributionSetting =
+  process.env.CLAUDE_CODE_ATTRIBUTION_HEADER
+const originalFeatureFlagsFile = process.env.CLAUDE_FEATURE_FLAGS_FILE
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('anthropicAttribution.test.ts')
+})
+
+afterEach(() => {
+  try {
+    if (originalAttributionSetting === undefined) {
+      delete process.env.CLAUDE_CODE_ATTRIBUTION_HEADER
+    } else {
+      process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = originalAttributionSetting
+    }
+    if (originalFeatureFlagsFile === undefined) {
+      delete process.env.CLAUDE_FEATURE_FLAGS_FILE
+    } else {
+      process.env.CLAUDE_FEATURE_FLAGS_FILE = originalFeatureFlagsFile
+    }
+    resetGrowthBook()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+describe('resolveAnthropicAttributionPolicy', () => {
+  test('forces attribution only for official OAuth subscription requests', () => {
+    expect(
+      resolveAnthropicAttributionPolicy({
+        route: 'official_anthropic',
+        auth: 'oauth_subscription',
+        attributionEnabled: false,
+      }),
+    ).toEqual({
+      generate: true,
+      retain: true,
+      reason: 'official_oauth_required',
+    })
+
+    for (const route of ['non_official', 'unknown'] as const) {
+      expect(
+        resolveAnthropicAttributionPolicy({
+          route,
+          auth: 'oauth_subscription',
+          attributionEnabled: true,
+        }),
+      ).toMatchObject({ generate: false, retain: false })
+    }
+  })
+
+  test('preserves the global setting for official API-key and ambiguous auth', () => {
+    for (const auth of ['api_key', 'unknown'] as const) {
+      expect(
+        resolveAnthropicAttributionPolicy({
+          route: 'official_anthropic',
+          auth,
+          attributionEnabled: true,
+        }),
+      ).toMatchObject({ generate: true, retain: true })
+      expect(
+        resolveAnthropicAttributionPolicy({
+          route: 'official_anthropic',
+          auth,
+          attributionEnabled: false,
+        }),
+      ).toMatchObject({ generate: false, retain: false })
+    }
+  })
+})
+
+describe('resolveAnthropicAttributionAuth', () => {
+  test('gives explicit API credentials precedence over subscription state', () => {
+    expect(
+      resolveAnthropicAttributionAuth({
+        apiKey: 'external',
+        authToken: 'oauth',
+        isSubscriber: true,
+      }),
+    ).toBe('api_key')
+    expect(
+      resolveAnthropicAttributionAuth({
+        apiKey: 'none',
+        authToken: 'api_key',
+        isSubscriber: true,
+      }),
+    ).toBe('api_key')
+  })
+
+  test('requires both an OAuth source and subscriber state', () => {
+    expect(
+      resolveAnthropicAttributionAuth({
+        apiKey: 'none',
+        authToken: 'oauth',
+        isSubscriber: true,
+      }),
+    ).toBe('oauth_subscription')
+    expect(
+      resolveAnthropicAttributionAuth({
+        apiKey: 'none',
+        authToken: 'oauth',
+        isSubscriber: false,
+      }),
+    ).toBe('unknown')
+  })
+})
+
+describe('applyAnthropicAttributionPolicy', () => {
+  const retainPolicy = resolveAnthropicAttributionPolicy({
+    route: 'official_anthropic',
+    auth: 'oauth_subscription',
+    attributionEnabled: true,
+  })
+  const stripPolicy = resolveAnthropicAttributionPolicy({
+    route: 'non_official',
+    auth: 'oauth_subscription',
+    attributionEnabled: true,
+  })
+
+  test('keeps the first attribution block and preserves later block order and metadata', () => {
+    const cachedBlock = {
+      type: 'text',
+      text: 'stable cached prompt',
+      cache_control: { type: 'ephemeral', scope: 'org' },
+    }
+    const blocks = [
+      { type: 'text', text: 'x-anthropic-billing-header: generated' },
+      { type: 'text', text: 'prefix' },
+      { type: 'text', text: 'x-anthropic-billing-header: stale' },
+      cachedBlock,
+    ]
+
+    const result = applyAnthropicAttributionPolicy(blocks, retainPolicy)
+
+    expect(result.map(block => block.text)).toEqual([
+      'x-anthropic-billing-header: generated',
+      'prefix',
+      'stable cached prompt',
+    ])
+    expect(result[2]).toBe(cachedBlock)
+  })
+
+  test('removes every attribution block after a route switch', () => {
+    expect(
+      applyAnthropicAttributionPolicy(
+        [
+          'x-anthropic-billing-header: previous route',
+          'stable prompt',
+        ],
+        stripPolicy,
+      ),
+    ).toEqual(['stable prompt'])
+  })
+})
+
+describe('CLAUDE_CODE_ATTRIBUTION_HEADER parsing', () => {
+  for (const [label, value, expected] of [
+    ['unset', undefined, true],
+    ['enabled', '1', true],
+    ['disabled', '0', false],
+    ['empty', '', true],
+    ['malformed', 'sometimes', true],
+  ] as const) {
+    test(`${label} preserves the existing setting contract`, () => {
+      process.env.CLAUDE_FEATURE_FLAGS_FILE =
+        '/nonexistent/openclaude-attribution-feature-flags.json'
+      if (value === undefined) {
+        delete process.env.CLAUDE_CODE_ATTRIBUTION_HEADER
+      } else {
+        process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = value
+      }
+      resetGrowthBook()
+
+      expect(isAttributionHeaderEnabled()).toBe(expected)
+    })
+  }
+})
+
+test('ambiguous diagnostics contain no route, secret, or fingerprint data', () => {
+  const diagnostic = getAnthropicAttributionDiagnostic(
+    resolveAnthropicAttributionPolicy({
+      route: 'unknown',
+      auth: 'unknown',
+      attributionEnabled: true,
+    }),
+  )
+
+  expect(diagnostic).toBe(
+    '[anthropic-attribution] disabled for an unresolved request route',
+  )
+  for (const sensitive of [
+    'https://proxy.example/secret/path',
+    'sk-ant-secret',
+    'fingerprint-abc123',
+  ]) {
+    expect(diagnostic).not.toContain(sensitive)
+  }
+})
+
+test('prompt telemetry selects the CLI prefix instead of the attribution fingerprint', () => {
+  const block = getSystemPromptTelemetryBlock(
+    asSystemPrompt([
+      'x-anthropic-billing-header: cc_version=0.0.0.fingerprint-abc123',
+      'You are OpenClaude, an open-source coding agent and CLI.',
+      'stable prompt',
+    ]),
+  )
+
+  expect(block?.text).toBe(
+    'You are OpenClaude, an open-source coding agent and CLI.',
+  )
+  expect(block?.text).not.toContain('fingerprint-abc123')
+})

--- a/src/utils/anthropicAttribution.test.ts
+++ b/src/utils/anthropicAttribution.test.ts
@@ -98,6 +98,13 @@ describe('resolveAnthropicAttributionAuth', () => {
         isSubscriber: true,
       }),
     ).toBe('api_key')
+    expect(
+      resolveAnthropicAttributionAuth({
+        apiKey: 'managed',
+        authToken: 'none',
+        isSubscriber: false,
+      }),
+    ).toBe('api_key')
   })
 
   test('requires both an OAuth source and subscriber state', () => {

--- a/src/utils/anthropicAttribution.ts
+++ b/src/utils/anthropicAttribution.ts
@@ -1,0 +1,139 @@
+export const ANTHROPIC_BILLING_ATTRIBUTION_PREFIX =
+  'x-anthropic-billing-header'
+
+export type AnthropicAttributionRoute =
+  | 'official_anthropic'
+  | 'non_official'
+  | 'unknown'
+
+export type AnthropicAttributionAuth =
+  | 'oauth_subscription'
+  | 'api_key'
+  | 'unknown'
+
+export type AnthropicAttributionCredentialInput = {
+  apiKey: 'external' | 'managed' | 'none'
+  authToken: 'oauth' | 'api_key' | 'none'
+  isSubscriber: boolean
+}
+
+export type AnthropicAttributionPolicyReason =
+  | 'official_oauth_required'
+  | 'official_api_key_enabled'
+  | 'official_api_key_disabled'
+  | 'official_auth_unknown_enabled'
+  | 'official_auth_unknown_disabled'
+  | 'non_official_route'
+  | 'unknown_route'
+
+export type AnthropicAttributionPolicy = {
+  generate: boolean
+  retain: boolean
+  reason: AnthropicAttributionPolicyReason
+}
+
+export function resolveAnthropicAttributionAuth({
+  apiKey,
+  authToken,
+  isSubscriber,
+}: AnthropicAttributionCredentialInput): AnthropicAttributionAuth {
+  if (apiKey === 'external' || authToken === 'api_key') return 'api_key'
+  if (authToken === 'oauth' && isSubscriber) return 'oauth_subscription'
+  if (apiKey === 'managed') return 'api_key'
+  return 'unknown'
+}
+
+export function resolveAnthropicAttributionPolicy({
+  route,
+  auth,
+  attributionEnabled,
+}: {
+  route: AnthropicAttributionRoute
+  auth: AnthropicAttributionAuth
+  attributionEnabled: boolean
+}): AnthropicAttributionPolicy {
+  if (route === 'unknown') {
+    return { generate: false, retain: false, reason: 'unknown_route' }
+  }
+  if (route !== 'official_anthropic') {
+    return { generate: false, retain: false, reason: 'non_official_route' }
+  }
+
+  if (auth === 'oauth_subscription') {
+    return {
+      generate: true,
+      retain: true,
+      reason: 'official_oauth_required',
+    }
+  }
+
+  if (auth === 'api_key') {
+    return attributionEnabled
+      ? {
+          generate: true,
+          retain: true,
+          reason: 'official_api_key_enabled',
+        }
+      : {
+          generate: false,
+          retain: false,
+          reason: 'official_api_key_disabled',
+        }
+  }
+
+  return attributionEnabled
+    ? {
+        generate: true,
+        retain: true,
+        reason: 'official_auth_unknown_enabled',
+      }
+    : {
+        generate: false,
+        retain: false,
+        reason: 'official_auth_unknown_disabled',
+      }
+}
+
+export function isAnthropicBillingAttributionBlock(
+  text: string | undefined,
+): boolean {
+  return text?.startsWith(ANTHROPIC_BILLING_ATTRIBUTION_PREFIX) ?? false
+}
+
+type AttributionBlock = string | { type?: string; text?: string }
+
+function getAttributionBlockText(block: AttributionBlock): string | undefined {
+  if (typeof block === 'string') return block
+  return block.type === undefined || block.type === 'text'
+    ? block.text
+    : undefined
+}
+
+export function applyAnthropicAttributionPolicy<T extends AttributionBlock>(
+  blocks: readonly T[],
+  policy: AnthropicAttributionPolicy,
+): T[] {
+  let retainedAttribution = false
+  return blocks.filter(block => {
+    if (!isAnthropicBillingAttributionBlock(getAttributionBlockText(block))) {
+      return true
+    }
+    if (!policy.retain || retainedAttribution) return false
+    retainedAttribution = true
+    return true
+  })
+}
+
+export function getAnthropicAttributionDiagnostic(
+  policy: AnthropicAttributionPolicy,
+): string | null {
+  switch (policy.reason) {
+    case 'unknown_route':
+      return '[anthropic-attribution] disabled for an unresolved request route'
+    case 'official_auth_unknown_enabled':
+    case 'official_auth_unknown_disabled':
+      return '[anthropic-attribution] preserved the configured setting for ambiguous official auth'
+    default:
+      return null
+  }
+}

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -45,6 +45,7 @@ import { getCwd } from './cwd.js'
 import { logForDebugging } from './debug.js'
 import { isEnvTruthy } from './envUtils.js'
 import { createUserMessage } from './messages.js'
+import { isAnthropicBillingAttributionBlock } from './anthropicAttribution.js'
 import {
   getAPIProvider,
   isFirstPartyAnthropicBaseUrl,
@@ -337,8 +338,16 @@ function logStripOnce(stripped: string[]): void {
  * Log stats about first block for analyzing prefix matching config
  * (see https://console.statsig.com/4aF3Ewatb6xPVpCwxb5nA3/dynamic_configs/claude_cli_system_prompt_prefixes)
  */
+export function getSystemPromptTelemetryBlock(
+  systemPrompt: SystemPrompt,
+): SystemPromptBlock | undefined {
+  return splitSysPromptPrefix(systemPrompt).find(
+    block => !isAnthropicBillingAttributionBlock(block.text),
+  )
+}
+
 export function logAPIPrefix(systemPrompt: SystemPrompt): void {
-  const [firstSyspromptBlock] = splitSysPromptPrefix(systemPrompt)
+  const firstSyspromptBlock = getSystemPromptTelemetryBlock(systemPrompt)
   const firstSystemPrompt = firstSyspromptBlock?.text
   logEvent('tengu_sysprompt_block', {
     snippet: firstSystemPrompt?.slice(
@@ -395,7 +404,7 @@ export function splitSysPromptPrefix(
     for (const prompt of systemPrompt) {
       if (!prompt) continue
       if (prompt === SYSTEM_PROMPT_DYNAMIC_BOUNDARY) continue // Skip boundary
-      if (prompt.startsWith('x-anthropic-billing-header')) {
+      if (isAnthropicBillingAttributionBlock(prompt)) {
         attributionHeader = prompt
       } else if (CLI_SYSPROMPT_PREFIXES.has(prompt)) {
         systemPromptPrefix = prompt
@@ -432,7 +441,7 @@ export function splitSysPromptPrefix(
         const block = systemPrompt[i]
         if (!block || block === SYSTEM_PROMPT_DYNAMIC_BOUNDARY) continue
 
-        if (block.startsWith('x-anthropic-billing-header')) {
+        if (isAnthropicBillingAttributionBlock(block)) {
           attributionHeader = block
         } else if (CLI_SYSPROMPT_PREFIXES.has(block)) {
           systemPromptPrefix = block
@@ -474,7 +483,7 @@ export function splitSysPromptPrefix(
   for (const block of systemPrompt) {
     if (!block) continue
 
-    if (block.startsWith('x-anthropic-billing-header')) {
+    if (isAnthropicBillingAttributionBlock(block)) {
       attributionHeader = block
     } else if (CLI_SYSPROMPT_PREFIXES.has(block)) {
       systemPromptPrefix = block

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -85,17 +85,15 @@ import { clearToolSchemaCache } from './toolSchemaCache.js'
 const DEFAULT_API_KEY_HELPER_TTL = 5 * 60 * 1000
 
 /**
- * CCR and Claude Desktop spawn the CLI with OAuth and should never fall back
- * to the user's ~/.claude/settings.json API-key config (apiKeyHelper,
- * env.ANTHROPIC_API_KEY, env.ANTHROPIC_AUTH_TOKEN). Those settings exist for
- * the user's terminal CLI, not managed sessions. Without this guard, a user
- * who runs `claude` in their terminal with an API key sees every CCD session
- * also use that key — and fail if it's stale/wrong-org.
+ * Managed launchers and the SSH auth proxy own the effective OAuth credential
+ * and must not inherit the user's terminal API-key configuration.
  */
 export function isManagedOAuthContext(): boolean {
   return (
     isEnvTruthy(process.env.CLAUDE_CODE_REMOTE) ||
-    process.env.CLAUDE_CODE_ENTRYPOINT === 'claude-desktop'
+    process.env.CLAUDE_CODE_ENTRYPOINT === 'claude-desktop' ||
+    (!!process.env.ANTHROPIC_UNIX_SOCKET &&
+      !!process.env.CLAUDE_CODE_OAUTH_TOKEN)
   )
 }
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -92,7 +92,7 @@ const DEFAULT_API_KEY_HELPER_TTL = 5 * 60 * 1000
  * who runs `claude` in their terminal with an API key sees every CCD session
  * also use that key — and fail if it's stale/wrong-org.
  */
-function isManagedOAuthContext(): boolean {
+export function isManagedOAuthContext(): boolean {
   return (
     isEnvTruthy(process.env.CLAUDE_CODE_REMOTE) ||
     process.env.CLAUDE_CODE_ENTRYPOINT === 'claude-desktop'

--- a/src/utils/sideQuery.attribution.test.ts
+++ b/src/utils/sideQuery.attribution.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
-import { mkdtempSync, rmSync } from 'fs'
+import { mkdtempSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
 import {
@@ -43,6 +43,7 @@ const envKeys = [
   'ANTHROPIC_AUTH_TOKEN',
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_MODEL',
+  'ANTHROPIC_UNIX_SOCKET',
   'CLAUDE_CODE_ATTRIBUTION_HEADER',
   'CLAUDE_CODE_ENTRYPOINT',
   'CLAUDE_CODE_OAUTH_TOKEN',
@@ -205,7 +206,11 @@ afterEach(() => {
       }
     }
     globalThis.fetch = originalFetch
-    process.env.NODE_ENV = originalNodeEnv
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = originalNodeEnv
+    }
     setFlagSettingsPath(undefined)
     setFlagSettingsInline(null)
     setAllowedSettingSources([...SETTING_SOURCES])
@@ -245,12 +250,21 @@ describeAttribution('sideQuery Anthropic attribution', () => {
       'claude-desktop',
       'api-key-helper',
     ],
+    [
+      'Unix-socket OAuth proxy',
+      'ANTHROPIC_UNIX_SOCKET',
+      '/tmp/openclaude-auth-test.sock',
+      'auth-token',
+    ],
   ] as const) {
     test(`uses OAuth headers and attribution in managed ${label} sessions`, async () => {
       process.env[envKey] = envValue
       process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-test-token'
       process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
       if (ambientAuth === 'api-key-helper') setIgnoredApiKeyHelper()
+      if (ambientAuth === 'auth-token') {
+        process.env.ANTHROPIC_AUTH_TOKEN = 'ignored-test-auth-token'
+      }
       getClaudeAIOAuthTokens.cache?.clear?.()
 
       const request = await captureSideQueryRequest()
@@ -265,6 +279,34 @@ describeAttribution('sideQuery Anthropic attribution', () => {
       expect(request.headers.has('x-api-key')).toBe(false)
     })
   }
+
+  test('keeps Unix-socket API-key auth when the OAuth placeholder is absent', async () => {
+    writeFileSync(
+      join(configRoot!, '.credentials.json'),
+      JSON.stringify({
+        claudeAiOauth: {
+          accessToken: 'stored-test-oauth-token',
+          refreshToken: null,
+          expiresAt: null,
+          scopes: ['user:inference'],
+          subscriptionType: null,
+          rateLimitTier: null,
+        },
+      }),
+    )
+    process.env.ANTHROPIC_UNIX_SOCKET = '/tmp/openclaude-auth-test.sock'
+    process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+    getClaudeAIOAuthTokens.cache?.clear?.()
+
+    const request = await captureSideQueryRequest()
+    const texts = blockTexts(request.system)
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+    expect(request.headers.get('x-api-key')).toBe('sk-test-side-query')
+    expect(request.headers.has('authorization')).toBe(false)
+  })
 
   test('strips the block from a custom native endpoint', async () => {
     process.env.ANTHROPIC_BASE_URL = 'https://custom-anthropic.example/v1'

--- a/src/utils/sideQuery.attribution.test.ts
+++ b/src/utils/sideQuery.attribution.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { resetGrowthBook } from '../services/analytics/growthbook.js'
+import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
+import { getClaudeAIOAuthTokens } from './auth.js'
+import { sideQuery } from './sideQuery.js'
+
+const envKeys = [
+  'ANTHROPIC_API_KEY',
+  'ANTHROPIC_AUTH_TOKEN',
+  'ANTHROPIC_BASE_URL',
+  'ANTHROPIC_MODEL',
+  'CLAUDE_CODE_ATTRIBUTION_HEADER',
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  'CLAUDE_CODE_USE_BEDROCK',
+  'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_USE_GEMINI',
+  'CLAUDE_CODE_USE_GITHUB',
+  'CLAUDE_CODE_USE_MISTRAL',
+  'CLAUDE_CODE_USE_OPENAI',
+  'CLAUDE_CODE_USE_VERTEX',
+  'CLAUDE_FEATURE_FLAGS_FILE',
+  'OPENAI_API_BASE',
+  'OPENAI_API_KEY',
+  'OPENAI_BASE_URL',
+  'OPENAI_MODEL',
+  'OPENCLAUDE_CONFIG_DIR',
+] as const
+const originalEnv = { ...process.env }
+const originalFetch = globalThis.fetch
+const hadSavedMacro = Object.hasOwn(globalThis, 'MACRO')
+const savedMacro = (globalThis as Record<string, unknown>).MACRO
+let configRoot: string | undefined
+
+function makeMessageResponse(): Response {
+  return new Response(
+    JSON.stringify({
+      id: 'msg-side-attribution-test',
+      type: 'message',
+      role: 'assistant',
+      model: 'claude-side-attribution-test',
+      content: [],
+      container: null,
+      context_management: null,
+      stop_details: null,
+      stop_reason: 'end_turn',
+      stop_sequence: null,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+      },
+    }),
+    {
+      headers: {
+        'content-type': 'application/json',
+        'request-id': 'req-side-attribution-test',
+      },
+    },
+  )
+}
+
+async function captureSideQuerySystem(
+  system:
+    | string
+    | Array<{
+        type: 'text'
+        text: string
+        cache_control?: { type: 'ephemeral'; scope?: 'global' | 'org' }
+      }> = 'stable side prompt',
+): Promise<Array<Record<string, unknown>>> {
+  let requestBody: Record<string, unknown> | undefined
+  globalThis.fetch = (async (input, init) => {
+    const request =
+      input instanceof Request
+        ? input.clone()
+        : new Request(input as RequestInfo, init)
+    const body = await request.text()
+    if (body) requestBody = JSON.parse(body) as Record<string, unknown>
+    return makeMessageResponse()
+  }) as typeof fetch
+
+  await sideQuery({
+    querySource: 'model_validation',
+    model: 'claude-side-attribution-test',
+    system,
+    messages: [{ role: 'user', content: 'hello' }],
+  })
+
+  if (!Array.isArray(requestBody?.system)) {
+    throw new Error('expected captured side-query system blocks')
+  }
+  return requestBody.system as Array<Record<string, unknown>>
+}
+
+function blockTexts(blocks: Array<Record<string, unknown>>): string[] {
+  return blocks.flatMap(block =>
+    typeof block.text === 'string' ? [block.text] : [],
+  )
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('sideQuery.attribution.test.ts')
+  configRoot = mkdtempSync(join(tmpdir(), 'side-query-attribution-'))
+  for (const key of envKeys) delete process.env[key]
+  process.env.ANTHROPIC_API_KEY = 'sk-test-side-query'
+  process.env.OPENCLAUDE_CONFIG_DIR = configRoot
+  process.env.CLAUDE_FEATURE_FLAGS_FILE = join(
+    configRoot,
+    'feature-flags.json',
+  )
+  ;(globalThis as Record<string, unknown>).MACRO = {
+    VERSION: '0.0.0-test',
+    DISPLAY_VERSION: '0.0.0-test',
+    BUILD_TIME: 'test',
+    ISSUES_EXPLAINER: 'test',
+    PACKAGE_URL: 'test',
+    NATIVE_PACKAGE_URL: undefined,
+  }
+  getClaudeAIOAuthTokens.cache?.clear?.()
+  resetGrowthBook()
+})
+
+afterEach(() => {
+  try {
+    for (const key of envKeys) {
+      if (originalEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = originalEnv[key]
+      }
+    }
+    globalThis.fetch = originalFetch
+    if (hadSavedMacro) {
+      ;(globalThis as Record<string, unknown>).MACRO = savedMacro
+    } else {
+      delete (globalThis as Record<string, unknown>).MACRO
+    }
+    getClaudeAIOAuthTokens.cache?.clear?.()
+    resetGrowthBook()
+    if (configRoot) {
+      rmSync(configRoot, { recursive: true, force: true })
+      configRoot = undefined
+    }
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+describe('sideQuery Anthropic attribution', () => {
+  test('strips the block from a custom native endpoint', async () => {
+    process.env.ANTHROPIC_BASE_URL = 'https://custom-anthropic.example/v1'
+
+    const texts = blockTexts(await captureSideQuerySystem())
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+    expect(texts).toContain('stable side prompt')
+  })
+
+  test('keeps the block for official OAuth when globally disabled', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-test-token'
+    process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+    getClaudeAIOAuthTokens.cache?.clear?.()
+
+    const texts = blockTexts(await captureSideQuerySystem())
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(true)
+    expect(texts).toContain('stable side prompt')
+  })
+
+  test('keeps one generated block and preserves cache metadata order', async () => {
+    const blocks = await captureSideQuerySystem([
+      { type: 'text', text: 'x-anthropic-billing-header: stale' },
+      {
+        type: 'text',
+        text: 'stable cached side prompt',
+        cache_control: { type: 'ephemeral', scope: 'org' },
+      },
+    ])
+
+    const texts = blockTexts(blocks)
+    expect(
+      texts.filter(text => text.startsWith('x-anthropic-billing-header')),
+    ).toHaveLength(1)
+    expect(texts[1]).toBe('stable cached side prompt')
+    expect(blocks[1]?.cache_control).toEqual({
+      type: 'ephemeral',
+      scope: 'org',
+    })
+  })
+})

--- a/src/utils/sideQuery.attribution.test.ts
+++ b/src/utils/sideQuery.attribution.test.ts
@@ -2,10 +2,41 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
 import { mkdtempSync, rmSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import {
+  setAllowedSettingSources,
+  setFlagSettingsInline,
+  setFlagSettingsPath,
+} from '../bootstrap/state.js'
 import { resetGrowthBook } from '../services/analytics/growthbook.js'
 import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
 import { getClaudeAIOAuthTokens } from './auth.js'
-import { sideQuery } from './sideQuery.js'
+import { enableConfigs } from './config.js'
+import { SETTING_SOURCES } from './settings/constants.js'
+import { resetSettingsCache } from './settings/settingsCache.js'
+import {
+  providerModuleIsMocked,
+  REAL_PROVIDER_TEST_CHILD_ENV,
+  REAL_PROVIDER_TEST_TIMEOUT_MS,
+  runTestFileWithRealProviders,
+} from '../test/providerModuleIsolation.js'
+
+// Bun keeps mock.module() registrations process-global across test files.
+// Bind sideQuery only when the canonical provider module is real. When a prior
+// file replaced it, run this file in a clean child process instead.
+const _realProvidersModule = await import(
+  `./model/providers.js?attributionReal=${Date.now()}-${Math.random()}`
+)
+const _loadedProvidersModule = await import('src/utils/model/providers.js')
+const runInProviderIsolatedChild =
+  process.env[REAL_PROVIDER_TEST_CHILD_ENV] !== '1' &&
+  providerModuleIsMocked(_loadedProvidersModule, _realProvidersModule)
+type SideQueryModule = typeof import('./sideQuery.js')
+let sideQuery!: SideQueryModule['sideQuery']
+if (!runInProviderIsolatedChild) {
+  ;({ sideQuery } = await import(
+    `./sideQuery.js?attributionReal=${Date.now()}-${Math.random()}`
+  ))
+}
 
 const envKeys = [
   'ANTHROPIC_API_KEY',
@@ -13,7 +44,9 @@ const envKeys = [
   'ANTHROPIC_BASE_URL',
   'ANTHROPIC_MODEL',
   'CLAUDE_CODE_ATTRIBUTION_HEADER',
+  'CLAUDE_CODE_ENTRYPOINT',
   'CLAUDE_CODE_OAUTH_TOKEN',
+  'CLAUDE_CODE_REMOTE',
   'CLAUDE_CODE_USE_BEDROCK',
   'CLAUDE_CODE_USE_FOUNDRY',
   'CLAUDE_CODE_USE_GEMINI',
@@ -32,6 +65,7 @@ const originalEnv = { ...process.env }
 const originalFetch = globalThis.fetch
 const hadSavedMacro = Object.hasOwn(globalThis, 'MACRO')
 const savedMacro = (globalThis as Record<string, unknown>).MACRO
+const originalNodeEnv = process.env.NODE_ENV
 let configRoot: string | undefined
 
 function makeMessageResponse(): Response {
@@ -63,7 +97,7 @@ function makeMessageResponse(): Response {
   )
 }
 
-async function captureSideQuerySystem(
+async function captureSideQueryRequest(
   system:
     | string
     | Array<{
@@ -71,8 +105,12 @@ async function captureSideQuerySystem(
         text: string
         cache_control?: { type: 'ephemeral'; scope?: 'global' | 'org' }
       }> = 'stable side prompt',
-): Promise<Array<Record<string, unknown>>> {
+): Promise<{
+  system: Array<Record<string, unknown>>
+  headers: Headers
+}> {
   let requestBody: Record<string, unknown> | undefined
+  let requestHeaders: Headers | undefined
   globalThis.fetch = (async (input, init) => {
     const request =
       input instanceof Request
@@ -80,6 +118,7 @@ async function captureSideQuerySystem(
         : new Request(input as RequestInfo, init)
     const body = await request.text()
     if (body) requestBody = JSON.parse(body) as Record<string, unknown>
+    requestHeaders = new Headers(request.headers)
     return makeMessageResponse()
   }) as typeof fetch
 
@@ -93,7 +132,25 @@ async function captureSideQuerySystem(
   if (!Array.isArray(requestBody?.system)) {
     throw new Error('expected captured side-query system blocks')
   }
-  return requestBody.system as Array<Record<string, unknown>>
+  if (!requestHeaders) {
+    throw new Error('expected captured side-query request headers')
+  }
+  return {
+    system: requestBody.system as Array<Record<string, unknown>>,
+    headers: requestHeaders,
+  }
+}
+
+async function captureSideQuerySystem(
+  system:
+    | string
+    | Array<{
+        type: 'text'
+        text: string
+        cache_control?: { type: 'ephemeral'; scope?: 'global' | 'org' }
+      }> = 'stable side prompt',
+): Promise<Array<Record<string, unknown>>> {
+  return (await captureSideQueryRequest(system)).system
 }
 
 function blockTexts(blocks: Array<Record<string, unknown>>): string[] {
@@ -104,6 +161,10 @@ function blockTexts(blocks: Array<Record<string, unknown>>): string[] {
 
 beforeEach(async () => {
   await acquireSharedMutationLock('sideQuery.attribution.test.ts')
+  setFlagSettingsPath(undefined)
+  setFlagSettingsInline(null)
+  setAllowedSettingSources([...SETTING_SOURCES])
+  resetSettingsCache()
   configRoot = mkdtempSync(join(tmpdir(), 'side-query-attribution-'))
   for (const key of envKeys) delete process.env[key]
   process.env.ANTHROPIC_API_KEY = 'sk-test-side-query'
@@ -124,6 +185,16 @@ beforeEach(async () => {
   resetGrowthBook()
 })
 
+function setIgnoredApiKeyHelper(): void {
+  delete process.env.ANTHROPIC_API_KEY
+  setFlagSettingsPath(undefined)
+  setFlagSettingsInline({ apiKeyHelper: 'ignored-test-helper' })
+  setAllowedSettingSources(['flagSettings'])
+  resetSettingsCache()
+  enableConfigs()
+  process.env.NODE_ENV = 'development'
+}
+
 afterEach(() => {
   try {
     for (const key of envKeys) {
@@ -134,6 +205,11 @@ afterEach(() => {
       }
     }
     globalThis.fetch = originalFetch
+    process.env.NODE_ENV = originalNodeEnv
+    setFlagSettingsPath(undefined)
+    setFlagSettingsInline(null)
+    setAllowedSettingSources([...SETTING_SOURCES])
+    resetSettingsCache()
     if (hadSavedMacro) {
       ;(globalThis as Record<string, unknown>).MACRO = savedMacro
     } else {
@@ -150,7 +226,46 @@ afterEach(() => {
   }
 })
 
-describe('sideQuery Anthropic attribution', () => {
+if (runInProviderIsolatedChild) {
+  test('runs side-query attribution cases with the real provider module', async () => {
+    await runTestFileWithRealProviders(import.meta.path)
+  }, { timeout: REAL_PROVIDER_TEST_TIMEOUT_MS + 5_000 })
+}
+
+const describeAttribution = runInProviderIsolatedChild
+  ? describe.skip
+  : describe
+
+describeAttribution('sideQuery Anthropic attribution', () => {
+  for (const [label, envKey, envValue, ambientAuth] of [
+    ['remote', 'CLAUDE_CODE_REMOTE', '1', 'api-key'],
+    [
+      'Claude Desktop',
+      'CLAUDE_CODE_ENTRYPOINT',
+      'claude-desktop',
+      'api-key-helper',
+    ],
+  ] as const) {
+    test(`uses OAuth headers and attribution in managed ${label} sessions`, async () => {
+      process.env[envKey] = envValue
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = 'oauth-test-token'
+      process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+      if (ambientAuth === 'api-key-helper') setIgnoredApiKeyHelper()
+      getClaudeAIOAuthTokens.cache?.clear?.()
+
+      const request = await captureSideQueryRequest()
+      const texts = blockTexts(request.system)
+
+      expect(
+        texts.some(text => text.startsWith('x-anthropic-billing-header')),
+      ).toBe(true)
+      expect(request.headers.get('authorization')).toBe(
+        'Bearer oauth-test-token',
+      )
+      expect(request.headers.has('x-api-key')).toBe(false)
+    })
+  }
+
   test('strips the block from a custom native endpoint', async () => {
     process.env.ANTHROPIC_BASE_URL = 'https://custom-anthropic.example/v1'
 

--- a/src/utils/sideQuery.attribution.test.ts
+++ b/src/utils/sideQuery.attribution.test.ts
@@ -154,6 +154,22 @@ describe('sideQuery Anthropic attribution', () => {
   test('strips the block from a custom native endpoint', async () => {
     process.env.ANTHROPIC_BASE_URL = 'https://custom-anthropic.example/v1'
 
+    const texts = blockTexts(
+      await captureSideQuerySystem([
+        { type: 'text', text: 'x-anthropic-billing-header: stale' },
+        { type: 'text', text: 'stable side prompt' },
+      ]),
+    )
+
+    expect(
+      texts.some(text => text.startsWith('x-anthropic-billing-header')),
+    ).toBe(false)
+    expect(texts).toContain('stable side prompt')
+  })
+
+  test('honors the disabled setting for an official API key', async () => {
+    process.env.CLAUDE_CODE_ATTRIBUTION_HEADER = '0'
+
     const texts = blockTexts(await captureSideQuerySystem())
 
     expect(

--- a/src/utils/sideQuery.ts
+++ b/src/utils/sideQuery.ts
@@ -9,11 +9,14 @@ import type { QuerySource } from '../constants/querySource.js'
 import {
   getAttributionHeader,
   getCLISyspromptPrefix,
+  isAttributionHeaderEnabled,
 } from '../constants/system.js'
 import { logEvent } from '../services/analytics/index.js'
 import type { AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS } from '../services/analytics/metadata.js'
 import { getAPIMetadata } from '../services/api/claude.js'
+import { resolveCurrentAnthropicAttributionPolicy } from '../services/api/authRouting.js'
 import { getAnthropicClient } from '../services/api/client.js'
+import { applyAnthropicAttributionPolicy } from './anthropicAttribution.js'
 import { getModelBetas, modelSupportsStructuredOutputs } from './betas.js'
 import { computeFingerprint } from './fingerprint.js'
 import { normalizeModelStringForAPI } from './model/model.js'
@@ -141,30 +144,39 @@ export async function sideQuery(opts: SideQueryOptions): Promise<BetaMessage> {
 
   // Compute fingerprint for OAuth attribution
   const fingerprint = computeFingerprint(messageText, MACRO.VERSION)
-  const attributionHeader = getAttributionHeader(fingerprint)
+  const attributionPolicy = resolveCurrentAnthropicAttributionPolicy({
+    attributionEnabled: isAttributionHeaderEnabled(),
+  })
+  const attributionHeader = getAttributionHeader(
+    fingerprint,
+    attributionPolicy,
+  )
 
   // Build system as array to keep attribution header in its own block
   // (prevents server-side parsing from including system content in cc_entrypoint)
-  const systemBlocks: TextBlockParam[] = [
-    attributionHeader ? { type: 'text', text: attributionHeader } : null,
-    // Skip CLI system prompt prefix for internal classifiers that provide their own prompt
-    ...(skipSystemPromptPrefix
-      ? []
-      : [
-          {
-            type: 'text' as const,
-            text: getCLISyspromptPrefix({
-              isNonInteractive: false,
-              hasAppendSystemPrompt: false,
-            }),
-          },
-        ]),
-    ...(Array.isArray(system)
-      ? system
-      : system
-        ? [{ type: 'text' as const, text: system }]
-        : []),
-  ].filter((block): block is TextBlockParam => block !== null)
+  const systemBlocks: TextBlockParam[] = applyAnthropicAttributionPolicy(
+    [
+      attributionHeader ? { type: 'text', text: attributionHeader } : null,
+      // Skip CLI system prompt prefix for internal classifiers that provide their own prompt
+      ...(skipSystemPromptPrefix
+        ? []
+        : [
+            {
+              type: 'text' as const,
+              text: getCLISyspromptPrefix({
+                isNonInteractive: false,
+                hasAppendSystemPrompt: false,
+              }),
+            },
+          ]),
+      ...(Array.isArray(system)
+        ? system
+        : system
+          ? [{ type: 'text' as const, text: system }]
+          : []),
+    ].filter((block): block is TextBlockParam => block !== null),
+    attributionPolicy,
+  )
 
   let thinkingConfig: BetaThinkingConfigParam | undefined
   if (thinking === false) {

--- a/src/utils/sideQuery.ts
+++ b/src/utils/sideQuery.ts
@@ -33,7 +33,8 @@ export type SideQueryOptions = {
   /** Model to use for the query */
   model: string
   /**
-   * System prompt - string or array of text blocks (will be prefixed with CLI attribution).
+   * System prompt - string or array of text blocks. Compatible first-party
+   * requests are prefixed with CLI attribution according to the resolved policy.
    *
    * The attribution header is always placed in its own TextBlockParam block to ensure
    * server-side parsing correctly extracts the cc_entrypoint value without including
@@ -54,7 +55,7 @@ export type SideQueryOptions = {
   maxRetries?: number
   /** Abort signal */
   signal?: AbortSignal
-  /** Skip CLI system prompt prefix (keeps attribution header for OAuth). Default true — side queries are internal classifiers with their own prompt. Set false only for queries that need the full "You are Claude Code…" prefix. */
+  /** Skip CLI system prompt prefix. Attribution is handled separately by the resolved request policy. Default true — side queries are internal classifiers with their own prompt. Set false only for queries that need the full "You are Claude Code…" prefix. */
   skipSystemPromptPrefix?: boolean
   /** Temperature override */
   temperature?: number


### PR DESCRIPTION
## Summary

- make Anthropic billing attribution follow one provider and auth policy for primary requests and side queries
- keep the required block on official Anthropic OAuth subscription requests while preserving the existing API-key setting behavior
- strip the block from custom Anthropic endpoints, provider overrides, cloud routes, and third-party native or shim transports
- resolve attribution after effective route normalization and remove duplicate or stale blocks without changing prompt order

Fixes #2129

## Impact

- user-facing impact: custom Anthropic-compatible endpoints no longer receive OpenClaude's internal billing block as prompt content, while official OAuth subscription requests retain the block required by Anthropic
- developer/maintainer impact: request attribution now has one testable policy that states whether to generate and retain the block and records a fixed reason

## Testing

- [x] `bun run build`
- [x] `bun run smoke`
- [x] `bun run check`
- [x] focused tests: `bun test src/utils/anthropicAttribution.test.ts src/utils/sideQuery.attribution.test.ts src/services/api/authRouting.attribution.test.ts src/services/api/claude.lifecycle.test.ts src/utils/anthropicBaseUrl.test.ts src/services/api/openaiShim/requestPlanner.test.ts`
- [x] `bun run test:provider`
- [x] `bun run typecheck`
- [x] `bun run typecheck:type-tests`
- [x] `bun run doctor:runtime`
- [x] `bun run security:pr-scan -- --base upstream/main --head HEAD`
- [x] `git diff --check`

## Notes

- reviewed `AGENTS.md` and `CONTRIBUTING.md`
- provider/model path tested: official Anthropic OAuth, official Anthropic API key, custom Anthropic base URL, canonical-host lookalike, approved loopback proxy, MiniMax native routing, GitHub native Anthropic transport, third-party Anthropic Messages planning, Bedrock, Vertex, Foundry, provider overrides, primary requests, and side queries
- screenshots attached (if UI changed): not applicable, no UI changed
- follow-up work or known limitations: no live credentialed Anthropic request was run; tests verify the exact outbound body invariant


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added billing attribution handling for Anthropic requests across supported routes and authentication methods.
  * Attribution now adapts to the provider, endpoint, authentication method, and feature settings.
  * Improved system prompt telemetry while preserving caching metadata.

* **Bug Fixes**
  * Prevented attribution on unsupported or custom provider routes.
  * Improved retry handling, stale attribution removal, and duplicate system prompt prevention.

* **Tests**
  * Added comprehensive coverage for routing, authentication, lifecycle requests, side queries, and attribution policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->