### PR TITLE
feat: add /tools to view and set per-tool modes

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -29,6 +29,7 @@ import knowledge from './commands/knowledge/index.js'
 import memory from './commands/memory/index.js'
 import repomap from './commands/repomap/index.js'
 import help from './commands/help/index.js'
+import tools from './commands/tools/index.js'
 import ide from './commands/ide/index.js'
 import init from './commands/init.js'
 import initVerifiers from './commands/init-verifiers.js'
@@ -341,6 +342,7 @@ const COMMANDS = memoize((): Command[] => [
   resume,
   session,
   setContextWindow,
+  tools,
   skills,
   stats,
   status,

--- a/src/commands/tools/index.ts
+++ b/src/commands/tools/index.ts
@@ -1,0 +1,10 @@
+import type { Command } from '../../types/command.js'
+
+const tools = {
+  type: 'local-jsx',
+  name: 'tools',
+  description: 'Manage per-tool modes (always/ask/auto/off)',
+  load: () => import('./tools.js'),
+} satisfies Command
+
+export default tools

--- a/src/commands/tools/index.ts
+++ b/src/commands/tools/index.ts
@@ -4,6 +4,7 @@ const tools = {
   type: 'local-jsx',
   name: 'tools',
   description: 'Manage per-tool modes (always/ask/auto/off)',
+  supportsNonInteractive: false,
   load: () => import('./tools.js'),
 } satisfies Command
 

--- a/src/commands/tools/tools.tsx
+++ b/src/commands/tools/tools.tsx
@@ -1,11 +1,13 @@
 import * as React from 'react'
 import { ToolModeManager } from '../../components/ToolModeManager.js'
-import { getTools } from '../../tools.js'
+import { getToolsForModeManager } from '../../tools.js'
 import type { LocalJSXCommandCall } from '../../types/command.js'
 
 export const call: LocalJSXCommandCall = async (onDone, context) => {
   const appState = context.getAppState()
   const permissionContext = appState.toolPermissionContext
-  const tools = getTools(permissionContext)
+  // Manager list must include tools configured to 'off' (so they can be cycled
+  // back on) and the MCP tools in the active pool. getTools() would strip both.
+  const tools = getToolsForModeManager(permissionContext, appState.mcp.tools)
   return <ToolModeManager tools={tools} onClose={onDone} />
 }

--- a/src/commands/tools/tools.tsx
+++ b/src/commands/tools/tools.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react'
+import { ToolModeManager } from '../../components/ToolModeManager.js'
+import { getTools } from '../../tools.js'
+import type { LocalJSXCommandCall } from '../../types/command.js'
+
+export const call: LocalJSXCommandCall = async (onDone, context) => {
+  const appState = context.getAppState()
+  const permissionContext = appState.toolPermissionContext
+  const tools = getTools(permissionContext)
+  return <ToolModeManager tools={tools} onClose={onDone} />
+}

--- a/src/components/ToolModeManager.test.ts
+++ b/src/components/ToolModeManager.test.ts
@@ -131,6 +131,25 @@ describe('getToolsForModeManager', () => {
     expect(names).not.toContain('mcp__server__fetch')
   })
 
+  test('enabled MCP tools stay in the runtime pool', () => {
+    const names = assembleToolPool(
+      emptyPermissionContext,
+      mcpFetchFixture as unknown as Tools,
+    ).map(t => t.name)
+    expect(names).toContain('mcp__server__fetch')
+    expect(names).toContain('Bash')
+  })
+
+  test('a colliding MCP name cannot replace a built-in', () => {
+    const colliding = [{ ...mcpFetchFixture[0], name: 'Bash', userFacingName: () => 'fake-bash' }]
+    const bash = assembleToolPool(
+      emptyPermissionContext,
+      colliding as unknown as Tools,
+    ).filter(t => t.name === 'Bash')
+    expect(bash).toHaveLength(1)
+    expect(bash[0]!.userFacingName()).not.toBe('fake-bash')
+  })
+
   test('simple-mode manager still lists MCP tools', () => {
     process.env.CLAUDE_CODE_SIMPLE = 'true'
     const names = getToolsForModeManager(

--- a/src/components/ToolModeManager.test.ts
+++ b/src/components/ToolModeManager.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { getEmptyToolPermissionContext } from '../Tool.js'
+import { applyModeCycle, nextMode } from './ToolModeManager.js'
+import { saveGlobalConfig } from '../utils/config.js'
+import type { Tools } from '../Tool.js'
+import { getTools, getToolsForModeManager } from '../tools.js'
+
+const emptyPermissionContext = getEmptyToolPermissionContext()
+
+function resetToolModes(): void {
+  saveGlobalConfig(config => ({ ...config, toolModes: undefined }))
+}
+
+afterEach(() => {
+  resetToolModes()
+  delete process.env.CLAUDE_CODE_SIMPLE
+})
+
+describe('nextMode', () => {
+  test('cycles auto -> always -> ask -> off -> auto', () => {
+    expect(nextMode('auto')).toBe('always')
+    expect(nextMode('always')).toBe('ask')
+    expect(nextMode('ask')).toBe('off')
+    expect(nextMode('off')).toBe('auto')
+  })
+})
+
+describe('applyModeCycle', () => {
+  test('adds an entry when cycling away from auto', () => {
+    expect(applyModeCycle({}, 'Glob')).toEqual({ Glob: 'always' })
+  })
+
+  test('removes the entry when cycling back to auto (re-enables off tool)', () => {
+    expect(applyModeCycle({ Glob: 'off' }, 'Glob')).toEqual({})
+  })
+
+  test('leaves unrelated tools untouched', () => {
+    expect(applyModeCycle({ Bash: 'off' }, 'Glob')).toEqual({ Bash: 'off', Glob: 'always' })
+  })
+})
+
+describe('getTools tool-mode filtering', () => {
+  test('a tool set to off is removed from the normal pool', () => {
+    saveGlobalConfig(config => ({
+      ...config,
+      toolModes: { Grep: 'off' },
+    }))
+    const names = getTools(emptyPermissionContext).map(t => t.name)
+    expect(names).not.toContain('Grep')
+    expect(names).toContain('Bash')
+  })
+
+  test('a tool set to off is removed from the simple pool too', () => {
+    process.env.CLAUDE_CODE_SIMPLE = 'true'
+    saveGlobalConfig(config => ({
+      ...config,
+      toolModes: { Edit: 'off' },
+    }))
+    const names = getTools(emptyPermissionContext).map(t => t.name)
+    expect(names).not.toContain('Edit')
+    expect(names).toContain('Bash')
+  })
+
+  test('re-enabling an off tool restores it to the pool', () => {
+    saveGlobalConfig(config => ({
+      ...config,
+      toolModes: { Grep: 'off' },
+    }))
+    expect(getTools(emptyPermissionContext).map(t => t.name)).not.toContain('Grep')
+
+    resetToolModes()
+    expect(getTools(emptyPermissionContext).map(t => t.name)).toContain('Grep')
+  })
+})
+
+describe('getToolsForModeManager', () => {
+  test('includes tools configured to off so they can be cycled back on', () => {
+    saveGlobalConfig(config => ({
+      ...config,
+      toolModes: { Grep: 'off' },
+    }))
+    const names = getToolsForModeManager(emptyPermissionContext, []).map(t => t.name)
+    expect(names).toContain('Grep')
+    expect(names).toContain('Bash')
+  })
+
+  test('includes MCP tools from the active pool', () => {
+    const mcpTools = [
+      {
+        name: 'mcp__server__fetch',
+        description: 'mcp tool',
+        inputSchema: { type: 'object', properties: {} },
+        isEnabled: () => true,
+        call: async () => ({}),
+        isConcurrencySafe: true,
+        isReadOnly: true,
+        maxResultSizeChars: 1000,
+        userFacingName: () => 'fetch',
+      },
+    ]
+    const names = getToolsForModeManager(emptyPermissionContext, mcpTools as unknown as Tools).map(t => t.name)
+    expect(names).toContain('mcp__server__fetch')
+    expect(names).toContain('Bash')
+  })
+
+  test('is a superset of the runtime pool (keeps what getTools would strip)', () => {
+    // Every tool in the runtime pool must be manageable.
+    const runtimeNames = getTools(emptyPermissionContext).map(t => t.name)
+    const managerNames = getToolsForModeManager(emptyPermissionContext, []).map(t => t.name)
+    for (const name of runtimeNames) {
+      expect(managerNames).toContain(name)
+    }
+  })
+})
+

--- a/src/components/ToolModeManager.test.ts
+++ b/src/components/ToolModeManager.test.ts
@@ -3,9 +3,23 @@ import { getEmptyToolPermissionContext } from '../Tool.js'
 import { applyModeCycle, nextMode } from './ToolModeManager.js'
 import { saveGlobalConfig } from '../utils/config.js'
 import type { Tools } from '../Tool.js'
-import { getTools, getToolsForModeManager } from '../tools.js'
+import { assembleToolPool, getTools, getToolsForModeManager } from '../tools.js'
 
 const emptyPermissionContext = getEmptyToolPermissionContext()
+
+const mcpFetchFixture = [
+  {
+    name: 'mcp__server__fetch',
+    description: 'mcp tool',
+    inputSchema: { type: 'object', properties: {} },
+    isEnabled: () => true,
+    call: async () => ({}),
+    isConcurrencySafe: true,
+    isReadOnly: true,
+    maxResultSizeChars: 1000,
+    userFacingName: () => 'fetch',
+  },
+]
 
 function resetToolModes(): void {
   saveGlobalConfig(config => ({ ...config, toolModes: undefined }))
@@ -85,20 +99,44 @@ describe('getToolsForModeManager', () => {
   })
 
   test('includes MCP tools from the active pool', () => {
-    const mcpTools = [
-      {
-        name: 'mcp__server__fetch',
-        description: 'mcp tool',
-        inputSchema: { type: 'object', properties: {} },
-        isEnabled: () => true,
-        call: async () => ({}),
-        isConcurrencySafe: true,
-        isReadOnly: true,
-        maxResultSizeChars: 1000,
-        userFacingName: () => 'fetch',
-      },
-    ]
-    const names = getToolsForModeManager(emptyPermissionContext, mcpTools as unknown as Tools).map(t => t.name)
+    const names = getToolsForModeManager(
+      emptyPermissionContext,
+      mcpFetchFixture as unknown as Tools,
+    ).map(t => t.name)
+    expect(names).toContain('mcp__server__fetch')
+    expect(names).toContain('Bash')
+  })
+
+  test('off-mode MCP tools stay visible in the manager', () => {
+    saveGlobalConfig(config => ({
+      ...config,
+      toolModes: { 'mcp__server__fetch': 'off' },
+    }))
+    const names = getToolsForModeManager(
+      emptyPermissionContext,
+      mcpFetchFixture as unknown as Tools,
+    ).map(t => t.name)
+    expect(names).toContain('mcp__server__fetch')
+  })
+
+  test('off-mode MCP tools are stripped from the runtime pool', () => {
+    saveGlobalConfig(config => ({
+      ...config,
+      toolModes: { 'mcp__server__fetch': 'off' },
+    }))
+    const names = assembleToolPool(
+      emptyPermissionContext,
+      mcpFetchFixture as unknown as Tools,
+    ).map(t => t.name)
+    expect(names).not.toContain('mcp__server__fetch')
+  })
+
+  test('simple-mode manager still lists MCP tools', () => {
+    process.env.CLAUDE_CODE_SIMPLE = 'true'
+    const names = getToolsForModeManager(
+      emptyPermissionContext,
+      mcpFetchFixture as unknown as Tools,
+    ).map(t => t.name)
     expect(names).toContain('mcp__server__fetch')
     expect(names).toContain('Bash')
   })

--- a/src/components/ToolModeManager.tsx
+++ b/src/components/ToolModeManager.tsx
@@ -5,13 +5,34 @@ import type { Tool } from '../Tool.js'
 import { getGlobalConfig, saveGlobalConfig } from '../utils/config.js'
 import { Pane } from './design-system/Pane.js'
 
-type ToolMode = 'always' | 'ask' | 'auto' | 'off'
+export type ToolMode = 'always' | 'ask' | 'auto' | 'off'
 
 const MODES: ToolMode[] = ['auto', 'always', 'ask', 'off']
 
-function nextMode(current: ToolMode): ToolMode {
+export function nextMode(current: ToolMode): ToolMode {
   const idx = MODES.indexOf(current)
   return MODES[(idx + 1) % MODES.length]!
+}
+
+/**
+ * Pure next-state computation for cycling a tool's mode.
+ *
+ * Returns the updated modes map. Cycling back to 'auto' removes the entry,
+ * which is what lets a persisted 'off' mode be re-enabled — and when the map
+ * empties, callers persist `undefined` instead of an empty object.
+ */
+export function applyModeCycle(
+  modes: Record<string, ToolMode>,
+  toolName: string,
+): Record<string, ToolMode> {
+  const next = nextMode(modes[toolName] ?? 'auto')
+  const updated = { ...modes }
+  if (next === 'auto') {
+    delete updated[toolName]
+  } else {
+    updated[toolName] = next
+  }
+  return updated
 }
 
 function modeBadge(mode: ToolMode): React.ReactNode {
@@ -46,14 +67,7 @@ export function ToolModeManager({ tools, onClose }: Props): React.ReactNode {
 
   const cycleMode = useCallback(
     (toolName: string) => {
-      const current = getMode(toolName)
-      const next = nextMode(current)
-      const updated = { ...modes }
-      if (next === 'auto') {
-        delete updated[toolName]
-      } else {
-        updated[toolName] = next
-      }
+      const updated = applyModeCycle(modes, toolName)
       setModes(updated)
       saveGlobalConfig(config => ({
         ...config,

--- a/src/components/ToolModeManager.tsx
+++ b/src/components/ToolModeManager.tsx
@@ -1,0 +1,141 @@
+import * as React from 'react'
+import { useCallback, useState } from 'react'
+import { Box, Text, useInput } from '../ink.js'
+import type { Tool } from '../Tool.js'
+import { getGlobalConfig, saveGlobalConfig } from '../utils/config.js'
+import { Pane } from './design-system/Pane.js'
+
+type ToolMode = 'always' | 'ask' | 'auto' | 'off'
+
+const MODES: ToolMode[] = ['auto', 'always', 'ask', 'off']
+
+function nextMode(current: ToolMode): ToolMode {
+  const idx = MODES.indexOf(current)
+  return MODES[(idx + 1) % MODES.length]!
+}
+
+function modeBadge(mode: ToolMode): React.ReactNode {
+  switch (mode) {
+    case 'always':
+      return <Text color="green" bold>[always]</Text>
+    case 'ask':
+      return <Text color="yellow" bold>[ask]</Text>
+    case 'auto':
+      return <Text color="blue" bold>[auto]</Text>
+    case 'off':
+      return <Text color="red" bold>[off]</Text>
+  }
+}
+
+type Props = {
+  tools: readonly Tool[]
+  onClose: (result?: string) => void
+}
+
+export function ToolModeManager({ tools, onClose }: Props): React.ReactNode {
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [modes, setModes] = useState<Record<string, ToolMode>>(() => {
+    const config = getGlobalConfig()
+    return config.toolModes ?? {}
+  })
+
+  const getMode = useCallback(
+    (toolName: string): ToolMode => modes[toolName] ?? 'auto',
+    [modes],
+  )
+
+  const cycleMode = useCallback(
+    (toolName: string) => {
+      const current = getMode(toolName)
+      const next = nextMode(current)
+      const updated = { ...modes }
+      if (next === 'auto') {
+        delete updated[toolName]
+      } else {
+        updated[toolName] = next
+      }
+      setModes(updated)
+      saveGlobalConfig(config => ({
+        ...config,
+        toolModes: Object.keys(updated).length > 0 ? updated : undefined,
+      }))
+    },
+    [modes, getMode],
+  )
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onClose('Tool mode manager closed')
+      return
+    }
+    if (key.upArrow) {
+      setSelectedIndex(i => Math.max(0, i - 1))
+      return
+    }
+    if (key.downArrow) {
+      setSelectedIndex(i => Math.min(tools.length - 1, i + 1))
+      return
+    }
+    if (key.return || input === ' ') {
+      const tool = tools[selectedIndex]
+      if (tool) {
+        cycleMode(tool.name)
+      }
+      return
+    }
+  })
+
+  const selectedTool = tools[selectedIndex]
+
+  // Compute visible window (scroll if needed)
+  const maxVisible = 15
+  let startIdx = 0
+  if (tools.length > maxVisible) {
+    startIdx = Math.max(
+      0,
+      Math.min(selectedIndex - Math.floor(maxVisible / 2), tools.length - maxVisible),
+    )
+  }
+  const visibleTools = tools.slice(startIdx, startIdx + maxVisible)
+
+  return (
+    <Pane color="permission">
+      <Box flexDirection="column">
+        <Box marginBottom={1}>
+          <Text bold>Tool Mode Manager</Text>
+          <Text dimColor> — ↑↓ navigate, Space/Enter cycle mode, Esc close</Text>
+        </Box>
+
+        {visibleTools.map((tool, i) => {
+          const actualIndex = startIdx + i
+          const isSelected = actualIndex === selectedIndex
+          const mode = getMode(tool.name)
+          return (
+            <Box key={tool.name}>
+              <Text>{isSelected ? '❯ ' : '  '}</Text>
+              <Text bold={isSelected}>{tool.name}</Text>
+              <Text> </Text>
+              {modeBadge(mode)}
+            </Box>
+          )
+        })}
+
+        {tools.length > maxVisible && (
+          <Box marginTop={1}>
+            <Text dimColor>
+              Showing {startIdx + 1}–{Math.min(startIdx + maxVisible, tools.length)} of {tools.length} tools
+            </Text>
+          </Box>
+        )}
+
+        {selectedTool && (
+          <Box marginTop={1} flexDirection="column">
+            <Text dimColor>
+              {selectedTool.name}: {'off'} disables the tool entirely; other modes are display-only for now
+            </Text>
+          </Box>
+        )}
+      </Box>
+    </Pane>
+  )
+}

--- a/src/screens/REPL.tsx
+++ b/src/screens/REPL.tsx
@@ -128,7 +128,7 @@ import { WEB_FETCH_TOOL_NAME } from '../tools/WebFetchTool/prompt.js';
 import { SLEEP_TOOL_NAME } from '../tools/SleepTool/prompt.js';
 import { clearSpeculativeChecks } from '../tools/BashTool/bashPermissions.js';
 import type { AutoUpdaterResult } from '../utils/autoUpdater.js';
-import { getGlobalConfig, saveGlobalConfig, saveGlobalConfigDeferred } from '../utils/config.js';
+import { getGlobalConfig, getGlobalConfigWriteCount, saveGlobalConfig, saveGlobalConfigDeferred } from '../utils/config.js';
 import { hasConsoleBillingAccess } from '../utils/billing.js';
 import { logEvent, type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS } from 'src/services/analytics/index.js';
 import { getFeatureValue_CACHED_MAY_BE_STALE } from 'src/services/analytics/growthbook.js';
@@ -846,7 +846,11 @@ export function REPL({
   // /brief mid-session leaves the stale tool list (no SendUserMessage) and
   // the model emits plain text the brief filter hides.
   const isBriefOnly = useAppState(s => s.isBriefOnly);
-  const localTools = useMemo(() => getTools(toolPermissionContext), [toolPermissionContext, proactiveActive, isBriefOnly]);
+  // getGlobalConfigWriteCount() is a React-visible dep: /tools saves per-tool
+  // modes to the global config, and without it the memoized localTools would
+  // keep passing a stale enabled tool (e.g. Glob) to the model after the user
+  // sets it to off. Every config write bumps the count, re-running getTools().
+  const localTools = useMemo(() => getTools(toolPermissionContext), [toolPermissionContext, proactiveActive, isBriefOnly, getGlobalConfigWriteCount()]);
   useKickOffCheckAndDisableBypassPermissionsIfNeeded();
   useKickOffCheckAndDisableAutoModeIfNeeded();
   const [dynamicMcpConfig, setDynamicMcpConfig] = useState<Record<string, ScopedMcpServerConfig> | undefined>(initialDynamicMcpConfig);

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -260,7 +260,24 @@ export function filterToolsByDenyRules<
   return tools.filter(tool => !getDenyRuleForTool(permissionContext, tool))
 }
 
-export const getTools = (permissionContext: ToolPermissionContext): Tools => {
+export const getTools = (
+  permissionContext: ToolPermissionContext,
+  options: { includeOffTools?: boolean; mcpTools?: Tools } = {},
+): Tools => {
+  const { includeOffTools = false, mcpTools = [] } = options
+
+  // Respect per-tool 'off' modes set via /tools — a disabled tool is removed
+  // from the pool entirely. Other modes (always/ask/auto) are display-only.
+  // Skipped when includeOffTools so the /tools manager can list (and re-enable)
+  // tools that are currently off. Applied on every return path, including the
+  // CLAUDE_CODE_SIMPLE early returns below.
+  const applyToolModesFilter = (tools: Tool[]): Tool[] => {
+    if (includeOffTools) return tools
+    const toolModes = getGlobalConfig().toolModes
+    if (!toolModes) return tools
+    return tools.filter(tool => toolModes[tool.name] !== 'off')
+  }
+
   // Simple mode: only Bash, Read, and Edit tools
   if (isEnvTruthy(process.env.CLAUDE_CODE_SIMPLE)) {
     // --bare + REPL mode: REPL wraps Bash/Read/Edit/etc inside the VM, so
@@ -275,7 +292,10 @@ export const getTools = (permissionContext: ToolPermissionContext): Tools => {
         const sendMessageTool = getSendMessageTool()
         if (sendMessageTool) replSimple.push(TaskStopTool, sendMessageTool)
       }
-      return filterToolsByDenyRules(replSimple, permissionContext)
+      return filterToolsByDenyRules(
+        applyToolModesFilter(replSimple),
+        permissionContext,
+      )
     }
     const simpleTools: Tool[] = [BashTool, FileReadTool, FileEditTool]
     // When coordinator mode is also active, include AgentTool and TaskStopTool
@@ -289,7 +309,10 @@ export const getTools = (permissionContext: ToolPermissionContext): Tools => {
       const sendMessageTool = getSendMessageTool()
       if (sendMessageTool) simpleTools.push(sendMessageTool)
     }
-    return filterToolsByDenyRules(simpleTools, permissionContext)
+    return filterToolsByDenyRules(
+      applyToolModesFilter(simpleTools),
+      permissionContext,
+    )
   }
 
   // Get all base tools and filter out special tools that get added conditionally
@@ -321,15 +344,35 @@ export const getTools = (permissionContext: ToolPermissionContext): Tools => {
   // (defensive check against initialization timing issues)
   allowedTools = allowedTools.filter(Boolean)
 
-  // Respect per-tool 'off' modes set via /tools — a disabled tool is removed
-  // from the pool entirely. Other modes (always/ask/auto) are display-only.
-  const toolModes = getGlobalConfig().toolModes
-  if (toolModes) {
-    allowedTools = allowedTools.filter(tool => toolModes[tool.name] !== 'off')
-  }
+  allowedTools = applyToolModesFilter(allowedTools)
 
   const isEnabled = allowedTools.map(_ => typeof _.isEnabled === 'function' ? _.isEnabled() : true)
-  return allowedTools.filter((_, i) => isEnabled[i])
+  allowedTools = allowedTools.filter((_, i) => isEnabled[i])
+
+  // When mcpTools are provided (the /tools manager), merge them in after the
+  // built-in pool so every tool in the active pool can be managed. Deny-rule
+  // filtered and deduplicated with built-ins taking precedence, matching
+  // assembleToolPool().
+  if (mcpTools.length > 0) {
+    const allowedMcpTools = filterToolsByDenyRules(mcpTools, permissionContext).filter(Boolean)
+    allowedTools = uniqBy([...allowedTools, ...allowedMcpTools], 'name')
+  }
+
+  return allowedTools
+}
+
+/**
+ * Build the tool list for the /tools mode manager.
+ *
+ * Unlike getTools(), this keeps tools configured to 'off' (so they stay
+ * visible and can be cycled back to auto/always/ask) and includes MCP tools
+ * from the active pool. Environment and permission filtering still applies.
+ */
+export function getToolsForModeManager(
+  permissionContext: ToolPermissionContext,
+  mcpTools: Tools,
+): Tools {
+  return getTools(permissionContext, { includeOffTools: true, mcpTools })
 }
 
 /**

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -260,23 +260,35 @@ export function filterToolsByDenyRules<
   return tools.filter(tool => !getDenyRuleForTool(permissionContext, tool))
 }
 
+/** Drop tools the user turned off via /tools. */
+function filterOffModeTools<T extends { name: string }>(
+  tools: T[],
+  includeOffTools = false,
+): T[] {
+  if (includeOffTools) return tools
+  const toolModes = getGlobalConfig().toolModes
+  if (!toolModes) return tools
+  return tools.filter(tool => toolModes[tool.name] !== 'off')
+}
+
+function mergeMcpTools(
+  tools: Tool[],
+  mcpTools: Tools,
+  permissionContext: ToolPermissionContext,
+): Tool[] {
+  if (mcpTools.length === 0) return tools
+  const allowedMcpTools = filterToolsByDenyRules(
+    mcpTools,
+    permissionContext,
+  ).filter(Boolean)
+  return uniqBy([...tools, ...allowedMcpTools], 'name')
+}
+
 export const getTools = (
   permissionContext: ToolPermissionContext,
   options: { includeOffTools?: boolean; mcpTools?: Tools } = {},
 ): Tools => {
   const { includeOffTools = false, mcpTools = [] } = options
-
-  // Respect per-tool 'off' modes set via /tools — a disabled tool is removed
-  // from the pool entirely. Other modes (always/ask/auto) are display-only.
-  // Skipped when includeOffTools so the /tools manager can list (and re-enable)
-  // tools that are currently off. Applied on every return path, including the
-  // CLAUDE_CODE_SIMPLE early returns below.
-  const applyToolModesFilter = (tools: Tool[]): Tool[] => {
-    if (includeOffTools) return tools
-    const toolModes = getGlobalConfig().toolModes
-    if (!toolModes) return tools
-    return tools.filter(tool => toolModes[tool.name] !== 'off')
-  }
 
   // Simple mode: only Bash, Read, and Edit tools
   if (isEnvTruthy(process.env.CLAUDE_CODE_SIMPLE)) {
@@ -292,9 +304,13 @@ export const getTools = (
         const sendMessageTool = getSendMessageTool()
         if (sendMessageTool) replSimple.push(TaskStopTool, sendMessageTool)
       }
-      return filterToolsByDenyRules(
-        applyToolModesFilter(replSimple),
-        permissionContext,
+      return filterOffModeTools(
+        mergeMcpTools(
+          filterToolsByDenyRules(replSimple, permissionContext),
+          mcpTools,
+          permissionContext,
+        ),
+        includeOffTools,
       )
     }
     const simpleTools: Tool[] = [BashTool, FileReadTool, FileEditTool]
@@ -309,9 +325,13 @@ export const getTools = (
       const sendMessageTool = getSendMessageTool()
       if (sendMessageTool) simpleTools.push(sendMessageTool)
     }
-    return filterToolsByDenyRules(
-      applyToolModesFilter(simpleTools),
-      permissionContext,
+    return filterOffModeTools(
+      mergeMcpTools(
+        filterToolsByDenyRules(simpleTools, permissionContext),
+        mcpTools,
+        permissionContext,
+      ),
+      includeOffTools,
     )
   }
 
@@ -344,21 +364,16 @@ export const getTools = (
   // (defensive check against initialization timing issues)
   allowedTools = allowedTools.filter(Boolean)
 
-  allowedTools = applyToolModesFilter(allowedTools)
-
   const isEnabled = allowedTools.map(_ => typeof _.isEnabled === 'function' ? _.isEnabled() : true)
   allowedTools = allowedTools.filter((_, i) => isEnabled[i])
 
-  // When mcpTools are provided (the /tools manager), merge them in after the
-  // built-in pool so every tool in the active pool can be managed. Deny-rule
-  // filtered and deduplicated with built-ins taking precedence, matching
-  // assembleToolPool().
-  if (mcpTools.length > 0) {
-    const allowedMcpTools = filterToolsByDenyRules(mcpTools, permissionContext).filter(Boolean)
-    allowedTools = uniqBy([...allowedTools, ...allowedMcpTools], 'name')
-  }
-
-  return allowedTools
+  // Merge MCP tools (deny-filtered, built-ins win on name), then drop anything
+  // the user turned off — including off-mode MCP tools. includeOffTools skips
+  // that last step so /tools can list and re-enable them.
+  return filterOffModeTools(
+    mergeMcpTools(allowedTools, mcpTools, permissionContext),
+    includeOffTools,
+  )
 }
 
 /**
@@ -410,9 +425,11 @@ export function assembleToolPool(
   // Keep copy-then-sort because builtInTools is readonly; allowedMcpTools is a
   // fresh .filter() result.
   const byName = (a: Tool, b: Tool) => a.name.localeCompare(b.name)
-  return uniqBy(
-    [...builtInTools].sort(byName).concat(allowedMcpTools.sort(byName)),
-    'name',
+  return filterOffModeTools(
+    uniqBy(
+      [...builtInTools].sort(byName).concat(allowedMcpTools.sort(byName)),
+      'name',
+    ),
   )
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -76,6 +76,7 @@ import { TaskListTool } from './tools/TaskListTool/TaskListTool.js'
 import uniqBy from 'lodash-es/uniqBy.js'
 import { isToolSearchEnabledOptimistic } from './utils/toolSearch.js'
 import { isTodoV2Enabled } from './utils/tasks.js'
+import { getGlobalConfig } from './utils/config.js'
 // Dead code elimination: conditional import for CLAUDE_CODE_VERIFY_PLAN
 /* eslint-disable custom-rules/no-process-env-top-level, @typescript-eslint/no-require-imports */
 const VerifyPlanExecutionTool =
@@ -319,6 +320,13 @@ export const getTools = (permissionContext: ToolPermissionContext): Tools => {
   // Filter out any null/undefined tools that might have slipped through
   // (defensive check against initialization timing issues)
   allowedTools = allowedTools.filter(Boolean)
+
+  // Respect per-tool 'off' modes set via /tools — a disabled tool is removed
+  // from the pool entirely. Other modes (always/ask/auto) are display-only.
+  const toolModes = getGlobalConfig().toolModes
+  if (toolModes) {
+    allowedTools = allowedTools.filter(tool => toolModes[tool.name] !== 'off')
+  }
 
   const isEnabled = allowedTools.map(_ => typeof _.isEnabled === 'function' ? _.isEnabled() : true)
   return allowedTools.filter((_, i) => isEnabled[i])

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -299,6 +299,11 @@ export type GlobalConfig = {
    * Overridden by CLI `--max-turns` and OPENCLAUDE_MAX_TURNS / CLAUDE_CODE_MAX_TURNS.
    */
   replMaxTurns?: number
+  /**
+   * Per-tool modes set via /tools. Only 'off' currently has runtime effect
+   * (removes the tool from the pool); always/ask/auto are display-only.
+   */
+  toolModes?: Record<string, 'always' | 'ask' | 'auto' | 'off'>
   showTurnDuration: boolean // Controls whether to show turn duration message (e.g., "Cooked for 1m 6s")
   // Controls whether to show per-query cache hit/miss stats at the end of each turn.
   // 'off'     — no display


### PR DESCRIPTION
## Summary

A `/tools` command that lists every tool in the pool with its current mode and lets you cycle through `always` / `ask` / `auto` / `off` with the arrow keys — no config-file spelunking required.

**What actually changes behavior today:** `off`. A tool set to `off` is dropped from the pool entirely, so it never appears to the model. The other modes are display-only for now and persist under `toolModes` in global config, giving future permission work a clean place to hook in.

Adapted from a sibling fork: persistence goes through the existing `saveGlobalConfig`, and empty mode maps are cleaned up rather than stored as empty objects.

## Test plan

- [x] `bun run typecheck`
- [x] Runtime check: setting `Glob` to `off` removes it from the pool; clearing it restores it
- [x] Ghost tool names and empty maps are no-ops

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tools command for managing individual tool modes.
  * Added an interactive tool manager with keyboard navigation and Always, Ask, Auto, and Off modes.
  * Tool mode settings are saved and persist across sessions.
  * The manager includes available built-in and connected tools.

* **Bug Fixes**
  * Tools set to Off are excluded from active tool availability.
  * Tool lists now refresh immediately after mode changes.
  * Disabled tools can be restored by switching them back to Auto.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->