### PR TITLE
fix(sdk): preserve async generator session context

### DIFF
--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -434,6 +434,41 @@ export function runWithSdkContext<T>(context: SdkContext, fn: () => T): T {
   return sdkContextStorage.run(context, fn)
 }
 
+/** Run process-global setup without inheriting the active SDK session. */
+export function runOutsideSdkContext<T>(fn: () => T): T {
+  return sdkContextStorage.exit(fn)
+}
+
+/**
+ * Bind every continuation of a lazy async generator to one SDK context.
+ * Creating a generator inside `AsyncLocalStorage.run()` is insufficient:
+ * its body executes later, when `next()`, `return()`, or `throw()` is called.
+ */
+export function bindSdkContextToAsyncGenerator<
+  TYield,
+  TReturn = void,
+  TNext = unknown,
+>(
+  context: SdkContext,
+  generator: AsyncGenerator<TYield, TReturn, TNext>,
+): AsyncGenerator<TYield, TReturn, TNext> {
+  const bound = {
+    next: (value?: TNext) =>
+      runWithSdkContext(context, () => generator.next(value as TNext)),
+    return: (value: TReturn | PromiseLike<TReturn>) =>
+      runWithSdkContext(context, () => generator.return(value)),
+    throw: (error?: unknown) =>
+      runWithSdkContext(context, () => generator.throw(error)),
+    [Symbol.asyncDispose]: () =>
+      runWithSdkContext(context, () => generator[Symbol.asyncDispose]()),
+    [Symbol.asyncIterator]() {
+      return this
+    },
+  }
+
+  return bound as AsyncGenerator<TYield, TReturn, TNext>
+}
+
 function getSdkContext(): SdkContext | undefined {
   return sdkContextStorage.getStore()
 }

--- a/src/bootstrap/state.ts
+++ b/src/bootstrap/state.ts
@@ -460,7 +460,14 @@ export function bindSdkContextToAsyncGenerator<
     throw: (error?: unknown) =>
       runWithSdkContext(context, () => generator.throw(error)),
     [Symbol.asyncDispose]: () =>
-      runWithSdkContext(context, () => generator[Symbol.asyncDispose]()),
+      runWithSdkContext(context, async () => {
+        const dispose = generator[Symbol.asyncDispose]
+        if (typeof dispose === 'function') {
+          await dispose.call(generator)
+          return
+        }
+        await generator.return(undefined as TReturn)
+      }),
     [Symbol.asyncIterator]() {
       return this
     },

--- a/src/entrypoints/sdk/query.ts
+++ b/src/entrypoints/sdk/query.ts
@@ -1176,6 +1176,6 @@ export async function queryAsync(params: {
   prompt: string | AsyncIterable<SDKUserMessage>
   options?: QueryOptions
 }): Promise<Query> {
-  await init()
+  await runOutsideSdkContext(init)
   return query(params)
 }

--- a/src/entrypoints/sdk/query.ts
+++ b/src/entrypoints/sdk/query.ts
@@ -33,7 +33,8 @@ import {
   switchSession,
   regenerateSessionId,
   getSessionId,
-  runWithSdkContext,
+  bindSdkContextToAsyncGenerator,
+  runOutsideSdkContext,
 } from '../../bootstrap/state.js'
 import type { SessionId } from '../../types/ids.js'
 import {
@@ -510,8 +511,9 @@ class QueryImpl implements Query {
     }
 
     const self = this
-    const inner = runWithSdkContext(sdkContext, () => {
-      return (async function* (): AsyncGenerator<SDKMessage> {
+    const inner = bindSdkContextToAsyncGenerator(
+      sdkContext,
+      (async function* (): AsyncGenerator<SDKMessage> {
         // Fast exit: if interrupt()/close() was called before iteration
         // started, skip init entirely — avoids auth/network side-effects.
         if (self.abortController.signal.aborted) return
@@ -519,7 +521,7 @@ class QueryImpl implements Query {
         // Skip init for mock/host-injected engines; they are self-contained.
         const engineWasOverridden = self._engineWasInjected
         if (!engineWasOverridden) {
-          await init()
+          await runOutsideSdkContext(init)
         }
 
         // Load agent definitions BEFORE creating engine context
@@ -721,8 +723,8 @@ class QueryImpl implements Query {
               releaseEnvMutex()
             }
           }
-      })()
-    })
+      })(),
+    )
 
     yield* inner
   }

