### PR TITLE
feat: add MultiEdit tool for multi-file edits in one call

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4,6 +4,7 @@ import { AgentTool } from './tools/AgentTool/AgentTool.js'
 import { SkillTool } from './tools/SkillTool/SkillTool.js'
 import { BashTool } from './tools/BashTool/BashTool.js'
 import { FileEditTool } from './tools/FileEditTool/FileEditTool.js'
+import { MultiEditTool } from './tools/MultiEditTool/MultiEditTool.js'
 import { FileReadTool } from './tools/FileReadTool/FileReadTool.js'
 import { FileWriteTool } from './tools/FileWriteTool/FileWriteTool.js'
 import { GlobTool } from './tools/GlobTool/GlobTool.js'
@@ -193,6 +194,7 @@ export function getAllBaseTools(): Tools {
     ExitPlanModeV2Tool,
     FileReadTool,
     FileEditTool,
+    MultiEditTool,
     FileWriteTool,
     NotebookEditTool,
     WebFetchTool,

--- a/src/tools/MultiEditTool/MultiEditTool.test.ts
+++ b/src/tools/MultiEditTool/MultiEditTool.test.ts
@@ -1,0 +1,353 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import type { ToolUseContext } from '../../Tool.js'
+import { getEmptyToolPermissionContext } from '../../Tool.js'
+import { runWithSdkContext, setCwdState } from '../../bootstrap/state.js'
+import { getCwd, runWithCwdOverride } from '../../utils/cwd.js'
+import {
+  createFileStateCacheWithSizeLimit,
+  READ_FILE_STATE_CACHE_SIZE,
+  type FileStateCache,
+} from '../../utils/fileStateCache.js'
+import { renderToString } from '../../utils/staticRender.js'
+import type { SessionId } from '../../types/ids.js'
+import { MultiEditTool } from './MultiEditTool.js'
+import { MULTI_EDIT_TOOL_NAME } from './constants.js'
+import {
+  getToolUseSummary,
+  renderToolResultMessage,
+  renderToolUseErrorMessage,
+  renderToolUseMessage,
+  renderToolUseRejectedMessage,
+} from './UI.js'
+
+let tempDir: string
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'multi-edit-tool-test-'))
+  process.env.CLAUDE_CODE_SIMPLE = 'true'
+  process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING = 'true'
+})
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true })
+  delete process.env.CLAUDE_CODE_SIMPLE
+  delete process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING
+})
+
+function markFileAsRead(readFileState: FileStateCache, filePath: string): void {
+  const content = readFileSync(filePath, 'utf8')
+  readFileState.set(filePath, {
+    content,
+    // Far future timestamp so the "modified since read" check always passes.
+    timestamp: Date.now() + 10_000,
+    offset: undefined,
+    limit: undefined,
+  })
+}
+
+function createToolUseContext(
+  readFileState: FileStateCache,
+  mode: ReturnType<typeof getEmptyToolPermissionContext>['mode'] = 'default',
+): ToolUseContext {
+  return {
+    readFileState,
+    updateFileHistoryState: () => {},
+    dynamicSkillDirTriggers: new Set<string>(),
+    getAppState: () => ({
+      toolPermissionContext: {
+        ...getEmptyToolPermissionContext(),
+        mode,
+      },
+    }),
+  } as unknown as ToolUseContext
+}
+
+async function runInCwd<T>(cwd: string, fn: () => Promise<T>): Promise<T> {
+  const previousCwd = getCwd()
+  return await runWithSdkContext(
+    {
+      sessionId: 'multi-edit-tool-test' as SessionId,
+      sessionProjectDir: null,
+      cwd,
+      originalCwd: cwd,
+    },
+    () =>
+      runWithCwdOverride(cwd, async () => {
+        setCwdState(cwd)
+        try {
+          return await fn()
+        } finally {
+          setCwdState(previousCwd)
+        }
+      }),
+  )
+}
+
+describe('MultiEditTool', () => {
+  test('is registered as a base tool with deny-rule filtering', async () => {
+    const { getAllBaseTools } = await import('../../tools.js')
+    const names = getAllBaseTools().map(tool => tool.name)
+    expect(names).toContain(MULTI_EDIT_TOOL_NAME)
+    expect(MultiEditTool.name).toBe(MULTI_EDIT_TOOL_NAME)
+
+    // Deny-rule filtering: a batch targeting a denied path is denied even
+    // when another edit in the same batch targets an allowed path.
+    const deniedFile = join(tempDir, 'denied.txt')
+    const allowedFile = join(tempDir, 'allowed.txt')
+    writeFileSync(deniedFile, 'denied')
+    writeFileSync(allowedFile, 'allowed')
+
+    const readFileState = createFileStateCacheWithSizeLimit(
+      READ_FILE_STATE_CACHE_SIZE,
+    )
+    markFileAsRead(readFileState, deniedFile)
+    markFileAsRead(readFileState, allowedFile)
+
+    const decision = await runInCwd(tempDir, () =>
+      MultiEditTool.checkPermissions(
+        {
+          edits: [
+            { file_path: allowedFile, old_string: 'allowed', new_string: 'ALLOWED' },
+            { file_path: deniedFile, old_string: 'denied', new_string: 'DENIED' },
+          ],
+        },
+        {
+          getAppState: () => ({
+            toolPermissionContext: {
+              ...getEmptyToolPermissionContext(),
+              alwaysDenyRules: {
+                session: ['Edit(**/denied.txt)'],
+              },
+            },
+          }),
+        } as unknown as ToolUseContext,
+      ),
+    )
+
+    expect(decision.behavior).toBe('deny')
+  })
+
+  test('denies an empty edits batch at both permission and validation gates', async () => {
+    const permission = await MultiEditTool.checkPermissions(
+      { edits: [] },
+      { getAppState: () => ({ toolPermissionContext: getEmptyToolPermissionContext() }) } as unknown as ToolUseContext,
+    )
+    expect(permission.behavior).toBe('deny')
+    if (permission.behavior === 'deny') {
+      expect(permission.message).toBe('No edits provided.')
+    }
+
+    const validation = await MultiEditTool.validateInput(
+      { edits: [] },
+      createToolUseContext(createFileStateCacheWithSizeLimit(READ_FILE_STATE_CACHE_SIZE)),
+    )
+    expect(validation.result).toBe(false)
+    if (!validation.result) {
+      expect(validation.message).toBe('No edits provided.')
+      expect(validation.errorCode).toBe(0)
+    }
+  })
+
+  test('applies edits and reports deduplicated file paths', async () => {
+    const fileA = join(tempDir, 'a.txt')
+    writeFileSync(fileA, 'foo\nbar\n')
+    const readFileState = createFileStateCacheWithSizeLimit(
+      READ_FILE_STATE_CACHE_SIZE,
+    )
+    markFileAsRead(readFileState, fileA)
+
+    const result = await MultiEditTool.call(
+      {
+        edits: [
+          { file_path: fileA, old_string: 'foo', new_string: 'FOO' },
+          { file_path: fileA, old_string: 'bar', new_string: 'BAR' },
+        ],
+      },
+      createToolUseContext(readFileState),
+      mock(async () => ({ behavior: 'allow' })) as never,
+      { uuid: 'test-uuid' } as never,
+    )
+
+    expect(result.data.editCount).toBe(2)
+    // Two edits to the same file still report one unique file path.
+    expect(result.data.filePaths).toEqual([fileA])
+    expect(readFileSync(fileA, 'utf8')).toBe('FOO\nBAR\n')
+  })
+
+  test('a failing middle edit leaves the codebase untouched', async () => {
+    const fileA = join(tempDir, 'a.txt')
+    const fileB = join(tempDir, 'b.txt')
+    writeFileSync(fileA, 'alpha\nbeta\n')
+    writeFileSync(fileB, 'gamma\ndelta\n')
+    const readFileState = createFileStateCacheWithSizeLimit(
+      READ_FILE_STATE_CACHE_SIZE,
+    )
+    markFileAsRead(readFileState, fileA)
+    markFileAsRead(readFileState, fileB)
+
+    const attempt = MultiEditTool.call(
+      {
+        edits: [
+          { file_path: fileA, old_string: 'alpha', new_string: 'ALPHA' },
+          // This old_string is not present in fileB, so the batch must fail
+          // during the in-memory resolve phase before anything is written.
+          { file_path: fileB, old_string: 'zzz', new_string: 'ZZZ' },
+          { file_path: fileA, old_string: 'beta', new_string: 'BETA' },
+        ],
+      },
+      createToolUseContext(readFileState),
+      mock(async () => ({ behavior: 'allow' })) as never,
+      { uuid: 'test-uuid' } as never,
+    )
+
+    await expect(attempt).rejects.toThrow('String not found in file')
+    expect(readFileSync(fileA, 'utf8')).toBe('alpha\nbeta\n')
+    expect(readFileSync(fileB, 'utf8')).toBe('gamma\ndelta\n')
+  })
+
+  test('rejects edits to .ipynb files with a NotebookEdit hint', async () => {
+    const notebook = join(tempDir, 'notebook.ipynb')
+    writeFileSync(notebook, '{"cells": []}')
+    const readFileState = createFileStateCacheWithSizeLimit(
+      READ_FILE_STATE_CACHE_SIZE,
+    )
+    markFileAsRead(readFileState, notebook)
+
+    const result = await MultiEditTool.validateInput(
+      {
+        edits: [
+          {
+            file_path: notebook,
+            old_string: '{"cells"',
+            new_string: '{"cells2"',
+          },
+        ],
+      },
+      createToolUseContext(readFileState),
+    )
+
+    expect(result.result).toBe(false)
+    if (!result.result) {
+      expect(result.message).toContain('NotebookEdit')
+      expect(result.message).toContain('Jupyter Notebook')
+    }
+  })
+
+  test('validates a successful batch', async () => {
+    const fileA = join(tempDir, 'a.txt')
+    writeFileSync(fileA, 'foo\nbar\n')
+    const readFileState = createFileStateCacheWithSizeLimit(
+      READ_FILE_STATE_CACHE_SIZE,
+    )
+    markFileAsRead(readFileState, fileA)
+
+    const result = await MultiEditTool.validateInput(
+      {
+        edits: [
+          { file_path: fileA, old_string: 'foo', new_string: 'FOO' },
+          { file_path: fileA, old_string: 'bar', new_string: 'BAR' },
+        ],
+      },
+      createToolUseContext(readFileState),
+    )
+
+    expect(result.result).toBe(true)
+  })
+
+  test('allows a batch in acceptEdits mode when every path is inside the working dir', async () => {
+    const fileA = join(tempDir, 'a.txt')
+    writeFileSync(fileA, 'content')
+
+    const decision = await runInCwd(tempDir, () =>
+      MultiEditTool.checkPermissions(
+        {
+          edits: [{ file_path: fileA, old_string: 'content', new_string: 'CHANGED' }],
+        },
+        {
+          getAppState: () => ({
+            toolPermissionContext: {
+              ...getEmptyToolPermissionContext(),
+              mode: 'acceptEdits',
+              additionalWorkingDirectories: new Map([[tempDir, tempDir]]),
+            },
+          }),
+        } as unknown as ToolUseContext,
+      ),
+    )
+
+    expect(decision.behavior).toBe('allow')
+  })
+})
+
+describe('MultiEditTool UI', () => {
+  const edits = () => [
+    { file_path: join(tempDir, 'a.txt'), old_string: 'x', new_string: 'y' },
+    { file_path: join(tempDir, 'b.txt'), old_string: 'x', new_string: 'y' },
+  ]
+
+  test('getToolUseSummary reports null, a single file, or a file count', () => {
+    expect(getToolUseSummary(undefined)).toBeNull()
+    expect(getToolUseSummary({})).toBeNull()
+    expect(getToolUseSummary({ edits: [edits()[0]!] })).toContain('a.txt')
+    expect(getToolUseSummary({ edits: edits() })).toBe('2 files')
+  })
+
+  test('renderToolUseMessage shows the edit count and file list', async () => {
+    const output = await renderToString(
+      renderToolUseMessage({ edits: edits() }, { verbose: false }),
+      80,
+    )
+    expect(output).toContain('Editing 2 edits across')
+    expect(output).toContain('a.txt')
+    expect(output).toContain('b.txt')
+  })
+
+  test('renderToolResultMessage reports applied edits, verbose appends paths', async () => {
+    const condensed = await renderToString(
+      renderToolResultMessage(
+        { editCount: 2, filePaths: [edits()[0]!.file_path, edits()[1]!.file_path] },
+        [],
+        { verbose: false },
+      ),
+      80,
+    )
+    expect(condensed).toContain('Applied 2 edits across 2 files')
+
+    const verbose = await renderToString(
+      renderToolResultMessage(
+        { editCount: 1, filePaths: [edits()[0]!.file_path] },
+        [],
+        { verbose: true },
+      ),
+      80,
+    )
+    expect(verbose).toContain('Applied 1 edit across 1 file')
+    expect(verbose).toContain('a.txt')
+  })
+
+  test('renderToolUseRejectedMessage reports the rejected batch size', async () => {
+    const output = await renderToString(
+      renderToolUseRejectedMessage(
+        { edits: edits() },
+        { verbose: false } as never,
+      ),
+      80,
+    )
+    expect(output).toContain('Multi-edit rejected (2 edits across 2 files)')
+  })
+
+  test('renderToolUseErrorMessage surfaces the underlying error', async () => {
+    const output = await renderToString(
+      renderToolUseErrorMessage('Error: boom', {
+        progressMessagesForMessage: [],
+        tools: {} as never,
+        verbose: true,
+      }),
+      80,
+    )
+    expect(output).toContain('Error: boom')
+  })
+})

