### PR TITLE
fix(integrations): keep managed AIMLAPI attribution over caller headers

### DIFF
--- a/src/commands/model/model.test.tsx
+++ b/src/commands/model/model.test.tsx
@@ -1651,6 +1651,16 @@ test('/model OpenGateway interactive refresh preserves availability filter and h
       { id: 'inclusionai/ling-3.0-tiny:free', apiName: 'inclusionai/ling-3.0-tiny:free', label: 'Ling 3.0 Tiny Live' },
       { id: 'moonshotai/kimi-k3', apiName: 'moonshotai/kimi-k3', label: 'Kimi K3' },
     ],
+    discoveredModels: [
+      { id: 'mimo-v2.5-pro', apiName: 'mimo-v2.5-pro', label: 'MiMo V2.5 Pro' },
+      { id: 'inclusionai/ling-3.0-tiny:free', apiName: 'inclusionai/ling-3.0-tiny:free', label: 'Ling 3.0 Tiny Live' },
+      { id: 'moonshotai/kimi-k3', apiName: 'moonshotai/kimi-k3', label: 'Kimi K3' },
+      {
+        id: 'refresh-only/live-model',
+        apiName: 'refresh-only/live-model',
+        label: 'Refresh Only Live Model',
+      },
+    ],
     routeId: 'gitlawb-opengateway',
   })
 
@@ -1663,21 +1673,23 @@ test('/model OpenGateway interactive refresh preserves availability filter and h
     ).map(option => option.value)
     expect(initialValues).not.toContain('inclusionai/ling-3.0-tiny:free')
     expect(initialValues).toContain('moonshotai/kimi-k3')
+    expect(initialValues).not.toContain('refresh-only/live-model')
 
-    rendered.getCapturedProps().onRefresh?.()
-    await waitForCondition(() => {
-      const message = rendered.getCapturedProps().discoveryState?.message
-      return (
-        message !== undefined &&
-        message !== 'Refreshing Gitlawb Opengateway models…'
-      )
-    })
+    const onRefresh = rendered.getCapturedProps().onRefresh
+    expect(onRefresh).toEqual(expect.any(Function))
+    onRefresh!()
+    await waitForCondition(() =>
+      (
+        rendered.getCapturedProps().optionsOverride as ModelOption[]
+      ).some(option => option.value === 'refresh-only/live-model'),
+    )
 
     const refreshedValues = (
       rendered.getCapturedProps().optionsOverride as ModelOption[]
     ).map(option => option.value)
     expect(refreshedValues).not.toContain('inclusionai/ling-3.0-tiny:free')
     expect(refreshedValues).toContain('moonshotai/kimi-k3')
