### PR TITLE
fix: identify OpenCode Go requests

### DIFF
--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -273,6 +273,8 @@ openclaude
 
 OpenCode Go is a $10/mo subscription for 13 open models (GLM, Kimi, DeepSeek,
 MiMo, MiniMax, Qwen). Uses the same `OPENCODE_API_KEY` as OpenCode Zen.
+OpenClaude automatically sends the session and product identity headers that
+OpenCode Go requires for prompt caching and traffic attribution.
 
 ### Gitlawb Opengateway
 

--- a/src/services/api/openaiShim/requestExecutor.integration.test.ts
+++ b/src/services/api/openaiShim/requestExecutor.integration.test.ts
@@ -2139,8 +2139,8 @@ test('opencode go sends required session and product identity headers', async ()
   delete process.env.OPENAI_API_KEY
 
   const captured = await captureChatCompletionRequest('mimo-v2.5-pro', {
-    'User-Agent': 'generic-client',
-    'x-opencode-session': 'stale-session',
+    'user-agent': 'generic-client',
+    'X-OpenCode-Session': 'stale-session',
   })
   const headers = new Headers(captured.headers)
 

--- a/src/services/api/openaiShim/requestExecutor.integration.test.ts
+++ b/src/services/api/openaiShim/requestExecutor.integration.test.ts
@@ -5,7 +5,7 @@ import { asMockFetch } from '../../../test/typedMocks.js'
 import { _clearRegistryForTesting, ensureIntegrationsLoaded, registerGateway } from '../../../integrations/index.ts'
 import { applyProviderFlag } from '../../../utils/providerFlag.ts'
 import { applyProviderProfileToProcessEnv } from '../../../utils/providerProfiles.ts'
-import { getSessionId } from '../../../bootstrap/state.ts'
+import { getSessionId, switchSession } from '../../../bootstrap/state.ts'
 import { getOpenClaudeUserAgent } from '../../../utils/userAgent.ts'
 import {
   getAssistantMessageFromError,
@@ -2151,11 +2151,14 @@ test('opencode go sends required session and product identity headers', async ()
   expect(headers.get('user-agent')).toBe(getOpenClaudeUserAgent())
 })
 
-test('opencode go messages endpoint rotates raw x-api-key credentials after rate-limit failure', async () => {
+test('opencode go messages endpoint keeps its session while rotating raw x-api-key credentials', async () => {
   const capturedUrls: string[] = []
   const capturedKeys: Array<string | null> = []
   const capturedSessions: Array<string | null> = []
   const capturedUserAgents: Array<string | null> = []
+  const originalSessionId = getSessionId()
+  const replacementSessionId =
+    '00000000-0000-4000-8000-000000000001' as typeof originalSessionId
 
   process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
   delete process.env.OPENAI_API_KEY
@@ -2172,6 +2175,7 @@ test('opencode go messages endpoint rotates raw x-api-key credentials after rate
     capturedUserAgents.push(headers.get('user-agent'))
 
     if (capturedKeys.length === 1) {
+      switchSession(replacementSessionId)
       return new Response(JSON.stringify({ error: { message: 'rate limited' } }), {
         status: 429,
         headers: { 'Content-Type': 'application/json' },
@@ -2202,23 +2206,27 @@ test('opencode go messages endpoint rotates raw x-api-key credentials after rate
 
   const client = createOpenAIShimClient({}) as OpenAIShimClient
 
-  await client.beta.messages.create({
-    model: 'minimax-m3',
-    messages: [{ role: 'user', content: 'hello' }],
-    max_tokens: 32,
-    stream: false,
-  })
+  try {
+    await client.beta.messages.create({
+      model: 'minimax-m3',
+      messages: [{ role: 'user', content: 'hello' }],
+      max_tokens: 32,
+      stream: false,
+    })
 
-  expect(capturedUrls).toEqual([
-    'https://opencode.ai/zen/go/v1/messages',
-    'https://opencode.ai/zen/go/v1/messages',
-  ])
-  expect(capturedKeys).toEqual(['fake-opencode-a', 'fake-opencode-b'])
-  expect(capturedSessions).toEqual([getSessionId(), getSessionId()])
-  expect(capturedUserAgents).toEqual([
-    getOpenClaudeUserAgent(),
-    getOpenClaudeUserAgent(),
-  ])
+    expect(capturedUrls).toEqual([
+      'https://opencode.ai/zen/go/v1/messages',
+      'https://opencode.ai/zen/go/v1/messages',
+    ])
+    expect(capturedKeys).toEqual(['fake-opencode-a', 'fake-opencode-b'])
+    expect(capturedSessions).toEqual([originalSessionId, originalSessionId])
+    expect(capturedUserAgents).toEqual([
+      getOpenClaudeUserAgent(),
+      getOpenClaudeUserAgent(),
+    ])
+  } finally {
+    switchSession(originalSessionId)
+  }
 })
 
 test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY as bearer auth despite stale generic base URL', async () => {

--- a/src/services/api/openaiShim/requestExecutor.integration.test.ts
+++ b/src/services/api/openaiShim/requestExecutor.integration.test.ts
@@ -5,6 +5,8 @@ import { asMockFetch } from '../../../test/typedMocks.js'
 import { _clearRegistryForTesting, ensureIntegrationsLoaded, registerGateway } from '../../../integrations/index.ts'
 import { applyProviderFlag } from '../../../utils/providerFlag.ts'
 import { applyProviderProfileToProcessEnv } from '../../../utils/providerProfiles.ts'
+import { getSessionId } from '../../../bootstrap/state.ts'
+import { getOpenClaudeUserAgent } from '../../../utils/userAgent.ts'
 import {
   getAssistantMessageFromError,
   OPENCODE_GO_FREE_LIMIT_ERROR_MESSAGE,
@@ -405,19 +407,25 @@ function makeChatCompletionResponse(model: string): Response {
 
 async function captureChatCompletionRequest(
   model = 'mimo-v2.5-pro',
-): Promise<{ authorization: string | null; url: string | null }> {
+  defaultHeaders: Record<string, string> = {},
+): Promise<{
+  authorization: string | null
+  headers: Record<string, string>
+  url: string | null
+}> {
   let authorization: string | null = null
+  let headers: Record<string, string> = {}
   let url: string | null = null
 
   globalThis.fetch = (async (input, init) => {
     url = String(input)
-    const headers = init?.headers as Record<string, string> | undefined
-    authorization = headers?.Authorization ?? headers?.authorization ?? null
+    headers = (init?.headers as Record<string, string> | undefined) ?? {}
+    authorization = headers.Authorization ?? headers.authorization ?? null
 
     return makeChatCompletionResponse(model)
   }) as unknown as FetchType
 
-  const client = createOpenAIShimClient({}) as OpenAIShimClient
+  const client = createOpenAIShimClient({ defaultHeaders }) as OpenAIShimClient
 
   await client.beta.messages.create({
     model,
@@ -426,7 +434,7 @@ async function captureChatCompletionRequest(
     stream: false,
   })
 
-  return { authorization, url }
+  return { authorization, headers, url }
 }
 
 beforeEach(async () => {
@@ -2105,6 +2113,8 @@ test.each([
   expect(capturedUrl).toBe('https://opencode.ai/zen/go/v1/messages')
   expect(capturedHeaders?.get('x-api-key')).toBe('fake-opencode-key')
   expect(capturedHeaders?.get('authorization')).toBeNull()
+  expect(capturedHeaders?.get('x-opencode-session')).toBe(getSessionId())
+  expect(capturedHeaders?.get('user-agent')).toBe(getOpenClaudeUserAgent())
   expect(capturedBody).toEqual({
     model,
     messages: [
@@ -2121,9 +2131,31 @@ test.each([
   expect(capturedBody).not.toHaveProperty('store')
 })
 
+test('opencode go sends required session and product identity headers', async () => {
+  process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
+  process.env.OPENAI_MODEL = 'mimo-v2.5-pro'
+  process.env.CLAUDE_CODE_USE_OPENAI = '1'
+  process.env.OPENCODE_API_KEY = 'fake-opencode-key'
+  delete process.env.OPENAI_API_KEY
+
+  const captured = await captureChatCompletionRequest('mimo-v2.5-pro', {
+    'User-Agent': 'generic-client',
+    'x-opencode-session': 'stale-session',
+  })
+  const headers = new Headers(captured.headers)
+
+  expect(captured.url).toBe(
+    'https://opencode.ai/zen/go/v1/chat/completions',
+  )
+  expect(headers.get('x-opencode-session')).toBe(getSessionId())
+  expect(headers.get('user-agent')).toBe(getOpenClaudeUserAgent())
+})
+
 test('opencode go messages endpoint rotates raw x-api-key credentials after rate-limit failure', async () => {
   const capturedUrls: string[] = []
   const capturedKeys: Array<string | null> = []
+  const capturedSessions: Array<string | null> = []
+  const capturedUserAgents: Array<string | null> = []
 
   process.env.OPENAI_BASE_URL = 'https://opencode.ai/zen/go/v1'
   delete process.env.OPENAI_API_KEY
@@ -2136,6 +2168,8 @@ test('opencode go messages endpoint rotates raw x-api-key credentials after rate
     const headers = new Headers(init?.headers)
     capturedUrls.push(String(input))
     capturedKeys.push(headers.get('x-api-key'))
+    capturedSessions.push(headers.get('x-opencode-session'))
+    capturedUserAgents.push(headers.get('user-agent'))
 
     if (capturedKeys.length === 1) {
       return new Response(JSON.stringify({ error: { message: 'rate limited' } }), {
@@ -2180,6 +2214,11 @@ test('opencode go messages endpoint rotates raw x-api-key credentials after rate
     'https://opencode.ai/zen/go/v1/messages',
   ])
   expect(capturedKeys).toEqual(['fake-opencode-a', 'fake-opencode-b'])
+  expect(capturedSessions).toEqual([getSessionId(), getSessionId()])
+  expect(capturedUserAgents).toEqual([
+    getOpenClaudeUserAgent(),
+    getOpenClaudeUserAgent(),
+  ])
 })
 
 test('gitlawb opengateway provider flag sends OPENGATEWAY_API_KEY as bearer auth despite stale generic base URL', async () => {

--- a/src/services/api/openaiShim/requestExecutor.ts
+++ b/src/services/api/openaiShim/requestExecutor.ts
@@ -482,6 +482,15 @@ export async function executeOpenAIRequest(
     // route contract after caller headers are merged so stale custom values
     // cannot make otherwise valid Go traffic non-compliant.
     if (isOpenCodeGoRoute) {
+      for (const name of Object.keys(headers)) {
+        const normalizedName = name.toLowerCase()
+        if (
+          normalizedName === 'x-opencode-session' ||
+          normalizedName === 'user-agent'
+        ) {
+          delete headers[name]
+        }
+      }
       headers['x-opencode-session'] = getSessionId()
       headers['User-Agent'] = getOpenClaudeUserAgent()
     }

--- a/src/services/api/openaiShim/requestExecutor.ts
+++ b/src/services/api/openaiShim/requestExecutor.ts
@@ -284,7 +284,8 @@ export async function executeOpenAIRequest(
   // sent as a Bearer to api.x.ai/v1 — same surface as an API key.
   const isXaiRoute =
     runtimeShimContext.routeId === 'xai' || isXaiBaseUrl(request.baseUrl)
-  const isOpenCodeGoRoute = runtimeShimContext.routeId === 'opencode-go'
+  const openCodeGoSessionId =
+    runtimeShimContext.routeId === 'opencode-go' ? getSessionId() : null
   const openAIApiKeysPoolRaw =
     routeAcceptsGenericOpenAICredentials &&
     parseCredentialList(requestProcessEnv.OPENAI_API_KEYS).length > 0
@@ -481,7 +482,7 @@ export async function executeOpenAIRequest(
     // and a product-specific user agent for traffic attribution. Enforce the
     // route contract after caller headers are merged so stale custom values
     // cannot make otherwise valid Go traffic non-compliant.
-    if (isOpenCodeGoRoute) {
+    if (openCodeGoSessionId !== null) {
       for (const name of Object.keys(headers)) {
         const normalizedName = name.toLowerCase()
         if (
@@ -491,7 +492,7 @@ export async function executeOpenAIRequest(
           delete headers[name]
         }
       }
-      headers['x-opencode-session'] = getSessionId()
+      headers['x-opencode-session'] = openCodeGoSessionId
       headers['User-Agent'] = getOpenClaudeUserAgent()
     }
 

--- a/src/services/api/openaiShim/requestExecutor.ts
+++ b/src/services/api/openaiShim/requestExecutor.ts
@@ -6,6 +6,7 @@ import {
   redactSecretSubstringsForDisplay,
 } from '../../../utils/providerSecrets.js'
 import { parseCustomHeadersEnv } from '../../../utils/providerCustomHeaders.js'
+import { getOpenClaudeUserAgent } from '../../../utils/userAgent.js'
 
 export function formatRetryAfterHint(response: Response): string {
   const retryAfter = response.headers.get('retry-after')
@@ -283,6 +284,7 @@ export async function executeOpenAIRequest(
   // sent as a Bearer to api.x.ai/v1 — same surface as an API key.
   const isXaiRoute =
     runtimeShimContext.routeId === 'xai' || isXaiBaseUrl(request.baseUrl)
+  const isOpenCodeGoRoute = runtimeShimContext.routeId === 'opencode-go'
   const openAIApiKeysPoolRaw =
     routeAcceptsGenericOpenAICredentials &&
     parseCredentialList(requestProcessEnv.OPENAI_API_KEYS).length > 0
@@ -473,6 +475,15 @@ export async function executeOpenAIRequest(
     // implementation (RELEASE_v0.8.0 PR #5604).
     if (isXaiRoute) {
       headers['x-grok-conv-id'] ??= getSessionId()
+    }
+
+    // OpenCode Go requires a stable session header for prompt-cache affinity
+    // and a product-specific user agent for traffic attribution. Enforce the
+    // route contract after caller headers are merged so stale custom values
+    // cannot make otherwise valid Go traffic non-compliant.
+    if (isOpenCodeGoRoute) {
+      headers['x-opencode-session'] = getSessionId()
+      headers['User-Agent'] = getOpenClaudeUserAgent()
     }
 
     return headers

--- a/src/utils/userAgent.ts
+++ b/src/utils/userAgent.ts
@@ -10,7 +10,11 @@ export function getClaudeCodeUserAgent(): string {
 }
 
 export function getOpenClaudeUserAgent(): string {
-  const version =
-    typeof MACRO !== 'undefined' && MACRO.VERSION ? MACRO.VERSION : '0.0.0'
-  return `openclaude/${version}`
+  try {
+    // Keep macro properties in a direct expression so Bun substitutes them in
+    // shipped bundles. The fallback supports unbundled unit-test execution.
+    return `openclaude/${MACRO.DISPLAY_VERSION ?? MACRO.VERSION}`
+  } catch {
+    return 'openclaude/0.0.0'
+  }
 }

--- a/src/utils/userAgent.ts
+++ b/src/utils/userAgent.ts
@@ -8,3 +8,9 @@
 export function getClaudeCodeUserAgent(): string {
   return `claude-code/${MACRO.VERSION}`
 }
+
+export function getOpenClaudeUserAgent(): string {
+  const version =
+    typeof MACRO !== 'undefined' && MACRO.VERSION ? MACRO.VERSION : '0.0.0'
+  return `openclaude/${version}`
+}


### PR DESCRIPTION
## Summary

- send OpenCode Go's required `x-opencode-session` header on both supported request shapes and retries
- identify traffic with the narrow `openclaude/<version>` user agent required by OpenCode Go
- replace caller-provided identity headers case-insensitively and document the automatic behavior

OpenCode Go now requires compatible clients to provide a session identifier for prompt-cache affinity and to avoid broad user agents. Without these headers, OpenClaude traffic risks being rejected as noncompliant.

## Impact

- user-facing impact: OpenCode Go requests remain accepted and get stable prompt-cache routing; no setup changes are required
- developer/maintainer impact: the contract is isolated to the resolved `opencode-go` route and covered across `/messages`, `/chat/completions`, and credential retries

## Testing

- [x] I ran the required [local preflight](https://github.com/Gitlawb/openclaude/blob/main/CONTRIBUTING.md#validation).
- exact commands and results: `bun install --frozen-lockfile`; `bun run check`; `bun run typecheck`; `bun run typecheck:type-tests`; both launcher version commands; `bun run test:provider`; `npm run test:provider-recommendation`; fresh upstream fetch; and `bun run security:pr-scan -- --base FETCH_HEAD --head HEAD`
- focused tests: request executor integration 114/114; OpenCode gateway/runtime metadata 138/138; mixed-case header regression 1/1; `bun run integrations:check`; CLI/SDK production build with `openclaude/0.30.0` verified in bundled output
- documented skipped checks, platform limitations, or verified pre-existing failures: the provider suite required unrestricted loopback binding (1596 pass, 36 skip, 0 fail); provider-profile tests used an isolated `OPENCLAUDE_CONFIG_DIR` (152/152); `bun run check` exited 0 but its full-test child printed existing unrelated memory-extraction and timing-sensitive ProviderManager failures

## Notes

- provider/model path tested: OpenCode Go chat completions, all current Go `/messages` models, and credential-rotation retry continuity
- screenshots attached (if UI changed): not applicable
- follow-up work or known limitations: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved OpenCode Go compatibility by automatically applying the required session and product identity information to supported requests.
  - Requests now use consistent OpenClaude product identification and session values, including after credential-rotation retries.
  - Caller-provided session and user-agent values are overridden for OpenCode Go requests to ensure reliable prompt caching and traffic attribution.

- **Documentation**
  - Updated setup guidance to describe the automatically applied OpenCode Go headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->