--- a/src/entrypoints/sdk/v2.ts
+++ b/src/entrypoints/sdk/v2.ts
@@ -30,7 +30,8 @@ import { readJSONLFile } from '../../utils/json.js'
 import { stat } from 'fs/promises'
 import {
   switchSession,
-  runWithSdkContext,
+  bindSdkContextToAsyncGenerator,
+  runOutsideSdkContext,
 } from '../../bootstrap/state.js'
 import type { SessionId } from '../../types/ids.js'
 import {
@@ -267,13 +268,14 @@ class SDKSessionImpl implements SDKSession {
     }
 
     const self = this
-    const inner = runWithSdkContext(sdkContext, () => {
-      return (async function* (): AsyncGenerator<SDKMessage> {
+    const inner = bindSdkContextToAsyncGenerator(
+      sdkContext,
+      (async function* (): AsyncGenerator<SDKMessage> {
         // Fast exit: if the caller's AbortController was already aborted
         // before iteration starts, do not initialize or submit a turn.
         if (self._abortController?.signal.aborted) return
 
-        await init()
+        await runOutsideSdkContext(init)
 
         // Load agent definitions once (not on every sendMessage call)
         if (!self.agentsLoaded) {
@@ -377,8 +379,8 @@ class SDKSessionImpl implements SDKSession {
           self.timeoutQueue.length = 0
           self.agentFailureQueue.length = 0
         }
-      })()
-    })
+      })(),
+    )
 
     yield* inner
   }

--- a/tests/sdk/query-concurrency.test.ts
+++ b/tests/sdk/query-concurrency.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
-import { query } from '../../src/entrypoints/sdk/index.js'
+import { query, queryAsync } from '../../src/entrypoints/sdk/index.js'
 import { getSessionId, getSessionProjectDir, runWithSdkContext } from '../../src/bootstrap/state.js'
+import { init } from '../../src/entrypoints/init.js'
 import {
   acquireSharedMutationLock,
   releaseSharedMutationLock,
@@ -113,12 +114,53 @@ describe('SEC-1: env override isolation', () => {
 
 describe('CON-1: CWD and session isolation between concurrent queries', () => {
   test('queryAsync keeps eager process-global initialization detached', async () => {
-    const source = await Bun.file(
-      new URL('../../src/entrypoints/sdk/query.ts', import.meta.url),
-    ).text()
-    const queryAsyncSource = source.slice(source.indexOf('export async function queryAsync'))
+    const globalId = getSessionId()
+    const sdkSession = '00000000-0000-4000-8000-0000000000aa' as SessionId
+    const memoizedInit = init as typeof init & {
+      cache: { has(key: unknown): boolean; get(key: unknown): Promise<void> }
+    }
+    const originalCache = memoizedInit.cache
+    let observedDuringInit: SessionId | undefined
+    const probeCache = {
+      has: () => true,
+      get: () => {
+        observedDuringInit = getSessionId()
+        return Promise.resolve()
+      },
+      set() {
+        return this
+      },
+      delete() {
+        return true
+      },
+      clear() {},
+    }
+    memoizedInit.cache = probeCache as typeof originalCache
 
-    expect(queryAsyncSource).toContain('await runOutsideSdkContext(init)')
+    let created: ReturnType<typeof query> | undefined
+    try {
+      await runWithSdkContext(
+        {
+          sessionId: sdkSession,
+          sessionProjectDir: null,
+          cwd: process.cwd(),
+          originalCwd: process.cwd(),
+        },
+        async () => {
+          created = await queryAsync({
+            prompt: 'init-scope',
+            options: { cwd: process.cwd() },
+          })
+        },
+      )
+
+      expect(observedDuringInit).toBe(globalId)
+      expect(observedDuringInit).not.toBe(sdkSession)
+      expect(getSessionId()).toBe(globalId)
+    } finally {
+      created?.close()
+      memoizedInit.cache = originalCache
+    }
   })
 
   test('lazy query iteration keeps each query session scoped to its engine work', async () => {

--- a/tests/sdk/query-concurrency.test.ts
+++ b/tests/sdk/query-concurrency.test.ts
@@ -8,6 +8,7 @@ import {
 import { randomUUID } from 'crypto'
 import type { SessionId } from '../../src/types/ids.js'
 import { drainQuery, UUID_REGEX } from './helpers/query-test-doubles.js'
+import { MockQueryEngine } from './helpers/mock-engine.js'
 
 // Drain tests trigger init(), which checks auth. Stub it for CI.
 const AUTH_KEY = 'ANTHROPIC_API_KEY'
@@ -111,6 +112,38 @@ describe('SEC-1: env override isolation', () => {
 })
 
 describe('CON-1: CWD and session isolation between concurrent queries', () => {
+  test('lazy query iteration keeps each query session scoped to its engine work', async () => {
+    const globalId = getSessionId()
+    let arrivals = 0
+    let release!: () => void
+    const bothStarted = new Promise<void>(resolve => { release = resolve })
+
+    class ContextCapturingEngine extends MockQueryEngine {
+      observedSessionId: SessionId | undefined
+
+      override async *submitMessage(): AsyncGenerator<never, void, unknown> {
+        arrivals += 1
+        if (arrivals === 2) release()
+        await bothStarted
+        this.observedSessionId = getSessionId()
+      }
+    }
+
+    const q1 = query({ prompt: 'context-a', options: { cwd: process.cwd() } })
+    const q2 = query({ prompt: 'context-b', options: { cwd: process.cwd() } })
+    const engine1 = new ContextCapturingEngine()
+    const engine2 = new ContextCapturingEngine()
+    ;(q1 as unknown as { setEngine(engine: MockQueryEngine): void }).setEngine(engine1)
+    ;(q2 as unknown as { setEngine(engine: MockQueryEngine): void }).setEngine(engine2)
+
+    await Promise.all([drainQuery(q1), drainQuery(q2)])
+
+    expect(engine1.observedSessionId).toBe(q1.sessionId)
+    expect(engine2.observedSessionId).toBe(q2.sessionId)
+    expect(engine1.observedSessionId).not.toBe(engine2.observedSessionId)
+    expect(getSessionId()).toBe(globalId)
+  })
+
   test('AsyncLocalStorage context returns query-specific sessionId, not global', () => {
     // Simulate what the SDK query does: set up a context and verify reads
     const globalId = getSessionId()

--- a/tests/sdk/query-concurrency.test.ts
+++ b/tests/sdk/query-concurrency.test.ts
@@ -112,6 +112,15 @@ describe('SEC-1: env override isolation', () => {
 })
 
 describe('CON-1: CWD and session isolation between concurrent queries', () => {
+  test('queryAsync keeps eager process-global initialization detached', async () => {
+    const source = await Bun.file(
+      new URL('../../src/entrypoints/sdk/query.ts', import.meta.url),
+    ).text()
+    const queryAsyncSource = source.slice(source.indexOf('export async function queryAsync'))
+
+    expect(queryAsyncSource).toContain('await runOutsideSdkContext(init)')
+  })
+
   test('lazy query iteration keeps each query session scoped to its engine work', async () => {
     const globalId = getSessionId()
     let arrivals = 0

--- a/tests/sdk/sdk-context-isolation.test.ts
+++ b/tests/sdk/sdk-context-isolation.test.ts
@@ -120,6 +120,26 @@ describe('SDK context isolation', () => {
       expect(throwCleanupSession).toBe(throwSession)
     })
 
+    test('falls back to return when async disposal is unavailable', async () => {
+      const sdkSession = '00000000-0000-4000-8000-00000000000f' as SessionId
+      let cleanupSession: SessionId | undefined
+      const generator = {
+        next: async () => ({ value: 'ready', done: false as const }),
+        return: async () => {
+          cleanupSession = getSessionId()
+          return { value: undefined, done: true as const }
+        },
+        throw: async (error?: unknown) => { throw error },
+        [Symbol.asyncIterator]() { return this },
+      } as AsyncGenerator<string, void, unknown>
+      const bound = bindSessionGenerator(sdkSession, generator)
+
+      await bound[Symbol.asyncDispose]()
+
+      expect(cleanupSession).toBe(sdkSession)
+      expect(getSessionId()).toBe(originalSessionId)
+    })
+
     test('keeps process-global async setup outside the SDK context', async () => {
       const sdkSession = '00000000-0000-4000-8000-00000000000e' as SessionId
       const observedSession = await runWithSdkContext(

--- a/tests/sdk/sdk-context-isolation.test.ts
+++ b/tests/sdk/sdk-context-isolation.test.ts
@@ -1,6 +1,8 @@
 import { describe, test, expect, beforeEach, afterEach } from 'bun:test'
 import {
+  bindSdkContextToAsyncGenerator,
   runWithSdkContext,
+  runOutsideSdkContext,
   getSessionId,
   regenerateSessionId,
   switchSession,
@@ -41,6 +43,103 @@ describe('SDK context isolation', () => {
     } finally {
       releaseSharedMutationLock()
     }
+  })
+
+  describe('lazy async generators', () => {
+    function bindSessionGenerator<T>(
+      sessionId: SessionId,
+      generator: AsyncGenerator<T>,
+    ): AsyncGenerator<T> {
+      return bindSdkContextToAsyncGenerator(
+        {
+          sessionId,
+          sessionProjectDir: null,
+          cwd: process.cwd(),
+          originalCwd: process.cwd(),
+        },
+        generator,
+      )
+    }
+
+    test('isolates concurrent lazy iterations', async () => {
+      const sessionA = '00000000-0000-4000-8000-00000000000a' as SessionId
+      const sessionB = '00000000-0000-4000-8000-00000000000b' as SessionId
+
+      const makeGenerator = (sessionId: SessionId) =>
+        bindSessionGenerator(
+          sessionId,
+          (async function* () {
+            await Promise.resolve()
+            yield getSessionId()
+          })(),
+        )
+
+      const [resultA, resultB] = await Promise.all([
+        makeGenerator(sessionA).next(),
+        makeGenerator(sessionB).next(),
+      ])
+
+      expect(resultA).toEqual({ value: sessionA, done: false })
+      expect(resultB).toEqual({ value: sessionB, done: false })
+      expect(getSessionId()).toBe(originalSessionId)
+    })
+
+    test('scopes return and throw cleanup', async () => {
+      const returnSession = '00000000-0000-4000-8000-00000000000c' as SessionId
+      const throwSession = '00000000-0000-4000-8000-00000000000d' as SessionId
+      let returnCleanupSession: SessionId | undefined
+      let throwCleanupSession: SessionId | undefined
+
+      const returnGenerator = bindSessionGenerator(
+        returnSession,
+        (async function* () {
+          try {
+            yield 'ready'
+          } finally {
+            returnCleanupSession = getSessionId()
+          }
+        })(),
+      )
+      const throwGenerator = bindSessionGenerator(
+        throwSession,
+        (async function* () {
+          try {
+            yield 'ready'
+          } catch {
+            throwCleanupSession = getSessionId()
+          }
+        })(),
+      )
+
+      await returnGenerator.next()
+      await returnGenerator.return(undefined)
+      await throwGenerator.next()
+      await throwGenerator.throw(new Error('stop'))
+
+      expect(returnCleanupSession).toBe(returnSession)
+      expect(throwCleanupSession).toBe(throwSession)
+    })
+
+    test('keeps process-global async setup outside the SDK context', async () => {
+      const sdkSession = '00000000-0000-4000-8000-00000000000e' as SessionId
+      const observedSession = await runWithSdkContext(
+        {
+          sessionId: sdkSession,
+          sessionProjectDir: null,
+          cwd: process.cwd(),
+          originalCwd: process.cwd(),
+        },
+        () =>
+          runOutsideSdkContext(
+            () => new Promise<SessionId>(resolve => {
+              setTimeout(() => resolve(getSessionId()), 0)
+            }),
+          ),
+      )
+
+      expect(observedSession).toBe(originalSessionId)
+      expect(observedSession).not.toBe(sdkSession)
+    })
   })
 
   describe('setCwdState', () => {

--- a/tests/sdk/sdk-v2-lifecycle.test.ts
+++ b/tests/sdk/sdk-v2-lifecycle.test.ts
@@ -111,6 +111,46 @@ beforeEach(() => {
 })
 
 describe('V2: session creation', () => {
+  test('lazy sendMessage iteration keeps each session scoped to its engine work', async () => {
+    const globalId = getSessionId()
+    let arrivals = 0
+    let release!: () => void
+    const bothStarted = new Promise<void>(resolve => { release = resolve })
+
+    class ContextCapturingEngine extends MockQueryEngine {
+      observedSessionId: SessionId | undefined
+
+      override async *submitMessage(): AsyncGenerator<never, void, unknown> {
+        arrivals += 1
+        if (arrivals === 2) release()
+        await bothStarted
+        this.observedSessionId = getSessionId()
+      }
+    }
+
+    const session1 = unstable_v2_createSession({ cwd: process.cwd() })
+    const session2 = unstable_v2_createSession({ cwd: process.cwd() })
+    const engine1 = new ContextCapturingEngine()
+    const engine2 = new ContextCapturingEngine()
+    attachMockEngine(session1, engine1)
+    attachMockEngine(session2, engine2)
+
+    const drain = async (messages: AsyncIterable<unknown>) => {
+      for await (const _message of messages) {
+        // The capturing engines intentionally yield no messages.
+      }
+    }
+    await Promise.all([
+      drain(session1.sendMessage('context-a')),
+      drain(session2.sendMessage('context-b')),
+    ])
+
+    expect(engine1.observedSessionId).toBe(session1.sessionId)
+    expect(engine2.observedSessionId).toBe(session2.sessionId)
+    expect(engine1.observedSessionId).not.toBe(engine2.observedSessionId)
+    expect(getSessionId()).toBe(globalId)
+  })
+
   test('createSession() returns SDKSession with valid sessionId', () => {
     const session = unstable_v2_createSession({
       cwd: process.cwd(),

--- a/tests/sdk/sdk-v2-lifecycle.test.ts
+++ b/tests/sdk/sdk-v2-lifecycle.test.ts
@@ -130,25 +130,30 @@ describe('V2: session creation', () => {
 
     const session1 = unstable_v2_createSession({ cwd: process.cwd() })
     const session2 = unstable_v2_createSession({ cwd: process.cwd() })
-    const engine1 = new ContextCapturingEngine()
-    const engine2 = new ContextCapturingEngine()
-    attachMockEngine(session1, engine1)
-    attachMockEngine(session2, engine2)
+    try {
+      const engine1 = new ContextCapturingEngine()
+      const engine2 = new ContextCapturingEngine()
+      attachMockEngine(session1, engine1)
+      attachMockEngine(session2, engine2)
 
-    const drain = async (messages: AsyncIterable<unknown>) => {
-      for await (const _message of messages) {
-        // The capturing engines intentionally yield no messages.
+      const drain = async (messages: AsyncIterable<unknown>) => {
+        for await (const _message of messages) {
+          // The capturing engines intentionally yield no messages.
+        }
       }
-    }
-    await Promise.all([
-      drain(session1.sendMessage('context-a')),
-      drain(session2.sendMessage('context-b')),
-    ])
+      await Promise.all([
+        drain(session1.sendMessage('context-a')),
+        drain(session2.sendMessage('context-b')),
+      ])
 
-    expect(engine1.observedSessionId).toBe(session1.sessionId)
-    expect(engine2.observedSessionId).toBe(session2.sessionId)
-    expect(engine1.observedSessionId).not.toBe(engine2.observedSessionId)
-    expect(getSessionId()).toBe(globalId)
+      expect(engine1.observedSessionId).toBe(session1.sessionId)
+      expect(engine2.observedSessionId).toBe(session2.sessionId)
+      expect(engine1.observedSessionId).not.toBe(engine2.observedSessionId)
+      expect(getSessionId()).toBe(globalId)
+    } finally {
+      session1.close()
+      session2.close()
+    }
   })
 
   test('createSession() returns SDKSession with valid sessionId', () => {


### PR DESCRIPTION
## Summary

- keep every lazy SDK async-generator continuation inside its owning session context for `query()` and V2 `sendMessage()`
- keep process-global initialization outside SDK session context, including eager `queryAsync()` initialization
- preserve cleanup through `return`, `throw`, and async disposal, with a fallback for Node 22 generators that do not implement native `Symbol.asyncDispose`

PR #951 introduced per-query `AsyncLocalStorage` state so parallel SDK sessions would not contaminate each other. Creating an async generator inside `AsyncLocalStorage.run()` does not satisfy that contract because the generator body runs later when the consumer calls `next()`. This change binds the iterator continuations themselves and explicitly detaches process-global initialization.

## Impact

- user-facing impact: concurrent and nested SDK sessions retain their own session/cwd state during iteration and cleanup
- developer/maintainer impact: the correction is limited to the two SDK generator routes, their internal context utility, and focused regression coverage; it is intentionally separate from OpenCode Go PR #2203

## Testing

- [x] I ran the required [local preflight](https://github.com/Gitlawb/openclaude/blob/main/CONTRIBUTING.md#validation).
- exact commands and results: `bun install --frozen-lockfile`; `bun run check`; `bun run typecheck`; `bun run typecheck:type-tests`; both launcher version commands; `bun run test:provider`; `bun run test:provider-recommendation`; `bun run integrations:check`; fresh upstream fetch; `bun run security:pr-scan -- --base <upstream-main> --head <candidate-tree>`; and `git diff --check`
- focused tests: complete `tests/sdk` suite 294 passed, 0 failed; remediated context/query/V2 lifecycle selection 84 passed, 0 failed; provider suite 1,595 passed, 36 skipped, 0 failed; provider recommendation/profile suite 152 passed, 0 failed
- documented skipped checks, platform limitations, or verified pre-existing failures: `bun run check` exited 0 and completed its build/smoke/dead-code/full-test/conversation-arc chain, while its child output retained pre-existing non-TTY ProviderManager timeouts and sandbox-sensitive memory-extraction failures unrelated to this six-file SDK diff

## Notes

- provider/model path tested: not provider-specific; both public SDK query generations and concurrent session routes are covered
- screenshots attached (if UI changed): not applicable
- follow-up work or known limitations: none known; final reviewed SHA is `9752c703bf2db9b11252ebbd6f3b254ab2b85742`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for concurrent SDK queries and message streaming.
  - Preserved the correct session and engine context during asynchronous operations, including cleanup, cancellation, and disposal.
  - Prevented initialization from being affected by unrelated active SDK contexts.
  - Ensured concurrent operations restore the previous global session state after completion.
  - Improved isolation between concurrent asynchronous SDK operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
