### PR TITLE
feat(utils): add chunk and partition helpers to array utils

### DIFF
--- a/src/utils/array.ts
+++ b/src/utils/array.ts
@@ -11,3 +11,41 @@ export function count<T>(arr: readonly T[], pred: (x: T) => unknown): number {
 export function uniq<T>(xs: Iterable<T>): T[] {
   return [...new Set(xs)]
 }
+
+/**
+ * Split an array into chunks of the given size.
+ * The last chunk may be smaller if the array length is not divisible by size.
+ * @throws {RangeError} if size <= 0
+ */
+export function chunk<T>(arr: readonly T[], size: number): T[][] {
+  if (!Number.isInteger(size) || size <= 0) {
+    throw new RangeError('chunk size must be a positive integer')
+  }
+  if (arr.length === 0) return []
+  const result: T[][] = []
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size))
+  }
+  return result
+}
+
+/**
+ * Partition an array into two groups: those matching the predicate and those not.
+ * Returns [matching, nonMatching] to allow destructuring.
+ */
+export function partition<T>(
+  arr: readonly T[],
+  predicate: (value: T, index: number, array: readonly T[]) => unknown,
+): [T[], T[]] {
+  const pass: T[] = []
+  const fail: T[] = []
+  for (let i = 0; i < arr.length; i++) {
+    const item = arr[i]!
+    if (predicate(item, i, arr)) {
+      pass.push(item)
+    } else {
+      fail.push(item)
+    }
+  }
+  return [pass, fail]
+}


### PR DESCRIPTION
## Summary

Extends `src/utils/array.ts:1` (currently only `intersperse`, `count`, `uniq`) with two commonly needed helpers to avoid ad-hoc loops across the codebase.

- **`chunk(arr, size): T[][]`** — splits array into fixed-size chunks; last chunk may be smaller; returns `[]` for empty input; throws `RangeError` for non-integer or `size <= 0`.
- **`partition(arr, predicate): [T[], T[]]`** — splits into `[matching, nonMatching]` with index-aware predicate, enabling single-pass destructuring instead of double `filter`.

Both are zero-dependency, fully typed, and JSDoc-documented.

## Verification

- `bun run build` ✓
- `bun run typecheck` ✓
- Manual checks via `bun -e`:
  - `chunk([1,2,3,4,5],2) => [[1,2],[3,4],[5]]`
  - `chunk([],3) => []`, `chunk([1,2],5) => [[1,2]]`
  - `chunk` throws `RangeError` on `0` and non-integer `1.5`
  - `partition([1,2,3,4], x=>x%2===0) => [[2,4],[1,3]]`
  - `partition` respects index arg and empty input
- No overlapping open PR on upstream (checked `gh pr list --repo Gitlawb/openclaude` — no duplicate title).
- Own new work on new branch `feat/array-utils-chunk-partition`, not tied to any assigned issue.

## Scope

Only `src/utils/array.ts` changed. Strictly additive, no breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added utilities for splitting arrays into fixed-size chunks.
  * Added utilities for partitioning array elements into matching and non-matching groups.
  * Added validation to ensure chunk sizes are positive integers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->