+    expect(refreshedValues).toContain('refresh-only/live-model')
   } finally {
     rendered.instance.unmount()
     rendered.stdout.end()

--- a/src/integrations/aimlapi/config.test.ts
+++ b/src/integrations/aimlapi/config.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, expect, test } from 'bun:test'
 
 import {
+  AIMLAPI_MANAGED_ATTRIBUTION_HEADER_NAMES,
+  DEFAULT_PARTNER_ID,
   buildPartnerCheckoutReturnUrls,
   buildPartnerReturnUrl,
   isCanonicalAimlapiInferenceBaseUrl,
@@ -160,4 +162,105 @@ test('inference/catalog attribution sends both mandatory headers, stripped off-c
   )
   expect(proxied['X-AIMLAPI-Source']).toBeUndefined()
   expect(proxied['X-AIMLAPI-Partner-ID']).toBeUndefined()
+})
+
+function headerNames(headers: Headers): string[] {
+  const names: string[] = []
+  headers.forEach((_value, name) => {
+    names.push(name)
+  })
+  return names
+}
+
+function expectSingleManagedAttribution(
+  resolved: Record<string, string>,
+  expected: Record<string, string>,
+): void {
+  const headers = new Headers(resolved)
+  for (const [name, value] of Object.entries(expected)) {
+    expect(headers.get(name)).toBe(value)
+  }
+  const managedKeys = headerNames(headers).filter(name =>
+    AIMLAPI_MANAGED_ATTRIBUTION_HEADER_NAMES.has(name),
+  )
+  expect(managedKeys.sort()).toEqual(
+    Object.keys(expected)
+      .map(name => name.toLowerCase())
+      .sort(),
+  )
+}
+
+test('canonical attribution drops mixed-case managed names before restamping', () => {
+  // Same merge order discovery uses: caller headers first, descriptor second.
+  const resolved = resolveAimlapiAttributionHeaders(
+    {
+      'x-aimlapi-source': 'agent/attacker',
+      'x-aimlapi-partner-id': 'part_attackerOverride',
+      'x-aimlapi-integration-repo': 'attacker/repo',
+      'x-aimlapi-integration-version': '0.0.0-attacker',
+      'http-referer': 'https://attacker.example',
+      'x-title': 'Attacker',
+      'X-AIMLAPI-Source': 'agent/openclaude',
+      'X-AIMLAPI-Partner-ID': DEFAULT_PARTNER_ID,
+      'X-AIMLAPI-Integration-Repo': 'Gitlawb/openclaude',
+      'X-AIMLAPI-Integration-Version': '1.2.3',
+      'HTTP-Referer': 'OpenClaude',
+      'X-Title': 'OpenClaude',
+      'X-Tenant': 'acme',
+    },
+    'https://api.aimlapi.com/v1',
+  )
+
+  expect(resolved['X-Tenant']).toBe('acme')
+  expectSingleManagedAttribution(resolved, {
+    'X-AIMLAPI-Source': 'agent/openclaude',
+    'X-AIMLAPI-Partner-ID': DEFAULT_PARTNER_ID,
+    'X-AIMLAPI-Integration-Repo': 'Gitlawb/openclaude',
+    'X-AIMLAPI-Integration-Version': '1.2.3',
+    'HTTP-Referer': 'OpenClaude',
+    'X-Title': 'OpenClaude',
+  })
+})
+
+test('canonical attribution restamps mixed-case caller-only fields without combining them', () => {
+  const resolved = resolveAimlapiAttributionHeaders(
+    {
+      'x-aimlapi-source': 'agent/attacker',
+      'HTTP-REFERER': 'https://attacker.example',
+      'x-title': 'Attacker',
+      'X-Tenant': 'acme',
+    },
+    'https://api.aimlapi.com/v1',
+  )
+
+  const headers = new Headers(resolved)
+  expect(headers.get('x-aimlapi-source')).toBe('agent/openclaude')
+  expect(headers.get('x-aimlapi-partner-id')).toBe(DEFAULT_PARTNER_ID)
+  expect(headers.get('http-referer')).toBe('https://attacker.example')
+  expect(headers.get('x-title')).toBe('Attacker')
+  expect(headers.get('x-tenant')).toBe('acme')
+  expect(headers.get('x-aimlapi-source')).not.toContain(',')
+  expect(headers.get('http-referer')).not.toContain(',')
+})
+
+test('proxy attribution strips every managed name spelling and keeps X-Tenant', () => {
+  const resolved = resolveAimlapiAttributionHeaders(
+    {
+      'x-aimlapi-source': 'agent/attacker',
+      'X-AIMLAPI-Partner-ID': 'part_x',
+      'x-aimlapi-integration-repo': 'attacker/repo',
+      'X-AIMLAPI-Integration-Version': '0.0.0-attacker',
+      'HTTP-REFERER': 'https://attacker.example',
+      'x-title': 'Attacker',
+      'X-Tenant': 'acme',
+    },
+    'https://proxy.example.test/v1',
+  )
+
+  const headers = new Headers(resolved)
+  for (const name of AIMLAPI_MANAGED_ATTRIBUTION_HEADER_NAMES) {
+    expect(headers.get(name)).toBeNull()
+  }
+  expect(headers.get('x-tenant')).toBe('acme')
+  expect(Object.keys(resolved)).toEqual(['X-Tenant'])
 })

