### PR TITLE
fix(settings): stop proto-named permission rules from aborting validation

### DIFF
--- a/src/utils/settings/permissionValidation.protoName.test.ts
+++ b/src/utils/settings/permissionValidation.protoName.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test'
+import { validatePermissionRule } from './permissionValidation.js'
+import { getCustomValidation } from './toolValidationConfig.js'
+
+// Regression: TOOL_VALIDATION_CONFIG.customValidation is a plain object literal
+// indexed by the permission rule's tool name. validatePermissionRule gates tool
+// names on an uppercase first character, which rejects lowercase prototype
+// members (`constructor`, `toString`, ...). But the double-underscore members
+// (`__proto__`, `__defineGetter__`, ...) slip past that gate because
+// `'_'.toUpperCase() === '_'`, then the bare `customValidation[toolName]` lookup
+// resolves the inherited Object.prototype member — a truthy value the caller
+// invokes as a function. That threw an uncaught TypeError from
+// filterInvalidPermissionRules, so a single hostile rule in a project
+// .claude/settings.json aborted validation and discarded the whole file rather
+// than skipping just that rule.
+describe('getCustomValidation — prototype-safe lookup', () => {
+  const protoNames = [
+    'constructor',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+    '__proto__',
+    '__defineGetter__',
+    '__defineSetter__',
+    '__lookupGetter__',
+    '__lookupSetter__',
+  ]
+
+  for (const name of protoNames) {
+    test(`'${name}' is not treated as a configured tool`, () => {
+      expect(getCustomValidation(name)).toBeUndefined()
+    })
+  }
+
+  test('genuine custom-validation tools still resolve', () => {
+    expect(typeof getCustomValidation('WebSearch')).toBe('function')
+    expect(typeof getCustomValidation('WebFetch')).toBe('function')
+    expect(getCustomValidation('Bash')).toBeUndefined()
+  })
+})
+
+describe('validatePermissionRule — proto-name tool names do not crash', () => {
+  // The double-underscore members pass the uppercase gate and previously reached
+  // the invoke-as-function path. Each must validate without throwing.
+  const underscoreProtoRules = [
+    '__proto__(x)',
+    '__defineGetter__(x)',
+    '__defineSetter__(x)',
+    '__lookupGetter__(x)',
+    '__lookupSetter__(x)',
+  ]
+
+  for (const rule of underscoreProtoRules) {
+    test(`'${rule}' validates without throwing`, () => {
+      expect(() => validatePermissionRule(rule)).not.toThrow()
+      // The rule targets no real tool, so it is inert (valid) rather than a
+      // crash — the important guarantee is that validation completes.
+      expect(validatePermissionRule(rule).valid).toBe(true)
+    })
+  }
+
+  // Controls: the uppercase gate still rejects lowercase proto-name rules, and
+  // genuine custom validation still fires for its own tools.
+  test('lowercase proto-name rules are rejected by the uppercase gate', () => {
+    const result = validatePermissionRule('constructor(x)')
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/uppercase/i)
+  })
+
+  test('WebSearch custom validation still rejects wildcard content', () => {
+    const result = validatePermissionRule('WebSearch(foo?)')
+    expect(result.valid).toBe(false)
+    expect(result.error).toMatch(/wildcard/i)
+  })
+
+  test('ordinary rules remain valid', () => {
+    expect(validatePermissionRule('Bash(npm install)').valid).toBe(true)
+    expect(validatePermissionRule('Read(src/**)').valid).toBe(true)
+  })
+})