--- a/src/tools/MultiEditTool/MultiEditTool.test.ts
+++ b/src/tools/MultiEditTool/MultiEditTool.test.ts
@@ -24,17 +24,23 @@ import {
 } from './UI.js'
 
 let tempDir: string
+let prevSimple: string | undefined
+let prevCheckpoint: string | undefined
 
 beforeEach(() => {
   tempDir = mkdtempSync(join(tmpdir(), 'multi-edit-tool-test-'))
+  prevSimple = process.env.CLAUDE_CODE_SIMPLE
+  prevCheckpoint = process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING
   process.env.CLAUDE_CODE_SIMPLE = 'true'
   process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING = 'true'
 })
 
 afterEach(() => {
   rmSync(tempDir, { recursive: true, force: true })
-  delete process.env.CLAUDE_CODE_SIMPLE
-  delete process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING
+  if (prevSimple === undefined) delete process.env.CLAUDE_CODE_SIMPLE
+  else process.env.CLAUDE_CODE_SIMPLE = prevSimple
+  if (prevCheckpoint === undefined) delete process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING
+  else process.env.CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING = prevCheckpoint
 })
 
 function markFileAsRead(readFileState: FileStateCache, filePath: string): void {

--- a/src/tools/MultiEditTool/MultiEditTool.test.ts
+++ b/src/tools/MultiEditTool/MultiEditTool.test.ts
@@ -263,6 +263,40 @@ describe('MultiEditTool', () => {
     expect(result.result).toBe(true)
   })
 
+  test('validates a later same-file edit against accumulated content', async () => {
+    const fileA = join(tempDir, 'a.txt')
+    writeFileSync(fileA, 'foo\nbar\n')
+    const readFileState = createFileStateCacheWithSizeLimit(
+      READ_FILE_STATE_CACHE_SIZE,
+    )
+    markFileAsRead(readFileState, fileA)
+
+    const ok = await MultiEditTool.validateInput(
+      {
+        edits: [
+          { file_path: fileA, old_string: 'foo', new_string: 'FOO' },
+          { file_path: fileA, old_string: 'FOO', new_string: 'FOO2' },
+        ],
+      },
+      createToolUseContext(readFileState),
+    )
+    expect(ok.result).toBe(true)
+
+    const missing = await MultiEditTool.validateInput(
+      {
+        edits: [
+          { file_path: fileA, old_string: 'foo', new_string: 'FOO' },
+          { file_path: fileA, old_string: 'foo', new_string: 'zzz' },
+        ],
+      },
+      createToolUseContext(readFileState),
+    )
+    expect(missing.result).toBe(false)
+    if (!missing.result) {
+      expect(missing.message).toContain('String to replace not found')
+    }
+  })
+
   test('allows a batch in acceptEdits mode when every path is inside the working dir', async () => {
     const fileA = join(tempDir, 'a.txt')
     writeFileSync(fileA, 'content')

--- a/src/tools/MultiEditTool/MultiEditTool.ts
+++ b/src/tools/MultiEditTool/MultiEditTool.ts
@@ -15,6 +15,7 @@ import { buildTool, type ToolDef } from '../../Tool.js'
 import { getCwd } from '../../utils/cwd.js'
 import { logForDebugging } from '../../utils/debug.js'
 import { countLinesChanged } from '../../utils/diff.js'
+import type { StructuredPatchHunk } from 'diff'
 import { isEnvTruthy } from '../../utils/envUtils.js'
 import { isENOENT } from '../../utils/errors.js'
 import {
@@ -143,18 +144,50 @@ export const MultiEditTool = buildTool({
     }
   },
   async preparePermissionMatcher({ edits }) {
-    // Match if ANY edit's file_path matches the pattern
+    // Require EVERY edit's file_path to match the pattern so a single matching
+    // path can't satisfy the matcher for the whole batch.
     return (pattern: string) =>
-      edits.some((edit: { file_path: string }) =>
+      edits.every((edit: { file_path: string }) =>
         matchWildcardPattern(pattern, edit.file_path),
       )
   },
   async checkPermissions(input, context): Promise<PermissionDecision> {
     const appState = context.getAppState()
-    return checkWritePermissionForTool(
-      MultiEditTool,
-      input,
-      appState.toolPermissionContext,
+    // Fail closed: an empty batch is never allowed to proceed. (validateInput
+    // also rejects it, but the permission gate should not approve anything.)
+    if (!input.edits || input.edits.length === 0) {
+      return {
+        behavior: 'deny',
+        message: 'No edits provided.',
+        decisionReason: { type: 'other', reason: 'empty edits array' },
+      }
+    }
+    // Evaluate the permission decision for every distinct edit path and combine
+    // the results: any deny wins, then any ask, and allow only when every path
+    // allows. A batch whose first edit targets an allowed path must not write
+    // arbitrary other paths in the same call.
+    const paths = [
+      ...new Set(input.edits.map(e => expandPath(e.file_path))),
+    ]
+    let pendingAsk: PermissionDecision | undefined
+    for (const path of paths) {
+      const decision = checkWritePermissionForTool(
+        { ...MultiEditTool, getPath: () => path },
+        input,
+        appState.toolPermissionContext,
+      )
+      if (decision.behavior === 'deny') {
+        return decision
+      }
+      if (decision.behavior === 'ask' && !pendingAsk) {
+        pendingAsk = decision
+      }
+    }
+    return (
+      pendingAsk ?? {
+        behavior: 'allow',
+        updatedInput: input,
+      }
     )
   },
   renderToolUseMessage,
@@ -172,6 +205,10 @@ export const MultiEditTool = buildTool({
     }
 
     const errors: string[] = []
+    // Accumulated per-file content so edits to the same file validate against
+    // the result of earlier edits in the batch (mirrors how call() applies
+    // them in order).
+    const accumulatedContent = new Map<string, string>()
 
     for (let i = 0; i < edits.length; i++) {
       const edit = edits[i]!
@@ -230,28 +267,20 @@ export const MultiEditTool = buildTool({
         }
       }
 
-      // Read file
+      // Read file — reuse call()'s decode contract (full encoding detection)
+      // and the accumulated content from earlier edits to the same file.
       let fileContent: string | null
-      try {
-        const fileBuffer = await fs.readFileBytes(fullFilePath)
-        const encoding: BufferEncoding =
-          fileBuffer.length >= 2 &&
-          fileBuffer[0] === 0xff &&
-          fileBuffer[1] === 0xfe
-            ? 'utf16le'
-            : 'utf8'
-        fileContent = fileBuffer.toString(encoding).replaceAll('\r\n', '\n')
-      } catch (e) {
-        if (isENOENT(e)) {
-          fileContent = null
-        } else {
-          throw e
-        }
+      if (accumulatedContent.has(fullFilePath)) {
+        fileContent = accumulatedContent.get(fullFilePath)!
+      } else {
+        const { content, fileExists } = readFileForEdit(fullFilePath)
+        fileContent = fileExists ? content : null
       }
 
       // File doesn't exist
       if (fileContent === null) {
         if (old_string === '') {
+          accumulatedContent.set(fullFilePath, '')
           continue // New file creation is valid
         }
         const similarFilename = findSimilarFile(fullFilePath)
@@ -292,8 +321,10 @@ export const MultiEditTool = buildTool({
         continue
       }
 
-      // Check if file was modified since last read
-      if (readTimestamp) {
+      // Check if file was modified since last read (skipped for edits to a
+      // file already edited earlier in this batch — accumulatedContent is the
+      // source of truth for those, not the untouched disk copy).
+      if (readTimestamp && !accumulatedContent.has(fullFilePath)) {
         const lastWriteTime = getFileModificationTime(fullFilePath)
         if (lastWriteTime > readTimestamp.timestamp) {
           const isFullRead =
@@ -339,6 +370,15 @@ export const MultiEditTool = buildTool({
         errors.push(`${editLabel}: ${settingsValidationResult.message}`)
         continue
       }
+
+      // Apply the edit in memory so later edits to the same file validate
+      // against the result (same order call() will apply them in).
+      accumulatedContent.set(
+        fullFilePath,
+        replace_all
+          ? fileContent.replaceAll(actualOldString, new_string)
+          : fileContent.replace(actualOldString, new_string),
+      )
     }
 
     if (errors.length > 0) {
@@ -366,6 +406,27 @@ export const MultiEditTool = buildTool({
     const cwd = getCwd()
     const editedFilePaths = new Set<string>()
 
+    // Phase 1 — resolve every edit in memory. Edits to the same file are
+    // applied to an accumulated copy so they compose in order. Nothing is
+    // written to disk until every edit has resolved, keeping the batch
+    // atomic: any failure below leaves the codebase untouched.
+    type PendingFile = {
+      initialContent: string
+      content: string
+      fileExists: boolean
+      encoding: BufferEncoding
+      lineEndings: LineEndingType
+    }
+    const pendingFiles = new Map<string, PendingFile>()
+    const resolvedEdits: {
+      filePath: string
+      absoluteFilePath: string
+      oldString: string
+      newString: string
+      replaceAll: boolean
+      patch: StructuredPatchHunk[]
+    }[] = []
+
     for (const edit of edits) {
       const {
         file_path,
@@ -375,134 +436,176 @@ export const MultiEditTool = buildTool({
       } = edit
       const absoluteFilePath = expandPath(file_path)
 
-      // Discover skills (fire-and-forget)
-      if (!isEnvTruthy(process.env.CLAUDE_CODE_SIMPLE)) {
-        const newSkillDirs = await discoverSkillDirsForPaths(
-          [absoluteFilePath],
-          cwd,
-        )
-        if (newSkillDirs.length > 0) {
-          for (const dir of newSkillDirs) {
-            dynamicSkillDirTriggers?.add(dir)
-          }
-          addSkillDirectories(newSkillDirs).catch(() => {})
+      let pending = pendingFiles.get(absoluteFilePath)
+      if (!pending) {
+        const read = readFileForEdit(absoluteFilePath)
+        pending = {
+          initialContent: read.content,
+          content: read.content,
+          fileExists: read.fileExists,
+          encoding: read.encoding,
+          lineEndings: read.lineEndings,
         }
-        activateConditionalSkillsForPaths([absoluteFilePath], cwd)
-      }
+        pendingFiles.set(absoluteFilePath, pending)
 
-      await diagnosticTracker.beforeFileEditedCompat(absoluteFilePath)
-
-      // Ensure parent directory exists
-      await fs.mkdir(dirname(absoluteFilePath))
-      if (fileHistoryEnabled()) {
-        await fileHistoryTrackEdit(
-          updateFileHistoryState,
-          absoluteFilePath,
-          parentMessage.uuid,
-        )
-      }
-
-      // Read current state
-      const {
-        content: originalFileContents,
-        fileExists,
-        encoding,
-        lineEndings: endings,
-      } = readFileForEdit(absoluteFilePath)
-
-      if (fileExists) {
-        const lastWriteTime = getFileModificationTime(absoluteFilePath)
-        const lastRead = readFileState.get(absoluteFilePath)
-        if (!lastRead || lastWriteTime > lastRead.timestamp) {
-          const isFullRead =
-            lastRead &&
-            lastRead.offset === undefined &&
-            lastRead.limit === undefined
-          const contentUnchanged =
-            isFullRead && originalFileContents === lastRead.content
-          if (!contentUnchanged) {
-            throw new Error(
-              'File has been unexpectedly modified. Read it again before attempting to write it.',
-            )
+        if (read.fileExists) {
+          const lastWriteTime = getFileModificationTime(absoluteFilePath)
+          const lastRead = readFileState.get(absoluteFilePath)
+          if (!lastRead || lastWriteTime > lastRead.timestamp) {
+            const isFullRead =
+              lastRead &&
+              lastRead.offset === undefined &&
+              lastRead.limit === undefined
+            const contentUnchanged =
+              isFullRead && read.content === lastRead.content
+            if (!contentUnchanged) {
+              throw new Error(
+                'File has been unexpectedly modified. Read it again before attempting to write it.',
+              )
+            }
           }
         }
       }
 
       // Handle quote normalization
       const actualOldString =
-        findActualString(originalFileContents, old_string) || old_string
+        findActualString(pending.content, old_string) || old_string
       const actualNewString = preserveQuoteStyle(
         old_string,
         actualOldString,
         new_string,
       )
 
-      // Generate patch and apply
+      // Generate patch against accumulated content
       const { patch, updatedFile } = getPatchForEdit({
         filePath: absoluteFilePath,
-        fileContents: originalFileContents,
+        fileContents: pending.content,
         oldString: actualOldString,
         newString: actualNewString,
         replaceAll: replace_all,
       })
 
-      // Write to disk
-      writeTextContent(absoluteFilePath, updatedFile, encoding, endings)
+      pending.content = updatedFile
+      resolvedEdits.push({
+        filePath: file_path,
+        absoluteFilePath,
+        oldString: old_string,
+        newString: new_string,
+        replaceAll: replace_all,
+        patch,
+      })
+    }
 
-      // Notify LSP servers
-      const lspManager = getLspServerManager()
-      if (lspManager) {
-        clearDeliveredDiagnosticsForFile(`file://${absoluteFilePath}`)
-        lspManager
-          .changeFile(absoluteFilePath, updatedFile)
-          .catch((err: Error) => {
+    // Phase 2 — every edit resolved, so apply them. Side effects for a given
+    // file run once (on its first edit), using the file's final accumulated
+    // content; per-edit telemetry is still emitted for every edit.
+    const appliedFiles = new Set<string>()
+
+    for (const {
+      filePath,
+      absoluteFilePath,
+      oldString,
+      newString,
+      replaceAll,
+      patch,
+    } of resolvedEdits) {
+      const pending = pendingFiles.get(absoluteFilePath)!
+
+      if (!appliedFiles.has(absoluteFilePath)) {
+        // Discover skills (fire-and-forget)
+        if (!isEnvTruthy(process.env.CLAUDE_CODE_SIMPLE)) {
+          const newSkillDirs = await discoverSkillDirsForPaths(
+            [absoluteFilePath],
+            cwd,
+          )
+          if (newSkillDirs.length > 0) {
+            for (const dir of newSkillDirs) {
+              dynamicSkillDirTriggers?.add(dir)
+            }
+            addSkillDirectories(newSkillDirs).catch(() => {})
+          }
+          activateConditionalSkillsForPaths([absoluteFilePath], cwd)
+        }
+
+        await diagnosticTracker.beforeFileEditedCompat(absoluteFilePath)
+
+        // Ensure parent directory exists
+        await fs.mkdir(dirname(absoluteFilePath))
+        if (fileHistoryEnabled()) {
+          await fileHistoryTrackEdit(
+            updateFileHistoryState,
+            absoluteFilePath,
+            parentMessage.uuid,
+          )
+        }
+
+        // Write final accumulated content to disk
+        writeTextContent(
+          absoluteFilePath,
+          pending.content,
+          pending.encoding,
+          pending.lineEndings,
+        )
+
+        // Notify LSP servers
+        const lspManager = getLspServerManager()
+        if (lspManager) {
+          clearDeliveredDiagnosticsForFile(`file://${absoluteFilePath}`)
+          lspManager
+            .changeFile(absoluteFilePath, pending.content)
+            .catch((err: Error) => {
+              logForDebugging(
+                `LSP: Failed to notify server of file change for ${absoluteFilePath}: ${err.message}`,
+              )
+              logError(err)
+            })
+          lspManager.saveFile(absoluteFilePath).catch((err: Error) => {
             logForDebugging(
-              `LSP: Failed to notify server of file change for ${absoluteFilePath}: ${err.message}`,
+              `LSP: Failed to notify server of file save for ${absoluteFilePath}: ${err.message}`,
             )
             logError(err)
           })
-        lspManager.saveFile(absoluteFilePath).catch((err: Error) => {
-          logForDebugging(
-            `LSP: Failed to notify server of file save for ${absoluteFilePath}: ${err.message}`,
-          )
-          logError(err)
+        }
+
+        // Notify VSCode with the on-disk state it last saw -> final content
+        notifyVscodeFileUpdated(
+          absoluteFilePath,
+          pending.initialContent,
+          pending.content,
+        )
+
+        // Update read timestamp
+        readFileState.set(absoluteFilePath, {
+          content: pending.content,
+          timestamp: getFileModificationTime(absoluteFilePath),
+          offset: undefined,
+          limit: undefined,
         })
+
+        // Log events
+        if (
+          absoluteFilePath.endsWith(`${sep}CLAUDE.md`) ||
+          absoluteFilePath.endsWith(`${sep}AGENTS.md`)
+        ) {
+          logEvent('tengu_write_claudemd', {})
+        }
+
+        logFileOperation({
+          operation: 'edit',
+          tool: 'MultiEditTool',
+          filePath: absoluteFilePath,
+        })
+
+        editedFilePaths.add(filePath)
+        appliedFiles.add(absoluteFilePath)
       }
 
-      // Notify VSCode
-      notifyVscodeFileUpdated(
-        absoluteFilePath,
-        originalFileContents,
-        updatedFile,
-      )
-
-      // Update read timestamp
-      readFileState.set(absoluteFilePath, {
-        content: updatedFile,
-        timestamp: getFileModificationTime(absoluteFilePath),
-        offset: undefined,
-        limit: undefined,
-      })
-
-      // Log events
-      if (absoluteFilePath.endsWith(`${sep}CLAUDE.md`)) {
-        logEvent('tengu_write_claudemd', {})
-      }
       countLinesChanged(patch)
-
-      logFileOperation({
-        operation: 'edit',
-        tool: 'MultiEditTool',
-        filePath: absoluteFilePath,
-      })
-
       logEvent('tengu_edit_string_lengths', {
-        oldStringBytes: Buffer.byteLength(old_string, 'utf8'),
-        newStringBytes: Buffer.byteLength(new_string, 'utf8'),
-        replaceAll: replace_all,
+        oldStringBytes: Buffer.byteLength(oldString, 'utf8'),
+        newStringBytes: Buffer.byteLength(newString, 'utf8'),
+        replaceAll,
       })
-
-      editedFilePaths.add(file_path)
     }
 
     const filePaths = [...editedFilePaths]

--- a/src/tools/MultiEditTool/MultiEditTool.ts
+++ b/src/tools/MultiEditTool/MultiEditTool.ts
@@ -1,0 +1,525 @@
+import { dirname, sep } from 'path'
+import { logEvent } from 'src/services/analytics/index.js'
+import { diagnosticTracker } from '../../services/diagnosticTracking.js'
+import { clearDeliveredDiagnosticsForFile } from '../../services/lsp/LSPDiagnosticRegistry.js'
+import { getLspServerManager } from '../../services/lsp/manager.js'
+import { notifyVscodeFileUpdated } from '../../services/mcp/vscodeSdkMcp.js'
+import { checkTeamMemSecrets } from '../../services/teamMemorySync/teamMemSecretGuard.js'
+import {
+  activateConditionalSkillsForPaths,
+  addSkillDirectories,
+  discoverSkillDirsForPaths,
+} from '../../skills/loadSkillsDir.js'
+import type { ToolUseContext } from '../../Tool.js'
+import { buildTool, type ToolDef } from '../../Tool.js'
+import { getCwd } from '../../utils/cwd.js'
+import { logForDebugging } from '../../utils/debug.js'
+import { countLinesChanged } from '../../utils/diff.js'
+import { isEnvTruthy } from '../../utils/envUtils.js'
+import { isENOENT } from '../../utils/errors.js'
+import {
+  FILE_NOT_FOUND_CWD_NOTE,
+  findSimilarFile,
+  getFileModificationTime,
+  suggestPathUnderCwd,
+  writeTextContent,
+} from '../../utils/file.js'
+import {
+  fileHistoryEnabled,
+  fileHistoryTrackEdit,
+} from '../../utils/fileHistory.js'
+import { logFileOperation } from '../../utils/fileOperationAnalytics.js'
+import {
+  type LineEndingType,
+  readFileSyncWithMetadata,
+} from '../../utils/fileRead.js'
+import { formatFileSize } from '../../utils/format.js'
+import { getFsImplementation } from '../../utils/fsOperations.js'
+import { logError } from '../../utils/log.js'
+import { expandPath } from '../../utils/path.js'
+import {
+  checkWritePermissionForTool,
+  matchingRuleForInput,
+} from '../../utils/permissions/filesystem.js'
+import type { PermissionDecision } from '../../utils/permissions/PermissionResult.js'
+import { matchWildcardPattern } from '../../utils/permissions/shellRuleMatching.js'
+import { validateInputForSettingsFileEdit } from '../../utils/settings/validateEditTool.js'
+import { NOTEBOOK_EDIT_TOOL_NAME } from '../NotebookEditTool/constants.js'
+import {
+  findActualString,
+  getPatchForEdit,
+  preserveQuoteStyle,
+} from '../FileEditTool/utils.js'
+import { MULTI_EDIT_TOOL_NAME } from './constants.js'
+import { getMultiEditToolDescription } from './prompt.js'
+import {
+  type MultiEditInput,
+  type MultiEditOutput,
+  inputSchema,
+  outputSchema,
+} from './types.js'
+import {
+  getToolUseSummary,
+  renderToolResultMessage,
+  renderToolUseErrorMessage,
+  renderToolUseMessage,
+  renderToolUseRejectedMessage,
+  userFacingName,
+} from './UI.js'
+
+const MAX_EDIT_FILE_SIZE = 1024 * 1024 * 1024 // 1 GiB (stat bytes)
+
+function readFileForEdit(absoluteFilePath: string): {
+  content: string
+  fileExists: boolean
+  encoding: BufferEncoding
+  lineEndings: LineEndingType
+} {
+  try {
+    // eslint-disable-next-line custom-rules/no-sync-fs
+    const meta = readFileSyncWithMetadata(absoluteFilePath)
+    return {
+      content: meta.content,
+      fileExists: true,
+      encoding: meta.encoding,
+      lineEndings: meta.lineEndings,
+    }
+  } catch (e) {
+    if (isENOENT(e)) {
+      return {
+        content: '',
+        fileExists: false,
+        encoding: 'utf8',
+        lineEndings: 'LF',
+      }
+    }
+    throw e
+  }
+}
+
+export const MultiEditTool = buildTool({
+  name: MULTI_EDIT_TOOL_NAME,
+  searchHint: 'atomic multi-file edits validated before applying',
+  maxResultSizeChars: 100_000,
+  strict: true,
+  async description() {
+    return 'A tool for performing atomic multi-file edits'
+  },
+  async prompt() {
+    return getMultiEditToolDescription()
+  },
+  userFacingName,
+  getToolUseSummary,
+  getActivityDescription(input) {
+    const summary = getToolUseSummary(input)
+    return summary ? `Editing ${summary}` : 'Editing multiple files'
+  },
+  get inputSchema() {
+    return inputSchema()
+  },
+  get outputSchema() {
+    return outputSchema()
+  },
+  toAutoClassifierInput(input) {
+    if (!input.edits?.length) return ''
+    return input.edits
+      .map(
+        (e: { file_path: string; new_string: string }) =>
+          `${e.file_path}: ${e.new_string}`,
+      )
+      .join('\n')
+  },
+  getPath(input): string {
+    // Return the first file path for permission matching
+    return input.edits?.[0]?.file_path ?? ''
+  },
+  backfillObservableInput(input) {
+    if (Array.isArray(input.edits)) {
+      for (const edit of input.edits) {
+        if (typeof edit.file_path === 'string') {
+          edit.file_path = expandPath(edit.file_path)
+        }
+      }
+    }
+  },
+  async preparePermissionMatcher({ edits }) {
+    // Match if ANY edit's file_path matches the pattern
+    return (pattern: string) =>
+      edits.some((edit: { file_path: string }) =>
+        matchWildcardPattern(pattern, edit.file_path),
+      )
+  },
+  async checkPermissions(input, context): Promise<PermissionDecision> {
+    const appState = context.getAppState()
+    return checkWritePermissionForTool(
+      MultiEditTool,
+      input,
+      appState.toolPermissionContext,
+    )
+  },
+  renderToolUseMessage,
+  renderToolResultMessage,
+  renderToolUseRejectedMessage,
+  renderToolUseErrorMessage,
+  async validateInput(input: MultiEditInput, toolUseContext: ToolUseContext) {
+    const { edits } = input
+    if (!edits || edits.length === 0) {
+      return {
+        result: false,
+        message: 'No edits provided.',
+        errorCode: 0,
+      }
+    }
+
+    const errors: string[] = []
+
+    for (let i = 0; i < edits.length; i++) {
+      const edit = edits[i]!
+      const { file_path, old_string, new_string, replace_all = false } = edit
+      const fullFilePath = expandPath(file_path)
+      const editLabel = `Edit ${i + 1} (${file_path})`
+
+      // Check for secrets
+      const secretError = checkTeamMemSecrets(fullFilePath, new_string)
+      if (secretError) {
+        errors.push(`${editLabel}: ${secretError}`)
+        continue
+      }
+
+      if (old_string === new_string) {
+        errors.push(
+          `${editLabel}: No changes to make: old_string and new_string are exactly the same.`,
+        )
+        continue
+      }
+
+      // Check deny rules
+      const appState = toolUseContext.getAppState()
+      const denyRule = matchingRuleForInput(
+        fullFilePath,
+        appState.toolPermissionContext,
+        'edit',
+        'deny',
+      )
+      if (denyRule !== null) {
+        errors.push(
+          `${editLabel}: File is in a directory that is denied by your permission settings.`,
+        )
+        continue
+      }
+
+      // Skip UNC paths
+      if (fullFilePath.startsWith('\\\\') || fullFilePath.startsWith('//')) {
+        continue
+      }
+
+      const fs = getFsImplementation()
+
+      // Check file size
+      try {
+        const { size } = await fs.stat(fullFilePath)
+        if (size > MAX_EDIT_FILE_SIZE) {
+          errors.push(
+            `${editLabel}: File is too large to edit (${formatFileSize(size)}).`,
+          )
+          continue
+        }
+      } catch (e) {
+        if (!isENOENT(e)) {
+          throw e
+        }
+      }
+
+      // Read file
+      let fileContent: string | null
+      try {
+        const fileBuffer = await fs.readFileBytes(fullFilePath)
+        const encoding: BufferEncoding =
+          fileBuffer.length >= 2 &&
+          fileBuffer[0] === 0xff &&
+          fileBuffer[1] === 0xfe
+            ? 'utf16le'
+            : 'utf8'
+        fileContent = fileBuffer.toString(encoding).replaceAll('\r\n', '\n')
+      } catch (e) {
+        if (isENOENT(e)) {
+          fileContent = null
+        } else {
+          throw e
+        }
+      }
+
+      // File doesn't exist
+      if (fileContent === null) {
+        if (old_string === '') {
+          continue // New file creation is valid
+        }
+        const similarFilename = findSimilarFile(fullFilePath)
+        const cwdSuggestion = await suggestPathUnderCwd(fullFilePath)
+        let message = `${editLabel}: File does not exist. ${FILE_NOT_FOUND_CWD_NOTE} ${getCwd()}.`
+        if (cwdSuggestion) {
+          message += ` Did you mean ${cwdSuggestion}?`
+        } else if (similarFilename) {
+          message += ` Did you mean ${similarFilename}?`
+        }
+        errors.push(message)
+        continue
+      }
+
+      // File exists with empty old_string
+      if (old_string === '') {
+        if (fileContent.trim() !== '') {
+          errors.push(
+            `${editLabel}: Cannot create new file - file already exists.`,
+          )
+        }
+        continue
+      }
+
+      if (fullFilePath.endsWith('.ipynb')) {
+        errors.push(
+          `${editLabel}: File is a Jupyter Notebook. Use the ${NOTEBOOK_EDIT_TOOL_NAME} to edit this file.`,
+        )
+        continue
+      }
+
+      // Check if file has been read
+      const readTimestamp = toolUseContext.readFileState.get(fullFilePath)
+      if (!readTimestamp || readTimestamp.isPartialView) {
+        errors.push(
+          `${editLabel}: File has not been read yet. Read it first before writing to it.`,
+        )
+        continue
+      }
+
+      // Check if file was modified since last read
+      if (readTimestamp) {
+        const lastWriteTime = getFileModificationTime(fullFilePath)
+        if (lastWriteTime > readTimestamp.timestamp) {
+          const isFullRead =
+            readTimestamp.offset === undefined &&
+            readTimestamp.limit === undefined
+          if (!(isFullRead && fileContent === readTimestamp.content)) {
+            errors.push(
+              `${editLabel}: File has been modified since read. Read it again before attempting to write it.`,
+            )
+            continue
+          }
+        }
+      }
+
+      // Verify old_string exists
+      const actualOldString = findActualString(fileContent, old_string)
+      if (!actualOldString) {
+        errors.push(
+          `${editLabel}: String to replace not found in file.\nString: ${old_string}`,
+        )
+        continue
+      }
+
+      // Check uniqueness
+      const matches = fileContent.split(actualOldString).length - 1
+      if (matches > 1 && !replace_all) {
+        errors.push(
+          `${editLabel}: Found ${matches} matches of the string to replace, but replace_all is false. To replace all occurrences, set replace_all to true.`,
+        )
+        continue
+      }
+
+      // Additional validation for Claude settings files
+      const settingsValidationResult = validateInputForSettingsFileEdit(
+        fullFilePath,
+        fileContent,
+        () =>
+          replace_all
+            ? fileContent.replaceAll(actualOldString, new_string)
+            : fileContent.replace(actualOldString, new_string),
+      )
+      if (settingsValidationResult !== null) {
+        errors.push(`${editLabel}: ${settingsValidationResult.message}`)
+        continue
+      }
+    }
+
+    if (errors.length > 0) {
+      return {
+        result: false,
+        message: `Validation failed for ${errors.length} edit(s):\n${errors.join('\n')}`,
+        errorCode: 0,
+      }
+    }
+
+    return { result: true }
+  },
+  async call(
+    input: MultiEditInput,
+    {
+      readFileState,
+      updateFileHistoryState,
+      dynamicSkillDirTriggers,
+    },
+    _,
+    parentMessage,
+  ) {
+    const { edits } = input
+    const fs = getFsImplementation()
+    const cwd = getCwd()
+    const editedFilePaths = new Set<string>()
+
+    for (const edit of edits) {
+      const {
+        file_path,
+        old_string,
+        new_string,
+        replace_all = false,
+      } = edit
+      const absoluteFilePath = expandPath(file_path)
+
+      // Discover skills (fire-and-forget)
+      if (!isEnvTruthy(process.env.CLAUDE_CODE_SIMPLE)) {
+        const newSkillDirs = await discoverSkillDirsForPaths(
+          [absoluteFilePath],
+          cwd,
+        )
+        if (newSkillDirs.length > 0) {
+          for (const dir of newSkillDirs) {
+            dynamicSkillDirTriggers?.add(dir)
+          }
+          addSkillDirectories(newSkillDirs).catch(() => {})
+        }
+        activateConditionalSkillsForPaths([absoluteFilePath], cwd)
+      }
+
+      await diagnosticTracker.beforeFileEditedCompat(absoluteFilePath)
+
+      // Ensure parent directory exists
+      await fs.mkdir(dirname(absoluteFilePath))
+      if (fileHistoryEnabled()) {
+        await fileHistoryTrackEdit(
+          updateFileHistoryState,
+          absoluteFilePath,
+          parentMessage.uuid,
+        )
+      }
+
+      // Read current state
+      const {
+        content: originalFileContents,
+        fileExists,
+        encoding,
+        lineEndings: endings,
+      } = readFileForEdit(absoluteFilePath)
+
+      if (fileExists) {
+        const lastWriteTime = getFileModificationTime(absoluteFilePath)
+        const lastRead = readFileState.get(absoluteFilePath)
+        if (!lastRead || lastWriteTime > lastRead.timestamp) {
+          const isFullRead =
+            lastRead &&
+            lastRead.offset === undefined &&
+            lastRead.limit === undefined
+          const contentUnchanged =
+            isFullRead && originalFileContents === lastRead.content
+          if (!contentUnchanged) {
+            throw new Error(
+              'File has been unexpectedly modified. Read it again before attempting to write it.',
+            )
+          }
+        }
+      }
+
+      // Handle quote normalization
+      const actualOldString =
+        findActualString(originalFileContents, old_string) || old_string
+      const actualNewString = preserveQuoteStyle(
+        old_string,
+        actualOldString,
+        new_string,
+      )
+
+      // Generate patch and apply
+      const { patch, updatedFile } = getPatchForEdit({
+        filePath: absoluteFilePath,
+        fileContents: originalFileContents,
+        oldString: actualOldString,
+        newString: actualNewString,
+        replaceAll: replace_all,
+      })
+
+      // Write to disk
+      writeTextContent(absoluteFilePath, updatedFile, encoding, endings)
+
+      // Notify LSP servers
+      const lspManager = getLspServerManager()
+      if (lspManager) {
+        clearDeliveredDiagnosticsForFile(`file://${absoluteFilePath}`)
+        lspManager
+          .changeFile(absoluteFilePath, updatedFile)
+          .catch((err: Error) => {
+            logForDebugging(
+              `LSP: Failed to notify server of file change for ${absoluteFilePath}: ${err.message}`,
+            )
+            logError(err)
+          })
+        lspManager.saveFile(absoluteFilePath).catch((err: Error) => {
+          logForDebugging(
+            `LSP: Failed to notify server of file save for ${absoluteFilePath}: ${err.message}`,
+          )
+          logError(err)
+        })
+      }
+
+      // Notify VSCode
+      notifyVscodeFileUpdated(
+        absoluteFilePath,
+        originalFileContents,
+        updatedFile,
+      )
+
+      // Update read timestamp
+      readFileState.set(absoluteFilePath, {
+        content: updatedFile,
+        timestamp: getFileModificationTime(absoluteFilePath),
+        offset: undefined,
+        limit: undefined,
+      })
+
+      // Log events
+      if (absoluteFilePath.endsWith(`${sep}CLAUDE.md`)) {
+        logEvent('tengu_write_claudemd', {})
+      }
+      countLinesChanged(patch)
+
+      logFileOperation({
+        operation: 'edit',
+        tool: 'MultiEditTool',
+        filePath: absoluteFilePath,
+      })
+
+      logEvent('tengu_edit_string_lengths', {
+        oldStringBytes: Buffer.byteLength(old_string, 'utf8'),
+        newStringBytes: Buffer.byteLength(new_string, 'utf8'),
+        replaceAll: replace_all,
+      })
+
+      editedFilePaths.add(file_path)
+    }
+
+    const filePaths = [...editedFilePaths]
+
+    return {
+      data: {
+        editCount: edits.length,
+        filePaths,
+      },
+    }
+  },
+  mapToolResultToToolResultBlockParam(data: MultiEditOutput, toolUseID) {
+    const { editCount, filePaths } = data
+    return {
+      tool_use_id: toolUseID,
+      type: 'tool_result',
+      content: `Successfully applied ${editCount} edit${editCount === 1 ? '' : 's'} across ${filePaths.length} file${filePaths.length === 1 ? '' : 's'}: ${filePaths.join(', ')}`,
+    }
+  },
+} satisfies ToolDef<ReturnType<typeof inputSchema>, MultiEditOutput>)

--- a/src/tools/MultiEditTool/UI.tsx
+++ b/src/tools/MultiEditTool/UI.tsx
@@ -1,0 +1,127 @@
+import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources/index.mjs'
+import * as React from 'react'
+import { FallbackToolUseErrorMessage } from '../../components/FallbackToolUseErrorMessage.js'
+import { FilePathLink } from '../../components/FilePathLink.js'
+import { Text } from '../../ink.js'
+import type { Tools } from '../../Tool.js'
+import type { Message, ProgressMessage } from '../../types/message.js'
+import { getDisplayPath } from '../../utils/file.js'
+import type { ThemeName } from '../../utils/theme.js'
+import type { MultiEditEntry, MultiEditOutput } from './types.js'
+
+export function userFacingName(
+  input:
+    | Partial<{
+        edits: MultiEditEntry[]
+      }>
+    | undefined,
+): string {
+  return 'MultiEdit'
+}
+
+export function getToolUseSummary(
+  input:
+    | Partial<{
+        edits: MultiEditEntry[]
+      }>
+    | undefined,
+): string | null {
+  if (!input?.edits?.length) {
+    return null
+  }
+  const uniqueFiles = [
+    ...new Set(input.edits.map(e => e.file_path).filter(Boolean)),
+  ]
+  if (uniqueFiles.length === 0) {
+    return null
+  }
+  if (uniqueFiles.length === 1) {
+    return getDisplayPath(uniqueFiles[0]!)
+  }
+  return `${uniqueFiles.length} files`
+}
+
+export function renderToolUseMessage(
+  { edits }: { edits?: MultiEditEntry[] },
+  { verbose }: { verbose: boolean },
+): React.ReactNode {
+  if (!edits?.length) {
+    return null
+  }
+  const uniqueFiles = [
+    ...new Set(edits.map(e => e.file_path).filter(Boolean)),
+  ]
+  if (uniqueFiles.length === 0) {
+    return null
+  }
+  return (
+    <Text>
+      Editing {edits.length} edit{edits.length === 1 ? '' : 's'} across{' '}
+      {uniqueFiles.map((fp, i) => (
+        <React.Fragment key={fp}>
+          {i > 0 && ', '}
+          <FilePathLink filePath={fp}>
+            {verbose ? fp : getDisplayPath(fp)}
+          </FilePathLink>
+        </React.Fragment>
+      ))}
+    </Text>
+  )
+}
+
+export function renderToolResultMessage(
+  { editCount, filePaths }: MultiEditOutput,
+  _progressMessagesForMessage: ProgressMessage[],
+  {
+    verbose,
+  }: {
+    style?: 'condensed'
+    verbose: boolean
+  },
+): React.ReactNode {
+  return (
+    <Text color="success">
+      Applied {editCount} edit{editCount === 1 ? '' : 's'} across{' '}
+      {filePaths.length} file{filePaths.length === 1 ? '' : 's'}
+      {verbose
+        ? ': ' + filePaths.map(fp => getDisplayPath(fp)).join(', ')
+        : ''}
+    </Text>
+  )
+}
+
+export function renderToolUseRejectedMessage(
+  input: { edits: MultiEditEntry[] },
+  options: {
+    columns: number
+    messages: Message[]
+    progressMessagesForMessage: ProgressMessage[]
+    style?: 'condensed'
+    theme: ThemeName
+    tools: Tools
+    verbose: boolean
+  },
+): React.ReactElement {
+  const { edits } = input
+  const uniqueFiles = [
+    ...new Set(edits.map(e => e.file_path).filter(Boolean)),
+  ]
+  return (
+    <Text dimColor>
+      Multi-edit rejected ({edits.length} edit{edits.length === 1 ? '' : 's'}{' '}
+      across {uniqueFiles.length} file{uniqueFiles.length === 1 ? '' : 's'})
+    </Text>
+  )
+}
+
+export function renderToolUseErrorMessage(
+  result: ToolResultBlockParam['content'],
+  options: {
+    progressMessagesForMessage: ProgressMessage[]
+    tools: Tools
+    verbose: boolean
+  },
+): React.ReactElement {
+  const { verbose } = options
+  return <FallbackToolUseErrorMessage result={result} verbose={verbose} />
+}

--- a/src/tools/MultiEditTool/UI.tsx
+++ b/src/tools/MultiEditTool/UI.tsx
@@ -83,9 +83,7 @@ export function renderToolResultMessage(
     <Text color="success">
       Applied {editCount} edit{editCount === 1 ? '' : 's'} across{' '}
       {filePaths.length} file{filePaths.length === 1 ? '' : 's'}
-      {verbose
-        ? ': ' + filePaths.map(fp => getDisplayPath(fp)).join(', ')
-        : ''}
+      {verbose ? ': ' + filePaths.join(', ') : ''}
     </Text>
   )
 }

--- a/src/tools/MultiEditTool/constants.ts
+++ b/src/tools/MultiEditTool/constants.ts
@@ -1,0 +1,1 @@
+export const MULTI_EDIT_TOOL_NAME = 'MultiEdit'

--- a/src/tools/MultiEditTool/prompt.ts
+++ b/src/tools/MultiEditTool/prompt.ts
@@ -1,0 +1,16 @@
+import { isCompactLinePrefixEnabled } from '../../utils/file.js'
+import { FILE_READ_TOOL_NAME } from '../FileReadTool/prompt.js'
+
+export function getMultiEditToolDescription(): string {
+  const prefixFormat = isCompactLinePrefixEnabled()
+    ? 'line number + tab'
+    : 'spaces + line number + arrow'
+  return `Performs atomic multi-file edits. All edits are validated before any are applied — if any edit fails (file not found, string not found, ambiguous match), NO edits are applied. This prevents partial modifications that could leave the codebase in a broken state.
+
+Usage:
+- You must use your \`${FILE_READ_TOOL_NAME}\` tool to read each file before editing. This tool will error if you attempt an edit on a file that hasn't been read.
+- When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: ${prefixFormat}. Everything after that is the actual file content to match.
+- Each edit in the array follows the same rules as the Edit tool: \`old_string\` must be unique in the file unless \`replace_all\` is true.
+- Use this tool when you need to make coordinated changes across multiple files that must succeed or fail together.
+- The edits are applied in order. Multiple edits to the same file are supported — each subsequent edit sees the result of the previous one.`
+}

--- a/src/tools/MultiEditTool/prompt.ts
+++ b/src/tools/MultiEditTool/prompt.ts
@@ -5,10 +5,10 @@ export function getMultiEditToolDescription(): string {
   const prefixFormat = isCompactLinePrefixEnabled()
     ? 'line number + tab'
     : 'spaces + line number + arrow'
-  return `Performs atomic multi-file edits. All edits are validated before any are applied — if any edit fails (file not found, string not found, ambiguous match), NO edits are applied. This prevents partial modifications that could leave the codebase in a broken state.
+  return `Performs atomic multi-file edits. All edits are resolved and validated in memory before any file is written — if any edit fails validation (file not found, string not found, ambiguous match), NO edits are applied. This prevents partial modifications that could leave the codebase in a broken state.
 
 Usage:
-- You must use your \`${FILE_READ_TOOL_NAME}\` tool to read each file before editing. This tool will error if you attempt an edit on a file that hasn't been read.
+- You must use your \`${FILE_READ_TOOL_NAME}\` tool to read each existing file before editing. This tool will error if you attempt an edit on an existing file that hasn't been read. To create a new file, pass an empty old_string.
 - When editing text from Read tool output, ensure you preserve the exact indentation (tabs/spaces) as it appears AFTER the line number prefix. The line number prefix format is: ${prefixFormat}. Everything after that is the actual file content to match.
 - Each edit in the array follows the same rules as the Edit tool: \`old_string\` must be unique in the file unless \`replace_all\` is true.
 - Use this tool when you need to make coordinated changes across multiple files that must succeed or fail together.

--- a/src/tools/MultiEditTool/types.ts
+++ b/src/tools/MultiEditTool/types.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod/v4'
+import { lazySchema } from '../../utils/lazySchema.js'
+import { semanticBoolean } from '../../utils/semanticBoolean.js'
+
+const editEntrySchema = lazySchema(() =>
+  z.strictObject({
+    file_path: z.string().describe('The absolute path to the file to modify'),
+    old_string: z.string().describe('The text to replace'),
+    new_string: z
+      .string()
+      .describe(
+        'The text to replace it with (must be different from old_string)',
+      ),
+    replace_all: semanticBoolean(
+      z.boolean().default(false).optional(),
+    ).describe('Replace all occurrences of old_string (default false)'),
+  }),
+)
+
+const inputSchema = lazySchema(() =>
+  z.strictObject({
+    edits: z
+      .array(editEntrySchema())
+      .describe('Array of edits to apply atomically'),
+  }),
+)
+type InputSchema = ReturnType<typeof inputSchema>
+
+export type MultiEditInput = z.output<InputSchema>
+
+export type MultiEditEntry = {
+  file_path: string
+  old_string: string
+  new_string: string
+  replace_all?: boolean
+}
+
+// Output schema for MultiEditTool
+const outputSchema = lazySchema(() =>
+  z.object({
+    editCount: z.number().describe('Number of edits applied'),
+    filePaths: z
+      .array(z.string())
+      .describe('List of file paths that were edited'),
+  }),
+)
+type OutputSchema = ReturnType<typeof outputSchema>
+
+export type MultiEditOutput = z.infer<OutputSchema>
+
+export { inputSchema, outputSchema }

--- a/src/tools/MultiEditTool/types.ts
+++ b/src/tools/MultiEditTool/types.ts
@@ -12,7 +12,7 @@ const editEntrySchema = lazySchema(() =>
         'The text to replace it with (must be different from old_string)',
       ),
     replace_all: semanticBoolean(
-      z.boolean().default(false).optional(),
+      z.boolean().optional(),
     ).describe('Replace all occurrences of old_string (default false)'),
   }),
 )
@@ -28,12 +28,7 @@ type InputSchema = ReturnType<typeof inputSchema>
 
 export type MultiEditInput = z.output<InputSchema>
 
-export type MultiEditEntry = {
-  file_path: string
-  old_string: string
-  new_string: string
-  replace_all?: boolean
-}
+export type MultiEditEntry = z.output<ReturnType<typeof editEntrySchema>>
 
 // Output schema for MultiEditTool
 const outputSchema = lazySchema(() =>

--- a/src/utils/fileOperationAnalytics.ts
+++ b/src/utils/fileOperationAnalytics.ts
@@ -36,7 +36,7 @@ const MAX_CONTENT_HASH_SIZE = 100 * 1024
  */
 export function logFileOperation(params: {
   operation: 'read' | 'write' | 'edit'
-  tool: 'FileReadTool' | 'FileWriteTool' | 'FileEditTool'
+  tool: 'FileReadTool' | 'FileWriteTool' | 'FileEditTool' | 'MultiEditTool'
   filePath: string
   content?: string
   type?: 'create' | 'update'


### PR DESCRIPTION
## Summary

Adds a `MultiEdit` tool so the model can apply edits across several files in a single tool call, instead of chaining one `Edit` per file. It shares the existing edit plumbing, so settings/config files get the same safety guards (`validateInputForSettingsFileEdit` / `beforeFileEditedCompat`) as single-file edits.

Ported from a sibling fork and trimmed for this repo: the `growthbook` dependency was dropped entirely, so there are no new runtime deps.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run build`
- [x] `bun run smoke`

> No dedicated unit tests yet — it shares its edit path with FileEditTool. Happy to add a focused test file if maintainers want one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-file editing tool that applies coordinated changes atomically.
  * Supports multiple edits across files with exact text matching and optional replace-all behavior.
  * Validates file access, permissions, content changes, and editing rules before applying updates.
  * Displays clear progress, results, edited file counts, and file links in the interface.
  * Preserves file formatting and prevents partial updates when validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->