--- a/src/integrations/aimlapi/config.ts
+++ b/src/integrations/aimlapi/config.ts
@@ -41,6 +41,58 @@ export const DEFAULT_PARTNER_ID = 'part_62yQoGYDq4Yqnrj2R1iGrDNJ'
 export const DEFAULT_PARTNER_NAME = 'Gitlawb'
 export const PARTNER_HEADER_NAME = 'X-AIMLAPI-Partner-ID'
 export const SOURCE_HEADER_NAME = 'X-AIMLAPI-Source'
+export const INTEGRATION_REPO_HEADER_NAME = 'X-AIMLAPI-Integration-Repo'
+export const INTEGRATION_VERSION_HEADER_NAME = 'X-AIMLAPI-Integration-Version'
+export const REFERER_HEADER_NAME = 'HTTP-Referer'
+export const TITLE_HEADER_NAME = 'X-Title'
+
+/**
+ * HTTP field names OpenClaude manages for AIMLAPI attribution. Fetch treats
+ * header names as case-insensitive, so every spelling of these names is
+ * stripped before a single canonical value is written back.
+ */
+const MANAGED_ATTRIBUTION_HEADER_CANONICAL_NAMES = {
+  [PARTNER_HEADER_NAME.toLowerCase()]: PARTNER_HEADER_NAME,
+  [SOURCE_HEADER_NAME.toLowerCase()]: SOURCE_HEADER_NAME,
+  [INTEGRATION_REPO_HEADER_NAME.toLowerCase()]: INTEGRATION_REPO_HEADER_NAME,
+  [INTEGRATION_VERSION_HEADER_NAME.toLowerCase()]:
+    INTEGRATION_VERSION_HEADER_NAME,
+  [REFERER_HEADER_NAME.toLowerCase()]: REFERER_HEADER_NAME,
+  [TITLE_HEADER_NAME.toLowerCase()]: TITLE_HEADER_NAME,
+} as const
+
+export const AIMLAPI_MANAGED_ATTRIBUTION_HEADER_NAMES = new Set<string>(
+  Object.keys(MANAGED_ATTRIBUTION_HEADER_CANONICAL_NAMES),
+)
+
+function isManagedAttributionHeaderName(name: string): boolean {
+  return AIMLAPI_MANAGED_ATTRIBUTION_HEADER_NAMES.has(name.trim().toLowerCase())
+}
+
+function omitManagedAttributionHeaders(
+  headers: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const resolved: Record<string, string> = {}
+  for (const [name, value] of Object.entries(headers)) {
+    if (isManagedAttributionHeaderName(name)) continue
+    resolved[name] = value
+  }
+  return resolved
+}
+
+function collectManagedAttributionValues(
+  headers: Readonly<Record<string, string>>,
+): Map<string, string> {
+  const collected = new Map<string, string>()
+  for (const [name, value] of Object.entries(headers)) {
+    const key = name.trim().toLowerCase()
+    if (AIMLAPI_MANAGED_ATTRIBUTION_HEADER_NAMES.has(key)) {
+      collected.set(key, value)
+    }
+  }
+  return collected
+}
+
 /**
  * Attribution `source` sent on EVERY aimlapi request (inference, catalog, auth,
  * checkout) alongside the partner id — identifies OpenClaude as the integration
@@ -155,20 +207,6 @@ export function isTrustedAimlapiRequestUrl(url: string): boolean {
 }
 
 /**
- * Attribution headers AI/ML API records for canonical `api.aimlapi.com`
- * traffic. They identify the partner and the referring integration, so they
- * belong to the canonical endpoint only — see `resolveAimlapiAttributionHeaders`.
- */
-const CATALOG_ATTRIBUTION_HEADER_NAMES = new Set([
-  PARTNER_HEADER_NAME.toLowerCase(),
-  SOURCE_HEADER_NAME.toLowerCase(),
-  'x-aimlapi-integration-repo',
-  'x-aimlapi-integration-version',
-  'http-referer',
-  'x-title',
-])
-
-/**
  * Resolve the aimlapi catalog headers for an outbound request. On the canonical
  * inference endpoint the partner id is resolved and attribution is sent; on any
  * other base URL (a user-controlled proxy) every attribution header is stripped,
@@ -177,21 +215,40 @@ const CATALOG_ATTRIBUTION_HEADER_NAMES = new Set([
  * Both the inference (openai shim) and the model-discovery request paths route
  * through here, so the two cannot drift apart. A missing base URL means the
  * caller falls back to the route default, which is canonical.
+ *
+ * Managed names are compared case-insensitively. Fetch combines duplicate
+ * field names, so a caller `x-aimlapi-source` would otherwise ride alongside
+ * the canonical `X-AIMLAPI-Source`.
  */
 export function resolveAimlapiAttributionHeaders(
   headers: Readonly<Record<string, string>>,
   baseUrl: string | undefined,
 ): Record<string, string> {
+  const rest = omitManagedAttributionHeaders(headers)
   if (!baseUrl || isCanonicalAimlapiInferenceBaseUrl(baseUrl)) {
-    // Canonical endpoint: send BOTH mandatory attribution headers.
-    return { ...withResolvedPartnerHeader(headers), [SOURCE_HEADER_NAME]: AIMLAPI_SOURCE }
+    const collected = collectManagedAttributionValues(headers)
+    const managed: Record<string, string> = {
+      [PARTNER_HEADER_NAME]: resolvePartnerId(),
+      [SOURCE_HEADER_NAME]: AIMLAPI_SOURCE,
+    }
+    for (const [key, canonical] of Object.entries(
+      MANAGED_ATTRIBUTION_HEADER_CANONICAL_NAMES,
+    )) {
+      if (
+        key === PARTNER_HEADER_NAME.toLowerCase() ||
+        key === SOURCE_HEADER_NAME.toLowerCase()
+      ) {
+        continue
+      }
+      const value = collected.get(key)
+      if (value !== undefined) {
+        managed[canonical] = value
+      }
+    }
+    return { ...rest, ...managed }
   }
 
-  return Object.fromEntries(
-    Object.entries(headers).filter(
-      ([name]) => !CATALOG_ATTRIBUTION_HEADER_NAMES.has(name.trim().toLowerCase()),
-    ),
-  )
+  return rest
 }
 
 /**

--- a/src/integrations/discoveryService.test.ts
+++ b/src/integrations/discoveryService.test.ts
@@ -767,6 +767,88 @@ describe('discoverModelsForRoute', () => {
     })
   })
 
+  test('AI/ML API discovery ignores mixed-case caller attribution headers', async () => {
+    const { discoverModelsForRoute } = await loadDiscoveryServiceModule()
+
+    let capturedHeaders: HeadersInit | undefined
+    setMockFetch(mock((_input, init) => {
+      capturedHeaders = init?.headers
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: [{ id: 'gpt-4o', type: 'chat-completion' }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    }) as unknown as typeof globalThis.fetch)
+
+    const result = await discoverModelsForRoute('aimlapi', {
+      forceRefresh: true,
+      headers: {
+        'x-aimlapi-source': 'agent/attacker',
+        'x-aimlapi-partner-id': 'part_attackerOverride',
+        'x-aimlapi-integration-repo': 'attacker/repo',
+        'x-aimlapi-integration-version': '0.0.0-attacker',
+        'http-referer': 'https://attacker.example',
+        'HTTP-REFERER': 'https://attacker.example/referer',
+        'x-title': 'Attacker',
+        'X-Tenant': 'acme',
+      },
+    })
+
+    expect(result?.source).toBe('network')
+    const headers = new Headers(capturedHeaders)
+    expect(headers.get('x-aimlapi-source')).toBe('agent/openclaude')
+    expect(headers.get('x-aimlapi-partner-id')).toBe(
+      'part_62yQoGYDq4Yqnrj2R1iGrDNJ',
+    )
+    expect(headers.get('x-aimlapi-integration-repo')).toBe('Gitlawb/openclaude')
+    expect(headers.get('x-aimlapi-integration-version')).toBe(publicBuildVersion)
+    expect(headers.get('http-referer')).toBe('OpenClaude')
+    expect(headers.get('x-title')).toBe('OpenClaude')
+    expect(headers.get('x-tenant')).toBe('acme')
+    expect(headers.get('x-aimlapi-source')).not.toContain(',')
+    expect(headers.get('http-referer')).not.toContain(',')
+  })
+
+  test('AI/ML API proxy discovery strips mixed-case attribution and keeps X-Tenant', async () => {
+    const { discoverModelsForRoute } = await loadDiscoveryServiceModule()
+
+    let capturedHeaders: HeadersInit | undefined
+    setMockFetch(mock((_input, init) => {
+      capturedHeaders = init?.headers
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: [{ id: 'gpt-4o', type: 'chat-completion' }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    }) as unknown as typeof globalThis.fetch)
+
+    const result = await discoverModelsForRoute('aimlapi', {
+      forceRefresh: true,
+      baseUrl: 'https://proxy.example.test/v1',
+      headers: {
+        'x-aimlapi-source': 'agent/attacker',
+        'X-AIMLAPI-Partner-ID': 'part_attackerOverride',
+        'HTTP-REFERER': 'https://attacker.example',
+        'x-title': 'Attacker',
+        'X-Tenant': 'acme',
+      },
+    })
+
+    expect(result?.source).toBe('network')
+    const headers = new Headers(capturedHeaders)
+    expect(headers.get('x-aimlapi-source')).toBeNull()
+    expect(headers.get('x-aimlapi-partner-id')).toBeNull()
+    expect(headers.get('http-referer')).toBeNull()
+    expect(headers.get('x-title')).toBeNull()
+    expect(headers.get('x-tenant')).toBe('acme')
+  })
+
   test('AI/ML API discovery maps the live GET /models response shape', async () => {
     // Captured from the public, unauthenticated `GET https://api.aimlapi.com/v1/models`
     // (returns HTTP 200 without credentials). Chat models use `openai/chat-completions`;

--- a/src/integrations/discoveryService.test.ts
+++ b/src/integrations/discoveryService.test.ts
@@ -726,6 +726,47 @@ describe('discoverModelsForRoute', () => {
     })
   })
 
+  test('AI/ML API discovery keeps managed attribution headers over conflicting caller headers', async () => {
+    const { discoverModelsForRoute } = await loadDiscoveryServiceModule()
+
+    let capturedHeaders: HeadersInit | undefined
+    setMockFetch(mock((_input, init) => {
+      capturedHeaders = init?.headers
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            data: [{ id: 'gpt-4o', type: 'chat-completion' }],
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ),
+      )
+    }) as unknown as typeof globalThis.fetch)
+
+    const result = await discoverModelsForRoute('aimlapi', {
+      forceRefresh: true,
+      headers: {
+        'X-AIMLAPI-Source': 'agent/attacker',
+        'X-AIMLAPI-Partner-ID': 'part_attackerOverride',
+        'X-AIMLAPI-Integration-Repo': 'attacker/repo',
+        'X-AIMLAPI-Integration-Version': '0.0.0-attacker',
+        'HTTP-Referer': 'https://attacker.example',
+        'X-Title': 'Attacker',
+        'X-Tenant': 'acme',
+      },
+    })
+
+    expect(result?.source).toBe('network')
+    expect(capturedHeaders).toEqual({
+      'X-AIMLAPI-Source': 'agent/openclaude',
+      'X-AIMLAPI-Partner-ID': 'part_62yQoGYDq4Yqnrj2R1iGrDNJ',
+      'X-AIMLAPI-Integration-Repo': 'Gitlawb/openclaude',
+      'X-AIMLAPI-Integration-Version': publicBuildVersion,
+      'HTTP-Referer': 'OpenClaude',
+      'X-Title': 'OpenClaude',
+      'X-Tenant': 'acme',
+    })
+  })
+
   test('AI/ML API discovery maps the live GET /models response shape', async () => {
     // Captured from the public, unauthenticated `GET https://api.aimlapi.com/v1/models`
     // (returns HTTP 200 without credentials). Chat models use `openai/chat-completions`;

--- a/src/integrations/discoveryService.ts
+++ b/src/integrations/discoveryService.ts
@@ -260,15 +260,23 @@ export function getRouteDiscoveryHeaders(
     ...(transportConfig?.headers ?? {}),
     ...(transportConfig?.openaiShim?.headers ?? {}),
   }
-  const headers = {
-    ...(routeId === 'aimlapi'
+  const callerHeaders = options?.headers ?? {}
+  // Caller headers first, then managed AIMLAPI attribution, so ANTHROPIC_CUSTOM_HEADERS
+  // cannot replace partner/source/integration identity. resolveAimlapiAttributionHeaders
+  // also strips those names on a non-canonical proxy, including caller-supplied copies.
+  const headers =
+    routeId === 'aimlapi'
       ? resolveAimlapiAttributionHeaders(
-          descriptorHeaders,
+          {
+            ...callerHeaders,
+            ...descriptorHeaders,
+          },
           getRouteBaseUrl(routeId, options),
         )
-      : descriptorHeaders),
-    ...(options?.headers ?? {}),
-  }
+      : {
+          ...descriptorHeaders,
+          ...callerHeaders,
+        }
 
   return Object.keys(headers).length > 0 ? headers : undefined
 }


### PR DESCRIPTION
Fixes #2178.

## Summary

`getRouteDiscoveryHeaders()` spread caller-supplied headers *after* `resolveAimlapiAttributionHeaders()` had sanitized the descriptor headers, so caller values won every collision and silently undid the sanitizer on the `aimlapi` model-discovery path. Because `src/services/api/bootstrap.ts` populates those caller headers from `parseCustomHeadersEnv(process.env.ANTHROPIC_CUSTOM_HEADERS)`, all six managed attribution headers were caller-overridable, and the non-canonical filter that is supposed to strip them before talking to a user-controlled proxy was defeated by the re-add.

The comment above the code already documented the intended invariant — *"the `/models` request must be filtered on the same canonical predicate the inference shim uses ... Without this the discovery path would hand the partner identity to an arbitrary host"* — so this restores the behavior the code claimed rather than changing policy.

## Changes

- Fold caller headers into the *input* of `resolveAimlapiAttributionHeaders()` so both of its branches see them: the canonical branch re-stamps them via `resolvePartnerId()`, and the non-canonical branch strips caller-supplied copies too.
- Preserve the previous `descriptor`-then-`caller` precedence for every non-`aimlapi` route, so ordinary custom headers are unaffected.
- Add a discovery test that supplies seven attacker-controlled headers and asserts the six attribution headers are replaced with managed values while an unrelated header (`X-Tenant`) passes through.
- Extend the `/model` interactive-refresh test to pin discovered-model behavior through the refresh path.

## Test plan

Run against this branch:

| Scope | Result |
| --- | --- |
| `src/integrations/discoveryService.test.ts` | 30 pass, 0 fail |
| `src/commands/model/model.test.tsx` | 48 pass, 0 fail |
| `src/integrations/` (32 files) | 529 pass, 0 fail |
| `src/services/api/` (74 files) | 1573 pass, 13 skip, 0 fail |

Regression check — reverting only `src/integrations/discoveryService.ts` to the pre-fix revision while keeping the new tests produces exactly one failure, confirming the test covers the behavior change rather than passing vacuously:

```
- "X-AIMLAPI-Partner-ID": "part_62yQoGYDq4Yqnrj2R1iGrDNJ"
+ "X-AIMLAPI-Partner-ID": "part_attackerOverride"
- "X-AIMLAPI-Source": "agent/openclaude"
+ "X-AIMLAPI-Source": "agent/attacker"
```

(all six attribution headers differ; trimmed for brevity)

## Notes

The ordering predates #2084 — it arrived with the aimlapi foundation in #1995. #2084 then removed the `acceptsCallerHeaders` gate that had limited caller headers to routes with `discovery.requiresAuth !== false`, widening the reach without introducing the underlying flaw.

Impact is low: `DEFAULT_PARTNER_ID` is a hardcoded public constant, nothing secret is exposed, and this is discovery rather than billable inference. It is an integrity and consistency fix — the discovery path now honors its own documented invariant and matches the inference shim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Interactive model refresh now displays newly discovered models while continuing to exclude expired entries.
  - Managed AI/ML API attribution headers are applied consistently, even when conflicting or differently capitalized custom headers are provided.
  - Custom proxy requests no longer forward managed attribution headers unintentionally.
  - Non-managed custom headers continue to be retained during model discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->