--- a/src/utils/settings/toolValidationConfig.ts
+++ b/src/utils/settings/toolValidationConfig.ts
@@ -99,5 +99,14 @@ export function isBashPrefixTool(toolName: string): boolean {
 
 // Helper to get custom validation for a tool
 export function getCustomValidation(toolName: string) {
-  return TOOL_VALIDATION_CONFIG.customValidation[toolName]
+  // customValidation is a plain object, so a bracket lookup keyed by a
+  // caller-supplied tool name resolves inherited Object.prototype members. A
+  // permission-rule name like `__proto__` (or `__defineGetter__`, which slips
+  // past the uppercase-first gate because `'_'.toUpperCase() === '_'`) would
+  // otherwise return a truthy inherited value that the caller then invokes as a
+  // function, throwing and aborting settings validation. Only treat own tools
+  // as configured — mirrors normalizeLegacyToolName in permissionRuleParser.
+  return Object.hasOwn(TOOL_VALIDATION_CONFIG.customValidation, toolName)
+    ? TOOL_VALIDATION_CONFIG.customValidation[toolName]
+    : undefined
 }


### PR DESCRIPTION
## Problem

`getCustomValidation` looks a tool name up in the plain-object `TOOL_VALIDATION_CONFIG.customValidation` with a bare bracket access, so the prototype chain is live:

```ts
export function getCustomValidation(toolName: string) {
  return TOOL_VALIDATION_CONFIG.customValidation[toolName]
}
```

`validatePermissionRule` gates tool names on an uppercase first character, which rejects the lowercase prototype members (`constructor`, `toString`, `valueOf`, `hasOwnProperty`). But the **double-underscore** members slip past the gate because `'_'.toUpperCase() === '_'`:

```ts
if (parsed.toolName[0] !== parsed.toolName[0]?.toUpperCase()) { /* reject */ }
const customValidation = getCustomValidation(parsed.toolName)   // __proto__ -> Object.prototype (truthy)
if (customValidation && parsed.ruleContent !== undefined) {
  const customResult = customValidation(parsed.ruleContent)     // invokes it -> TypeError
```

So a rule like `__proto__(x)` returns the inherited `Object.prototype` (or, for `__defineGetter__(x)`, a real inherited function), the caller treats it as a configured validator and invokes it, and it throws an uncaught `TypeError`.

## Impact

`filterInvalidPermissionRules` runs this validation over every `permissions` allow/deny/ask entry when a `settings.json` is loaded. Its stated purpose (see the comment above the call) is *"Filter invalid permission rules before schema validation so one bad rule doesn't cause the entire settings file to be rejected."* The throw defeats exactly that:

- For a project `.claude/settings.json`, the loader's `catch` runs `handleFileSystemError` and returns `{ settings: null }` — the **entire file's** settings are discarded, not just the bad rule.
- `parseCommandOutputAsSettings` (MDM/managed settings) calls `filterInvalidPermissionRules` with **no** surrounding try/catch, so the throw propagates.

A single hostile or fat-fingered rule in an untrusted cloned repo's settings therefore silently wipes that file's configuration.

## Fix

Guard the lookup with `Object.hasOwn`, so an unrecognized tool name resolves to `undefined` and the rule validates as an ordinary (inert) rule instead of crashing. This mirrors `normalizeLegacyToolName` in `permissionRuleParser.ts`, which already hardened the sibling `LEGACY_TOOL_NAME_ALIASES` lookup against this exact class (its comment names `__proto__`).

## Tests

New `permissionValidation.protoName.test.ts`:
- `getCustomValidation` returns `undefined` for every prototype member (lowercase and double-underscore) and still resolves genuine tools (`WebSearch`, `WebFetch`).
- `validatePermissionRule` completes without throwing for `__proto__(x)`, `__defineGetter__(x)`, `__defineSetter__(x)`, `__lookupGetter__(x)`, `__lookupSetter__(x)`.
- Controls: the uppercase gate still rejects `constructor(x)`, WebSearch custom validation still rejects wildcard content, and ordinary rules stay valid.

Verified fails-on-bug (reverting the guard returns the inherited function and the suite fails); `tsc` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Permission validation no longer treats inherited prototype names as valid custom-validation tools.
  - Rules using prototype-related names are handled safely without unexpected errors.
  - Existing valid tool rules and custom validators continue to work as expected.

- **Tests**
  - Added coverage for prototype-name handling, wildcard rejection, and standard permission rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->