### PR TITLE
feat(attachments): make TODO reminders configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -481,6 +481,10 @@ ANTHROPIC_API_KEY=sk-ant-your-key-here
 # Useful for users who want full transparency over what the model sees
 # OPENCLAUDE_DISABLE_TOOL_REMINDERS=1
 
+# Configure todo/task reminder thresholds (default: 10 turns each)
+# OPENCLAUDE_TODO_REMINDER_TURNS_SINCE_WRITE=15
+# OPENCLAUDE_TODO_REMINDER_TURNS_BETWEEN_REMINDERS=20
+
 # Log structured per-request token usage (including cache metrics) to stderr.
 # Useful for auditing cache hit rate / debugging cost spikes outside the REPL.
 # Any truthy value enables it ("verbose", "1", "true").

--- a/src/utils/attachments.todoReminder.test.ts
+++ b/src/utils/attachments.todoReminder.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { acquireSharedMutationLock, releaseSharedMutationLock } from '../test/sharedMutationLock.js'
+import { getTodoReminderConfig } from './attachments.js'
+
+const ENV_KEYS = [
+  'OPENCLAUDE_TODO_REMINDER_TURNS_SINCE_WRITE',
+  'OPENCLAUDE_TODO_REMINDER_TURNS_BETWEEN_REMINDERS',
+] as const
+
+const SAVED_ENV = Object.fromEntries(
+  ENV_KEYS.map(key => [key, process.env[key]]),
+) as Record<(typeof ENV_KEYS)[number], string | undefined>
+
+function restoreEnv(): void {
+  for (const key of ENV_KEYS) {
+    const value = SAVED_ENV[key]
+    if (value === undefined) {
+      delete process.env[key]
+    } else {
+      process.env[key] = value
+    }
+  }
+}
+
+function clearTestEnv(): void {
+  for (const key of ENV_KEYS) {
+    delete process.env[key]
+  }
+}
+
+beforeEach(async () => {
+  await acquireSharedMutationLock('utils/attachments.todoReminder.test.ts')
+  clearTestEnv()
+})
+
+afterEach(() => {
+  try {
+    restoreEnv()
+  } finally {
+    releaseSharedMutationLock()
+  }
+})
+
+describe('getTodoReminderConfig', () => {
+  test('returns defaults when nothing is configured', () => {
+    const config = getTodoReminderConfig()
+    expect(config.turnsSinceWrite).toBe(10)
+    expect(config.turnsBetweenReminders).toBe(10)
+  })
+
+  test('reads from environment variables', () => {
+    process.env.OPENCLAUDE_TODO_REMINDER_TURNS_SINCE_WRITE = '15'
+    process.env.OPENCLAUDE_TODO_REMINDER_TURNS_BETWEEN_REMINDERS = '20'
+
+    const config = getTodoReminderConfig()
+    expect(config.turnsSinceWrite).toBe(15)
+    expect(config.turnsBetweenReminders).toBe(20)
+  })
+
+  test('handles invalid environment variable values', () => {
+    process.env.OPENCLAUDE_TODO_REMINDER_TURNS_SINCE_WRITE = 'invalid'
+    process.env.OPENCLAUDE_TODO_REMINDER_TURNS_BETWEEN_REMINDERS = '0'
+
+    const config = getTodoReminderConfig()
+    expect(config.turnsSinceWrite).toBe(10)
+    expect(config.turnsBetweenReminders).toBe(10)
+  })
+
+  test('handles negative environment variable values', () => {
+    process.env.OPENCLAUDE_TODO_REMINDER_TURNS_SINCE_WRITE = '-5'
+    process.env.OPENCLAUDE_TODO_REMINDER_TURNS_BETWEEN_REMINDERS = '-10'
+
+    const config = getTodoReminderConfig()
+    expect(config.turnsSinceWrite).toBe(10)
+    expect(config.turnsBetweenReminders).toBe(10)
+  })
+
+  test('handles partial environment variable configuration', () => {
+    process.env.OPENCLAUDE_TODO_REMINDER_TURNS_SINCE_WRITE = '15'
+
+    const config = getTodoReminderConfig()
+    expect(config.turnsSinceWrite).toBe(15)
+    expect(config.turnsBetweenReminders).toBe(10)
+  })
+})

