### PR TITLE
docs: tighten PR review expectations in CONTRIBUTING and AGENTS guides

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,10 +10,10 @@
 
 ## Testing
 
-- [ ] `bun run build`
-- [ ] `bun run smoke`
-- [ ] `bun run check`
-- [ ] focused tests:
+- [ ] I ran the required [local preflight](https://github.com/Gitlawb/openclaude/blob/main/CONTRIBUTING.md#validation).
+- exact commands and results:
+- focused tests:
+- documented platform limitations or base-reproduced failures:
 
 ## Notes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@
 - [ ] I ran the required [local preflight](https://github.com/Gitlawb/openclaude/blob/main/CONTRIBUTING.md#validation).
 - exact commands and results:
 - focused tests:
-- documented platform limitations or base-reproduced failures:
+- documented skipped checks, platform limitations, or verified pre-existing failures:
 
 ## Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ The installed CLI runs on Node.js `>=22.0.0`. Bun is used for source builds, scr
 - Update docs when setup, commands, provider behavior, or user-facing behavior changes.
 - For new features, larger refactors, dependencies, or runtime changes, follow the issue-first guidance in [CONTRIBUTING.md](CONTRIBUTING.md).
 - Keep PR branches current with `main` — rebase onto `main` whenever resuming work or pushing follow-up fixes. Stale branches attract redundant fix-churn requests for issues already fixed on `main`.
-- Run the authoritative pre-push validation contract defined in [CONTRIBUTING.md § Validation](CONTRIBUTING.md#validation) — the full CI-equivalent suite, green before every push to a PR, not just the first one. Platform-specific checks you cannot run locally (e.g., Windows checks from macOS) are the only exception.
+- Run the authoritative local pre-push validation contract defined in [CONTRIBUTING.md § Validation](CONTRIBUTING.md#validation) before every push to a PR, not just the first one. CI adds clean-runner and supported-Node-matrix coverage that is not practical to reproduce in one local shell.
 
 ## Stack And Conventions
 
@@ -48,7 +48,7 @@ Common libraries and patterns:
 
 ## Validation
 
-The authoritative pre-push validation contract lives in [CONTRIBUTING.md § Validation](CONTRIBUTING.md#validation) — it mirrors `.github/workflows/pr-checks.yml` exactly and must be green locally before every push to a PR, including follow-up fixes during review. Platform-specific checks that cannot run on your OS are the only exception. The lists below are for narrowing checks while you iterate; they do not replace the pre-push contract.
+The authoritative local pre-push validation contract lives in [CONTRIBUTING.md § Validation](CONTRIBUTING.md#validation) and must be run before every push to a PR, including follow-up fixes during review. It covers the same command families as `.github/workflows/pr-checks.yml`; CI remains authoritative for clean-runner, supported-Node-matrix, and platform-specific coverage. The lists below are for narrowing checks while you iterate; they do not replace the pre-push contract.
 
 Core checks:
 
@@ -103,7 +103,7 @@ When modifying provider behavior:
 - Do not skip tests for behavior changes.
 - Do not silently change provider tags; maintainers control them during review.
 - Do not ignore CodeRabbit or maintainer feedback; address it before requesting more review. Before applying an automated review suggestion, verify it does not pull the PR away from its stated scope or intent — decline out-of-scope suggestions with justification, or ask a maintainer when unsure. Never silently ignore findings.
-- Do not push commits with failing, incomplete, or unrun local checks; do not wait for GitHub CI to discover failures you could have caught locally.
+- Do not push commits with failing, incomplete, or unrun local checks. A platform limitation or failure reproduced unchanged on the PR base must be documented with evidence and agreed to by a maintainer; it is not an automatic waiver.
 - Do not submit a PR whose description still contains template placeholder text; fill in every section of the [PR template](.github/pull_request_template.md) for the actual change.
 - Do not surface-patch recurring review findings; repeated fix requests usually indicate a core design issue — investigate and fix the root cause instead of the reported symptom.
 - Do not add a manually maintained release-notes data source to the static site; link to GitHub Releases instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ The installed CLI runs on Node.js `>=22.0.0`. Bun is used for source builds, scr
 - Update docs when setup, commands, provider behavior, or user-facing behavior changes.
 - For new features, larger refactors, dependencies, or runtime changes, follow the issue-first guidance in [CONTRIBUTING.md](CONTRIBUTING.md).
 - Keep PR branches current with `main` — rebase onto `main` whenever resuming work or pushing follow-up fixes. Stale branches attract redundant fix-churn requests for issues already fixed on `main`.
-- Run the full local CI-equivalent validation suite (see [Validation](#validation)) and get it green before every push, not just the first one. Platform-specific checks you cannot run locally (e.g., Windows checks from macOS) are the only exception.
+- Run the authoritative pre-push validation contract defined in [CONTRIBUTING.md § Validation](CONTRIBUTING.md#validation) — the full CI-equivalent suite, green before every push to a PR, not just the first one. Platform-specific checks you cannot run locally (e.g., Windows checks from macOS) are the only exception.
 
 ## Stack And Conventions
 
@@ -48,7 +48,7 @@ Common libraries and patterns:
 
 ## Validation
 
-Run the narrowest useful checks while iterating on your change, and list the exact commands in the PR. Before every push to a PR — including follow-up fixes during review — run the core checks and get them green locally instead of waiting for GitHub CI. Platform-specific checks that cannot run on your OS are the only exception.
+The authoritative pre-push validation contract lives in [CONTRIBUTING.md § Validation](CONTRIBUTING.md#validation) — it mirrors `.github/workflows/pr-checks.yml` exactly and must be green locally before every push to a PR, including follow-up fixes during review. Platform-specific checks that cannot run on your OS are the only exception. The lists below are for narrowing checks while you iterate; they do not replace the pre-push contract.
 
 Core checks:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ The installed CLI runs on Node.js `>=22.0.0`. Bun is used for source builds, scr
 - Add or update tests when behavior changes.
 - Update docs when setup, commands, provider behavior, or user-facing behavior changes.
 - For new features, larger refactors, dependencies, or runtime changes, follow the issue-first guidance in [CONTRIBUTING.md](CONTRIBUTING.md).
-- Keep PR branches current with `main` — rebase onto `main` whenever resuming work or pushing follow-up fixes. Stale branches attract redundant fix-churn requests for issues already fixed on `main`.
+- Keep PR branches current with `main` using the synchronization and guarded-push workflow in [CONTRIBUTING.md § Keep Your Branch Current](CONTRIBUTING.md#keep-your-branch-current). Rebase whenever resuming work or pushing follow-up fixes, but never overwrite remote PR-head updates with an unguarded force-push.
 - Run the authoritative local pre-push validation contract defined in [CONTRIBUTING.md § Validation](CONTRIBUTING.md#validation) before every push to a PR, not just the first one. CI adds clean-runner and supported-Node-matrix coverage that is not practical to reproduce in one local shell.
 
 ## Stack And Conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,8 +82,9 @@ Diagnostics and PR hygiene:
 
 ```bash
 bun run doctor:runtime
-bun run security:pr-scan
 ```
+
+For PR intent scanning, use the canonical upstream fetch and explicit-ref invocation in [CONTRIBUTING.md § Validation](CONTRIBUTING.md#validation); the scanner's default `origin/main` base is not portable to fork checkouts.
 
 ## Provider Changes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ bun run test:provider
 bun run test:provider-recommendation
 ```
 
-Web checks, when touching `web/`:
+Web checks, when changes can affect the site:
 
 ```bash
 bun run web:typecheck
@@ -103,7 +103,7 @@ When modifying provider behavior:
 - Do not skip tests for behavior changes.
 - Do not silently change provider tags; maintainers control them during review.
 - Do not ignore CodeRabbit or maintainer feedback; address it before requesting more review. Before applying an automated review suggestion, verify it does not pull the PR away from its stated scope or intent — decline out-of-scope suggestions with justification, or ask a maintainer when unsure. Never silently ignore findings.
-- Do not push commits with failing, incomplete, or unrun local checks. A platform limitation or failure reproduced unchanged on the PR base must be documented with evidence and agreed to by a maintainer; it is not an automatic waiver.
+- Do not push commits with failing, incomplete, or unrun local checks unless an exception in [CONTRIBUTING.md § Validation](CONTRIBUTING.md#validation) applies. Verify pre-existing failures against the current PR base and document the evidence in the PR; PR-owned failures must still be fixed.
 - Do not submit a PR whose description still contains template placeholder text; fill in every section of the [PR template](.github/pull_request_template.md) for the actual change.
 - Do not surface-patch recurring review findings; repeated fix requests usually indicate a core design issue — investigate and fix the root cause instead of the reported symptom.
 - Do not add a manually maintained release-notes data source to the static site; link to GitHub Releases instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ The installed CLI runs on Node.js `>=22.0.0`. Bun is used for source builds, scr
 - Add or update tests when behavior changes.
 - Update docs when setup, commands, provider behavior, or user-facing behavior changes.
 - For new features, larger refactors, dependencies, or runtime changes, follow the issue-first guidance in [CONTRIBUTING.md](CONTRIBUTING.md).
+- Keep PR branches current with `main` — rebase onto `main` whenever resuming work or pushing follow-up fixes. Stale branches attract redundant fix-churn requests for issues already fixed on `main`.
+- Run the full local CI-equivalent validation suite (see [Validation](#validation)) and get it green before every push, not just the first one. Platform-specific checks you cannot run locally (e.g., Windows checks from macOS) are the only exception.
 
 ## Stack And Conventions
 
@@ -46,7 +48,7 @@ Common libraries and patterns:
 
 ## Validation
 
-Run the narrowest useful checks for your change, and list the exact commands in the PR.
+Run the narrowest useful checks while iterating on your change, and list the exact commands in the PR. Before every push to a PR — including follow-up fixes during review — run the core checks and get them green locally instead of waiting for GitHub CI. Platform-specific checks that cannot run on your OS are the only exception.
 
 Core checks:
 
@@ -100,5 +102,8 @@ When modifying provider behavior:
 - Do not introduce dependencies without clear project benefit.
 - Do not skip tests for behavior changes.
 - Do not silently change provider tags; maintainers control them during review.
-- Do not ignore CodeRabbit or maintainer feedback; address it before requesting more review.
+- Do not ignore CodeRabbit or maintainer feedback; address it before requesting more review. Before applying an automated review suggestion, verify it does not pull the PR away from its stated scope or intent — decline out-of-scope suggestions with justification, or ask a maintainer when unsure. Never silently ignore findings.
+- Do not push commits with failing, incomplete, or unrun local checks; do not wait for GitHub CI to discover failures you could have caught locally.
+- Do not submit a PR whose description still contains template placeholder text; fill in every section of the [PR template](.github/pull_request_template.md) for the actual change.
+- Do not surface-patch recurring review findings; repeated fix requests usually indicate a core design issue — investigate and fix the root cause instead of the reported symptom.
 - Do not add a manually maintained release-notes data source to the static site; link to GitHub Releases instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,8 @@ The PR author is responsible for keeping their branch current with `main`. Rebas
 
 Stale branches cause real problems: maintainers end up requesting fixes for issues that are already resolved on `main`, which produces endless fix-churn requests for work nobody needs to do again. A quick rebase before each update keeps review feedback relevant and avoids wasted rounds on both sides.
 
+Before rebasing an already-pushed PR branch, fetch both the current remote PR head and upstream `main`, and incorporate any commits that were added to the remote branch. After the rebase, publish with `git push --force-with-lease`, never an unguarded `--force`; the lease prevents overwriting a maintainer, bot, or collaborator update that arrived after your fetch. If the branch is shared or does not allow force-pushes, coordinate with a maintainer and use a repository-approved non-rewriting update path instead of discarding remote work.
+
 Note that PRs with merge conflicts will not be reviewed or approved regardless (see [Pull Requests](#pull-requests)) — staying current prevents that state entirely.
 
 ### PR Follow-Up Requirements
@@ -238,6 +240,18 @@ bun run dev:profile
 
 CI runs a fixed set of checks on every PR (see `.github/workflows/pr-checks.yml`). This section is the **authoritative local pre-push validation contract** — `AGENTS.md` defers to it. **Run every locally applicable check before every push to an open PR, including follow-up pushes during review.** Do not wait for GitHub CI to discover failures you could have caught locally — wasted Actions minutes are a real cost on this repo.
 
+The security scan requires the commit ancestry needed to find the PR's merge base. Check whether your clone is shallow:
+
+```bash
+git rev-parse --is-shallow-repository
+```
+
+If that prints `true`, fetch the rest of the current branch's history before running the preflight (replace the default remote if your PR branch is tracked elsewhere):
+
+```bash
+git fetch --unshallow
+```
+
 Required local preflight:
 
 ```bash
@@ -263,9 +277,19 @@ NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version
 PowerShell:
 
 ```powershell
-$env:NODE_DISABLE_COMPILE_CACHE = '1'
-node bin/openclaude --version
-Remove-Item Env:NODE_DISABLE_COMPILE_CACHE
+& {
+  $previousValue = [Environment]::GetEnvironmentVariable('NODE_DISABLE_COMPILE_CACHE', 'Process')
+  try {
+    $env:NODE_DISABLE_COMPILE_CACHE = '1'
+    node bin/openclaude --version
+    $launcherExitCode = $LASTEXITCODE
+    if ($launcherExitCode -ne 0) {
+      throw "Launcher compatibility check failed with exit code $launcherExitCode"
+    }
+  } finally {
+    [Environment]::SetEnvironmentVariable('NODE_DISABLE_COMPILE_CACHE', $previousValue, 'Process')
+  }
+}
 ```
 
 If the PR can affect the website — including changes under `web/`, root or web dependency and lock files, shared site assets or content, or build/toolchain configuration used by the site — also run:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -244,19 +244,24 @@ The pre-push suite (mirrors CI exactly):
 bun install --frozen-lockfile
 bun run build
 bun run check
-bun run test:full
 bun run typecheck
 bun run typecheck:type-tests
 node bin/openclaude --version
 NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version
 bun run test:provider
 npm run test:provider-recommendation
-bun run security:pr-scan
+bun run security:pr-scan -- --base "$(git merge-base origin/main HEAD)" --head HEAD
 ```
 
-If your PR touches `web/`, add the web job's checks:
+Notes on that suite:
+
+- `bun run check` already includes smoke, deadcode, and the full unit pass (`test:full`) — do not run them separately, or you execute the suite twice.
+- The security scan is given explicit `--base`/`--head` refs to match CI, which scans against the PR's actual base SHA; the script's built-in defaults (`origin/main` / `HEAD`) can miss that target.
+
+If your PR touches `web/`, add the web job's checks (the web workspace has its own lockfile-driven install):
 
 ```bash
+bun install --cwd web --frozen-lockfile
 bun run web:typecheck
 bun run web:build
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,13 @@ The PR author is responsible for keeping their branch current with `main`. Rebas
 
 Stale branches cause real problems: maintainers end up requesting fixes for issues that are already resolved on `main`, which produces endless fix-churn requests for work nobody needs to do again. A quick rebase before each update keeps review feedback relevant and avoids wasted rounds on both sides.
 
-Before rebasing an already-pushed PR branch, fetch both the current remote PR head and upstream `main`, and incorporate any commits that were added to the remote branch. After the rebase, publish with `git push --force-with-lease`, never an unguarded `--force`; the lease prevents overwriting a maintainer, bot, or collaborator update that arrived after your fetch. If the branch is shared or does not allow force-pushes, coordinate with a maintainer and use a repository-approved non-rewriting update path instead of discarding remote work.
+Before rebasing an already-pushed PR branch, fetch the current remote PR head, record its exact commit SHA, and incorporate any commits that were added to the remote branch. Then fetch upstream `main` and rebase. Publish with an explicit lease pinned to the PR-head SHA you recorded, never an unguarded `--force` or an unqualified lease:
+
+```bash
+git push --force-with-lease=refs/heads/<pr-branch>:<recorded-pr-head-sha> <pr-remote> HEAD:refs/heads/<pr-branch>
+```
+
+Pinning the expected SHA prevents a background fetch from silently moving a remote-tracking ref and weakening the lease. If the lease is rejected, stop: fetch and inspect the new remote PR head, incorporate its commits, redo the rebase, and retry with that newly recorded SHA. If the branch is shared or does not allow force-pushes, coordinate with a maintainer and use a repository-approved non-rewriting update path instead of discarding remote work.
 
 Note that PRs with merge conflicts will not be reviewed or approved regardless (see [Pull Requests](#pull-requests)) — staying current prevents that state entirely.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ PRs may be closed without review if they:
 - drift from the approved scope of a linked issue
 - change the project's language, core runtime, or dependency stack without prior maintainer agreement
 - are drive-by contributions with no context, no tests, and no clear purpose
-- submit the [PR template](.github/pull_request_template.md) ignored — generic filler text or leftover template placeholders (`what changed`, `provider/model path tested:`, etc.) show the description was not written for your PR. These will not be reviewed until corrected and risk being closed without review
+- submit a PR with the [PR template](.github/pull_request_template.md) ignored — generic filler text or leftover template placeholders (`what changed`, `provider/model path tested:`, etc.) show the description was not written for your PR. These will not be reviewed until corrected and risk being closed without review
 - are automated bounty-hunting or mass-submitted PRs that provide little meaningful value to the codebase
 - are advertisements, sales pitches, or promotional submissions for a product or service — open an issue first to discuss with maintainers if you believe your product or service is relevant to this project
 
@@ -236,33 +236,32 @@ bun run dev:profile
 
 ## Validation
 
-CI runs the following checks on every PR. **Run the full suite locally and get it green before every push** — do not push commits with failing or unrun checks and wait for GitHub CI to discover the problem. Wasted Actions minutes on a repo this active are a real cost, and pushing red is how review queues back up.
+CI runs a fixed set of checks on every PR (see `.github/workflows/pr-checks.yml`). This section is the **authoritative pre-push validation contract** — `AGENTS.md` defers to it. **Run the full suite locally and get it green before every push to an open PR, including follow-up pushes during review.** Do not push commits with failing or unrun checks and wait for GitHub CI to discover the problem — wasted Actions minutes are a real cost on this repo.
 
-The full local pass (mirrors CI):
+The pre-push suite (mirrors CI exactly):
 
 ```bash
-bun install
+bun install --frozen-lockfile
 bun run build
-bun run smoke
 bun run check
 bun run test:full
 bun run typecheck
 bun run typecheck:type-tests
+node bin/openclaude --version
+NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version
 bun run test:provider
-bun run test:provider-recommendation
+npm run test:provider-recommendation
 bun run security:pr-scan
 ```
 
-If your PR touches `web/`, add:
+If your PR touches `web/`, add the web job's checks:
 
 ```bash
 bun run web:typecheck
 bun run web:build
 ```
 
-This applies to every push to an open PR, not just the first one. If you are iterating on review feedback, re-run the relevant subset at minimum before each push.
-
-Cross-platform exception: you are only required to run what is runnable on your platform. If you develop on macOS or Linux, Windows-specific verification is best-effort — do not hold back a push because you cannot execute another OS's checks locally. Everything else above is expected to be green on your machine before it reaches GitHub.
+Cross-platform exception: this is the only carve-out from the full suite. You are required to run what is runnable on your platform; platform-specific verification you cannot execute locally (e.g., Windows-specific behavior when developing on macOS) is best-effort and may be left to CI. Everything else above is expected to be green on your machine before it reaches GitHub.
 
 PRs that fail CI checks will not be merged.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ OpenClaude is a rapidly evolving open-source coding-agent CLI with support for m
 - [Proposing New Features](#proposing-new-features)
 - [Pull Requests](#pull-requests)
   - [Automated Review (CodeRabbit)](#automated-review-coderabbit)
+  - [Keep Your Branch Current](#keep-your-branch-current)
   - [PR Follow-Up Requirements](#pr-follow-up-requirements)
   - [Duplicate PRs](#duplicate-prs)
   - [What Gets Closed Without Review](#what-gets-closed-without-review)
@@ -74,15 +75,32 @@ We use [CodeRabbit](https://coderabbit.ai) to assist with PR reviews. CodeRabbit
 
 **PR authors must address CodeRabbit findings** — do not ignore its comments and wait for a maintainer override. If you're waiting for a maintainer review and CodeRabbit has completed its review with findings, fix those findings first. Maintainer reviews will not proceed until automated review feedback has been addressed.
 
+One important caveat: **verify each suggested change against your PR's stated scope and intent before applying it.** Automated reviewers can suggest fixes that accidentally force changes to surfaces you never intended to touch, or that quietly pull the PR away from its original framing. When a suggestion would cause that kind of drift:
+
+- you may decline it with a brief justification in the comment thread
+- when unsure whether a suggestion is in scope, ask a maintainer before applying or declining it
+
+Declining an out-of-scope suggestion with a clear reason is acceptable. Silently ignoring findings is not — every finding should end up either fixed, declined with justification, or escalated to a maintainer.
+
+### Keep Your Branch Current
+
+The PR author is responsible for keeping their branch current with `main`. Rebase onto `main` whenever you resume work on a PR, and before pushing follow-up fixes.
+
+Stale branches cause real problems: maintainers end up requesting fixes for issues that are already resolved on `main`, which produces endless fix-churn requests for work nobody needs to do again. A quick rebase before each update keeps review feedback relevant and avoids wasted rounds on both sides.
+
+Note that PRs with merge conflicts will not be reviewed or approved regardless (see [Pull Requests](#pull-requests)) — staying current prevents that state entirely.
+
 ### PR Follow-Up Requirements
 
-Submitting a PR is a commitment to see it through. Please be prepared to:
+Submitting a PR is a commitment to see it through to the end. Review here is in-depth and can take multiple rounds — do not be surprised if every review pass results in follow-up fix requests; that is the normal shape of this project's review process, not a signal that your PR is unwelcome. Please be prepared to:
 
 - **Respond to review feedback within 1 week** of a maintainer or CodeRabbit review request
 - **If you need more time**, leave a comment explaining your situation and expected timeline
 - **PRs with no activity for 2 weeks after a review request** will be closed as abandoned. At that point, another contributor may pick up the work under a new PR
 
 This policy ensures the project stays maintainable and that contributor queue doesn't grow stale. We understand life happens — a quick note explaining a delay goes a long way.
+
+If you find yourself getting fix requests on every round, treat that as a signal rather than noise: repeated findings on the same PR usually trace back to a core design issue, with each surface-level patch exposing another symptom. Investigate the root cause of what reviewers are flagging instead of patching the reported problem. And if you are driving the work with an AI agent, this is also the moment to re-evaluate how you are prompting it — vague or narrow prompts produce surface fixes; detailed instructions to investigate the requested change and its surrounding design produce fixes that hold up under review.
 
 ### Duplicate PRs
 
@@ -104,6 +122,7 @@ PRs may be closed without review if they:
 - drift from the approved scope of a linked issue
 - change the project's language, core runtime, or dependency stack without prior maintainer agreement
 - are drive-by contributions with no context, no tests, and no clear purpose
+- submit the [PR template](.github/pull_request_template.md) ignored — generic filler text or leftover template placeholders (`what changed`, `provider/model path tested:`, etc.) show the description was not written for your PR. These will not be reviewed until corrected and risk being closed without review
 - are automated bounty-hunting or mass-submitted PRs that provide little meaningful value to the codebase
 - are advertisements, sales pitches, or promotional submissions for a product or service — open an issue first to discuss with maintainers if you believe your product or service is relevant to this project
 
@@ -217,51 +236,33 @@ bun run dev:profile
 
 ## Validation
 
-CI runs the following checks on every PR. Run the relevant ones locally before pushing.
+CI runs the following checks on every PR. **Run the full suite locally and get it green before every push** — do not push commits with failing or unrun checks and wait for GitHub CI to discover the problem. Wasted Actions minutes on a repo this active are a real cost, and pushing red is how review queues back up.
 
-Full check (smoke + unit tests):
+The full local pass (mirrors CI):
 
 ```bash
+bun install
+bun run build
+bun run smoke
 bun run check
-```
-
-Full test pass (single concurrency, matches CI):
-
-```bash
 bun run test:full
-```
-
-Provider tests:
-
-```bash
-bun run test:provider
-```
-
-Provider recommendation tests:
-
-```bash
-bun run test:provider-recommendation
-```
-
-Typecheck (enforced by the dedicated `typecheck` CI job):
-
-```bash
 bun run typecheck
 bun run typecheck:type-tests
-```
-
-PR intent scan:
-
-```bash
+bun run test:provider
+bun run test:provider-recommendation
 bun run security:pr-scan
 ```
 
-Web (if touching `web/`):
+If your PR touches `web/`, add:
 
 ```bash
 bun run web:typecheck
 bun run web:build
 ```
+
+This applies to every push to an open PR, not just the first one. If you are iterating on review feedback, re-run the relevant subset at minimum before each push.
+
+Cross-platform exception: you are only required to run what is runnable on your platform. If you develop on macOS or Linux, Windows-specific verification is best-effort — do not hold back a push because you cannot execute another OS's checks locally. Everything else above is expected to be green on your machine before it reaches GitHub.
 
 PRs that fail CI checks will not be merged.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,9 +250,6 @@ bun run test:provider
 npm run test:provider-recommendation
 git fetch https://github.com/Gitlawb/openclaude.git main
 bun run security:pr-scan -- --base FETCH_HEAD --head HEAD
-bun install --cwd web --frozen-lockfile
-bun run web:typecheck
-bun run web:build
 ```
 
 Also run the compile-cache-disabled launcher check using the syntax for your shell.
@@ -271,16 +268,32 @@ node bin/openclaude --version
 Remove-Item Env:NODE_DISABLE_COMPILE_CACHE
 ```
 
+If the PR can affect the website — including changes under `web/`, root or web dependency and lock files, shared site assets or content, or build/toolchain configuration used by the site — also run:
+
+```bash
+bun install --cwd web --frozen-lockfile
+bun run web:typecheck
+bun run web:build
+```
+
 Notes on the local preflight:
 
 - `bun run check` already builds the CLI and includes smoke, deadcode, and the full unit pass (`test:full`) — do not run those separately, or you execute work twice.
 - Fetching upstream `main` by URL avoids assuming that a fork checkout's `origin` points at Gitlawb/openclaude. `FETCH_HEAD` is the fetched upstream tip. The scan deliberately uses local `HEAD` so it includes commits that have not been pushed yet; CI uses the pushed PR head SHA after the push.
-- Web checks are required for every PR because the `web` CI job is unconditional, even when the changed files are outside `web/`.
+- The web CI job remains unconditional as an integration backstop. Contributors do not need to run the web suite locally for changes that cannot affect the site.
 - This preflight covers the same command families as CI, but it does not reproduce CI exactly in one shell. CI runs the main checks under Node 22 and 24.11.x, separately builds and launches under exact Node 22.0.0, and executes every job on a clean runner.
 
-If a required check cannot run on your platform, document the limitation and leave that coverage to CI. If a check fails identically on the PR base and your branch, record the exact command, base commit, and comparison in the PR, then obtain maintainer agreement before treating it as waived. A pre-existing failure is not an automatic waiver, and PR-owned failures must be fixed.
+If a local or GitHub CI check fails, first determine whether the PR owns the failure. Treat a failure as pre-existing only when you can reproduce it on the PR's current base (or link to the same failure on a current `main` CI run) and the PR neither changes the causal surface nor claims to fix that problem.
 
-PRs that fail CI checks will not be merged.
+For a verified pre-existing failure:
+
+- record the failing check, relevant output, and base commit or `main` CI run in the PR
+- note the pre-existing failure in the PR summary or testing notes so maintainers can track it separately; link an existing issue when one is already available
+- explain briefly why the failure is unrelated to the PR
+
+The contributor may then proceed and is not responsible for repairing that failure in the current PR. A maintainer may still need to rerun or waive a required GitHub check, or land the separate fix, before branch protection permits a merge. Failures caused by the PR, or in behavior the PR claims to fix, remain the author's responsibility and must be resolved.
+
+PRs with unresolved PR-owned CI failures will not be merged. Verified pre-existing failures follow the exception above.
 
 ### Recommended Local Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Before opening a PR:
 - Read [`AGENTS.md`](AGENTS.md) for repo-specific coding-agent conventions, validation commands, provider guidance, and architecture rules.
 - Re-check open and recently closed PRs for duplicates.
 - Keep the branch focused on one issue or one clearly scoped improvement.
-- Run the narrowest meaningful validation command for the touched area.
+- Run narrow checks while iterating, then complete the required [Validation](#validation) contract before opening the PR.
 
 Every PR needs a reason. Your PR description must include:
 
@@ -236,38 +236,49 @@ bun run dev:profile
 
 ## Validation
 
-CI runs a fixed set of checks on every PR (see `.github/workflows/pr-checks.yml`). This section is the **authoritative pre-push validation contract** — `AGENTS.md` defers to it. **Run the full suite locally and get it green before every push to an open PR, including follow-up pushes during review.** Do not push commits with failing or unrun checks and wait for GitHub CI to discover the problem — wasted Actions minutes are a real cost on this repo.
+CI runs a fixed set of checks on every PR (see `.github/workflows/pr-checks.yml`). This section is the **authoritative local pre-push validation contract** — `AGENTS.md` defers to it. **Run every locally applicable check before every push to an open PR, including follow-up pushes during review.** Do not wait for GitHub CI to discover failures you could have caught locally — wasted Actions minutes are a real cost on this repo.
 
-The pre-push suite (mirrors CI exactly):
+Required local preflight:
 
 ```bash
 bun install --frozen-lockfile
-bun run build
 bun run check
 bun run typecheck
 bun run typecheck:type-tests
 node bin/openclaude --version
-NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version
 bun run test:provider
 npm run test:provider-recommendation
-PR_SCAN_BASE="$(gh api repos/Gitlawb/openclaude/pulls/<PR-number> --jq .base.sha)"
-bun run security:pr-scan -- --base "$PR_SCAN_BASE" --head HEAD
-```
-
-Notes on that suite:
-
-- `bun run check` already includes smoke, deadcode, and the full unit pass (`test:full`) — do not run them separately, or you execute the suite twice.
-- The security scan is given explicit `--base`/`--head` refs to match CI, which scans against the PR's actual base commit. Replace `<PR-number>` with your pull request number; the GitHub API query returns that PR's base SHA, including when your fork's `main` is stale. The script's built-in defaults (`origin/main` / `HEAD`) are only an approximation for pull requests.
-
-If your PR touches `web/`, add the web job's checks (the web workspace has its own lockfile-driven install):
-
-```bash
+git fetch https://github.com/Gitlawb/openclaude.git main
+bun run security:pr-scan -- --base FETCH_HEAD --head HEAD
 bun install --cwd web --frozen-lockfile
 bun run web:typecheck
 bun run web:build
 ```
 
-Cross-platform exception: this is the only carve-out from the full suite. You are required to run what is runnable on your platform; platform-specific verification you cannot execute locally (e.g., Windows-specific behavior when developing on macOS) is best-effort and may be left to CI. Everything else above is expected to be green on your machine before it reaches GitHub.
+Also run the compile-cache-disabled launcher check using the syntax for your shell.
+
+Bash, zsh, and similar shells:
+
+```bash
+NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version
+```
+
+PowerShell:
+
+```powershell
+$env:NODE_DISABLE_COMPILE_CACHE = '1'
+node bin/openclaude --version
+Remove-Item Env:NODE_DISABLE_COMPILE_CACHE
+```
+
+Notes on the local preflight:
+
+- `bun run check` already builds the CLI and includes smoke, deadcode, and the full unit pass (`test:full`) — do not run those separately, or you execute work twice.
+- Fetching upstream `main` by URL avoids assuming that a fork checkout's `origin` points at Gitlawb/openclaude. `FETCH_HEAD` is the fetched upstream tip. The scan deliberately uses local `HEAD` so it includes commits that have not been pushed yet; CI uses the pushed PR head SHA after the push.
+- Web checks are required for every PR because the `web` CI job is unconditional, even when the changed files are outside `web/`.
+- This preflight covers the same command families as CI, but it does not reproduce CI exactly in one shell. CI runs the main checks under Node 22 and 24.11.x, separately builds and launches under exact Node 22.0.0, and executes every job on a clean runner.
+
+If a required check cannot run on your platform, document the limitation and leave that coverage to CI. If a check fails identically on the PR base and your branch, record the exact command, base commit, and comparison in the PR, then obtain maintainer agreement before treating it as waived. A pre-existing failure is not an automatic waiver, and PR-owned failures must be fixed.
 
 PRs that fail CI checks will not be merged.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,13 +250,13 @@ node bin/openclaude --version
 NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version
 bun run test:provider
 npm run test:provider-recommendation
-bun run security:pr-scan -- --base "$(git merge-base origin/main HEAD)" --head HEAD
+bun run security:pr-scan -- --base origin/main --head HEAD
 ```
 
 Notes on that suite:
 
 - `bun run check` already includes smoke, deadcode, and the full unit pass (`test:full`) — do not run them separately, or you execute the suite twice.
-- The security scan is given explicit `--base`/`--head` refs to match CI, which scans against the PR's actual base SHA; the script's built-in defaults (`origin/main` / `HEAD`) can miss that target.
+- The security scan is given explicit `--base`/`--head` refs to match CI, which scans against the PR's actual base commit. For the local command to match CI exactly, `origin/main` must resolve to the PR's real base — i.e., fetch it (`git fetch origin main`) and keep your branch rebased onto current `origin/main` before scanning. Without that invariant, the script's built-in defaults would also be only an approximation.
 
 If your PR touches `web/`, add the web job's checks (the web workspace has its own lockfile-driven install):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -250,13 +250,14 @@ node bin/openclaude --version
 NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version
 bun run test:provider
 npm run test:provider-recommendation
-bun run security:pr-scan -- --base origin/main --head HEAD
+PR_SCAN_BASE="$(gh api repos/Gitlawb/openclaude/pulls/<PR-number> --jq .base.sha)"
+bun run security:pr-scan -- --base "$PR_SCAN_BASE" --head HEAD
 ```
 
 Notes on that suite:
 
 - `bun run check` already includes smoke, deadcode, and the full unit pass (`test:full`) — do not run them separately, or you execute the suite twice.
-- The security scan is given explicit `--base`/`--head` refs to match CI, which scans against the PR's actual base commit. For the local command to match CI exactly, `origin/main` must resolve to the PR's real base — i.e., fetch it (`git fetch origin main`) and keep your branch rebased onto current `origin/main` before scanning. Without that invariant, the script's built-in defaults would also be only an approximation.
+- The security scan is given explicit `--base`/`--head` refs to match CI, which scans against the PR's actual base commit. Replace `<PR-number>` with your pull request number; the GitHub API query returns that PR's base SHA, including when your fork's `main` is stale. The script's built-in defaults (`origin/main` / `HEAD`) are only an approximation for pull requests.
 
 If your PR touches `web/`, add the web job's checks (the web workspace has its own lockfile-driven install):
 

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ OpenClaude leaves Node's standard compile-cache controls authoritative. Set
 `NODE_DISABLE_COMPILE_CACHE=1` to disable the optimization, including for V8
 coverage runs that require uncached compilation.
 
-Recommended validation before opening a PR:
+Before opening or updating a PR, run the authoritative [local pre-push validation contract](CONTRIBUTING.md#validation). The commands below are useful for narrow iteration, but they do not replace that required preflight:
 
 - `bun run build`
 - `bun run smoke`

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Day-to-day commands:
 - `bun test path/to/file.test.ts` — focused runs for the areas you touch
 - `bun run test:coverage` — coverage to `coverage/lcov.info` plus a visual report at `coverage/index.html` (`bun run test:coverage:ui` rebuilds just the UI)
 - `bun run smoke` — smoke checks
-- `bun run doctor:runtime`, `bun run verify:privacy`, `bun run security:pr-scan -- --base origin/main`
+- `bun run doctor:runtime`, `bun run verify:privacy`; for PR intent scanning, use the fresh-upstream, explicit-ref workflow in the [local pre-push validation contract](CONTRIBUTING.md#validation)
 
 Focused suites: `bun run test:provider`, `bun run test:provider-recommendation`.
 


### PR DESCRIPTION
## Summary

- Clarifies the CodeRabbit review policy: authors verify automated suggestions against PR scope, may decline out-of-scope requests with justification, and do not silently ignore findings.
- Adds branch-freshness, PR-template, and review-follow-up expectations in `CONTRIBUTING.md` and `AGENTS.md`.
- Documents the complete safe rebase lifecycle: refresh and incorporate the remote PR head, record its exact SHA, rebase onto upstream `main`, and publish with a SHA-pinned explicit lease that cannot be weakened by a background fetch.
- Defines a portable local pre-push contract without claiming to reproduce CI's clean runners and Node matrix exactly.
- Documents shallow-clone recovery so the security scan has the ancestry required to compute a merge base.
- Routes every contributor-facing PR scan entry point through the fresh-upstream `FETCH_HEAD`/explicit-`HEAD` contract instead of assuming a fork's `origin/main` is upstream.
- Limits local web checks to changes that can affect the site while keeping unconditional web CI as the integration backstop.
- Preserves a caller's existing `NODE_DISABLE_COMPILE_CACHE` value in the PowerShell launcher check, including failure paths.
- Allows authors to proceed past verified, unrelated failures already present on the current PR base or `main` after documenting the evidence in the PR; an issue link is optional.
- Aligns the README pre-open checklist and pull request template with the authoritative Validation section.

## Impact

- User-facing impact: none; documentation only.
- Contributor/maintainer impact: clearer, portable review and validation expectations without unrelated local web work or ownership of verified pre-existing failures.

## Testing

- [x] `bun install --frozen-lockfile`
- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `bun run typecheck:type-tests`
- [x] `node bin/openclaude --version`
- [x] `NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version`
- [x] `bun run test:provider` (1565 passed with required loopback access)
- [x] `OPENCLAUDE_CONFIG_DIR=<writable temporary directory> npm run test:provider-recommendation` (151 passed)
- [x] `git fetch https://github.com/Gitlawb/openclaude.git main`
- [x] `bun run security:pr-scan -- --base FETCH_HEAD --head HEAD`
- [x] `bun test scripts/pr-intent-scan.test.ts` (13 passed)
- [x] `bun install --cwd web --frozen-lockfile`
- [x] `bun run web:typecheck`
- [x] `bun run web:build`
- [x] `git diff --check`
- [x] Concurrent-update route reproduction: an explicit lease pinned to the recorded PR-head SHA rejected a divergent push after a collaborator update and background fetch (`stale info`).
- [x] Depth-1 fork route reproduction: `git fetch --unshallow` restored the merge base and allowed the explicit-ref security scan to pass.

## Notes

- Provider/model path tested: N/A.
- Screenshots: N/A.
- PowerShell was unavailable in the Linux review environment, so its save/`try`/`finally`/restore and nonzero-exit semantics were audited statically; both underlying Node launcher modes passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance for keeping branches current and completing pull request templates.
  * Clarified requirements for comprehensive CI-equivalent validation before each push and before opening a pull request.
  * Added guidance for evaluating review feedback, handling out-of-scope suggestions, and addressing recurring issues at their root.
  * Documented when web validation applies, along with skipped checks, platform limitations, and pre-existing failures.
  * Updated development documentation to reference the local pre-push validation contract.
  * Improved pull request testing fields for recording commands, results, and exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
