### PR TITLE
feat: show setting provenance badges in the settings panel

### DIFF
--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -91,7 +91,6 @@ type SubMenu = 'Theme' | 'Model' | 'TeammateModel' | 'CompactModel' | 'ExternalI
 // config or app state are intentionally absent — a provenance badge would be
 // misleading there.
 const SETTINGS_FILE_KEYS: Record<string, string> = {
-  theme: 'theme',
   outputStyle: 'outputStyle',
   language: 'language',
   defaultView: 'defaultView',

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -165,11 +165,13 @@ export function Config({
   const [initialUserSettings] = useState(() => getSettingsForSource('userSettings'));
   // Per-key provenance snapshot for the SourceBadge column. getSettingsWithSources()
   // resets the settings cache, so read it lazily at mount and refresh only when
-  // a setting actually changes (never on hover/scroll/search re-renders).
+  // a settings-file-backed setting actually changes (never on hover/scroll/search
+  // re-renders). Theme is deliberately excluded: it lives in global config, so
+  // cycling the UI theme must not reset the settings-file cache.
   const [settingsSources, setSettingsSources] = useState(() => getSettingsWithSources().sources);
   React.useEffect(() => {
     setSettingsSources(getSettingsWithSources().sources);
-  }, [settingsData, currentOutputStyle, currentLanguage, thinkingEnabled, isFastMode, themeSetting]);
+  }, [settingsData, currentOutputStyle, currentLanguage, thinkingEnabled, isFastMode]);
   const initialThemeSetting = React.useRef(themeSetting);
   // AppState fields Config may modify — snapshot once at mount.
   const store = useAppStateStore();

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -100,6 +100,8 @@ const SETTINGS_FILE_KEYS: Record<string, string> = {
   defaultPermissionMode: 'permissions.defaultMode',
   spinnerTipsEnabled: 'spinnerTipsEnabled',
   prefersReducedMotion: 'prefersReducedMotion',
+  promptSuggestionEnabled: 'promptSuggestionEnabled',
+  useAutoModeDuringPlan: 'useAutoModeDuringPlan',
 };
 export function Config({
   onClose,
@@ -173,7 +175,7 @@ export function Config({
   const [settingsSources, setSettingsSources] = useState(() => getSettingsWithSources().sources);
   React.useEffect(() => {
     setSettingsSources(getSettingsWithSources().sources);
-  }, [settingsData, currentOutputStyle, currentLanguage, thinkingEnabled, isFastMode]);
+  }, [settingsData, currentOutputStyle, currentLanguage, thinkingEnabled, isFastMode, promptSuggestionEnabled]);
   const initialThemeSetting = React.useRef(themeSetting);
   // AppState fields Config may modify — snapshot once at mount.
   const store = useAppStateStore();
@@ -1951,9 +1953,13 @@ export function Config({
                           </Box>
                           {(() => {
                             const settingsKey = SETTINGS_FILE_KEYS[setting_2.id];
-                            return settingsKey ? (
+                            // Forced 'disabled' is env/build/config, not the settings-file value.
+                            if (!settingsKey || (setting_2.id === 'autoUpdatesChannel' && autoUpdaterDisabledReason)) {
+                              return null;
+                            }
+                            return (
                               <SourceBadge source={findSettingSource(settingsKey, settingsSources)} />
-                            ) : null;
+                            );
                           })()}
                         </Box>
                       </React.Fragment>;

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -86,6 +86,20 @@ type Setting = (SettingBase & {
   type: 'managedEnum';
 });
 type SubMenu = 'Theme' | 'Model' | 'TeammateModel' | 'CompactModel' | 'ExternalIncludes' | 'OutputStyle' | 'ChannelDowngrade' | 'Language' | 'EnableAutoUpdates';
+// Row ids whose displayed value is read from (and written to) settings files,
+// mapped to the actual settings-file key path. Row ids backed only by global
+// config or app state are intentionally absent — a provenance badge would be
+// misleading there.
+const SETTINGS_FILE_KEYS: Record<string, string> = {
+  theme: 'theme',
+  outputStyle: 'outputStyle',
+  language: 'language',
+  defaultView: 'defaultView',
+  autoUpdatesChannel: 'autoUpdatesChannel',
+  thinkingEnabled: 'alwaysThinkingEnabled',
+  fastMode: 'fastMode',
+  defaultPermissionMode: 'permissions.defaultMode',
+};
 export function Config({
   onClose,
   context,
@@ -156,7 +170,7 @@ export function Config({
   const [settingsSources, setSettingsSources] = useState(() => getSettingsWithSources().sources);
   React.useEffect(() => {
     setSettingsSources(getSettingsWithSources().sources);
-  }, [settingsData]);
+  }, [settingsData, currentOutputStyle, currentLanguage, thinkingEnabled, isFastMode, themeSetting]);
   const initialThemeSetting = React.useRef(themeSetting);
   // AppState fields Config may modify — snapshot once at mount.
   const store = useAppStateStore();
@@ -1932,7 +1946,12 @@ export function Config({
                                 {setting_2.value.toString()}
                               </Text>}
                           </Box>
-                          <SourceBadge source={findSettingSource(setting_2.id, settingsSources)} />
+                          {(() => {
+                            const settingsKey = SETTINGS_FILE_KEYS[setting_2.id];
+                            return settingsKey ? (
+                              <SourceBadge source={findSettingSource(settingsKey, settingsSources)} />
+                            ) : null;
+                          })()}
                         </Box>
                       </React.Fragment>;
           })}

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -98,6 +98,8 @@ const SETTINGS_FILE_KEYS: Record<string, string> = {
   thinkingEnabled: 'alwaysThinkingEnabled',
   fastMode: 'fastMode',
   defaultPermissionMode: 'permissions.defaultMode',
+  spinnerTipsEnabled: 'spinnerTipsEnabled',
+  prefersReducedMotion: 'prefersReducedMotion',
 };
 export function Config({
   onClose,

--- a/src/components/Settings/Config.tsx
+++ b/src/components/Settings/Config.tsx
@@ -37,7 +37,8 @@ import { useTabHeaderFocus } from '../design-system/Tabs.js';
 import { useIsInsideModal } from '../../context/modalContext.js';
 import { SearchBox } from '../SearchBox.js';
 import { isSupportedTerminal, hasAccessToIDEExtensionDiffFeature } from '../../utils/ide.js';
-import { getInitialSettings, getSettingsForSource, updateSettingsForSource } from '../../utils/settings/settings.js';
+import { findSettingSource, getInitialSettings, getSettingsForSource, getSettingsWithSources, updateSettingsForSource } from '../../utils/settings/settings.js';
+import { SourceBadge } from './SourceBadge.js';
 import { getUserMsgOptIn, setUserMsgOptIn } from '../../bootstrap/state.js';
 import { DEFAULT_OUTPUT_STYLE_NAME } from 'src/constants/outputStyles.js';
 import { isEnvTruthy, isRunningOnHomespace } from 'src/utils/envUtils.js';
@@ -149,6 +150,13 @@ export function Config({
   // eagerly even though only the first result is kept.
   const [initialLocalSettings] = useState(() => getSettingsForSource('localSettings'));
   const [initialUserSettings] = useState(() => getSettingsForSource('userSettings'));
+  // Per-key provenance snapshot for the SourceBadge column. getSettingsWithSources()
+  // resets the settings cache, so read it lazily at mount and refresh only when
+  // a setting actually changes (never on hover/scroll/search re-renders).
+  const [settingsSources, setSettingsSources] = useState(() => getSettingsWithSources().sources);
+  React.useEffect(() => {
+    setSettingsSources(getSettingsWithSources().sources);
+  }, [settingsData]);
   const initialThemeSetting = React.useRef(themeSetting);
   // AppState fields Config may modify — snapshot once at mount.
   const store = useAppStateStore();
@@ -1924,6 +1932,7 @@ export function Config({
                                 {setting_2.value.toString()}
                               </Text>}
                           </Box>
+                          <SourceBadge source={findSettingSource(setting_2.id, settingsSources)} />
                         </Box>
                       </React.Fragment>;
           })}

--- a/src/components/Settings/SourceBadge.tsx
+++ b/src/components/Settings/SourceBadge.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { Text } from '../../ink.js'
+import { getGlobalConfig } from '../../utils/config.js'
+import type { SettingSource } from '../../utils/settings/constants.js'
+import { resolveThemeSetting } from '../../utils/systemTheme.js'
+import { getTheme } from '../../utils/theme.js'
+
+/**
+ * Source Badge — small colored chip showing where a setting's effective value
+ * comes from (mirrors Dario's `[OC]`/`[CC]`/`[PRJ]` provenance badges, but for
+ * openclaude's settings sources). `[SYS]` means the value is a built-in
+ * default not defined by any settings file.
+ */
+
+export type BadgeSource = SettingSource | 'builtin'
+
+const BADGE_CONFIG: Record<
+  BadgeSource,
+  {
+    label: string
+    title: string
+    color?: keyof import('../../utils/theme.js').Theme
+  }
+> = {
+  userSettings: {
+    label: 'USR',
+    title: 'User settings (~/.openclaude/settings.json)',
+    color: 'success',
+  },
+  projectSettings: {
+    label: 'PRJ',
+    title: 'Project settings (.openclaude/settings.json)',
+    color: 'suggestion',
+  },
+  localSettings: {
+    label: 'LOC',
+    title: 'Local settings (.openclaude/settings.local.json)',
+    color: 'warning',
+  },
+  flagSettings: {
+    label: 'FLG',
+    title: 'CLI flag (--settings)',
+    color: 'error',
+  },
+  policySettings: {
+    label: 'POL',
+    title: 'Managed policy settings',
+    color: 'merged',
+  },
+  builtin: {
+    label: 'SYS',
+    title: 'Built-in default',
+    color: 'inactive',
+  },
+}
+
+export function SourceBadge({
+  source,
+  dim = false,
+}: {
+  source: BadgeSource
+  dim?: boolean
+}): React.ReactNode {
+  const theme = getTheme(resolveThemeSetting(getGlobalConfig().theme))
+  const config = BADGE_CONFIG[source] ?? BADGE_CONFIG.builtin
+  const color = config.color ? theme[config.color] : theme.inactive
+  return (
+    <Text color={color} dimColor={dim}>
+      {' '}
+      [{config.label}]
+    </Text>
+  )
+}

--- a/src/utils/settings/settingSource.test.ts
+++ b/src/utils/settings/settingSource.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test'
+import type { SettingsWithSources } from './settings.js'
+import { findSettingSource } from './settings.js'
+
+// Fixtures typed loosely (SettingsJson is a large zod schema; these only
+// exercise findSettingSource's key-lookup logic, not schema validation).
+const sources = [
+  { source: 'userSettings', settings: { theme: 'dark', verbose: true } },
+  { source: 'projectSettings', settings: { theme: 'nord' } },
+  { source: 'localSettings', settings: { verbose: false } },
+] as unknown as SettingsWithSources['sources']
+
+describe('findSettingSource', () => {
+  test('returns the highest-priority source that defines the key', () => {
+    // projectSettings is later in the array (higher priority) and overrides userSettings.
+    expect(findSettingSource('theme', sources)).toBe('projectSettings')
+  })
+
+  test('falls back to the next-lower source when the key is absent higher up', () => {
+    expect(findSettingSource('verbose', sources)).toBe('localSettings')
+  })
+
+  test('returns builtin when no source defines the key', () => {
+    expect(findSettingSource('definitelyNotASetting', sources)).toBe('builtin')
+  })
+
+  test('treats a key explicitly set to undefined as unset', () => {
+    const withUndefined = [
+      { source: 'userSettings', settings: { theme: undefined } },
+      { source: 'flagSettings', settings: { theme: 'light' } },
+    ] as unknown as SettingsWithSources['sources']
+    expect(findSettingSource('theme', withUndefined)).toBe('flagSettings')
+  })
+
+  test('returns builtin for an empty sources list', () => {
+    expect(findSettingSource('theme', [])).toBe('builtin')
+  })
+})

--- a/src/utils/settings/settingSource.test.ts
+++ b/src/utils/settings/settingSource.test.ts
@@ -32,6 +32,31 @@ describe('findSettingSource', () => {
     expect(findSettingSource('theme', withUndefined)).toBe('flagSettings')
   })
 
+  test('falls through when the highest-priority source sets undefined', () => {
+    // Higher-priority source (later in the array) explicitly sets undefined —
+    // the lookup must skip it and report the lower-priority source.
+    const undefinedAtTop = [
+      { source: 'userSettings', settings: { theme: 'light' } },
+      { source: 'flagSettings', settings: { theme: undefined } },
+    ] as unknown as SettingsWithSources['sources']
+    expect(findSettingSource('theme', undefinedAtTop)).toBe('userSettings')
+  })
+
+  test('resolves dotted keys to nested settings paths', () => {
+    const nested = [
+      { source: 'userSettings', settings: { permissions: { defaultMode: 'acceptEdits' } } },
+    ] as unknown as SettingsWithSources['sources']
+    expect(findSettingSource('permissions.defaultMode', nested)).toBe('userSettings')
+  })
+
+  test('does not match inherited Object.prototype keys', () => {
+    const plain = [
+      { source: 'userSettings', settings: { theme: 'dark' } },
+    ] as unknown as SettingsWithSources['sources']
+    expect(findSettingSource('hasOwnProperty', plain)).toBe('builtin')
+    expect(findSettingSource('constructor', plain)).toBe('builtin')
+  })
+
   test('returns builtin for an empty sources list', () => {
     expect(findSettingSource('theme', [])).toBe('builtin')
   })

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -900,6 +900,37 @@ export function getSettingsWithSources(): SettingsWithSources {
 }
 
 /**
+ * Find which enabled settings source defines a given key, or 'builtin' when
+ * no source sets it. `sources` is ordered low→high priority, so the LAST
+ * source that defines the key wins — mirroring how merge resolves the
+ * effective value. A key explicitly set to `undefined` is treated as unset.
+ *
+ * Pass a pre-fetched `sources` list when calling from render paths, since
+ * `getSettingsWithSources()` resets the settings cache on every call.
+ */
+export function findSettingSource(
+  key: string,
+  sources: SettingsWithSources['sources'],
+): SettingSource | 'builtin' {
+  for (let i = sources.length - 1; i >= 0; i--) {
+    const { source, settings } = sources[i]
+    if (settings && key in settings && settings[key] !== undefined) {
+      return source
+    }
+  }
+  return 'builtin'
+}
+
+/**
+ * Same as `findSettingSource`, but reads the current sources from disk. Not
+ * for render paths — prefer `getSettingsWithSources()` once and pass the
+ * result to `findSettingSource`.
+ */
+export function getSettingSource(key: string): SettingSource | 'builtin' {
+  return findSettingSource(key, getSettingsWithSources().sources)
+}
+
+/**
  * Get merged settings and validation errors from all sources
  * This function now uses session-level caching to avoid repeated file I/O.
  * Settings changes require Claude Code restart, so cache is valid for entire session.

--- a/src/utils/settings/settings.ts
+++ b/src/utils/settings/settings.ts
@@ -900,13 +900,30 @@ export function getSettingsWithSources(): SettingsWithSources {
 }
 
 /**
+ * Read a possibly-dotted settings key (e.g. `permissions.defaultMode`) from a
+ * source's raw settings, returning `undefined` when the path is absent.
+ * Walks with `hasOwnProperty` so inherited `Object.prototype` keys
+ * (`constructor`, `hasOwnProperty`, …) never count as "set".
+ */
+function readSettingAtPath(settings: SettingsJson, key: string): unknown {
+  let current: unknown = settings
+  for (const part of key.split('.')) {
+    if (current === null || typeof current !== 'object') return undefined
+    if (!Object.prototype.hasOwnProperty.call(current, part)) return undefined
+    current = (current as Record<string, unknown>)[part]
+  }
+  return current
+}
+
+/**
  * Find which enabled settings source defines a given key, or 'builtin' when
  * no source sets it. `sources` is ordered low→high priority, so the LAST
  * source that defines the key wins — mirroring how merge resolves the
  * effective value. A key explicitly set to `undefined` is treated as unset.
  *
- * Pass a pre-fetched `sources` list when calling from render paths, since
- * `getSettingsWithSources()` resets the settings cache on every call.
+ * Keys may be dotted paths (`permissions.defaultMode`) to match nested
+ * settings. Pass a pre-fetched `sources` list when calling from render paths,
+ * since `getSettingsWithSources()` resets the settings cache on every call.
  */
 export function findSettingSource(
   key: string,
@@ -914,7 +931,7 @@ export function findSettingSource(
 ): SettingSource | 'builtin' {
   for (let i = sources.length - 1; i >= 0; i--) {
     const { source, settings } = sources[i]
-    if (settings && key in settings && settings[key] !== undefined) {
+    if (settings && readSettingAtPath(settings, key) !== undefined) {
       return source
     }
   }


### PR DESCRIPTION
## Summary

Adds a small provenance chip to each row of the settings panel showing which settings source defines that setting's effective value — mirroring the `[OC]`/`[CC]`/`[PRJ]` style badges, but for openclaude's sources:

| Badge | Source |
|-------|--------|
| `[USR]` | `~/.openclaude/settings.json` |
| `[PRJ]` | `.openclaude/settings.json` |
| `[LOC]` | `.openclaude/settings.local.json` |
| `[FLG]` | CLI flag (`--settings`) |
| `[POL]` | Managed policy settings |
| `[SYS]` | Built-in default (no source defines it) |

## Changes

- **`src/components/Settings/SourceBadge.tsx`** — new `SourceBadge` component mapping each `SettingSource` to a labeled, theme-colored chip.
- **`src/utils/settings/settings.ts`** — new `findSettingSource(key, sources)` walks the source list high→low priority and reports which source defines a key (or `builtin`). Handles dotted key paths (`permissions.defaultMode`) and treats a key explicitly set to `undefined` as unset.
- **`src/components/Settings/Config.tsx`** — renders a badge per settings row, mapped from UI row id to the actual settings-file key (`defaultPermissionMode` → `permissions.defaultMode`, `thinkingEnabled` → `alwaysThinkingEnabled`). Rows backed by global config or app state (e.g. `model`, `verbose`, notification toggles) show no badge, since provenance would be misleading there. Sources are re-fetched on every settings-write path so badges stay fresh.
- **`src/utils/settings/settingSource.test.ts`** — unit tests for priority fallthrough, `undefined` handling, dotted paths, and builtin fallback.

## Test plan

- [ ] `bun test src/utils/settings/settingSource.test.ts`
- [ ] `bun test src/utils/settings/`
- [ ] `bun run typecheck`
- [ ] `bun run build`
- [ ] Manual: open settings panel with values set in user + project + local settings and verify the badges show the highest-priority source per row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings now display source badges identifying whether values come from user, project, local, policy, flag, or built-in defaults.
  * Badges use theme-aware colors and support dimmed display.
  * Provenance refreshes automatically when relevant settings change.

* **Bug Fixes**
  * Improved source detection for nested settings, unset values, fallback behavior, and inherited properties.
  * Settings without an applicable source now correctly display built-in defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->