### PR TITLE
fix: guard CLAUDE_CODE_MAX_RETRIES against non-numeric env values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ package-lock.json
 coverage/
 agent.log
 plan/
+
+.idea/

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -190,3 +190,42 @@ describe('getRateLimitResetDelayMs - providers without reset headers', () => {
     expect(getRateLimitResetDelayMs(error)).toBeNull()
   })
 })
+
+// --- getDefaultMaxRetries ---
+describe('getDefaultMaxRetries', () => {
+  afterEach(() => {
+    delete process.env.CLAUDE_CODE_MAX_RETRIES
+  })
+
+  test('returns DEFAULT_MAX_RETRIES when env var is unset', async () => {
+    const { getDefaultMaxRetries, DEFAULT_MAX_RETRIES } =
+      await importFreshWithRetryModule()
+    expect(getDefaultMaxRetries()).toBe(DEFAULT_MAX_RETRIES)
+  })
+
+  test('returns parsed value for a valid numeric env var', async () => {
+    process.env.CLAUDE_CODE_MAX_RETRIES = '5'
+    const { getDefaultMaxRetries } = await importFreshWithRetryModule()
+    expect(getDefaultMaxRetries()).toBe(5)
+  })
+
+  test('returns 0 for zero (valid — disables retries explicitly)', async () => {
+    process.env.CLAUDE_CODE_MAX_RETRIES = '0'
+    const { getDefaultMaxRetries } = await importFreshWithRetryModule()
+    expect(getDefaultMaxRetries()).toBe(0)
+  })
+
+  test('falls back to default for non-numeric env var', async () => {
+    process.env.CLAUDE_CODE_MAX_RETRIES = 'abc'
+    const { getDefaultMaxRetries, DEFAULT_MAX_RETRIES } =
+      await importFreshWithRetryModule()
+    expect(getDefaultMaxRetries()).toBe(DEFAULT_MAX_RETRIES)
+  })
+
+  test('falls back to default for negative env var', async () => {
+    process.env.CLAUDE_CODE_MAX_RETRIES = '-3'
+    const { getDefaultMaxRetries, DEFAULT_MAX_RETRIES } =
+      await importFreshWithRetryModule()
+    expect(getDefaultMaxRetries()).toBe(DEFAULT_MAX_RETRIES)
+  })
+})

--- a/src/services/api/withRetry.test.ts
+++ b/src/services/api/withRetry.test.ts
@@ -23,6 +23,7 @@ const envKeys = [
   'CLAUDE_CODE_USE_BEDROCK',
   'CLAUDE_CODE_USE_VERTEX',
   'CLAUDE_CODE_USE_FOUNDRY',
+  'CLAUDE_CODE_MAX_RETRIES',
   'OPENAI_MODEL',
   'OPENAI_BASE_URL',
   'OPENAI_API_BASE',
@@ -224,6 +225,13 @@ describe('getDefaultMaxRetries', () => {
 
   test('falls back to default for negative env var', async () => {
     process.env.CLAUDE_CODE_MAX_RETRIES = '-3'
+    const { getDefaultMaxRetries, DEFAULT_MAX_RETRIES } =
+      await importFreshWithRetryModule()
+    expect(getDefaultMaxRetries()).toBe(DEFAULT_MAX_RETRIES)
+  })
+
+  test('falls back for partial numeric values like "5abc"', async () => {
+    process.env.CLAUDE_CODE_MAX_RETRIES = '5abc'
     const { getDefaultMaxRetries, DEFAULT_MAX_RETRIES } =
       await importFreshWithRetryModule()
     expect(getDefaultMaxRetries()).toBe(DEFAULT_MAX_RETRIES)

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -808,7 +808,13 @@ function shouldRetry(error: APIError): boolean {
 
 export function getDefaultMaxRetries(): number {
   if (process.env.CLAUDE_CODE_MAX_RETRIES) {
-    return parseInt(process.env.CLAUDE_CODE_MAX_RETRIES, 10)
+    const parsed = parseInt(process.env.CLAUDE_CODE_MAX_RETRIES, 10)
+    if (!Number.isNaN(parsed) && parsed >= 0) {
+      return parsed
+    }
+    logForDebugging(
+      `Invalid CLAUDE_CODE_MAX_RETRIES="${process.env.CLAUDE_CODE_MAX_RETRIES}", falling back to default (${DEFAULT_MAX_RETRIES})`,
+    )
   }
   return DEFAULT_MAX_RETRIES
 }

--- a/src/services/api/withRetry.ts
+++ b/src/services/api/withRetry.ts
@@ -808,12 +808,13 @@ function shouldRetry(error: APIError): boolean {
 
 export function getDefaultMaxRetries(): number {
   if (process.env.CLAUDE_CODE_MAX_RETRIES) {
-    const parsed = parseInt(process.env.CLAUDE_CODE_MAX_RETRIES, 10)
-    if (!Number.isNaN(parsed) && parsed >= 0) {
+    const raw = process.env.CLAUDE_CODE_MAX_RETRIES.trim()
+    const parsed = Number(raw)
+    if (!Number.isNaN(parsed) && parsed >= 0 && Number.isInteger(parsed)) {
       return parsed
     }
     logForDebugging(
-      `Invalid CLAUDE_CODE_MAX_RETRIES="${process.env.CLAUDE_CODE_MAX_RETRIES}", falling back to default (${DEFAULT_MAX_RETRIES})`,
+      `Invalid CLAUDE_CODE_MAX_RETRIES="${raw}", falling back to default (${DEFAULT_MAX_RETRIES})`,
     )
   }
   return DEFAULT_MAX_RETRIES


### PR DESCRIPTION
Fix silent retry disable when CLAUDE_CODE_MAX_RETRIES contains non-numeric values (e.g. 'abc'). parseInt returns NaN, causing the retry loop to never execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for retry configuration values.
  - Invalid, negative, non-numeric, or partially numeric settings now safely fall back to the default retry count.
  - Leading and trailing whitespace is handled correctly.
  - Explicitly setting retry attempts to zero remains supported.

- **Tests**
  - Added coverage for default, valid, zero, invalid, negative, whitespace-padded, and partially numeric retry configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->