### PR TITLE
fix(plugins): anchor marketplace hostPattern against lookalike hosts

### DIFF
--- a/src/utils/plugins/marketplaceHelpers.ts
+++ b/src/utils/plugins/marketplaceHelpers.ts
@@ -275,7 +275,7 @@ export function extractHostFromSource(
  * @param pattern - The hostPattern entry from strictKnownMarketplaces
  * @returns true if the source's host matches the pattern
  */
-function doesSourceMatchHostPattern(
+export function doesSourceMatchHostPattern(
   source: MarketplaceSource,
   pattern: MarketplaceSource & { source: 'hostPattern' },
 ): boolean {
@@ -285,7 +285,16 @@ function doesSourceMatchHostPattern(
   }
 
   try {
-    const regex = new RegExp(pattern.hostPattern)
+    // Anchor the admin-supplied pattern so it must match the WHOLE host.
+    // `RegExp.test` is a substring search, so an unanchored pattern like
+    // `github\.mycompany\.com` also matches an attacker-controlled host such
+    // as `github.mycompany.com.evil.example` (or `evil-github.mycompany.com`),
+    // silently defeating the strictKnownMarketplaces allowlist. Host authority
+    // reads right-to-left, so a leading `^` alone is not sufficient either.
+    // The non-capturing group keeps a top-level alternation intact
+    // (`a\.com|b\.com` must not become `^a\.com|b\.com$`), and a pattern
+    // that is already fully anchored still behaves identically.
+    const regex = new RegExp(`^(?:${pattern.hostPattern})$`)
     return regex.test(host)
   } catch {
     // Invalid regex - log and return false

--- a/src/utils/plugins/marketplaceHostPattern.test.ts
+++ b/src/utils/plugins/marketplaceHostPattern.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test'
+import {
+  doesSourceMatchHostPattern,
+  extractHostFromSource,
+} from './marketplaceHelpers.js'
+import type { MarketplaceSource } from './schemas.js'
+
+function hostPattern(
+  pattern: string,
+): MarketplaceSource & { source: 'hostPattern' } {
+  return { source: 'hostPattern', hostPattern: pattern }
+}
+
+function urlSource(url: string): MarketplaceSource {
+  return { source: 'url', url }
+}
+
+function gitSource(url: string): MarketplaceSource {
+  return { source: 'git', url }
+}
+
+// Regression: strictKnownMarketplaces hostPattern entries are compiled with
+// `new RegExp(pattern)` and applied with `.test(host)`, which is a substring
+// search. An admin pattern that is not fully anchored therefore matched any
+// host merely CONTAINING it. Because host authority reads right-to-left, an
+// attacker who controls `evil.example` can serve `github.mycompany.com.evil.example`
+// and pass an allowlist meant to permit only `github.mycompany.com` — which
+// gates plugin marketplace installation, so it leads to plugin execution.
+describe('doesSourceMatchHostPattern — allowlist cannot be satisfied by a substring', () => {
+  const unanchored = hostPattern('github\\.mycompany\\.com')
+
+  test('the intended host still matches', () => {
+    expect(doesSourceMatchHostPattern(urlSource('https://github.mycompany.com/mp.json'), unanchored)).toBe(true)
+  })
+
+  test('an attacker-controlled parent domain is rejected', () => {
+    // Suffix attack: the pattern appears at the start, so a leading `^` alone
+    // would not have caught this one.
+    expect(doesSourceMatchHostPattern(urlSource('https://github.mycompany.com.evil.example/mp.json'), unanchored)).toBe(false)
+  })
+
+  test('an attacker-controlled prefix label is rejected', () => {
+    expect(doesSourceMatchHostPattern(urlSource('https://evil-github.mycompany.com/mp.json'), unanchored)).toBe(false)
+    expect(doesSourceMatchHostPattern(urlSource('https://notgithub.mycompany.com/mp.json'), unanchored)).toBe(false)
+  })
+
+  test('the attack is rejected for SSH git sources too', () => {
+    expect(doesSourceMatchHostPattern(gitSource('git@github.mycompany.com:team/repo.git'), unanchored)).toBe(true)
+    expect(doesSourceMatchHostPattern(gitSource('git@github.mycompany.com.evil.example:team/repo.git'), unanchored)).toBe(false)
+  })
+})
+
+describe('doesSourceMatchHostPattern — existing admin patterns keep working', () => {
+  test('a fully anchored pattern behaves identically', () => {
+    const anchored = hostPattern('^github\\.mycompany\\.com$')
+    expect(doesSourceMatchHostPattern(urlSource('https://github.mycompany.com/mp.json'), anchored)).toBe(true)
+    expect(doesSourceMatchHostPattern(urlSource('https://github.mycompany.com.evil.example/mp.json'), anchored)).toBe(false)
+  })
+
+  test('a top-level alternation is not broken by the added anchors', () => {
+    // Without the non-capturing group this would become
+    // `^github\.com|gitlab\.com$` and match far more than intended.
+    const either = hostPattern('github\\.com|gitlab\\.com')
+    expect(doesSourceMatchHostPattern(urlSource('https://github.com/mp.json'), either)).toBe(true)
+    expect(doesSourceMatchHostPattern(urlSource('https://gitlab.com/mp.json'), either)).toBe(true)
+    expect(doesSourceMatchHostPattern(urlSource('https://github.com.evil.example/mp.json'), either)).toBe(false)
+    expect(doesSourceMatchHostPattern(urlSource('https://evil.example/gitlab.com'), either)).toBe(false)
+  })
+
+  test('an intentional wildcard subdomain pattern still matches', () => {
+    const wildcard = hostPattern('.*\\.mycompany\\.com')
+    expect(doesSourceMatchHostPattern(urlSource('https://github.mycompany.com/mp.json'), wildcard)).toBe(true)
+    expect(doesSourceMatchHostPattern(urlSource('https://git.eu.mycompany.com/mp.json'), wildcard)).toBe(true)
+    expect(doesSourceMatchHostPattern(urlSource('https://mycompany.com.evil.example/mp.json'), wildcard)).toBe(false)
+  })
+
+  test('a catch-all pattern still allows everything', () => {
+    const all = hostPattern('.*')
+    expect(doesSourceMatchHostPattern(urlSource('https://anything.example/mp.json'), all)).toBe(true)
+  })
+
+  test('github shorthand sources resolve to github.com', () => {
+    expect(extractHostFromSource({ source: 'github', repo: 'owner/repo' })).toBe('github.com')
+    expect(doesSourceMatchHostPattern({ source: 'github', repo: 'owner/repo' }, hostPattern('github\\.com'))).toBe(true)
+    expect(doesSourceMatchHostPattern({ source: 'github', repo: 'owner/repo' }, hostPattern('hub\\.com'))).toBe(false)
+  })
+})
+
+describe('doesSourceMatchHostPattern — malformed input fails closed', () => {
+  test('an invalid regex does not match', () => {
+    expect(doesSourceMatchHostPattern(urlSource('https://github.com/mp.json'), hostPattern('['))).toBe(false)
+  })
+
+  test('a source with no extractable host does not match', () => {
+    expect(doesSourceMatchHostPattern(urlSource('not-a-url'), hostPattern('.*'))).toBe(false)
+  })
+})

--- a/src/utils/plugins/schemas.ts
+++ b/src/utils/plugins/schemas.ts
@@ -1030,7 +1030,11 @@ export const MarketplaceSourceSchema = lazySchema(() =>
           'Regex pattern to match the host/domain extracted from any marketplace source type. ' +
             'For github sources, matches against "github.com". For git sources (SSH or HTTPS), ' +
             'extracts the hostname from the URL. Use in strictKnownMarketplaces to allow all ' +
-            'marketplaces from a specific host (e.g., "^github\\.mycompany\\.com$").',
+            'marketplaces from a specific host (e.g., "^github\\.mycompany\\.com$"). ' +
+            'The pattern must match the ENTIRE host: it is anchored before use, so ' +
+            '"github\\.mycompany\\.com" cannot be satisfied by a lookalike host such as ' +
+            '"github.mycompany.com.evil.example". Use an explicit wildcard (e.g. ' +
+            '".*\\.mycompany\\.com") to allow subdomains.',
         ),
     }),
     z.object({


### PR DESCRIPTION
## Problem

`strictKnownMarketplaces` `hostPattern` entries are compiled and applied like this:

```ts
const regex = new RegExp(pattern.hostPattern)
return regex.test(host)
```

`RegExp.test` is a substring search, so an admin pattern that isn't fully anchored matches any host merely *containing* it.

This isn't just a missing leading anchor. Host authority reads **right-to-left**, so the dangerous direction is the suffix: a policy of `github\.mycompany\.com` is satisfied by an attacker-controlled

```
github.mycompany.com.evil.example
```

which a leading `^` alone would still admit. `evil-github.mycompany.com` passes too.

`host` comes from `extractHostFromSource`, i.e. `new URL(source.url).hostname` (or the SSH `user@HOST:` form) of whatever marketplace a user is trying to add — so it's attacker-influenced. `doesSourceMatchHostPattern` feeds `isSourceAllowedByPolicy`, which decides whether a marketplace may be installed **at all**, and installation leads to plugin code execution. The check runs before anything is fetched, so a bypass defeats the enterprise lockdown at its entry point.

## Fix

Anchor the admin pattern so it must match the entire host:

```ts
const regex = new RegExp(`^(?:${pattern.hostPattern})$`)
```

The non-capturing group matters: without it a top-level alternation would break (`a\.com|b\.com` must not become `^a\.com|b\.com$`). A pattern that is already fully anchored — `^github\.mycompany\.com$`, the form the schema documents — behaves exactly as before.

**Compatibility.** This tightens matching, so a deliberately loose pattern that relied on substring behavior now needs an explicit wildcard (`.*\.mycompany\.com`). That is the intended contract, and the change can only ever *narrow* the allowlist, never widen it — it fails closed. The schema description now states the whole-host requirement and shows the wildcard form.

**`pathPattern` is deliberately untouched.** Paths nest left-to-right, so its documented prefix form (`^/opt/approved/`) is correct there; anchoring the end would break it. Only the host case is wrong.

## Tests

New `marketplaceHostPattern.test.ts` (11 cases):
- The bypass matrix for an unanchored policy: intended host still matches; attacker-controlled parent domain, prefix label, and the SSH-git variant are all rejected.
- Compatibility: fully anchored patterns unchanged, top-level alternation preserved, intentional `.*\.mycompany\.com` wildcard still matches subdomains (and still rejects `mycompany.com.evil.example`), `.*` still allows everything, github shorthand resolves to `github.com`.
- Fail-closed: invalid regex and unparseable source both return false.

Verified fails-on-bug — reverting the anchoring fails 5 of them, including the two lookalike-host cases. Plugins suites green (86), `tsc` and `bun run deadcode` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved marketplace source host allowlisting to require complete host matches.
  - Prevented lookalike domain suffixes and prefixes from being incorrectly accepted.
  - Preserved support for wildcard subdomains, alternation, GitHub shorthand sources, and catch-all patterns.
  - Invalid patterns and sources without recognizable hosts continue to be rejected safely.

- **Documentation**
  - Clarified host-pattern matching rules, including anchoring and explicit wildcard requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->