### PR TITLE
fix(openai-shim): drop synthetic tool-results marker and guard echoes (#2039)

### DIFF
--- a/src/services/api/openaiShim.test.ts
+++ b/src/services/api/openaiShim.test.ts
@@ -5069,13 +5069,11 @@ test('preserves valid tool_result and drops orphan tool_result', async () => {
 
   const orphanMessage = toolMessages.find(m => m.tool_call_id === 'orphan_call_2')
   expect(orphanMessage).toBeUndefined()
-  // Actually, the semantic message IS injected here because the user block with orphan
-  // tool result is converted to:
-  // 1. Tool result (valid_call_1) -> role 'tool'
-  // 2. User content ("What happened?") -> role 'user'
-  // This triggers the tool -> assistant injection.
+  // Tool results stay as role:"tool" messages; a follow-up user turn after
+  // them is valid chat-completions history and must not get a synthetic
+  // assistant bridge inserted before it (issue #2039).
   const assistantMessages = messages.filter(m => m.role === 'assistant')
-  expect(assistantMessages.some(m => m.content === '[Tool results received]')).toBe(true)
+  expect(assistantMessages.some(m => m.content === '[Tool results received]')).toBe(false)
 })
 // openaiShim test extraction seam 133 end
 
@@ -5160,8 +5158,8 @@ test('drops empty assistant message when only redacted_thinking block was presen
 // openaiShim test extraction seam 135 end
 
 
-// openaiShim test extraction seam 136 start: injects semantic assistant message when tool result is followed by user message
-test('injects semantic assistant message when tool result is followed by user message', async () => {
+// openaiShim test extraction seam 136 start: passes tool results through as role:tool messages without synthetic assistant filler (issue #2039)
+test('passes tool results through as role:tool messages without synthetic assistant filler (issue #2039)', async () => {
   let requestBody: Record<string, unknown> | undefined
 
   globalThis.fetch = (async (_input, init) => {
@@ -5198,15 +5196,11 @@ test('injects semantic assistant message when tool result is followed by user me
   })
 
   const messages = requestBody?.messages as Array<Record<string, unknown>>
-  // Roles should be: assistant (tool_calls) -> tool -> assistant (semantic) -> user
+  // Roles should be: assistant (tool_calls) -> tool -> user — no synthetic
+  // assistant marker between the tool results and the next user query.
   const roles = messages.map(m => m.role)
-  expect(roles).toEqual(['assistant', 'tool', 'assistant', 'user'])
-
-  const semanticMsg = messages[2]
-  expect(semanticMsg.role).toBe('assistant')
-  expect(semanticMsg.content).toBe('[Tool results received]')
-  expect(semanticMsg.content).not.toContain('interrupted')
-  expect(semanticMsg.content).not.toContain('user')
+  expect(roles).toEqual(['assistant', 'tool', 'user'])
+  expect(messages.some(m => m.content === '[Tool results received]')).toBe(false)
 })
 // openaiShim test extraction seam 156 end
 

--- a/src/services/api/openaiShim/markerEchoGuard.test.ts
+++ b/src/services/api/openaiShim/markerEchoGuard.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from 'bun:test'
+import {
+  TOOL_RESULTS_RECEIVED_MARKER,
+  stripEchoedToolResultsMarker,
+  stripMarkerEchoesFromStream,
+} from './markerEchoGuard.js'
+
+type GuardEvent = {
+  type: string
+  index?: number
+  content_block?: Record<string, unknown>
+  delta?: Record<string, unknown>
+}
+
+async function collect(events: AsyncGenerator<GuardEvent>): Promise<GuardEvent[]> {
+  const out: GuardEvent[] = []
+  for await (const event of events) out.push(event)
+  return out
+}
+
+function streamOf(events: GuardEvent[]): AsyncGenerator<GuardEvent> {
+  return (async function* () {
+    for (const event of events) yield event
+  })()
+}
+
+function textDelta(index: number, text: string): GuardEvent {
+  return { type: 'content_block_delta', index, delta: { type: 'text_delta', text } }
+}
+
+function textDeltasOf(events: GuardEvent[]): string {
+  return events
+    .filter(event =>
+      event.type === 'content_block_delta' &&
+      (event.delta as { type?: string } | undefined)?.type === 'text_delta',
+    )
+    .map(event => (event.delta as { text: string }).text)
+    .join('')
+}
+
+test('stripEchoedToolResultsMarker removes every literal marker occurrence', () => {
+  expect(stripEchoedToolResultsMarker(`A ${TOOL_RESULTS_RECEIVED_MARKER} B`)).toBe('A  B')
+  expect(
+    stripEchoedToolResultsMarker(`${TOOL_RESULTS_RECEIVED_MARKER}${TOOL_RESULTS_RECEIVED_MARKER}`),
+  ).toBe('')
+})
+
+test('stripEchoedToolResultsMarker leaves unrelated text untouched', () => {
+  expect(stripEchoedToolResultsMarker('array[0] = "[Tool"')).toBe('array[0] = "[Tool"')
+  expect(stripEchoedToolResultsMarker('')).toBe('')
+})
+
+test('stream wrapper passes non-text events through untouched', async () => {
+  const messageStart: GuardEvent = { type: 'message_start' }
+  const thinkingDelta: GuardEvent = {
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'thinking_delta', thinking: 'hmm' },
+  }
+  const jsonDelta: GuardEvent = {
+    type: 'content_block_delta',
+    index: 1,
+    delta: { type: 'input_json_delta', partial_json: '{"cmd":true}' },
+  }
+
+  const events = await collect(stripMarkerEchoesFromStream(
+    streamOf([messageStart, thinkingDelta, jsonDelta]),
+  ))
+
+  expect(events).toEqual([messageStart, thinkingDelta, jsonDelta])
+})
+
+test('stream wrapper drops a marker split across deltas exactly as issue #2039 captured it', async () => {
+  const events = await collect(stripMarkerEchoesFromStream(streamOf([
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    textDelta(0, '['),
+    textDelta(0, 'Tool'),
+    textDelta(0, ' results'),
+    textDelta(0, ' received'),
+    textDelta(0, ']'),
+    { type: 'content_block_stop', index: 0 },
+  ])))
+
+  expect(textDeltasOf(events)).toBe('')
+  expect(events.some(event => event.type === 'content_block_stop')).toBe(true)
+})
+
+test('stream wrapper strips an inline marker while preserving surrounding prose', async () => {
+  const events = await collect(stripMarkerEchoesFromStream(streamOf([
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    textDelta(0, 'Before '),
+    textDelta(0, TOOL_RESULTS_RECEIVED_MARKER),
+    textDelta(0, ' After'),
+    { type: 'content_block_stop', index: 0 },
+  ])))
+
+  expect(textDeltasOf(events)).toBe('Before  After')
+})
+
+test('stream wrapper reassembles plain text byte-for-byte across deltas', async () => {
+  const chunks = ['const arr', 'ay = [1,', ' 2]; done']
+  const events = await collect(stripMarkerEchoesFromStream(streamOf([
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    ...chunks.map((chunk, i) => textDelta(0, chunk)),
+    { type: 'content_block_stop', index: 0 },
+  ])))
+
+  expect(textDeltasOf(events)).toBe(chunks.join(''))
+})
+
+test('stream wrapper releases a trailing partial marker verbatim at block close', async () => {
+  const events = await collect(stripMarkerEchoesFromStream(streamOf([
+    { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    textDelta(0, 'looks like [Tool res'),
+    { type: 'content_block_stop', index: 0 },
+  ])))
+
+  expect(textDeltasOf(events)).toBe('looks like [Tool res')
+})

--- a/src/services/api/openaiShim/markerEchoGuard.ts
+++ b/src/services/api/openaiShim/markerEchoGuard.ts
@@ -1,0 +1,126 @@
+/**
+ * Guard against "[Tool results received]" marker echoes (issue #2039).
+ *
+ * The OpenAI shim used to inject a synthetic assistant message containing
+ * "[Tool results received]" whenever tool results were followed by a user
+ * message. Models reproduced that marker verbatim as their reply with
+ * finish_reason "stop", ending the agent loop mid-task. The insertion was
+ * removed from convertMessages, but two residual paths remain:
+ *
+ *   1. Legacy session histories already contain marker assistant messages.
+ *      They must never be re-sent to providers or echoed back to the agent.
+ *   2. Models may still echo markers copied into history by older versions.
+ *
+ * Two layers:
+ *
+ *   - `stripEchoedToolResultsMarker()` — whole-text cleanup for complete
+ *     responses (non-streaming conversion) and request-side assistant
+ *     history.
+ *   - `stripMarkerEchoesFromStream()` — Anthropic stream-event wrapper that
+ *     applies the same cleanup per text content block before events reach
+ *     the agent loop, holding back only a trailing partial-marker prefix so
+ *     markers split across SSE deltas are still recognized.
+ */
+
+export const TOOL_RESULTS_RECEIVED_MARKER = '[Tool results received]'
+
+const MAX_PARTIAL_MARKER = TOOL_RESULTS_RECEIVED_MARKER.length - 1
+
+/** Remove every literal occurrence of the shim's tool-results marker. */
+export function stripEchoedToolResultsMarker(text: string): string {
+  if (!text || !text.includes(TOOL_RESULTS_RECEIVED_MARKER)) return text
+  return text.split(TOOL_RESULTS_RECEIVED_MARKER).join('')
+}
+
+function longestPartialMarkerSuffix(text: string): number {
+  const max = Math.min(MAX_PARTIAL_MARKER, text.length)
+  for (let len = max; len > 0; len--) {
+    if (TOOL_RESULTS_RECEIVED_MARKER.startsWith(text.slice(text.length - len))) {
+      return len
+    }
+  }
+  return 0
+}
+
+type StreamEventLike = {
+  type?: unknown
+  index?: unknown
+  content_block?: Record<string, unknown> | null
+  delta?: Record<string, unknown> | null
+}
+
+/**
+ * Wrap an Anthropic-format event stream so literal marker echoes are stripped
+ * from text content blocks before they reach the agent loop. All non-text
+ * events pass through untouched. Text held back as a possible partial marker
+ * is released when its content block closes.
+ */
+export async function* stripMarkerEchoesFromStream<T extends StreamEventLike>(
+  events: AsyncGenerator<T>,
+): AsyncGenerator<T> {
+  const accumulated = new Map<number, string>()
+  const forwardedLengths = new Map<number, number>()
+
+  for await (const event of events) {
+    switch (event.type) {
+      case 'content_block_start': {
+        const index = typeof event.index === 'number' ? event.index : 0
+        if (event.content_block?.type === 'text') {
+          accumulated.set(index, '')
+          forwardedLengths.set(index, 0)
+        }
+        yield event
+        break
+      }
+      case 'content_block_delta': {
+        const delta = event.delta as { type?: unknown; text?: unknown } | null
+        const index = typeof event.index === 'number' ? event.index : 0
+        if (
+          delta?.type !== 'text_delta' ||
+          typeof delta.text !== 'string' ||
+          !delta.text ||
+          !accumulated.has(index)
+        ) {
+          yield event
+          break
+        }
+        const acc = accumulated.get(index)! + delta.text
+        accumulated.set(index, acc)
+        const clean = stripEchoedToolResultsMarker(acc)
+        // Hold back a trailing partial marker until the next delta resolves it.
+        const holdLen = longestPartialMarkerSuffix(clean)
+        const emitLength = clean.length - holdLen
+        const forwarded = forwardedLengths.get(index) ?? 0
+        if (emitLength > forwarded) {
+          forwardedLengths.set(index, emitLength)
+          yield {
+            ...event,
+            delta: { type: 'text_delta', text: clean.slice(forwarded, emitLength) },
+          } as unknown as T
+        }
+        break
+      }
+      case 'content_block_stop': {
+        const index = typeof event.index === 'number' ? event.index : 0
+        if (accumulated.has(index)) {
+          const clean = stripEchoedToolResultsMarker(accumulated.get(index)!)
+          const forwarded = forwardedLengths.get(index) ?? 0
+          if (clean.length > forwarded) {
+            forwardedLengths.set(index, clean.length)
+            yield {
+              type: 'content_block_delta',
+              index,
+              delta: { type: 'text_delta', text: clean.slice(forwarded) },
+            } as unknown as T
+          }
+          accumulated.delete(index)
+          forwardedLengths.delete(index)
+        }
+        yield event
+        break
+      }
+      default:
+        yield event
+    }
+  }
+}

--- a/src/services/api/openaiShim/messageConversion.test.ts
+++ b/src/services/api/openaiShim/messageConversion.test.ts
@@ -136,7 +136,7 @@ test('preserves valid tool_result and drops orphan tool_result', () => {
 
   expect(tools).toHaveLength(1)
   expect(tools[0]?.tool_call_id).toBe('valid_call_1')
-  expect(messages.some(message => message.content === '[Tool results received]')).toBe(true)
+  expect(messages.some(message => message.content === '[Tool results received]')).toBe(false)
   expect(logs).toContain('Dropping orphan tool_result for ID: orphan_call_2 to prevent API error')
 })
 
@@ -160,7 +160,7 @@ test('drops empty assistant message when only redacted_thinking block was presen
   expect(messages).toEqual([{ role: 'user', content: 'Initial\nInterrupting query' }])
 })
 
-test('injects semantic assistant message when tool result is followed by user message', () => {
+test('passes tool results through as role:tool messages without synthetic assistant filler (issue #2039)', () => {
   const messages = convert([
     {
       role: 'assistant',
@@ -173,9 +173,65 @@ test('injects semantic assistant message when tool result is followed by user me
     { role: 'user', content: 'Next user query' },
   ])
 
-  expect(messages.map(message => message.role)).toEqual(['assistant', 'tool', 'assistant', 'user'])
-  expect(messages[2]?.content).toBe('[Tool results received]')
-  expect(messages[2]?.content).not.toContain('interrupted')
+  expect(messages.map(message => message.role)).toEqual(['assistant', 'tool', 'user'])
+  expect(messages.some(message => message.content === '[Tool results received]')).toBe(false)
+})
+
+test('keeps parallel tool results as consecutive role:tool messages before the next user turn (issue #2039)', () => {
+  const messages = convert([
+    {
+      role: 'assistant',
+      content: [
+        { type: 'tool_use', id: 'call_a', name: 'Read', input: { file_path: 'a.ts' } },
+        { type: 'tool_use', id: 'call_b', name: 'Read', input: { file_path: 'b.ts' } },
+      ],
+    },
+    {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'call_a', content: 'A contents' },
+        { type: 'tool_result', tool_use_id: 'call_b', content: 'B contents' },
+      ],
+    },
+    { role: 'user', content: 'Summarize both files' },
+  ])
+
+  expect(messages.map(message => message.role)).toEqual(['assistant', 'tool', 'tool', 'user'])
+  expect(messages.filter(message => message.role === 'tool').map(message => message.tool_call_id))
+    .toEqual(['call_a', 'call_b'])
+  expect(messages[messages.length - 1]).toEqual({ role: 'user', content: 'Summarize both files' })
+})
+
+test('strips echoed [Tool results received] markers from legacy assistant history (issue #2039)', () => {
+  const messages = convert([
+    { role: 'user', content: 'go' },
+    { role: 'assistant', content: [{ type: 'text', text: '[Tool results received]' }] },
+    { role: 'user', content: 'ok' },
+  ])
+
+  expect(messages).toEqual([{ role: 'user', content: 'go\nok' }])
+})
+
+test('strips inline [Tool results received] echoes while keeping surrounding assistant prose', () => {
+  const messages = convert([
+    {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Working.\n[Tool results received]\nDone.' }],
+    },
+    { role: 'user', content: 'next' },
+  ])
+
+  expect(messages[0]).toEqual({ role: 'assistant', content: 'Working.\n\nDone.' })
+})
+
+test('drops legacy string assistant messages containing only the marker echo', () => {
+  const messages = convert([
+    { role: 'user', content: 'run' },
+    { role: 'assistant', content: '[Tool results received]' },
+    { role: 'user', content: 'done?' },
+  ])
+
+  expect(messages).toEqual([{ role: 'user', content: 'run\ndone?' }])
 })
 
 test('collapses multiple text blocks in tool_result to string for DeepSeek compatibility (issue #774)', () => {

--- a/src/services/api/openaiShim/messageConversion.ts
+++ b/src/services/api/openaiShim/messageConversion.ts
@@ -1,3 +1,5 @@
+import { stripEchoedToolResultsMarker } from './markerEchoGuard.js'
+
 export type OpenAIContentPart =
   | { type: 'text'; text: string }
   | { type: 'image_url'; image_url: { url: string } }
@@ -203,7 +205,9 @@ export function convertMessages(
     if (role !== 'assistant') continue
     if (!Array.isArray(content)) {
       const converted = convertContentBlocks(content, options)
-      const text = typeof converted === 'string' ? converted : joinTextContentParts(converted)
+      const text = stripEchoedToolResultsMarker(
+        typeof converted === 'string' ? converted : joinTextContentParts(converted),
+      )
       if (text) result.push({ role: 'assistant', content: text })
       continue
     }
@@ -224,7 +228,9 @@ export function convertMessages(
     const converted = convertContentBlocks(textContent, options)
     const assistantMsg: ConvertedOpenAIMessage = {
       role: 'assistant',
-      content: typeof converted === 'string' ? converted : joinTextContentParts(converted),
+      content: stripEchoedToolResultsMarker(
+        typeof converted === 'string' ? converted : joinTextContentParts(converted),
+      ),
     }
     if (options.preserveReasoningContent) {
       const thinking = thinkingBlock?.type === 'redacted_thinking' ? thinkingBlock.data : thinkingBlock?.thinking
@@ -260,10 +266,6 @@ export function convertMessages(
 
   const coalesced: ConvertedOpenAIMessage[] = []
   for (const msg of result) {
-    const prev = coalesced[coalesced.length - 1]
-    if (prev?.role === 'tool' && msg.role === 'user') {
-      coalesced.push({ role: 'assistant', content: '[Tool results received]' })
-    }
     const last = coalesced[coalesced.length - 1]
     if (!last || last.role !== msg.role || msg.role === 'tool' || msg.role === 'system') {
       coalesced.push(msg)

--- a/src/services/api/openaiShim/responseAdapters.ts
+++ b/src/services/api/openaiShim/responseAdapters.ts
@@ -22,6 +22,7 @@ import {
   type NonStreamingOpenAIResponse,
 } from './responseConversion.js'
 import { openaiStreamToAnthropic as convertOpenAIStream } from './streamConversion.js'
+import { stripMarkerEchoesFromStream } from './markerEchoGuard.js'
 import { geminiSseToAnthropic as convertGeminiStream } from './geminiStreamConversion.js'
 import {
   anthropicSsePassthrough as parseAnthropicSsePassthrough,
@@ -130,32 +131,34 @@ export async function* openaiStreamToAnthropic(
   requestUrl?: string,
   headersWithRequestUrl?: (headers: Headers, requestUrl?: string) => Headers,
 ): AsyncGenerator<AnthropicStreamEvent> {
-  yield* convertOpenAIStream(response, model, signal, isOllama, requestUrl, {
-    convertNonStreamingResponseToAnthropicMessage: (data, streamModel) =>
-      convertNonStreamingResponseToAnthropicMessage(
-        data as NonStreamingOpenAIResponse,
-        streamModel,
-      ),
-    couldBeRawToolCallsRequestedPrefix,
-    createProviderStreamTrace,
-    createReaderCanceller,
-    createStreamAbortError,
-    findXmlToolCallOpener,
-    geminiThoughtSignatureFromExtraContent,
-    getStreamIdleTimeoutMs,
-    headersWithRequestUrl: headersWithRequestUrl ?? ((headers) => headers),
-    isHy3Model,
-    makeMessageId,
-    mergeGeminiThoughtSignature,
-    parseRawToolCallsRequestedText,
-    parseTextToolCalls,
-    parseXmlToolCalls,
-    readWithIdleTimeout,
-    repairPossiblyTruncatedObjectJson,
-    stripRanges,
-    throwIfStreamAborted,
-    trailingXmlOpenerPrefixLen,
-  })
+  yield* stripMarkerEchoesFromStream(
+    convertOpenAIStream(response, model, signal, isOllama, requestUrl, {
+      convertNonStreamingResponseToAnthropicMessage: (data, streamModel) =>
+        convertNonStreamingResponseToAnthropicMessage(
+          data as NonStreamingOpenAIResponse,
+          streamModel,
+        ),
+      couldBeRawToolCallsRequestedPrefix,
+      createProviderStreamTrace,
+      createReaderCanceller,
+      createStreamAbortError,
+      findXmlToolCallOpener,
+      geminiThoughtSignatureFromExtraContent,
+      getStreamIdleTimeoutMs,
+      headersWithRequestUrl: headersWithRequestUrl ?? ((headers) => headers),
+      isHy3Model,
+      makeMessageId,
+      mergeGeminiThoughtSignature,
+      parseRawToolCallsRequestedText,
+      parseTextToolCalls,
+      parseXmlToolCalls,
+      readWithIdleTimeout,
+      repairPossiblyTruncatedObjectJson,
+      stripRanges,
+      throwIfStreamAborted,
+      trailingXmlOpenerPrefixLen,
+    }),
+  )
 }
 
 export function convertGeminiToAnthropicResponse(

--- a/src/services/api/openaiShim/responseConversion.ts
+++ b/src/services/api/openaiShim/responseConversion.ts
@@ -1,3 +1,8 @@
+import {
+  TOOL_RESULTS_RECEIVED_MARKER,
+  stripEchoedToolResultsMarker,
+} from './markerEchoGuard.js'
+
 export type NonStreamingOpenAIResponse = {
   id?: string
   model?: string
@@ -49,7 +54,11 @@ export function convertNonStreamingResponseToAnthropicMessage(
   if (typeof reasoning === 'string' && reasoning) content.push({ type: 'thinking', thinking: reasoning })
 
   const appendTextOrRecoveredToolCalls = (rawText: string) => {
-    const stripped = deps.stripThinkTags(rawText)
+    const stripped = stripEchoedToolResultsMarker(deps.stripThinkTags(rawText))
+    // A reply that only echoes the shim's old tool-results placeholder carries
+    // no information — emit nothing rather than an empty terminal message.
+    const echoedMarkerOnly =
+      rawText.includes(TOOL_RESULTS_RECEIVED_MARKER) && !stripped.trim()
     if (!hasStructuredToolCalls) {
       const { calls, toolCallRanges } = deps.parseXmlToolCalls(stripped, deps.isHy3Model(model))
       if (calls.length) {
@@ -62,7 +71,7 @@ export function convertNonStreamingResponseToAnthropicMessage(
     const rawToolCalls = hasStructuredToolCalls ? null : deps.parseRawToolCalls(stripped)
     if (rawToolCalls) {
       for (const call of rawToolCalls) content.push({ type: 'tool_use', id: call.id, name: call.name, input: JSON.parse(call.argumentsJson) })
-    } else content.push({ type: 'text', text: stripped })
+    } else if (!echoedMarkerOnly) content.push({ type: 'text', text: stripped })
   }
 
   const rawContent = choice?.message?.content !== '' && choice?.message?.content != null


### PR DESCRIPTION
Closes #2039

The shim inserted a synthetic assistant message containing [Tool results received] after every tool-result turn. Models echoed the marker back and the agent loop terminated prematurely.

- Removed the synthetic insertion entirely: tool results already flow as proper role:tool messages with tool_call_id pairing, and no provider requires the assistant-side filler (the Mistral rationale in the original code was speculative)
- Added echo guards at both boundaries: literal markers stripped from request history and from response streams (with cross-delta partial-prefix holdback), so legacy sessions cannot re-seed the loop
- Tests updated to assert pass-through conversion plus new marker-stripping regression cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unwanted tool-result marker text from regular and streamed responses.
  * Preserved clean assistant content when markers appear alone, inline, or across streamed chunks.
  * Improved tool-result message sequencing without inserting synthetic assistant messages.
  * Preserved non-text streaming events and incomplete text at stream boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->