### PR TITLE
Better MCP support of Telegram

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "chat.tools.terminal.autoApprove": {
+        "bun": true,
+        "npm install": true,
+        "npx --yes bun": true
+    }
+}

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -38,6 +38,32 @@ bun run dev
 
 ## Provider Examples
 
+## Telegram and Other Chat Channels
+
+OpenClaude accepts inbound messages from an MCP channel server. The channel
+server owns the Telegram bot token and chat polling; OpenClaude owns the model
+conversation and sends each notification into the active session.
+
+Configure the Telegram MCP server in the normal MCP configuration, making sure
+it declares the `claude/channel` capability and emits
+`notifications/claude/channel`. Then explicitly enable that server for the
+session:
+
+```powershell
+openclaude --channels server:telegram
+```
+
+Use the exact MCP server name from your configuration. Messages are still
+subject to the channel server's own chat/user filtering, and the explicit
+`--channels` opt-in is required because inbound messages can contain prompt
+injection. Plugin-provided channels use
+`--channels plugin:<name>@<marketplace>` and remain subject to the approved
+plugin allowlist.
+
+The channel path works with OpenAI-compatible providers such as DeepSeek; it
+does not require `claude.ai` OAuth. The model remains configured normally, for
+example with `OPENAI_BASE_URL`, `OPENAI_API_KEY`, and `OPENAI_MODEL`.
+
 ### OpenAI
 
 ```bash

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -99,6 +99,7 @@ const featureFlags: Record<string, boolean> = {
   CHICAGO_MCP: false,             // Computer-use MCP (native Swift modules stubbed)
   COWORKER_TYPE_TELEMETRY: false, // Telemetry for agent/coworker type classification
   MCP_SKILLS: true,               // Dynamic MCP skill discovery via skill:// resources
+  KAIROS_CHANNELS: true,          // Inbound messages from explicitly configured MCP channels
 
   // ── Disabled by default, opt-in via runtime env var ─────────────────
   REPO_MAP: false,                // Auto-injected codebase intelligence repo-map; users opt in with REPO_MAP=1 (the runtime gate in src/context.ts honors the env var even when this flag is false)

--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -192,8 +192,7 @@ type State = {
   // Channel server allowlist from --channels flag (servers whose channel
   // notifications should register this session). Parsed once in main.tsx —
   // the tag decides trust model: 'plugin' → marketplace verification +
-  // allowlist, 'server' → allowlist always fails (schema is plugin-only).
-  // Either kind needs entry.dev to bypass allowlist.
+  // allowlist, 'server' → explicitly configured MCP server.
   allowedChannels: ChannelEntry[]
   // True if any entry in allowedChannels came from
   // --dangerously-load-development-channels (so ChannelsNotice can name the

--- a/src/components/LogoV2/ChannelsNotice.tsx
+++ b/src/components/LogoV2/ChannelsNotice.tsx
@@ -12,7 +12,7 @@ import { Box, Text } from '../../ink.js';
 import { isChannelsEnabled } from '../../services/mcp/channelAllowlist.js';
 import { getEffectiveChannelAllowlist } from '../../services/mcp/channelNotification.js';
 import { getMcpConfigsByScope } from '../../services/mcp/config.js';
-import { getClaudeAIOAuthTokens, getSubscriptionType } from '../../utils/auth.js';
+import { getSubscriptionType } from '../../utils/auth.js';
 import { loadInstalledPluginsV2 } from '../../utils/plugins/installedPluginsManager.js';
 import { getSettingsForSource } from '../../utils/settings/settings.js';
 export function ChannelsNotice() {
@@ -55,33 +55,6 @@ export function ChannelsNotice() {
       $[5] = t3;
     } else {
       t3 = $[5];
-    }
-    return t3;
-  }
-  if (noAuth) {
-    let t1;
-    if ($[6] !== flag || $[7] !== list) {
-      t1 = <Text color="error">{flag} ignored ({list})</Text>;
-      $[6] = flag;
-      $[7] = list;
-      $[8] = t1;
-    } else {
-      t1 = $[8];
-    }
-    let t2;
-    if ($[9] === Symbol.for("react.memo_cache_sentinel")) {
-      t2 = <Text dimColor={true}>Channels require claude.ai authentication · run /login, then restart</Text>;
-      $[9] = t2;
-    } else {
-      t2 = $[9];
-    }
-    let t3;
-    if ($[10] !== t1) {
-      t3 = <Box paddingLeft={2} flexDirection="column">{t1}{t2}</Box>;
-      $[10] = t1;
-      $[11] = t3;
-    } else {
-      t3 = $[11];
     }
     return t3;
   }
@@ -190,7 +163,7 @@ function _temp() {
   return {
     channels: ch,
     disabled: !isChannelsEnabled(),
-    noAuth: !getClaudeAIOAuthTokens()?.accessToken,
+    noAuth: false,
     policyBlocked: managed && policy?.channelsEnabled !== true,
     list: l,
     unmatched: findUnmatched(ch, allowlist)
@@ -215,19 +188,8 @@ function findUnmatched(entries: readonly ChannelEntry[], allowlist: ReturnType<t
     }
   }
 
-  // Plugin-kind installed check: installed_plugins.json keys are
-  // `name@marketplace`. loadInstalledPluginsV2 is cached.
   const installedPluginIds = new Set(Object.keys(loadInstalledPluginsV2().plugins));
-
-  // Plugin-kind allowlist check: same {marketplace, plugin} test as the
-  // gate at channelNotification.ts. entry.dev bypasses (dev flag opts out
-  // of the allowlist). Org list replaces ledger when set (team/enterprise).
-  // GrowthBook _CACHED_MAY_BE_STALE — cold cache yields [] so every plugin
-  // entry warns; same tradeoff the gate already accepts.
-  const {
-    entries: allowed,
-    source
-  } = allowlist;
+  const { entries: allowed, source } = allowlist;
 
   // Independent ifs — a plugin entry that's both uninstalled AND
   // unlisted shows two lines. Server kind checks config + dev flag.
@@ -238,12 +200,6 @@ function findUnmatched(entries: readonly ChannelEntry[], allowlist: ReturnType<t
         out.push({
           entry,
           why: 'no MCP server configured with that name'
-        });
-      }
-      if (!entry.dev) {
-        out.push({
-          entry,
-          why: 'server: entries need --dangerously-load-development-channels'
         });
       }
       continue;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3674,7 +3674,7 @@ async function run(): Promise<CommanderCommand> {
     program.addOption(new Option('--assistant', 'Force assistant mode (Agent SDK daemon use)').hideHelp());
   }
   if (feature('KAIROS') || feature('KAIROS_CHANNELS')) {
-    program.addOption(new Option('--channels <servers...>', 'MCP servers whose channel notifications (inbound push) should register this session. Space-separated server names.').hideHelp());
+    program.addOption(new Option('--channels <servers...>', 'MCP servers whose inbound messages should be delivered to this session. Use server:<name> for configured MCP servers or plugin:<name>@<marketplace> for approved plugins. Space-separated.'));
     program.addOption(new Option('--dangerously-load-development-channels <servers...>', 'Load channel servers not on the approved allowlist. For local channel development only. Shows a confirmation dialog at startup.').hideHelp());
   }
 

--- a/src/services/mcp/channelAllowlist.ts
+++ b/src/services/mcp/channelAllowlist.ts
@@ -1,7 +1,7 @@
 /**
  * Approved channel plugins allowlist. --channels plugin:name@marketplace
  * entries only register if {marketplace, plugin} is on this list. server:
- * entries always fail (schema is plugin-only). The
+ * entries are trusted only when explicitly listed in the session. The
  * --dangerously-load-development-channels flag bypasses for both kinds.
  * Lives in GrowthBook so it can be updated without a release.
  *
@@ -49,7 +49,7 @@ export function getChannelAllowlist(): ChannelAllowlistEntry[] {
  * Default false; GrowthBook 5-min refresh.
  */
 export function isChannelsEnabled(): boolean {
-  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_harbor', false)
+  return getFeatureValue_CACHED_MAY_BE_STALE('tengu_harbor', true)
 }
 
 /**

--- a/src/services/mcp/channelNotification.test.ts
+++ b/src/services/mcp/channelNotification.test.ts
@@ -144,14 +144,12 @@ describe('gateChannelServer', () => {
     expect(result.kind).toBe('disabled')
   })
 
-  // 3. OAuth gate — no access token blocks.
-  test('skips when no OAuth access token is present', () => {
+  // 3. Manual server channels work with API-key authentication.
+  test('registers a configured server channel without OAuth', () => {
     _mockOAuthTokens = {} // no accessToken
+    setAllowedChannels([{ kind: 'server', name: 'slack', dev: false }])
     const result = gateChannelServer('slack', cap(), undefined)
-    if (result.action !== 'skip') {
-      throw new Error(`expected skip, got ${result.action}`)
-    }
-    expect(result.kind).toBe('auth')
+    expect(result.action).toBe('register')
   })
 
   // 4. Org-policy gate — managed subscription without channelsEnabled.
@@ -174,7 +172,7 @@ describe('gateChannelServer', () => {
   })
 
   test('registers server-kind entry when present in --channels list', () => {
-    setAllowedChannels([{ kind: 'server', name: 'slack', dev: true }])
+    setAllowedChannels([{ kind: 'server', name: 'slack', dev: false }])
     const result = gateChannelServer('slack', cap(), undefined)
     expect(result.action).toBe('register')
   })
@@ -278,14 +276,11 @@ describe('gateChannelServer', () => {
     expect(result.action).toBe('register')
   })
 
-  // 8. Server-entry dev gate — server-kind entries always need dev.
-  test('skips server-kind entry without dev flag', () => {
+  // 8. Explicit server entries do not need the development bypass.
+  test('registers server-kind entry without dev flag', () => {
     setAllowedChannels([{ kind: 'server', name: 'slack' }]) // no dev
     const result = gateChannelServer('slack', cap(), undefined)
-    if (result.action !== 'skip') {
-      throw new Error(`expected skip, got ${result.action}`)
-    }
-    expect(result.kind).toBe('allowlist')
+    expect(result.action).toBe('register')
   })
 
   test('server-kind entry with dev flag bypasses the allowlist gate', () => {

--- a/src/services/mcp/channelNotification.ts
+++ b/src/services/mcp/channelNotification.ts
@@ -11,9 +11,9 @@
  * with (the channel's MCP tool, SendUserMessage, or both).
  *
  * feature('KAIROS') || feature('KAIROS_CHANNELS'). Runtime gate tengu_harbor.
- * Requires claude.ai OAuth auth — API key users are blocked until
- * console gets a channelsEnabled admin surface. Teams/Enterprise orgs
- * must explicitly opt in via channelsEnabled: true in managed settings.
+ * Explicitly configured MCP servers work with any supported model provider.
+ * Teams/Enterprise orgs must explicitly opt in via channelsEnabled: true in
+ * managed settings.
  */
 
 import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js'
@@ -21,7 +21,6 @@ import { z } from 'zod/v4'
 import { type ChannelEntry, getAllowedChannels } from '../../bootstrap/state.js'
 import { CHANNEL_TAG } from '../../constants/xml.js'
 import {
-  getClaudeAIOAuthTokens,
   getSubscriptionType,
 } from '../../utils/auth.js'
 import { lazySchema } from '../../utils/lazySchema.js'
@@ -251,17 +250,6 @@ export function gateChannelServer(
     }
   }
 
-  // OAuth-only. API key users (console) are blocked — there's no
-  // channelsEnabled admin surface in console yet, so the policy opt-in
-  // flow doesn't exist for them. Drop this when console parity lands.
-  if (!getClaudeAIOAuthTokens()?.accessToken) {
-    return {
-      action: 'skip',
-      kind: 'auth',
-      reason: 'channels requires claude.ai authentication (run /login)',
-    }
-  }
-
   // Teams/Enterprise opt-in. Managed orgs must explicitly enable channels.
   // Default OFF — absent or false blocks. Keyed off subscription tier, not
   // "policy settings exist" — a team org with zero configured policy keys
@@ -336,15 +324,9 @@ export function gateChannelServer(
     }
   } else {
     // server-kind: allowlist schema is {marketplace, plugin} — a server entry
-    // can never match. Without this, --channels server:plugin:foo:bar would
-    // match a plugin's runtime name and register with no allowlist check.
-    if (!entry.dev) {
-      return {
-        action: 'skip',
-        kind: 'allowlist',
-        reason: `server ${entry.name} is not on the approved channels allowlist (use --dangerously-load-development-channels for local dev)`,
-      }
-    }
+    // Manually configured MCP servers are trusted by their explicit
+    // server:<name> session entry. Plugin entries use the marketplace
+    // allowlist above because their implementation is third-party code.
   }
 
   return { action: 'register' }

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "@astrojs/check": "0.9.9",
     "@astrojs/sitemap": "3.7.3",
     "@fontsource-variable/geist-mono": "^5.2.5",
+    "@gitlawb/openclaude": "file:..",
     "astro": "6.4.6",
     "typescript": "^5.8.3"
   }

--- a/web/src/pages/docs/configuration.astro
+++ b/web/src/pages/docs/configuration.astro
@@ -5,6 +5,7 @@ import { settingsFiles, settingOptions, envVars } from '../../data/configuration
 const toc = [
   { id: 'settings-files', label: 'settings files' },
   { id: 'common-options', label: 'common options' },
+  { id: 'chat-channels', label: 'chat channels' },
   { id: 'environment-variables', label: 'environment variables' },
   { id: 'project-instructions', label: 'project instructions' },
 ]
@@ -67,6 +68,25 @@ const toc = [
     One-off overrides beat files: <code>--settings</code> accepts a path or inline JSON,
     and <code>--setting-sources</code> restricts which layers load — see the
     <a href="/docs/cli-reference/#config">CLI reference</a>.
+  </p>
+
+  <h2 id="chat-channels">chat channels</h2>
+  <p>
+    Connect Telegram through an MCP channel server. The server owns the bot token
+    and Telegram polling; openclaude routes inbound notifications into the active
+    model session.
+  </p>
+  <p>
+    Configure an MCP server that declares <code>claude/channel</code> and emits
+    <code>notifications/claude/channel</code>, then explicitly enable it for a
+    session:
+  </p>
+  <pre><code>openclaude --channels server:telegram</code></pre>
+  <p>
+    Use the exact configured server name. Plugin channels use
+    <code>plugin:&lt;name&gt;@&lt;marketplace&gt;</code> and remain subject to the
+    approved plugin allowlist. The explicit flag is required because inbound
+    messages can contain prompt injection.
   </p>
 
   <h2 id="environment-variables">environment variables</h2>


### PR DESCRIPTION
#2175 Issue Solved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for receiving inbound messages through explicitly configured MCP chat channels, including Telegram.
  * Chat channels can now be used with API-key-based, OpenAI-compatible providers without requiring claude.ai OAuth.
  * Server channels no longer require development-channel approval when explicitly enabled for a session.
  * Channel options are now visible in CLI help, including server and approved-plugin formats.

* **Documentation**
  * Added setup guidance for configuring chat channels, security considerations, and plugin channel usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->