### PR TITLE
docs(web): add llms.txt for LLM discovery (#2205)

### DIFF
--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -19,7 +19,7 @@ OpenClaude originated from the Claude Code codebase and has since been substanti
 - [Non-technical setup](https://github.com/Gitlawb/openclaude/blob/main/docs/non-technical-setup.md)
 - [Android install](https://github.com/Gitlawb/openclaude/blob/main/ANDROID_INSTALL.md)
 - [npm install](https://www.npmjs.com/package/@gitlawb/openclaude): `npm install -g @gitlawb/openclaude@latest` (requires Node >= 22)
-- AUR package: [openclaude](https://aur.archlinux.org/packages/openclaude)
+- [AUR package: openclaude](https://aur.archlinux.org/packages/openclaude)
 
 ## Documentation
 

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -10,7 +10,7 @@ OpenClaude originated from the Claude Code codebase and has since been substanti
 - [npm package](https://www.npmjs.com/package/@gitlawb/openclaude): `@gitlawb/openclaude`
 - [GitLawb mirror](https://gitlawb.com/node/repos/z6MkqDnb/openclaude)
 - [Security policy](https://github.com/Gitlawb/openclaude/security/policy)
-- [License (MIT)](https://github.com/Gitlawb/openclaude/blob/main/LICENSE)
+- [License notice](https://github.com/Gitlawb/openclaude/blob/main/LICENSE): MIT applies only to OpenClaude contributors' modifications; the underlying Claude Code code is Anthropic's proprietary software.
 
 ## Install
 
@@ -18,7 +18,7 @@ OpenClaude originated from the Claude Code codebase and has since been substanti
 - [Quick start (Windows)](https://github.com/Gitlawb/openclaude/blob/main/docs/quick-start-windows.md)
 - [Non-technical setup](https://github.com/Gitlawb/openclaude/blob/main/docs/non-technical-setup.md)
 - [Android install](https://github.com/Gitlawb/openclaude/blob/main/ANDROID_INSTALL.md)
-- One-liner: `npm install -g @gitlawb/openclaude@latest` (requires Node >= 22)
+- [npm install](https://www.npmjs.com/package/@gitlawb/openclaude): `npm install -g @gitlawb/openclaude@latest` (requires Node >= 22)
 - AUR package: [openclaude](https://aur.archlinux.org/packages/openclaude)
 
 ## Documentation

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -1,0 +1,38 @@
+# OpenClaude
+
+> OpenClaude is an open-source coding-agent CLI for cloud and local model providers. It is an independent community project — not affiliated with, endorsed by, or sponsored by Anthropic. The CLI lets you use OpenAI, Gemini, DeepSeek, Ollama, and 200+ other models through one terminal-first workflow: prompts, tools, agents, MCP, slash commands, and streaming output.
+
+OpenClaude originated from the Claude Code codebase and has since been substantially modified to support multiple providers and open use. "Claude" and "Claude Code" are trademarks of Anthropic PBC.
+
+## Project
+
+- [GitHub repository](https://github.com/Gitlawb/openclaude): source code, releases, and issue tracker
+- [npm package](https://www.npmjs.com/package/@gitlawb/openclaude): `@gitlawb/openclaude`
+- [GitLawb mirror](https://gitlawb.com/node/repos/z6MkqDnb/openclaude)
+- [Security policy](https://github.com/Gitlawb/openclaude/security/policy)
+- [License (MIT)](https://github.com/Gitlawb/openclaude/blob/main/LICENSE)
+
+## Install
+
+- [Quick start (Mac/Linux)](https://github.com/Gitlawb/openclaude/blob/main/docs/quick-start-mac-linux.md)
+- [Quick start (Windows)](https://github.com/Gitlawb/openclaude/blob/main/docs/quick-start-windows.md)
+- [Non-technical setup](https://github.com/Gitlawb/openclaude/blob/main/docs/non-technical-setup.md)
+- [Android install](https://github.com/Gitlawb/openclaude/blob/main/ANDROID_INSTALL.md)
+- One-liner: `npm install -g @gitlawb/openclaude@latest` (requires Node >= 22)
+- AUR package: [openclaude](https://aur.archlinux.org/packages/openclaude)
+
+## Documentation
+
+- [README](https://github.com/Gitlawb/openclaude/blob/main/README.md): overview, supported providers, features
+- [Advanced setup](https://github.com/Gitlawb/openclaude/blob/main/docs/advanced-setup.md)
+- [Smart routing](https://github.com/Gitlawb/openclaude/blob/main/docs/smart-routing.md)
+- [Agent routing](https://github.com/Gitlawb/openclaude/blob/main/docs/agent-routing.md)
+- [Headless gRPC server](https://github.com/Gitlawb/openclaude/blob/main/docs/grpc-server.md)
+- [Repository map](https://github.com/Gitlawb/openclaude/blob/main/docs/repo-map.md)
+- [VS Code extension](https://github.com/Gitlawb/openclaude/blob/main/vscode-extension/openclaude-vscode/README.md)
+
+## Community
+
+- [Discord](https://discord.gg/k68zFR6AcB)
+- [GitHub Discussions](https://github.com/Gitlawb/openclaude/discussions)
+- [X / Twitter](https://x.com/gitlawb)


### PR DESCRIPTION
## Summary

- Adds `web/public/llms.txt`, an llmstxt.org-spec summary of OpenClaude served from the website root (will be reachable at `https://openclaude.gitlawb.com/llms.txt` after the next deploy).
- Resolves #2205 — gives downstream LLMs a canonical, citable source so they stop conflating OpenClaude with unrelated tools named "Openclaw".

## Impact

- user-facing: none (marketing/discoverability asset only; no product or UI change).
- developer/maintainer: web deploys will pick up the new static file automatically; no build or config changes required.

## Testing

- [x] I ran the required [local preflight](https://github.com/Gitlawb/openclaude/blob/main/CONTRIBUTING.md#validation).
- exact commands and results:
  - `bun install --cwd web --frozen-lockfile` → 341 packages installed, exit 0
  - `bun run web:typecheck` → 0 errors / 0 warnings / 0 hints
  - `bun run web:build` → built successfully; `web/dist/llms.txt` produced and verified verbatim
- focused tests: not applicable (static text asset)
- documented skipped checks: none — only the `web:*` checks from the preflight apply here, and all three passed.

## Notes

- provider/model path tested: N/A
- screenshots attached (if UI changed): N/A
- follow-up work or known limitations: none

Closes #2205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a public OpenClaude overview covering multi-provider support, project origins, independence, and licensing.
  * Organized links for installation options, project documentation, and community resources.
  * Added access to technical documentation and community channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->