--- a/src/utils/attachments.ts
+++ b/src/utils/attachments.ts
@@ -66,6 +66,7 @@ import {
 import { randomUUID, type UUID } from 'crypto'
 import { getSettings_DEPRECATED } from './settings/settings.js'
 import { getAPIProvider, isFirstPartyAnthropicBaseUrl } from './model/providers.js'
+import { getEnvNumber } from './envUtils.js'
 import { getEffortEnvOverride, modelSupportsXHighEffort } from './effort.js'
 import { getSnippetForTwoFileDiff } from 'src/tools/FileEditTool/utils.js'
 import type {
@@ -266,10 +267,36 @@ import { unassignTeammateTasks } from './tasks.js'
 import { getCompanionIntroAttachment } from '../buddy/prompt.js'
 import { isBuddyEnabled } from '../buddy/feature.js'
 
-export const TODO_REMINDER_CONFIG = {
-  TURNS_SINCE_WRITE: 10,
-  TURNS_BETWEEN_REMINDERS: 10,
-} as const
+export function getTodoReminderConfig(): {
+  turnsSinceWrite: number
+  turnsBetweenReminders: number
+} {
+  // Try to get settings from merged settings (includes all sources)
+  const settings = getSettings_DEPRECATED()
+  const config = settings?.todoReminder
+
+  if (config?.turnsSinceWrite !== undefined && config?.turnsBetweenReminders !== undefined) {
+    return {
+      turnsSinceWrite: config.turnsSinceWrite,
+      turnsBetweenReminders: config.turnsBetweenReminders,
+    }
+  }
+
+  // Fall back to environment variables
+  const envTurnsSinceWrite = getEnvNumber(
+    'OPENCLAUDE_TODO_REMINDER_TURNS_SINCE_WRITE',
+    10,
+  )
+  const envTurnsBetweenReminders = getEnvNumber(
+    'OPENCLAUDE_TODO_REMINDER_TURNS_BETWEEN_REMINDERS',
+    10,
+  )
+
+  return {
+    turnsSinceWrite: envTurnsSinceWrite,
+    turnsBetweenReminders: envTurnsBetweenReminders,
+  }
+}
 
 export const PLAN_MODE_ATTACHMENT_CONFIG = {
   TURNS_BETWEEN_ATTACHMENTS: 5,
@@ -3711,10 +3738,12 @@ async function getTodoReminderAttachments(
   const { turnsSinceLastTodoWrite, turnsSinceLastReminder } =
     getTodoReminderTurnCounts(messages)
 
+  const reminderConfig = getTodoReminderConfig()
+
   // Check if we should show a reminder
   if (
-    turnsSinceLastTodoWrite >= TODO_REMINDER_CONFIG.TURNS_SINCE_WRITE &&
-    turnsSinceLastReminder >= TODO_REMINDER_CONFIG.TURNS_BETWEEN_REMINDERS
+    turnsSinceLastTodoWrite >= reminderConfig.turnsSinceWrite &&
+    turnsSinceLastReminder >= reminderConfig.turnsBetweenReminders
   ) {
     const todoKey = toolUseContext.agentId ?? getSessionId()
     const appState = toolUseContext.getAppState()
@@ -3828,10 +3857,12 @@ async function getTaskReminderAttachments(
   const { turnsSinceLastTaskManagement, turnsSinceLastReminder } =
     getTaskReminderTurnCounts(messages)
 
+  const reminderConfig = getTodoReminderConfig()
+
   // Check if we should show a reminder
   if (
-    turnsSinceLastTaskManagement >= TODO_REMINDER_CONFIG.TURNS_SINCE_WRITE &&
-    turnsSinceLastReminder >= TODO_REMINDER_CONFIG.TURNS_BETWEEN_REMINDERS
+    turnsSinceLastTaskManagement >= reminderConfig.turnsSinceWrite &&
+    turnsSinceLastReminder >= reminderConfig.turnsBetweenReminders
   ) {
     const tasks = await listTasks(getTaskListId())
     return [

--- a/src/utils/envUtils.ts
+++ b/src/utils/envUtils.ts
@@ -208,6 +208,29 @@ export function isRunningOnHomespace(): boolean {
  *
  * Used for telemetry to measure auto-mode usage in sensitive environments.
  */
+export function getEnvNumber(key: string, defaultValue: number): number {
+  const value = process.env[key]
+  if (value === undefined) {
+    return defaultValue
+  }
+  const parsed = Number.parseInt(value, 10)
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    return defaultValue
+  }
+  return parsed
+}
+
+/**
+ * Conservative check for whether Claude Code is running inside a protected
+ * (privileged or ASL3+) COO namespace or cluster.
+ *
+ * Conservative means: when signals are ambiguous, assume protected. We would
+ * rather over-report protected usage than miss it. Unprotected environments
+ * are homespace, namespaces on the open allowlist, and no k8s/COO signals
+ * at all (laptop/local dev).
+ *
+ * Used for telemetry to measure auto-mode usage in sensitive environments.
+ */
 export function isInProtectedNamespace(): boolean {
   // USER_TYPE is build-time --define'd; in external builds this block is
   // DCE'd so the require() and namespace allowlist never appear in the bundle.

--- a/src/utils/settings/types.ts
+++ b/src/utils/settings/types.ts
@@ -574,6 +574,29 @@ export const SettingsSchema = lazySchema(() =>
           'Auto-fix configuration: automatically run lint/test after AI file edits ' +
           'and feed errors back for self-repair.',
         ),
+      todoReminder: z
+        .object({
+          turnsSinceWrite: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              'Assistant turns since last TodoWrite/TaskUpdate before showing reminder (default: 10)',
+            ),
+          turnsBetweenReminders: z
+            .number()
+            .int()
+            .positive()
+            .optional()
+            .describe(
+              'Assistant turns between reminders (default: 10)',
+            ),
+        })
+        .optional()
+        .describe(
+          'Configuration for todo/task tool usage reminders',
+        ),
       worktree: z
         .preprocess((val: any) => {
           if (val && typeof val === 'object') {


### PR DESCRIPTION
## Summary

- Add settings-based configuration for TODO/task reminder thresholds.
- Add environment variable fallbacks:
  - `OPENCLAUDE_TODO_REMINDER_TURNS_SINCE_WRITE`
  - `OPENCLAUDE_TODO_REMINDER_TURNS_BETWEEN_REMINDERS`
- Preserve the default behavior of 10 turns.
- Document the new options in `.env.example`.
- Add focused coverage in `attachments.todoReminder.test.ts`.

## Impact

Users can tune how frequently TODO and task reminders appear without changing source code. Invalid, zero, negative, or unset values fall back to the default threshold.

## Testing

- `bun test src/utils/attachments.todoReminder.test.ts` ✅ 5 tests passed
- `git diff --check main...HEAD` ✅
- `bun run typecheck` currently fails on the existing missing `@sentry/node` dependency in `sentry.ts`, unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration options for controlling when todo and task reminders appear.
  * Reminder thresholds can be set through application settings or environment variables.
  * Invalid, zero, negative, or missing values automatically use safe defaults.

* **Documentation**
  * Added commented examples describing the available reminder threshold environment variables and their default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->