### PR TITLE
feat(plugins): add memlawb as an opt-in built-in plugin

### DIFF
--- a/src/plugins/bundled/index.ts
+++ b/src/plugins/bundled/index.ts
@@ -15,10 +15,12 @@
  */
 
 import { registerKarpathyGuidelinesPlugin } from './karpathyGuidelines.js'
+import { registerMemlawbPlugin } from './memlawb.js'
 
 /**
  * Initialize built-in plugins. Called during CLI startup.
  */
 export function initBuiltinPlugins(): void {
   registerKarpathyGuidelinesPlugin()
+  registerMemlawbPlugin()
 }

--- a/src/plugins/bundled/memlawb.test.ts
+++ b/src/plugins/bundled/memlawb.test.ts
@@ -69,6 +69,18 @@ function resolvedEnv(
   return (resolved as { env?: Record<string, string> }).env ?? {}
 }
 
+// The plugin references a memlawb input that older builds do not read, so the
+// description has to name the version. Without it, the failure a user meets is
+// "no passphrase set", which points at their configuration rather than at their
+// binary being too old.
+test('the description names the memlawb version the passphrase file needs', () => {
+  const plugin = getBuiltinPluginDefinition('memlawb')
+  expect(plugin?.description).toContain('0.1.0')
+  // Control: it still names the variable that needs that version, so this is a
+  // version stated for a reason rather than a number sitting in a sentence.
+  expect(plugin?.description).toContain('MEMLAWB_PASSPHRASE_FILE')
+})
+
 test('memlawb registers disabled, with one stdio server and no prompting', () => {
   const plugin = getBuiltinPluginDefinition('memlawb')
 

--- a/src/plugins/bundled/memlawb.test.ts
+++ b/src/plugins/bundled/memlawb.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test'
+
+import type { McpServerConfig } from '../../services/mcp/types.js'
+import type { PluginError } from '../../types/plugin.js'
+import { resolvePluginMcpEnvironment } from '../../utils/plugins/mcpPluginIntegration.js'
+import {
+  clearBuiltinPlugins,
+  getBuiltinPluginDefinition,
+} from '../builtinPlugins.js'
+import { initBuiltinPlugins } from './index.js'
+import { registerMemlawbPlugin } from './memlawb.js'
+
+const MEMLAWB_VARS = [
+  'MEMLAWB_URL',
+  'MEMLAWB_API_KEY',
+  'MEMLAWB_NAMESPACE',
+  'MEMLAWB_PASSPHRASE_FILE',
+] as const
+
+/** The secret itself. It lives in a file; nothing here should carry its value. */
+const PASSPHRASE = 'correct-horse-battery-staple-9f3a'
+const PASSPHRASE_PATH = '/home/alice/.config/memlawb/passphrase'
+const API_KEY = 'mk_live_servicekey_7c21'
+
+const PLUGIN_REF = { path: 'builtin', source: 'memlawb@builtin' }
+
+const TOUCHED = [...MEMLAWB_VARS, 'MEMLAWB_PASSPHRASE'] as const
+const saved: Record<string, string | undefined> = {}
+
+beforeEach(() => {
+  registerMemlawbPlugin()
+  for (const name of TOUCHED) saved[name] = process.env[name]
+  process.env.MEMLAWB_URL = 'https://memlawb.example/api'
+  process.env.MEMLAWB_API_KEY = API_KEY
+  process.env.MEMLAWB_NAMESPACE = 'user:alice/repo'
+  process.env.MEMLAWB_PASSPHRASE_FILE = PASSPHRASE_PATH
+  // A stale export of the raw passphrase, which is exactly the thing the path
+  // form exists to stop mattering. The plugin must not pick it up.
+  process.env.MEMLAWB_PASSPHRASE = PASSPHRASE
+})
+
+afterEach(() => {
+  clearBuiltinPlugins()
+  for (const name of TOUCHED) {
+    if (saved[name] === undefined) delete process.env[name]
+    else process.env[name] = saved[name]
+  }
+})
+
+function memlawbServer(): McpServerConfig {
+  const servers = getBuiltinPluginDefinition('memlawb')?.mcpServers
+  const entries = Object.entries(servers ?? {})
+  expect(entries.map(([name]) => name)).toEqual(['memlawb'])
+  return entries[0]![1]!
+}
+
+function resolvedEnv(
+  config: McpServerConfig,
+  errors?: PluginError[],
+): Record<string, string> {
+  const resolved = resolvePluginMcpEnvironment(
+    config,
+    PLUGIN_REF,
+    undefined,
+    errors,
+    'memlawb',
+    'memlawb',
+  )
+  return (resolved as { env?: Record<string, string> }).env ?? {}
+}
+
+test('memlawb registers disabled, with one stdio server and no prompting', () => {
+  const plugin = getBuiltinPluginDefinition('memlawb')
+
+  expect(plugin).toBeDefined()
+  expect(plugin?.defaultEnabled).toBe(false)
+  // R7: no skill, no hook, no agent — openclaude's memdir pipeline and team
+  // memory must be untouched by enabling this.
+  expect(plugin?.skills).toBeUndefined()
+  expect(plugin?.hooks).toBeUndefined()
+
+  const server = memlawbServer() as { command: string; args?: string[] }
+  expect(server.command).toBe('memlawb')
+  expect(server.args).toEqual(['mcp'])
+})
+
+test('every memlawb env value is a ${VAR} reference and none is a literal', () => {
+  const server = memlawbServer() as { env?: Record<string, string> }
+  const env = server.env ?? {}
+
+  expect(Object.keys(env).sort()).toEqual([...MEMLAWB_VARS].sort())
+  for (const [key, value] of Object.entries(env)) {
+    expect(value).toMatch(/^\$\{[A-Z_][A-Z0-9_]*\}$/)
+    // A reference to some unrelated variable would satisfy the shape above.
+    expect(value).toBe(`\${${key}}`)
+  }
+})
+
+test('the passphrase rides as a path and the raw-value variable is not declared', () => {
+  const env = (memlawbServer() as { env?: Record<string, string> }).env ?? {}
+
+  // Path alone, never both. memlawb's startup lets the file win but still
+  // refuses an unexpanded MEMLAWB_PASSPHRASE, so declaring both would make the
+  // safe configuration — file set, raw variable unset — fail to start.
+  expect(env.MEMLAWB_PASSPHRASE_FILE).toBe('${MEMLAWB_PASSPHRASE_FILE}')
+  expect(env.MEMLAWB_PASSPHRASE).toBeUndefined()
+})
+
+test('the passphrase value reaches no configured server, and the service key does reach memlawb', () => {
+  // Recorded limitation: this reads resolved plugin config. It cannot see the
+  // spawn-time `{ ...subprocessEnv(), ...serverRef.env }` spread in
+  // src/services/mcp/client.ts:1056, which hands every stdio child the whole
+  // parent environment. What it does prove is that the secret is not something
+  // this plugin puts there.
+  const memlawbEnv = resolvedEnv(memlawbServer())
+  expect(Object.values(memlawbEnv)).not.toContain(PASSPHRASE)
+  expect(memlawbEnv.MEMLAWB_PASSPHRASE_FILE).toBe(PASSPHRASE_PATH)
+
+  // Neighbour: a second MCP server the user has configured. It never declares
+  // the passphrase, so expansion must not put the value in its environment.
+  const neighbour: McpServerConfig = {
+    type: 'stdio',
+    command: 'other-server',
+    args: [],
+    env: { OTHER_TOKEN: '${MEMLAWB_API_KEY}', OTHER_MODE: 'plain' },
+  }
+  expect(Object.values(resolvedEnv(neighbour))).not.toContain(PASSPHRASE)
+
+  // Positive control 1 (the plan's): the service key does ride expansion, so
+  // the same reading of a resolved environment finds a secret where one belongs.
+  expect(memlawbEnv.MEMLAWB_API_KEY).toBe(API_KEY)
+
+  // Positive control 2: the absence checks above are capable of finding the
+  // passphrase. A server that does declare the reference gets the value, so
+  // neither `not.toContain` is vacuously true.
+  const leaky: McpServerConfig = {
+    ...neighbour,
+    env: { OTHER_TOKEN: '${MEMLAWB_PASSPHRASE}' },
+  }
+  expect(Object.values(resolvedEnv(leaky))).toContain(PASSPHRASE)
+})
+
+test('resolving with the four variables set yields their values', () => {
+  const errors: PluginError[] = []
+  const env = resolvedEnv(memlawbServer(), errors)
+
+  expect(env.MEMLAWB_URL).toBe('https://memlawb.example/api')
+  expect(env.MEMLAWB_API_KEY).toBe(API_KEY)
+  expect(env.MEMLAWB_NAMESPACE).toBe('user:alice/repo')
+  expect(env.MEMLAWB_PASSPHRASE_FILE).toBe(PASSPHRASE_PATH)
+  expect(errors).toEqual([])
+})
+
+test('an unset variable is named in the missing-variable error', () => {
+  delete process.env.MEMLAWB_PASSPHRASE_FILE
+
+  const errors: PluginError[] = []
+  const env = resolvedEnv(memlawbServer(), errors)
+
+  expect(errors).toHaveLength(1)
+  const error = errors[0]!
+  if (error.type !== 'mcp-config-invalid') {
+    throw new Error(`unexpected plugin error type: ${error.type}`)
+  }
+  expect(error.serverName).toBe('memlawb')
+  expect(error.validationError).toBe(
+    'Missing environment variables: MEMLAWB_PASSPHRASE_FILE',
+  )
+  // openclaude leaves an unresolved reference as its literal text and still
+  // registers the server, so memlawb receives the literal as a path. Its own
+  // startup refuses that rather than falling back to MEMLAWB_PASSPHRASE.
+  expect(env.MEMLAWB_PASSPHRASE_FILE).toBe('${MEMLAWB_PASSPHRASE_FILE}')
+})
+
+test('startup registration wires memlawb in alongside the other built-ins', () => {
+  clearBuiltinPlugins()
+  initBuiltinPlugins()
+
+  expect(getBuiltinPluginDefinition('memlawb')).toBeDefined()
+  // Control: the sweep is capable of missing a plugin, so the assertion above
+  // is not just "initBuiltinPlugins registered something".
+  expect(getBuiltinPluginDefinition('karpathy-guidelines')).toBeDefined()
+  expect(getBuiltinPluginDefinition('not-a-plugin')).toBeUndefined()
+})

--- a/src/plugins/bundled/memlawb.ts
+++ b/src/plugins/bundled/memlawb.ts
@@ -41,6 +41,10 @@
  * Setup is two steps: write the passphrase into a file only you can read
  * (`umask 077`), then export MEMLAWB_PASSPHRASE_FILE pointing at it, alongside
  * MEMLAWB_URL, MEMLAWB_API_KEY and MEMLAWB_NAMESPACE.
+ *
+ * MEMLAWB_PASSPHRASE_FILE needs memlawb 0.1.0 or newer; earlier builds read
+ * only MEMLAWB_PASSPHRASE and would refuse to start with no passphrase at all,
+ * which reads as a configuration mistake rather than an out-of-date binary.
  */
 
 import { registerBuiltinPlugin } from '../builtinPlugins.js'
@@ -49,7 +53,7 @@ export function registerMemlawbPlugin(): void {
   registerBuiltinPlugin({
     name: 'memlawb',
     description:
-      'End-to-end-encrypted agent memory via the memlawb MCP server. Requires the memlawb CLI and MEMLAWB_URL, MEMLAWB_API_KEY, MEMLAWB_NAMESPACE and MEMLAWB_PASSPHRASE_FILE (a path to a file holding the passphrase) in the environment.',
+      'End-to-end-encrypted agent memory via the memlawb MCP server. Needs memlawb 0.1.0 or newer on PATH, and MEMLAWB_URL, MEMLAWB_API_KEY, MEMLAWB_NAMESPACE and MEMLAWB_PASSPHRASE_FILE (a path to a file holding the passphrase) in the environment.',
     version: '1.0.0',
     defaultEnabled: false,
     mcpServers: {

--- a/src/plugins/bundled/memlawb.ts
+++ b/src/plugins/bundled/memlawb.ts
@@ -1,0 +1,69 @@
+/**
+ * memlawb — durable, end-to-end-encrypted agent memory as an opt-in MCP server.
+ *
+ * memlawb is a zero-knowledge memory backend. The `memlawb mcp` process runs
+ * locally, holds the passphrase, and encrypts before anything leaves the
+ * machine, so the remote server stores ciphertext it could not decrypt.
+ *
+ * Two shapes of this plugin are deliberate rather than incidental:
+ *
+ * 1. It contributes an MCP server and NOTHING else — no skill, no hook, no
+ *    agent. openclaude's own memdir pipeline and team memory keep working
+ *    untouched, so enabling this adds a tool surface and no prompting.
+ *
+ * 2. Every environment value is a `${VAR}` reference, never a literal, and the
+ *    passphrase rides as a PATH to a file rather than as the secret itself.
+ *
+ * Why the path, specifically. Plugin MCP env goes through
+ * resolvePluginMcpEnvironment, which expands from openclaude's own process
+ * environment, and the stdio transport then spawns each child with
+ * `{ ...subprocessEnv(), ...serverRef.env }` (src/services/mcp/client.ts:1056)
+ * — and `subprocessEnv()` returns `process.env` itself
+ * (src/utils/subprocessEnv.ts:79-98). So whatever a user exports for this
+ * server is handed to every other stdio MCP server they run. A path survives
+ * that: knowing where a secret lives is not knowing the secret, and a file can
+ * carry permissions an environment variable cannot. The value would not.
+ *
+ * What this buys, stated honestly: the SECRET no longer rides the shared
+ * environment. The path still does, along with the rest of `process.env`, and
+ * any MCP server running as the same user could read that file. This narrows
+ * the exposure from "every configured MCP server already has your passphrase"
+ * to "every configured MCP server knows where it is"; it is not isolation.
+ *
+ * Path alone, never both. memlawb's startup lets MEMLAWB_PASSPHRASE_FILE win
+ * over MEMLAWB_PASSPHRASE when both are set, but its misexpansion check still
+ * refuses to start on an unexpanded MEMLAWB_PASSPHRASE (memlawb
+ * src/mcp/startup.ts:129,196-205). Declaring both here would therefore break
+ * the very configuration this is for — file set, raw variable unset — because
+ * openclaude leaves an unset reference as literal `${MEMLAWB_PASSPHRASE}`
+ * text. Verified against memlawb's preflight before choosing.
+ *
+ * Setup is two steps: write the passphrase into a file only you can read
+ * (`umask 077`), then export MEMLAWB_PASSPHRASE_FILE pointing at it, alongside
+ * MEMLAWB_URL, MEMLAWB_API_KEY and MEMLAWB_NAMESPACE.
+ */
+
+import { registerBuiltinPlugin } from '../builtinPlugins.js'
+
+export function registerMemlawbPlugin(): void {
+  registerBuiltinPlugin({
+    name: 'memlawb',
+    description:
+      'End-to-end-encrypted agent memory via the memlawb MCP server. Requires the memlawb CLI and MEMLAWB_URL, MEMLAWB_API_KEY, MEMLAWB_NAMESPACE and MEMLAWB_PASSPHRASE_FILE (a path to a file holding the passphrase) in the environment.',
+    version: '1.0.0',
+    defaultEnabled: false,
+    mcpServers: {
+      memlawb: {
+        type: 'stdio',
+        command: 'memlawb',
+        args: ['mcp'],
+        env: {
+          MEMLAWB_URL: '${MEMLAWB_URL}',
+          MEMLAWB_API_KEY: '${MEMLAWB_API_KEY}',
+          MEMLAWB_NAMESPACE: '${MEMLAWB_NAMESPACE}',
+          MEMLAWB_PASSPHRASE_FILE: '${MEMLAWB_PASSPHRASE_FILE}',
+        },
+      },
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- Adds `memlawb` as an opt-in built-in plugin, disabled by default, contributing one stdio MCP server and nothing else: no skill, no hook, no prompting.
- memlawb is a zero-knowledge memory backend; its MCP server gives an agent durable end-to-end-encrypted memory. The passphrase is the encryption key and never reaches the memlawb server.
- The plugin ships no prompting on purpose. The memdir pipeline and team memory are untouched, and nothing here competes with them for when a fact gets written.

I read `CONTRIBUTING.md` and `AGENTS.md` before opening this.

## Impact

- **User:** `/plugin` gains a memlawb entry. Enabling it needs the memlawb CLI 0.1.0 or newer on `PATH` and four environment variables. Nothing changes for anyone who leaves it off, which is everyone by default.
- **Developer:** one new bundled plugin and its test, plus one line in `initBuiltinPlugins`. No existing behaviour is modified.

## Why the passphrase is a path, not a value

This is the part worth reviewing. Every value in the server's env is a `${VAR}` reference, and the passphrase is referenced as a **file path** via `MEMLAWB_PASSPHRASE_FILE`.

The reason is specific to this codebase rather than general caution. `src/services/mcp/client.ts` builds a stdio child's environment as `{ ...subprocessEnv(), ...server env }`, and `subprocessEnv()` returns the parent's own environment. So a passphrase exported so openclaude can expand it into memlawb's config is equally readable by **every other MCP server the user runs**, not just this one.

A path still rides that same shared environment. The secret no longer does. That narrows the exposure from "every configured MCP server has your passphrase" to "every configured MCP server knows where the file is", which is a real improvement and is not isolation. The plugin's doc comment says exactly that rather than implying more.

Only the path form is declared, and not merely to avoid re-opening what this closes: memlawb checks `MEMLAWB_PASSPHRASE` for unexpanded template text, and this host leaves an unset reference as its own literal, so a correctly configured user (file exported, variable deliberately unset) would be handed template text and refused at startup. Declaring both is a hard break of the intended setup, not a fallback.

`MEMLAWB_PASSPHRASE_FILE` is a memlawb-side input added for this integration, which is why the description names the minimum version. An older binary reads only `MEMLAWB_PASSPHRASE` and fails saying no passphrase is set, which points a user at their own config rather than at a stale install.

## Testing

- [x] I ran the required local preflight.

Exact commands and results:

```
bun install --frozen-lockfile              ok
bun run check                              1 pass, 0 fail
bun run typecheck                          3 errors, all pre-existing (see below)
bun run typecheck:type-tests               passed, 10 files
node bin/openclaude --version              0.30.0 (OpenClaude)
bun run test:provider                      1630 tests, 0 fail
npm run test:provider-recommendation       152 pass, 0 fail
bun run security:pr-scan                   no suspicious additions found
```

Focused tests: `bun test src/plugins/bundled/` (10 pass), and `bun test src/plugins/ src/utils/plugins/ src/services/mcp/` (257 pass, 23 files).

Verified pre-existing failures: `bun run typecheck` reports three errors, in `src/tools/AgentTool/AgentTool.teammateModel.test.ts:457` and `src/utils/permissions/permissions.test.ts:695,713`. I confirmed these by running the same typecheck on a clean `origin/main` worktree, which produces the identical three. They are in files this PR does not touch.

Every guard in the new test was removed once and the named test observed red: default-enabled flipped, a skill added, a hook added, the command and args changed, a second server added, the registration removed, the passphrase written as a literal, declared as both forms, and pointed at the wrong variable.

The absence test ("the passphrase reaches no configured server") carries two positive controls, because without them it passes against a check that finds nothing: the service key **is** present in memlawb's resolved env, and a server that deliberately declares the passphrase **does** receive it. Its limit is recorded in the test body: it reads resolved plugin config and cannot see the spawn-time spread, so what it proves is that this plugin does not put the secret there.

## Notes

- Provider path tested: none touched. This PR adds no provider code.
- No screenshots: nothing renders differently beyond the plugin's entry in the existing `/plugin` list.
- **Known limitation, not automated:** two scenarios need a recorded human session and nothing here stands in for them. First, that with the plugin enabled the memdir daily log is still written and memories still surface, and that disabling leaves no memlawb artifact behind. Second, that a durable cross-machine preference saved in a session lands in memlawb, with a session-log fact as the control that does not. I can prove the wiring; I cannot prove the model's behaviour without running it.
- Draft until the memlawb release that carries `MEMLAWB_PASSPHRASE_FILE` is published, since the plugin is unusable before then.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in Memlawb integration as a built-in plugin.
  * Supports connecting to Memlawb through its MCP server with configurable URL, API key, namespace, and passphrase file settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->