### PR TITLE
feat: raise default interactive max turns from 50 to 200

### DIFF
--- a/src/screens/replMaxTurnsProp.test.ts
+++ b/src/screens/replMaxTurnsProp.test.ts
@@ -95,8 +95,8 @@ describe('interactive REPL max-turn cap', () => {
   test('supplies the local interactive default at runtime', () => {
     clearTurnEnv()
     setReplMaxTurnsConfig(undefined)
-    expect(DEFAULT_REPL_MAX_TURNS).toBe(50)
-    expect(resolveReplMaxTurns()).toBe(50)
+    expect(DEFAULT_REPL_MAX_TURNS).toBe(200)
+    expect(resolveReplMaxTurns()).toBe(200)
   })
 
   test('preserves an explicit interactive cap at runtime', () => {
@@ -244,7 +244,7 @@ describe('interactive REPL max-turn cap', () => {
     expect(GLOBAL_CONFIG_KEYS).toContain('replMaxTurns')
     expect(isGlobalConfigKey('replMaxTurns')).toBe(true)
     expect(DEFAULT_GLOBAL_CONFIG.replMaxTurns).toBeUndefined()
-    expect(REPL_MAX_TURNS_OPTIONS).toEqual([50, 100, 200, 500])
+    expect(REPL_MAX_TURNS_OPTIONS).toEqual([200, 100, 50, 500])
   })
 
   test('headless --max-turns 0 stays distinct from interactive unlimited resolution', () => {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -295,7 +295,7 @@ export type GlobalConfig = {
   toolHistoryCompressionEnabled: boolean // Compress old tool_result content (shim providers; Anthropic-native only while prompt caching is inactive)
   compactTailTurns?: number // Recent messages preserved verbatim by auto-compact's relevance pruning (default: 3)
   /**
-   * Per-prompt local interactive REPL turn cap (default: 50).
+   * Per-prompt local interactive REPL turn cap (default: 200).
    * Overridden by CLI `--max-turns` and OPENCLAUDE_MAX_TURNS / CLAUDE_CODE_MAX_TURNS.
    */
   replMaxTurns?: number

--- a/src/utils/replMaxTurns.ts
+++ b/src/utils/replMaxTurns.ts
@@ -2,19 +2,19 @@ import { getGlobalConfig } from './config.js'
 import { logForDebugging } from './debug.js'
 import { InvalidArgumentError } from '@commander-js/extra-typings'
 
-export const DEFAULT_REPL_MAX_TURNS = 50
+export const DEFAULT_REPL_MAX_TURNS = 200
 export const MAX_TURNS_UNLIMITED_WARNING =
   'Warning: --max-turns 0 disables the local turn limit when applicable. Use with caution.'
 
 /** Preset values offered in `/config` (plus any current custom value). */
-export const REPL_MAX_TURNS_OPTIONS = [50, 100, 200, 500] as const
+export const REPL_MAX_TURNS_OPTIONS = [200, 100, 50, 500] as const
 
 /**
  * Shared `--max-turns` help text for Commander registration and behavior tests.
  * Keep remote-backed sessions explicitly out of scope in this string.
  */
 export const MAX_TURNS_CLI_DESCRIPTION =
-  'Maximum number of agentic turns per prompt. In local interactive mode, set to 0 for unlimited turns (use with caution). This overrides the default 50-turn REPL query cap and is also configurable via OPENCLAUDE_MAX_TURNS or /config. Does not apply to remote-backed sessions (connect/ssh/--remote). In --print mode this early-exits after the specified number of turns.'
+  'Maximum number of agentic turns per prompt. In local interactive mode, set to 0 for unlimited turns (use with caution). This overrides the default 200-turn REPL query cap and is also configurable via OPENCLAUDE_MAX_TURNS or /config. Does not apply to remote-backed sessions (connect/ssh/--remote). In --print mode this early-exits after the specified number of turns.'
 
 export function parseMaxTurnsCli(value: string): number {
   const parsed = value.trim() === '' ? Number.NaN : Number(value)
@@ -83,7 +83,7 @@ function resolveConfiguredReplMaxTurns(): number {
  *
  * Precedence: explicit prop (CLI `--max-turns`) → OPENCLAUDE_MAX_TURNS →
  * CLAUDE_CODE_MAX_TURNS (only if OPENCLAUDE_MAX_TURNS unset) →
- * `/config` `replMaxTurns` → DEFAULT_REPL_MAX_TURNS (50).
+ * `/config` `replMaxTurns` → DEFAULT_REPL_MAX_TURNS (200).
  *
  * Applies to local interactive query loops only. Remote-backed sessions
  * (connect/ssh/--remote) send prompts to a remote executor and are not


### PR DESCRIPTION
## Summary

The 50-turn default cap has been biting people running long agentic tasks in the local REPL — the loop gets cut off mid-work before the model can wrap up. This bumps the interactive default to 200 turns, which comfortably fits multi-step tool workflows while still leaving a guardrail in place.

- `DEFAULT_REPL_MAX_TURNS` 50 → 200, so `resolveReplMaxTurns()` returns 200 when nothing else is set
- `/config` preset options reordered to `[200, 100, 50, 500]` with 200 leading
- CLI `--max-turns`, `OPENCLAUDE_MAX_TURNS`, and `CLAUDE_CODE_MAX_TURNS` still override as before
- Print/SDK paths untouched — they use explicit `maxTurns` contracts and are not affected by the interactive default

## Test plan

- [x] `bun run typecheck`
- [x] `bun test src/screens/replMaxTurnsProp.test.ts` — 27 pass, including the updated default assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Increased the default interactive REPL limit from 50 to 200 turns.
  * Updated the `/config` options to prioritize 200 turns, followed by 100 and 50.
  * Updated configuration and command-line help text to reflect the new default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->