### PR TITLE
fix(profiles): apply context limit to all profile models

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -494,6 +494,12 @@ Model env vars are provider-scoped: first-party Anthropic sessions read
 `GEMINI_MODEL`, and Mistral reads `MISTRAL_MODEL`. For manual Bedrock, Vertex,
 or Foundry launches, select the model with `--model`.
 
+An OpenAI-compatible provider profile's maximum context length applies to every
+model in its configured list and the supported saved `/model` selection restored
+for that profile. Query options such as `?reasoning=high` or `?thinking=disabled`
+remain in the selected model, but context-limit keys use the model name before
+`?`. For example, `gpt-5.4?reasoning=high` uses the `gpt-5.4` context limit.
+
 ### Per-model limit overrides (`settings.json`)
 
 When a custom OpenAI-compatible provider does not expose context metadata from

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -2990,69 +2990,87 @@ describe('applyActiveProviderProfileFromConfig', () => {
     expect(process.env.OPENAI_MODEL).toBe('gpt-4o')
   })
 
-  test('preserves context limits for configured and saved models across profile rehydration', async () => {
-    const {
-      _setSavedModelOverrideForTesting,
-      applyActiveProviderProfileFromConfig,
-      getProviderProfiles,
-    } = await importFreshProviderProfileModules()
-    const { resolveModelRuntimeLimits } = await import(
-      '../integrations/runtimeMetadata.js'
-    )
-    _setSavedModelOverrideForTesting('gpt-5.4')
-    const activeProfile = buildProfile({
-      id: 'saved_hicap',
-      provider: 'hicap',
-      baseUrl: 'https://api.hicap.ai/v1',
-      model: 'glm-5.2; gpt-5.2',
-      maxContextLength: 200_000,
-    })
-    const config = {
-      providerProfiles: [activeProfile],
-      activeProviderProfileId: activeProfile.id,
-    } as any
-    const expectedContextWindows = JSON.stringify({
-      'glm-5.2': 200_000,
-      'gpt-5.2': 200_000,
-      'gpt-5.4': 200_000,
-    })
+  test.each(['', '?reasoning=high', '?thinking=disabled&reasoning=high'])(
+    'preserves context limits for configured and saved models across profile rehydration (%j)',
+    async query => {
+      const {
+        _setSavedModelOverrideForTesting,
+        applyActiveProviderProfileFromConfig,
+        getProviderProfiles,
+      } = await importFreshProviderProfileModules()
+      const { resolveModelRuntimeLimits } = await import(
+        '../integrations/runtimeMetadata.js'
+      )
+      const configuredModel = `gpt-5.2${query}`
+      const savedModel = `gpt-5.4${query}`
+      const modelList = `glm-5.2; ${configuredModel}`
+      _setSavedModelOverrideForTesting(savedModel)
+      const activeProfile = buildProfile({
+        id: 'saved_hicap',
+        provider: 'hicap',
+        baseUrl: 'https://api.hicap.ai/v1',
+        model: modelList,
+        maxContextLength: 200_000,
+      })
+      const config = {
+        providerProfiles: [activeProfile],
+        activeProviderProfileId: activeProfile.id,
+      } as any
+      const expectedContextWindows = JSON.stringify({
+        'glm-5.2': 200_000,
+        'gpt-5.2': 200_000,
+        'gpt-5.4': 200_000,
+      })
 
-    const applied = applyActiveProviderProfileFromConfig(config)
+      const applied = applyActiveProviderProfileFromConfig(config)
 
-    expect(applied?.id).toBe(activeProfile.id)
-    expect(process.env.OPENAI_BASE_URL).toBe('https://api.hicap.ai/v1')
-    expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
-    expect(process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
-      expectedContextWindows,
-    )
-    for (const model of ['glm-5.2', 'gpt-5.2', 'gpt-5.4']) {
-      expect(
-        resolveModelRuntimeLimits({ model, processEnv: process.env }).contextWindow,
-      ).toBe(200_000)
-    }
+      expect(applied?.id).toBe(activeProfile.id)
+      expect(process.env.OPENAI_BASE_URL).toBe('https://api.hicap.ai/v1')
+      const expectProfileContextLimits = () => {
+        expect(process.env.OPENAI_MODEL).toBe(savedModel)
+        for (const model of [
+          'glm-5.2',
+          'gpt-5.2',
+          'gpt-5.4',
+          configuredModel,
+          savedModel,
+        ]) {
+          expect(
+            resolveModelRuntimeLimits({ model, processEnv: process.env }).contextWindow,
+          ).toBe(200_000)
+        }
+        expect(process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
+          expectedContextWindows,
+        )
+        const saved = getProviderProfiles(config).find(
+          (profile: ProviderProfile) => profile.id === activeProfile.id,
+        )
+        expect(saved?.model).toBe(modelList)
+      }
+      expectProfileContextLimits()
 
-    expect(applyActiveProviderProfileFromConfig(config)?.id).toBe(activeProfile.id)
-    expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
-    expect(process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
-      expectedContextWindows,
-    )
+      expect(applyActiveProviderProfileFromConfig(config)?.id).toBe(activeProfile.id)
+      expectProfileContextLimits()
 
-    // Alignment must repair the old configured-only map, even though the
-    // effective model and all other profile-managed environment values match.
-    process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
-      'glm-5.2': 200_000,
-      'gpt-5.2': 200_000,
-    })
-    applyActiveProviderProfileFromConfig(config)
-    expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
-    expect(process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
-      expectedContextWindows,
-    )
-    const saved = getProviderProfiles(config).find(
-      (profile: ProviderProfile) => profile.id === activeProfile.id,
-    )
-    expect(saved?.model).toBe('glm-5.2; gpt-5.2')
-  })
+      // Alignment must repair the old configured-only map, even though the
+      // effective model and all other profile-managed environment values match.
+      process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
+        'glm-5.2': 200_000,
+        'gpt-5.2': 200_000,
+      })
+      applyActiveProviderProfileFromConfig(config)
+      expectProfileContextLimits()
+
+      // Also repair a complete map written with the old raw query-bearing keys.
+      process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
+        'glm-5.2': 200_000,
+        [configuredModel]: 200_000,
+        [savedModel]: 200_000,
+      })
+      applyActiveProviderProfileFromConfig(config)
+      expectProfileContextLimits()
+    },
+  )
 
   test('uses saved Codex /model choice when rehydrating the Codex OAuth profile', async () => {
     // Regression: the Codex OAuth profile is created with a single
@@ -3745,7 +3763,7 @@ describe('setActiveProviderProfile', () => {
         name: 'DeepSeek',
         provider: 'openai',
         baseUrl: 'https://api.deepseek.com/v1',
-        model: 'deepseek-v4-flash, deepseek-v4-pro, deepseek-chat',
+        model: 'deepseek-v4-flash?thinking=disabled, deepseek-v4-pro?reasoning=high, deepseek-chat',
         apiKey: 'sk-deepseek-live',
         apiFormat: 'responses',
         maxContextLength: 200_000,
@@ -3768,7 +3786,7 @@ describe('setActiveProviderProfile', () => {
       expect(persisted.profile).toBe('openai')
       expect(persisted.env).toEqual({
         OPENAI_BASE_URL: 'https://api.deepseek.com/v1',
-        OPENAI_MODEL: 'deepseek-v4-flash',
+        OPENAI_MODEL: 'deepseek-v4-flash?thinking=disabled',
         OPENAI_API_KEY: 'sk-deepseek-live',
         CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS: JSON.stringify({
           'deepseek-v4-flash': 200_000,
@@ -3793,7 +3811,7 @@ describe('setActiveProviderProfile', () => {
         id: 'keyless_multi_model_prof',
         provider: 'custom',
         baseUrl: 'http://localhost:4000/v1',
-        model: 'model-a; model-b, model-c',
+        model: 'model-a?reasoning=high; Model-B[1m]?thinking=disabled, model-c',
         maxContextLength: 64_000,
       })
 
@@ -3810,11 +3828,11 @@ describe('setActiveProviderProfile', () => {
       )
 
       expect(result?.id).toBe('keyless_multi_model_prof')
-      expect(persisted.env.OPENAI_MODEL).toBe('model-a')
+      expect(persisted.env.OPENAI_MODEL).toBe('model-a?reasoning=high')
       expect(persisted.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
         JSON.stringify({
           'model-a': 64_000,
-          'model-b': 64_000,
+          'Model-B[1m]': 64_000,
           'model-c': 64_000,
         }),
       )

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -2996,12 +2996,16 @@ describe('applyActiveProviderProfileFromConfig', () => {
       applyActiveProviderProfileFromConfig,
       getProviderProfiles,
     } = await importFreshProviderProfileModules()
+    const { resolveModelRuntimeLimits } = await import(
+      '../integrations/runtimeMetadata.js'
+    )
     _setSavedModelOverrideForTesting('gpt-5.4')
     const activeProfile = buildProfile({
       id: 'saved_hicap',
       provider: 'hicap',
       baseUrl: 'https://api.hicap.ai/v1',
       model: 'glm-5.2',
+      maxContextLength: 200_000,
     })
 
     const applied = applyActiveProviderProfileFromConfig({
@@ -3012,6 +3016,18 @@ describe('applyActiveProviderProfileFromConfig', () => {
     expect(applied?.id).toBe(activeProfile.id)
     expect(process.env.OPENAI_BASE_URL).toBe('https://api.hicap.ai/v1')
     expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
+    expect(process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
+      JSON.stringify({
+        'glm-5.2': 200_000,
+        'gpt-5.4': 200_000,
+      }),
+    )
+    expect(
+      resolveModelRuntimeLimits({
+        model: 'gpt-5.4',
+        processEnv: process.env,
+      }).contextWindow,
+    ).toBe(200_000)
     const saved = getProviderProfiles({
       providerProfiles: [activeProfile],
       activeProviderProfileId: activeProfile.id,

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -2139,24 +2139,37 @@ describe('applyProviderProfileToProcessEnv', () => {
     expect(getFreshAPIProvider()).not.toBe('xai')
   })
 
-  test('openai-compatible profile applies maxContextLength env override', async () => {
+  test('openai-compatible profile applies maxContextLength to every configured model', async () => {
     const { applyProviderProfileToProcessEnv } =
       await importFreshProviderProfileModules()
+    const { resolveModelRuntimeLimits } = await import(
+      '../integrations/runtimeMetadata.js'
+    )
 
     applyProviderProfileToProcessEnv(
       buildProfile({
         provider: 'custom',
         baseUrl: 'http://localhost:4000/v1',
-        model: 'gpt-4o',
+        model: 'local-large, local-small; local-reasoning',
         maxContextLength: 200_000,
       }),
     )
 
     expect(process.env.OPENAI_BASE_URL).toBe('http://localhost:4000/v1')
-    expect(process.env.OPENAI_MODEL).toBe('gpt-4o')
+    expect(process.env.OPENAI_MODEL).toBe('local-large')
     expect(process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
-      JSON.stringify({ 'gpt-4o': 200_000 }),
+      JSON.stringify({
+        'local-large': 200_000,
+        'local-small': 200_000,
+        'local-reasoning': 200_000,
+      }),
     )
+    expect(
+      resolveModelRuntimeLimits({
+        model: 'local-small',
+        processEnv: process.env,
+      }).contextWindow,
+    ).toBe(200_000)
   })
 
   test('openai-compatible profile switch clears previous same-model context override', async () => {
@@ -3700,6 +3713,7 @@ describe('setActiveProviderProfile', () => {
         model: 'deepseek-v4-flash, deepseek-v4-pro, deepseek-chat',
         apiKey: 'sk-deepseek-live',
         apiFormat: 'responses',
+        maxContextLength: 200_000,
       })
 
       saveMockGlobalConfig(current => ({
@@ -3721,10 +3735,55 @@ describe('setActiveProviderProfile', () => {
         OPENAI_BASE_URL: 'https://api.deepseek.com/v1',
         OPENAI_MODEL: 'deepseek-v4-flash',
         OPENAI_API_KEY: 'sk-deepseek-live',
+        CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS: JSON.stringify({
+          'deepseek-v4-flash': 200_000,
+          'deepseek-v4-pro': 200_000,
+          'deepseek-chat': 200_000,
+        }),
       })
     } finally {
       process.chdir(originalCwd)
       rmSync(tempDir, { recursive: true, force: true })
+      rmSync(configDir, { recursive: true, force: true })
+    }
+  })
+
+  test('persists context window for every model in a keyless openai-compatible profile', async () => {
+    const configDir = mkdtempSync(join(tmpdir(), 'openclaude-provider-config-'))
+
+    try {
+      const { setActiveProviderProfile } =
+        await importFreshProviderProfileModules()
+      const openaiProfile = buildProfile({
+        id: 'keyless_multi_model_prof',
+        provider: 'custom',
+        baseUrl: 'http://localhost:4000/v1',
+        model: 'model-a; model-b, model-c',
+        maxContextLength: 64_000,
+      })
+
+      saveMockGlobalConfig(current => ({
+        ...current,
+        providerProfiles: [openaiProfile],
+      }))
+
+      const result = setActiveProviderProfile('keyless_multi_model_prof', {
+        configDir,
+      })
+      const persisted = JSON.parse(
+        readFileSync(join(configDir, '.openclaude-profile.json'), 'utf8'),
+      )
+
+      expect(result?.id).toBe('keyless_multi_model_prof')
+      expect(persisted.env.OPENAI_MODEL).toBe('model-a')
+      expect(persisted.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
+        JSON.stringify({
+          'model-a': 64_000,
+          'model-b': 64_000,
+          'model-c': 64_000,
+        }),
+      )
+    } finally {
       rmSync(configDir, { recursive: true, force: true })
     }
   })

--- a/src/utils/providerProfiles.test.ts
+++ b/src/utils/providerProfiles.test.ts
@@ -2990,7 +2990,7 @@ describe('applyActiveProviderProfileFromConfig', () => {
     expect(process.env.OPENAI_MODEL).toBe('gpt-4o')
   })
 
-  test('uses saved valid Hicap /model choice when rehydrating active profile', async () => {
+  test('preserves context limits for configured and saved models across profile rehydration', async () => {
     const {
       _setSavedModelOverrideForTesting,
       applyActiveProviderProfileFromConfig,
@@ -3004,35 +3004,54 @@ describe('applyActiveProviderProfileFromConfig', () => {
       id: 'saved_hicap',
       provider: 'hicap',
       baseUrl: 'https://api.hicap.ai/v1',
-      model: 'glm-5.2',
+      model: 'glm-5.2; gpt-5.2',
       maxContextLength: 200_000,
     })
-
-    const applied = applyActiveProviderProfileFromConfig({
+    const config = {
       providerProfiles: [activeProfile],
       activeProviderProfileId: activeProfile.id,
-    } as any)
+    } as any
+    const expectedContextWindows = JSON.stringify({
+      'glm-5.2': 200_000,
+      'gpt-5.2': 200_000,
+      'gpt-5.4': 200_000,
+    })
+
+    const applied = applyActiveProviderProfileFromConfig(config)
 
     expect(applied?.id).toBe(activeProfile.id)
     expect(process.env.OPENAI_BASE_URL).toBe('https://api.hicap.ai/v1')
     expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
     expect(process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
-      JSON.stringify({
-        'glm-5.2': 200_000,
-        'gpt-5.4': 200_000,
-      }),
+      expectedContextWindows,
     )
-    expect(
-      resolveModelRuntimeLimits({
-        model: 'gpt-5.4',
-        processEnv: process.env,
-      }).contextWindow,
-    ).toBe(200_000)
-    const saved = getProviderProfiles({
-      providerProfiles: [activeProfile],
-      activeProviderProfileId: activeProfile.id,
-    } as any).find((profile: ProviderProfile) => profile.id === activeProfile.id)
-    expect(saved?.model).toBe('glm-5.2')
+    for (const model of ['glm-5.2', 'gpt-5.2', 'gpt-5.4']) {
+      expect(
+        resolveModelRuntimeLimits({ model, processEnv: process.env }).contextWindow,
+      ).toBe(200_000)
+    }
+
+    expect(applyActiveProviderProfileFromConfig(config)?.id).toBe(activeProfile.id)
+    expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
+    expect(process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
+      expectedContextWindows,
+    )
+
+    // Alignment must repair the old configured-only map, even though the
+    // effective model and all other profile-managed environment values match.
+    process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
+      'glm-5.2': 200_000,
+      'gpt-5.2': 200_000,
+    })
+    applyActiveProviderProfileFromConfig(config)
+    expect(process.env.OPENAI_MODEL).toBe('gpt-5.4')
+    expect(process.env.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS).toBe(
+      expectedContextWindows,
+    )
+    const saved = getProviderProfiles(config).find(
+      (profile: ProviderProfile) => profile.id === activeProfile.id,
+    )
+    expect(saved?.model).toBe('glm-5.2; gpt-5.2')
   })
 
   test('uses saved Codex /model choice when rehydrating the Codex OAuth profile', async () => {

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -753,7 +753,12 @@ function serializeProfileContextWindows(
 
   return JSON.stringify(
     Object.fromEntries(
-      contextModels.map(model => [model, maxContextLength]),
+      // Match resolveModelRuntimeLimits' query-stripped lookup key without
+      // changing case, [1m] tags, or the raw model selection and its options.
+      contextModels.map(model => [
+        model.split('?', 1)[0]?.trim() || model,
+        maxContextLength,
+      ]),
     ),
   )
 }

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -738,14 +738,22 @@ function sameOptionalEnvValue(
 function serializeProfileContextWindows(
   modelField: string,
   maxContextLength: number,
+  activeModel?: string,
 ): string {
   const models = parseModelList(modelField)
   const configuredModels =
     models.length > 0 ? models : [getPrimaryModel(modelField)]
+  // A saved /model choice can be valid for the provider catalog without
+  // being listed in profile.model. Include the model that will actually run
+  // so it does not fall back to a different context limit.
+  const selectedModel = trimOrUndefined(activeModel)
+  const contextModels = selectedModel
+    ? [...new Set([...configuredModels, selectedModel])]
+    : configuredModels
 
   return JSON.stringify(
     Object.fromEntries(
-      configuredModels.map(model => [model, maxContextLength]),
+      contextModels.map(model => [model, maxContextLength]),
     ),
   )
 }
@@ -865,7 +873,11 @@ function isProcessEnvAlignedWithProfile(
   }
 
   const expectedContextWindows = profile.maxContextLength
-    ? serializeProfileContextWindows(profile.model, profile.maxContextLength)
+    ? serializeProfileContextWindows(
+        profile.model,
+        profile.maxContextLength,
+        primaryModel,
+      )
     : undefined
   const isAimlapiRoute =
     profile.provider === 'aimlapi' ||
@@ -1295,7 +1307,11 @@ export function applyProviderProfileToProcessEnv(
     }
     if (profile.maxContextLength) {
       openAIProfileEnv.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS =
-        serializeProfileContextWindows(profile.model, profile.maxContextLength)
+        serializeProfileContextWindows(
+          profile.model,
+          profile.maxContextLength,
+          primaryModel,
+        )
     }
 
     profileEnv = openAIProfileEnv

--- a/src/utils/providerProfiles.ts
+++ b/src/utils/providerProfiles.ts
@@ -735,6 +735,21 @@ function sameOptionalEnvValue(
   return trimOrUndefined(left) === trimOrUndefined(right)
 }
 
+function serializeProfileContextWindows(
+  modelField: string,
+  maxContextLength: number,
+): string {
+  const models = parseModelList(modelField)
+  const configuredModels =
+    models.length > 0 ? models : [getPrimaryModel(modelField)]
+
+  return JSON.stringify(
+    Object.fromEntries(
+      configuredModels.map(model => [model, maxContextLength]),
+    ),
+  )
+}
+
 function isProcessEnvAlignedWithProfile(
   processEnv: NodeJS.ProcessEnv,
   profile: ProviderProfile,
@@ -850,9 +865,7 @@ function isProcessEnvAlignedWithProfile(
   }
 
   const expectedContextWindows = profile.maxContextLength
-    ? JSON.stringify({
-        [primaryModel]: profile.maxContextLength,
-      })
+    ? serializeProfileContextWindows(profile.model, profile.maxContextLength)
     : undefined
   const isAimlapiRoute =
     profile.provider === 'aimlapi' ||
@@ -1281,9 +1294,8 @@ export function applyProviderProfileToProcessEnv(
       openAIProfileEnv.NVIDIA_NIM = '1'
     }
     if (profile.maxContextLength) {
-      openAIProfileEnv.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS = JSON.stringify({
-        [primaryModel]: profile.maxContextLength,
-      })
+      openAIProfileEnv.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS =
+        serializeProfileContextWindows(profile.model, profile.maxContextLength)
     }
 
     profileEnv = openAIProfileEnv
@@ -1599,6 +1611,13 @@ function buildOpenAICompatibleStartupEnv(
       processEnv: {},
     })
     if (strictEnv) {
+      if (activeProfile.maxContextLength) {
+        strictEnv.CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS =
+          serializeProfileContextWindows(
+            activeProfile.model,
+            activeProfile.maxContextLength,
+          )
+      }
       if (isAimlapiProfile) {
         strictEnv.AIMLAPI_API_KEY = activeProfile.apiKey
         strictEnv.CLAUDE_CODE_PROVIDER_ROUTE_ID = 'aimlapi'
@@ -1657,9 +1676,10 @@ function buildOpenAICompatibleStartupEnv(
     ...(activeProfile.authHeaderValue ? { OPENAI_AUTH_HEADER_VALUE: activeProfile.authHeaderValue } : {}),
     ...(activeProfile.maxContextLength
       ? {
-          CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS: JSON.stringify({
-            [getPrimaryModel(activeProfile.model)]: activeProfile.maxContextLength,
-          }),
+          CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS: serializeProfileContextWindows(
+            activeProfile.model,
+            activeProfile.maxContextLength,
+          ),
         }
       : {}),
   }


### PR DESCRIPTION
## Summary

- Apply a profile's `maxContextLength` to every configured model and its supported saved `/model` selection.
- Generate context-limit keys using the query-stripped model identity consumed by `resolveModelRuntimeLimits()`. For a Hicap profile capped at 200,000, configured `glm-5.2; gpt-5.2?reasoning=high` and saved `gpt-5.4?reasoning=high` all resolve the profile cap instead of falling back to catalog/default limits.
- Reuse the shared serializer for process application, alignment and generic keyed/keyless startup. Preserve the raw model selection, query options, case, `[1m]` tags and stored profile model list.

Fixes #2182

## Impact

- Context metering and auto-compaction honor the profile cap for configured secondary models and supported saved models outside the configured list, including query-bearing selections.
- Rehydration preserves the correct map; alignment repairs both incomplete maps and maps using the previous raw query-bearing keys.
- Documented exact/prefix override precedence and provider-specific startup routing remain unchanged.

## Testing

- [x] I ran the required [local preflight](https://github.com/Gitlawb/openclaude/blob/main/CONTRIBUTING.md#validation), with the verified baseline failures and coverage limitation below.
- Candidate: `6cfafbe9278da52390ab710b51c1d02f2779dd70`, rebased onto upstream `main` at `1afeb4b1e7a892b6456c6b86f6fd6683222b2005`. Node 22.22.1, Bun 1.3.14, macOS arm64.
- Passed: `bun install --frozen-lockfile`, `bun run typecheck`, `bun run typecheck:type-tests`, `node bin/openclaude --version`, `NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version`, and exact changed-scope lint.
- `bun test ./src/utils/providerProfiles.test.ts ./src/integrations/runtimeMetadata.test.ts ./src/utils/model/openaiContextWindows.test.ts`: **283 passed, 0 failed**.
- Focused composition/persistence regressions: before this correction **1 passed, 4 failed**; after it **5 passed, 0 failed**. Covers plain models, reasoning/thinking query options, a configured secondary plus an out-of-list saved model, actual runtime limits for raw and base identities, repeated rehydration, old-map repair, unchanged stored selection and keyed/keyless startup persistence.
- `npm run test:provider-recommendation`: **160 passed, 0 failed**.
- `git fetch https://github.com/Gitlawb/openclaude.git main` followed by `bun run security:pr-scan -- --base FETCH_HEAD --head HEAD`: passed on the committed candidate.
- `bun run check`: build, smoke and deadcode complete, but its unit-test log contains **57 failures despite exit code 0** and ends at `src/cli/bgRegistry.test.ts` without an aggregate summary. The separate conversation-arc test passes. This is not a clean/full unit-suite pass.
- On an isolated worktree at upstream `1afeb4b1`, the same `bun run check` produces exactly the same 57 named failures and the same early end; comparison found no candidate-only failures. Affected groups include fact extraction, persistence, attribution, pricing, model output limits and fast mode. Example: `deepseek-v4-flash uses the gateway-safe output cap by default` expects 65,536 output tokens but receives 8,000 on both trees. These failures also occur before the provider-profile tests in both runs; the PR does not modify their causal surfaces.
- `bun run test:provider`: **1641 passed, 1 failed**: `Claude stream watchdog > falls back when the top-level stream iterator never settles`, with `ENOENT` reading `interruption-trace.jsonl`. The same failure is reproduced on upstream `1afeb4b1`, including an isolated run of `bun test --feature=UNATTENDED_RETRY ./src/services/api/claude.streamWatchdog.test.ts --test-name-pattern 'falls back when the top-level stream iterator never settles'`. The watchdog/trace implementation is unchanged by this PR.
- Web checks are not applicable: the edited setup document is linked on GitHub, not imported into the site; no website, dependency, shared site asset or web build configuration changes. Local checks do not reproduce CI's clean-runner, supported-Node-matrix or platform-specific coverage.

## Notes

- Reviewed `CONTRIBUTING.md` and `AGENTS.md`.
- Provider/model paths tested: generic custom OpenAI-compatible keyed/keyless startup persistence and Hicap saved-model rehydration with query-bearing configured and saved models.
- Screenshots: not applicable; no UI changes.
- Provider-specific routed startup persistence remains outside this PR's scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provider profiles with multiple models so the configured maximum context length is applied consistently to every model.
  * Ensured context-length settings are preserved when switching between provider profiles, including profiles without an explicit key.
  * Preserved context limits for saved model selections, including models not originally listed in the provider profile.
  * Improved startup configuration so context limits remain consistent across supported provider profile configurations.

* **Documentation**
  * Clarified how context limits apply to model lists, saved selections, and models with query options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
