### PR TITLE
perf(bg): avoid full scans for exact session IDs

### DIFF
--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import * as backgroundSessionRegistry from './bgRegistry.js'
@@ -73,6 +82,45 @@ describe('background session registry', () => {
       nameReservationPath(name),
       JSON.stringify({ name, ...reservation }),
     )
+  }
+
+  async function snapshotRegistryTree(
+    root: string,
+    relative = '',
+  ): Promise<string[]> {
+    const current = join(root, relative)
+    const entries = await readdir(current, { withFileTypes: true })
+    const snapshot: string[] = []
+    for (const entry of entries.toSorted((a, b) =>
+      a.name.localeCompare(b.name),
+    )) {
+      const entryRelative = join(relative, entry.name)
+      if (entry.isDirectory()) {
+        snapshot.push(`${entryRelative}/`)
+        snapshot.push(...(await snapshotRegistryTree(root, entryRelative)))
+        continue
+      }
+      const path = join(root, entryRelative)
+      const metadata = await stat(path, { bigint: true })
+      snapshot.push(
+        `${entryRelative}:${metadata.mtimeNs}:${await readFile(path, 'utf8')}`,
+      )
+    }
+    return snapshot
+  }
+
+  async function resolveWithListCallCount(target: string): Promise<{
+    session: BackgroundSession
+    listCalls: number
+  }> {
+    let listCalls = 0
+    const session = await resolveBackgroundSession(target, {
+      _listSessionsForTesting: async () => {
+        listCalls += 1
+        return await listBackgroundSessions()
+      },
+    })
+    return { session, listCalls }
   }
 
   beforeEach(async () => {
@@ -232,7 +280,9 @@ describe('background session registry', () => {
       sessionId: 'conversation-2',
     })
 
-    expect((await resolveBackgroundSession('bg-abc')).id).toBe('bg-named')
+    const { session, listCalls } = await resolveWithListCallCount('bg-abc')
+    expect(session.id).toBe('bg-named')
+    expect(listCalls).toBe(1)
   })
 
   it('resolves exact session ids before exact session names', async () => {
@@ -252,7 +302,206 @@ describe('background session registry', () => {
       sessionId: 'conversation-name',
     })
 
-    expect((await resolveBackgroundSession('bg-target')).id).toBe('bg-target')
+    const { session, listCalls } = await resolveWithListCallCount('bg-target')
+    expect(session.id).toBe('bg-target')
+    expect(listCalls).toBe(0)
+  })
+
+  it('resolves an exact session id without listing the metadata directory', async () => {
+    await createBackgroundSession({
+      id: 'bg-direct',
+      pid: 111,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'direct'],
+      sessionId: 'conversation-direct',
+    })
+    const metadataDir = join(configDir, 'bg-sessions', 'sessions')
+    await writeFile(join(metadataDir, 'unrelated-malformed.json'), '{')
+
+    const { session, listCalls } = await resolveWithListCallCount('bg-direct')
+    expect(session.id).toBe('bg-direct')
+    expect(listCalls).toBe(0)
+  })
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'resolves an exact session id when directory enumeration is unavailable',
+    async () => {
+      await createBackgroundSession({
+        id: 'bg-direct-unlisted',
+        pid: 112,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'direct unlisted'],
+        sessionId: 'conversation-direct-unlisted',
+      })
+      const metadataDir = join(configDir, 'bg-sessions', 'sessions')
+
+      await chmod(metadataDir, 0o100)
+      try {
+        expect(
+          (await resolveBackgroundSession('bg-direct-unlisted')).id,
+        ).toBe('bg-direct-unlisted')
+      } finally {
+        await chmod(metadataDir, 0o700)
+      }
+    },
+  )
+
+  it('applies natural terminal facts on the direct exact-id path', async () => {
+    await createBackgroundSession({
+      id: 'bg-direct-natural',
+      pid: 333,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'direct natural'],
+      sessionId: 'conversation-direct-natural',
+    })
+    await writeTerminalFact('bg-direct-natural', 'natural', {
+      pid: 333,
+      status: 'failed',
+      finishedAt: '2026-06-15T08:04:00.000Z',
+      exitCode: 23,
+      terminalReason: 'exit_code',
+    })
+    const { session, listCalls } = await resolveWithListCallCount(
+      'bg-direct-natural',
+    )
+
+    expect(session).toMatchObject({
+      status: 'failed',
+      finishedAt: '2026-06-15T08:04:00.000Z',
+      exitCode: 23,
+      terminalReason: 'exit_code',
+    })
+    expect(listCalls).toBe(0)
+  })
+
+  it('keeps killed facts strongest on the direct exact-id path', async () => {
+    await createBackgroundSession({
+      id: 'bg-direct-killed',
+      pid: 334,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'direct killed'],
+      sessionId: 'conversation-direct-killed',
+    })
+    await writeTerminalFact('bg-direct-killed', 'natural', {
+      pid: 334,
+      status: 'failed',
+      finishedAt: '2026-06-15T08:04:00.000Z',
+      exitCode: 17,
+      terminalReason: 'exit_code',
+    })
+    await writeTerminalFact('bg-direct-killed', 'killed', {
+      pid: 334,
+      status: 'killed',
+      finishedAt: '2026-06-15T08:05:00.000Z',
+      terminalReason: 'explicit_kill',
+    })
+    const { session, listCalls } = await resolveWithListCallCount(
+      'bg-direct-killed',
+    )
+
+    expect(session).toMatchObject({
+      status: 'killed',
+      finishedAt: '2026-06-15T08:04:00.000Z',
+      exitCode: 17,
+      terminalReason: 'explicit_kill',
+    })
+    expect(listCalls).toBe(0)
+  })
+
+  it('falls back to an exact live name when exact-id metadata is malformed', async () => {
+    await createBackgroundSession({
+      id: 'bg-name-owner',
+      name: 'bg-malformed',
+      pid: 335,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'name owner'],
+      sessionId: 'conversation-name-owner',
+    })
+    await writeFile(
+      join(configDir, 'bg-sessions', 'sessions', 'bg-malformed.json'),
+      '{',
+    )
+
+    const { session, listCalls } = await resolveWithListCallCount(
+      'bg-malformed',
+    )
+    expect(session.id).toBe('bg-name-owner')
+    expect(listCalls).toBe(1)
+  })
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'falls back to an exact live name when exact-id metadata is unreadable',
+    async () => {
+      await createBackgroundSession({
+        id: 'bg-unreadable',
+        pid: 336,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'unreadable id'],
+        sessionId: 'conversation-unreadable-id',
+      })
+      await createBackgroundSession({
+        id: 'bg-unreadable-name-owner',
+        name: 'bg-unreadable',
+        pid: 337,
+        cwd: '/repo',
+        command: ['openclaude', '--print', 'unreadable name owner'],
+        sessionId: 'conversation-unreadable-name-owner',
+      })
+      const exactPath = join(
+        configDir,
+        'bg-sessions',
+        'sessions',
+        'bg-unreadable.json',
+      )
+
+      await chmod(exactPath, 0o000)
+      try {
+        const { session, listCalls } = await resolveWithListCallCount(
+          'bg-unreadable',
+        )
+        expect(session.id).toBe('bg-unreadable-name-owner')
+        expect(listCalls).toBe(1)
+      } finally {
+        await chmod(exactPath, 0o600)
+      }
+    },
+  )
+
+  it('does not interpret unsafe exact-id candidates as metadata paths', async () => {
+    const named = await createBackgroundSession({
+      id: 'bg-safe-name-owner',
+      name: '../outside',
+      pid: 338,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'safe name owner'],
+      sessionId: 'conversation-safe-name-owner',
+    })
+    await writeFile(
+      join(configDir, 'bg-sessions', 'outside.json'),
+      JSON.stringify({ ...named, id: 'outside' }),
+    )
+
+    expect((await resolveBackgroundSession('../outside')).id).toBe(
+      'bg-safe-name-owner',
+    )
+  })
+
+  it('does not write registry state while resolving an exact id', async () => {
+    await createBackgroundSession({
+      id: 'bg-read-only',
+      pid: 339,
+      cwd: '/repo',
+      command: ['openclaude', '--print', 'read only'],
+      sessionId: 'conversation-read-only',
+    })
+    const root = join(configDir, 'bg-sessions')
+    const before = await snapshotRegistryTree(root)
+
+    expect((await resolveBackgroundSession('bg-read-only')).id).toBe(
+      'bg-read-only',
+    )
+
+    expect(await snapshotRegistryTree(root)).toEqual(before)
   })
 
   it('resolves unique session id prefixes when no exact name matches', async () => {

--- a/src/cli/bgRegistry.test.ts
+++ b/src/cli/bgRegistry.test.ts
@@ -40,6 +40,17 @@ const {
   recordBackgroundSessionNaturalTerminationSync,
 } = backgroundSessionRegistry
 
+type Assert<T extends true> = T
+type IsEqual<A, B> = (<T>() => T extends A ? 1 : 2) extends <
+  T,
+>() => T extends B ? 1 : 2
+  ? true
+  : false
+
+type _ResolveBackgroundSessionParametersAreTargetOnly = Assert<
+  IsEqual<Parameters<typeof resolveBackgroundSession>, [target: string]>
+>
+
 describe('background session registry', () => {
   let configDir: string
 
@@ -114,12 +125,14 @@ describe('background session registry', () => {
     listCalls: number
   }> {
     let listCalls = 0
-    const session = await resolveBackgroundSession(target, {
-      _listSessionsForTesting: async () => {
-        listCalls += 1
-        return await listBackgroundSessions()
-      },
-    })
+    const session =
+      await backgroundSessionRegistry.__test.resolveBackgroundSessionWithList(
+        target,
+        async () => {
+          listCalls += 1
+          return await listBackgroundSessions()
+        },
+      )
     return { session, listCalls }
   }
 
@@ -131,6 +144,10 @@ describe('background session registry', () => {
   afterEach(async () => {
     _setBackgroundSessionsRootForTesting(undefined)
     await rm(configDir, { force: true, recursive: true })
+  })
+
+  it('keeps the exported resolver signature free of test dependencies', () => {
+    expect(resolveBackgroundSession.length).toBe(1)
   })
 
   it('creates session metadata and log files under the OpenClaude config dir', async () => {

--- a/src/cli/bgRegistry.ts
+++ b/src/cli/bgRegistry.ts
@@ -756,10 +756,22 @@ export async function createBackgroundSession(
   return session
 }
 
+type ResolveBackgroundSessionOptions = {
+  _listSessionsForTesting?: () => Promise<BackgroundSession[]>
+}
+
 export async function resolveBackgroundSession(
   target: string,
+  options?: ResolveBackgroundSessionOptions,
 ): Promise<BackgroundSession> {
-  const sessions = await listBackgroundSessions()
+  if (SAFE_ID_RE.test(target)) {
+    const exact = await readSessionFile(metadataPathForId(target))
+    if (exact) return await applyAuthoritativeTerminalFacts(exact)
+  }
+
+  const sessions = await (
+    options?._listSessionsForTesting ?? listBackgroundSessions
+  )()
   const exactId = sessions.filter(s => s.id === target)
   if (exactId.length === 1) return exactId[0]
 

--- a/src/cli/bgRegistry.ts
+++ b/src/cli/bgRegistry.ts
@@ -756,22 +756,16 @@ export async function createBackgroundSession(
   return session
 }
 
-type ResolveBackgroundSessionOptions = {
-  _listSessionsForTesting?: () => Promise<BackgroundSession[]>
-}
-
-export async function resolveBackgroundSession(
+async function resolveBackgroundSessionWithList(
   target: string,
-  options?: ResolveBackgroundSessionOptions,
+  listSessions: () => Promise<BackgroundSession[]>,
 ): Promise<BackgroundSession> {
   if (SAFE_ID_RE.test(target)) {
     const exact = await readSessionFile(metadataPathForId(target))
     if (exact) return await applyAuthoritativeTerminalFacts(exact)
   }
 
-  const sessions = await (
-    options?._listSessionsForTesting ?? listBackgroundSessions
-  )()
+  const sessions = await listSessions()
   const exactId = sessions.filter(s => s.id === target)
   if (exactId.length === 1) return exactId[0]
 
@@ -794,6 +788,16 @@ export async function resolveBackgroundSession(
   }
 
   throw new Error(`No background session found for "${target}"`)
+}
+
+export async function resolveBackgroundSession(
+  target: string,
+): Promise<BackgroundSession> {
+  return await resolveBackgroundSessionWithList(target, listBackgroundSessions)
+}
+
+export const __test = {
+  resolveBackgroundSessionWithList,
 }
 
 export async function refreshBackgroundSessionStatuses(options?: {


### PR DESCRIPTION
## Summary

- Read a safe exact background-session ID from its deterministic metadata path before listing the registry.
- Apply the existing natural and killed terminal-fact precedence to that direct read.
- Fall back to the unchanged tolerant list resolver when the candidate is missing, malformed, unreadable, invalid, or not a complete exact-ID match.

## Why

`resolveBackgroundSession` previously called `listBackgroundSessions` for every selector. One exact ID therefore read and validated every metadata document, attempted both terminal-fact reads for every valid session, and sorted the full result.

The direct path makes a valid exact hit constant-time without changing name or prefix selection. It adds no index, cache, watcher, dependency, metadata write, or public API.

## Impact

- User-facing impact: commands that select a background session by full ID avoid registry-size-dependent lookup delays.
- Developer and maintainer impact: tolerant name and prefix selection stays in one fallback path, with deterministic list-call coverage for exact hits and fallbacks.

## Compatibility

Selector precedence remains:

1. exact ID;
2. one live exact name;
3. one unambiguous ID prefix;
4. one terminal exact name.

Safe names and prefixes first attempt the possible exact metadata path. If that read does not produce a valid exact session, resolution uses the previous full-list logic. Invalid ID-like input never reaches path construction. Output, errors, exit codes, process identity checks, and sibling background commands are unchanged.

## Benchmark

Measured on Linux 7.1.8 with Bun 1.3.14 using warm disposable registries on tmpfs. Fixture creation was outside the timed interval. Runs alternated implementations to reduce cache-order bias. Repetition counts were 80, 40, 20, and 8 for registry sizes 1, 100, 1,000, and 10,000.

Exact full-ID median wall time:

| Entries | Before | After | Saving | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 0.099 ms | 0.088 ms | 0.011 ms | 1.1x |
| 100 | 8.153 ms | 0.078 ms | 8.075 ms | 104.5x |
| 1,000 | 76.671 ms | 0.094 ms | 76.577 ms | 815.6x |
| 10,000 | 880.864 ms | 0.148 ms | 880.716 ms | 5,951.8x |

Fallback-selector median wall time:

| Entries | Missing ID before to after | Exact name before to after | Unique prefix before to after |
| ---: | ---: | ---: | ---: |
| 1 | 0.104 to 0.144 ms | 0.101 to 0.133 ms | 0.100 to 0.133 ms |
| 100 | 8.534 to 8.478 ms | 7.967 to 8.098 ms | 8.214 to 8.134 ms |
| 1,000 | 79.905 to 92.717 ms | 77.656 to 89.941 ms | 78.453 to 93.381 ms |
| 10,000 | 931.416 to 897.866 ms | 867.360 to 882.260 ms | 885.182 to 901.877 ms |

Fallbacks retain linear full-scan behavior. The direct exact hit drops from one directory read plus 3N file-read attempts to three targeted file-read attempts. A safe fallback adds one candidate metadata read before the previous scan.

## Tests

Added behavior coverage for:

- zero full-list calls for exact hits and one full-list call for tolerant fallbacks;
- exact-ID resolution when metadata directory enumeration is unavailable;
- unrelated malformed registry entries on an exact hit;
- natural terminal facts and killed-over-natural precedence on the direct path;
- malformed and unreadable exact candidates falling back to a live exact name;
- unsafe ID-like selectors falling back without escaping the registry root;
- no registry state changes during exact-ID lookup.

Existing focused coverage continues to prove exact ID over exact name, missing exact path to live name, unique and ambiguous prefixes, terminal-name selection, and selector error behavior. Deterministic list-call assertions run on every platform. A supplemental directory-permission assertion runs only on non-root POSIX systems, where the filesystem can distinguish direct path reads from directory enumeration.

The primary regression was also replayed against the untouched base. It failed there with `No background session found for "bg-direct-unlisted"` and passed with this change.

## Validation

- `bun install`
- `bun test src/cli/bgRegistry.test.ts` with 68 passing tests
- `bun test src/cli/bg.test.ts` with 51 passing tests
- `bun run build`
- `bun run smoke`
- `bun run typecheck`
- `bun run typecheck:type-tests` with 10 focused files checked
- `bun run check`
- `bun run doctor:runtime`
- `bun run security:pr-scan -- --base upstream/main --head HEAD`
- `git diff --check upstream/main...HEAD`

All commands passed.

## Notes

- Reviewed `AGENTS.md` and `CONTRIBUTING.md`.
- No provider path, UI, documentation, dependency, or stored format changed.
- Screenshots are not applicable.
- No issue is linked because this is a private, semantics-preserving performance fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background-session resolution by checking exact session IDs directly.
  * Preserved fallback matching when session metadata is malformed, unavailable, or unreadable.
  * Added safeguards against unsafe session paths.
  * Ensured resolution remains read-only and applies terminal session status correctly.

* **Tests**
  * Expanded coverage for direct resolution, fallback behavior, path safety, permissions, terminal states, and registry listings.
  * Added validation for ambiguous and prefix-based session matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->