### PR TITLE
feat(launcher): support --max-old-space-size-percentage

### DIFF
--- a/bin/heap-limit.mjs
+++ b/bin/heap-limit.mjs
@@ -1,0 +1,194 @@
+import os from 'node:os'
+
+export const HEAP_SIZE_ENV = 'OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB'
+export const HEAP_PERCENTAGE_ENV = 'OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE'
+export const DEFAULT_HEAP_SIZE_MB = 8192
+export const HEAP_SIZE_FLAG = '--max-old-space-size'
+export const HEAP_PERCENTAGE_FLAG = '--max-old-space-size-percentage'
+export const MAX_MEMORY_FLAG = '--max-memory'
+
+/** @typedef {{ constrainedMemory?: () => unknown, totalmem?: () => unknown }} MemorySources */
+
+/**
+ * @param {string[]} args
+ * @param {string} flag
+ */
+export function hasNodeFlag(args, flag) {
+  return args.some(arg => arg === flag || arg.startsWith(`${flag}=`))
+}
+
+/**
+ * @param {string | undefined} nodeOptions
+ */
+export function nodeOptionArgs(nodeOptions) {
+  return (nodeOptions || '').split(/\s+/).filter(Boolean)
+}
+
+/**
+ * @param {string[]} args
+ */
+export function hasHeapLimitFlag(args) {
+  return hasNodeFlag(args, HEAP_SIZE_FLAG) || hasNodeFlag(args, HEAP_PERCENTAGE_FLAG)
+}
+
+/**
+ * @param {unknown} raw
+ * @returns {number | null}
+ */
+export function parsePositiveIntegerMb(raw) {
+  if (raw == null || raw === '') return null
+  const parsed = Number.parseInt(String(raw), 10)
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+/**
+ * Node accepts a number greater than 0 and up to 100.
+ * @param {unknown} raw
+ * @returns {number | null}
+ */
+export function parsePercentage(raw) {
+  if (raw == null) return null
+  const trimmed = String(raw).trim()
+  if (!trimmed) return null
+  const withoutPercent = trimmed.endsWith('%') ? trimmed.slice(0, -1) : trimmed
+  if (withoutPercent.trim() === '') return null
+  const parsed = Number(withoutPercent)
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 100) return null
+  return parsed
+}
+
+/**
+ * Prefer cgroup/OS memory constraints so container limits win over host RAM.
+ * @param {MemorySources} [sources]
+ */
+export function getAvailableMemoryBytes(sources = {}) {
+  const constrainedMemory =
+    sources.constrainedMemory ??
+    (() => {
+      try {
+        return typeof process.constrainedMemory === 'function'
+          ? process.constrainedMemory()
+          : undefined
+      } catch {
+        return undefined
+      }
+    })
+  const totalmem = sources.totalmem ?? (() => os.totalmem())
+
+  const constrained = constrainedMemory()
+  if (typeof constrained === 'number' && Number.isFinite(constrained) && constrained > 0) {
+    return constrained
+  }
+  const total = totalmem()
+  if (typeof total === 'number' && Number.isFinite(total) && total > 0) {
+    return total
+  }
+  return 0
+}
+
+/**
+ * @param {number} percentage
+ * @param {number} availableBytes
+ * @returns {number | null}
+ */
+export function heapSizeMbFromPercentage(percentage, availableBytes) {
+  if (!(percentage > 0 && percentage <= 100) || !(availableBytes > 0)) return null
+  const mb = Math.floor((availableBytes * (percentage / 100)) / (1024 * 1024))
+  return mb > 0 ? mb : null
+}
+
+/**
+ * @param {string[]} args
+ * @param {string} flag
+ * @returns {string | null}
+ */
+export function findEqualsFlagValue(args, flag) {
+  const prefix = `${flag}=`
+  for (const arg of args) {
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length)
+  }
+  return null
+}
+
+/**
+ * @param {string[]} args
+ * @param {string} flag
+ * @returns {string | null}
+ */
+export function findEqualsOrNextFlagValue(args, flag) {
+  const prefix = `${flag}=`
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length)
+    if (arg === flag) {
+      const next = args[i + 1]
+      if (next && !next.startsWith('-')) return next
+      return ''
+    }
+  }
+  return null
+}
+
+/**
+ * Strip launcher-only heap args so Commander does not reject them.
+ * `--max-memory` stays equals-only to match the previous launcher contract.
+ * @param {string[]} args
+ */
+export function stripLauncherHeapArgs(args) {
+  const stripped = []
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i]
+    if (arg === MAX_MEMORY_FLAG || arg.startsWith(`${MAX_MEMORY_FLAG}=`)) continue
+    if (arg.startsWith(`${HEAP_PERCENTAGE_FLAG}=`)) continue
+    if (arg === HEAP_PERCENTAGE_FLAG) {
+      const next = args[i + 1]
+      if (next && !next.startsWith('-')) i += 1
+      continue
+    }
+    stripped.push(arg)
+  }
+  return stripped
+}
+
+/**
+ * @param {{
+ *   argv?: string[],
+ *   env?: NodeJS.ProcessEnv,
+ *   availableBytes?: number,
+ *   memorySources?: MemorySources,
+ * }} [input]
+ */
+export function resolveHeapSizeMb(input = {}) {
+  const argv = input.argv ?? []
+  const env = input.env ?? {}
+  const availableBytes =
+    input.availableBytes ?? getAvailableMemoryBytes(input.memorySources)
+
+  const maxMem = parsePositiveIntegerMb(findEqualsFlagValue(argv, MAX_MEMORY_FLAG))
+  if (maxMem != null) {
+    return { mb: maxMem, source: 'max-memory', setMaxMemoryEnv: true }
+  }
+
+  const argvPercentage = parsePercentage(
+    findEqualsOrNextFlagValue(argv, HEAP_PERCENTAGE_FLAG),
+  )
+  if (argvPercentage != null) {
+    const mb = heapSizeMbFromPercentage(argvPercentage, availableBytes)
+    if (mb != null) {
+      return { mb, source: 'argv-percentage', percentage: argvPercentage }
+    }
+  }
+
+  const envPercentage = parsePercentage(env[HEAP_PERCENTAGE_ENV])
+  if (envPercentage != null) {
+    const mb = heapSizeMbFromPercentage(envPercentage, availableBytes)
+    if (mb != null) {
+      return { mb, source: 'env-percentage', percentage: envPercentage }
+    }
+  }
+
+  const envMb = parsePositiveIntegerMb(env[HEAP_SIZE_ENV])
+  if (envMb != null) return { mb: envMb, source: 'env-mb' }
+
+  return { mb: DEFAULT_HEAP_SIZE_MB, source: 'default' }
+}

--- a/bin/heap-limit.mjs
+++ b/bin/heap-limit.mjs
@@ -76,7 +76,9 @@ export function getAvailableMemoryBytes(sources = {}) {
   const totalmem = sources.totalmem ?? (() => os.totalmem())
 
   const constrained = constrainedMemory()
-  if (typeof constrained === 'number' && Number.isFinite(constrained) && constrained > 0) {
+  // Node/libuv reports UINT64_MAX (not a safe integer in JS) when there is no
+  // cgroup/OS memory limit. Treat only real byte caps as constraints.
+  if (typeof constrained === 'number' && Number.isSafeInteger(constrained) && constrained > 0) {
     return constrained
   }
   const total = totalmem()
@@ -94,7 +96,7 @@ export function getAvailableMemoryBytes(sources = {}) {
 export function heapSizeMbFromPercentage(percentage, availableBytes) {
   if (!(percentage > 0 && percentage <= 100) || !(availableBytes > 0)) return null
   const mb = Math.floor((availableBytes * (percentage / 100)) / (1024 * 1024))
-  return mb > 0 ? mb : null
+  return Math.max(1, mb)
 }
 
 /**

--- a/bin/heap-limit.mjs
+++ b/bin/heap-limit.mjs
@@ -144,7 +144,7 @@ export function stripLauncherHeapArgs(args) {
     if (arg.startsWith(`${HEAP_PERCENTAGE_FLAG}=`)) continue
     if (arg === HEAP_PERCENTAGE_FLAG) {
       const next = args[i + 1]
-      if (next && !next.startsWith('-')) i += 1
+      if (next && !next.startsWith('-') && parsePercentage(next) != null) i += 1
       continue
     }
     stripped.push(arg)

--- a/bin/heap-limit.mjs
+++ b/bin/heap-limit.mjs
@@ -179,6 +179,13 @@ export function resolveHeapSizeMb(input = {}) {
     if (mb != null) {
       return { mb, source: 'argv-percentage', percentage: argvPercentage }
     }
+    // Valid percentage requested; memory size unknown. Do not treat this as
+    // "no percentage" and fall through to an unrelated MB env value.
+    return {
+      mb: DEFAULT_HEAP_SIZE_MB,
+      source: 'percentage-unavailable',
+      percentage: argvPercentage,
+    }
   }
 
   const envPercentage = parsePercentage(env[HEAP_PERCENTAGE_ENV])
@@ -187,10 +194,27 @@ export function resolveHeapSizeMb(input = {}) {
     if (mb != null) {
       return { mb, source: 'env-percentage', percentage: envPercentage }
     }
+    return {
+      mb: DEFAULT_HEAP_SIZE_MB,
+      source: 'percentage-unavailable',
+      percentage: envPercentage,
+    }
   }
 
   const envMb = parsePositiveIntegerMb(env[HEAP_SIZE_ENV])
   if (envMb != null) return { mb: envMb, source: 'env-mb' }
 
   return { mb: DEFAULT_HEAP_SIZE_MB, source: 'default' }
+}
+
+/**
+ * One-line operator warning when a valid percentage cannot be converted.
+ * @param {number} percentage
+ * @param {number} [fallbackMb]
+ */
+export function formatPercentageUnavailableStderr(
+  percentage,
+  fallbackMb = DEFAULT_HEAP_SIZE_MB,
+) {
+  return `openclaude: could not convert heap percentage ${percentage} to megabytes because available memory is unknown; using ${fallbackMb}`
 }

--- a/bin/openclaude
+++ b/bin/openclaude
@@ -40,13 +40,27 @@ function applyResolvedHeapEnv(resolved) {
   }
 }
 
+function replaceProcessArgvWithStrippedLauncherArgs() {
+  process.argv = [
+    process.argv[0],
+    process.argv[1],
+    ...stripLauncherHeapArgs(process.argv.slice(2)),
+  ]
+}
+
 function relaunchWithLongSessionHeapIfNeeded() {
-  if (process.env[DISABLE_HEAP_RELAUNCH_ENV] === '1') return
+  if (process.env[DISABLE_HEAP_RELAUNCH_ENV] === '1') {
+    replaceProcessArgvWithStrippedLauncherArgs()
+    return
+  }
   if (process.env[HEAP_RELAUNCHED_ENV] === '1') return
   const nodeArgs = currentNodeOptionArgs()
   const hasHeapLimit = hasHeapLimitFlag(nodeArgs)
   const hasExplicitGc = hasNodeFlag(nodeArgs, '--expose-gc')
-  if (hasHeapLimit && hasExplicitGc) return
+  if (hasHeapLimit && hasExplicitGc) {
+    replaceProcessArgvWithStrippedLauncherArgs()
+    return
+  }
 
   const execArgv = [...process.execArgv]
   if (!hasHeapLimit) {

--- a/bin/openclaude
+++ b/bin/openclaude
@@ -53,7 +53,10 @@ function relaunchWithLongSessionHeapIfNeeded() {
     replaceProcessArgvWithStrippedLauncherArgs()
     return
   }
-  if (process.env[HEAP_RELAUNCHED_ENV] === '1') return
+  if (process.env[HEAP_RELAUNCHED_ENV] === '1') {
+    replaceProcessArgvWithStrippedLauncherArgs()
+    return
+  }
   const nodeArgs = currentNodeOptionArgs()
   const hasHeapLimit = hasHeapLimitFlag(nodeArgs)
   const hasExplicitGc = hasNodeFlag(nodeArgs, '--expose-gc')

--- a/bin/openclaude
+++ b/bin/openclaude
@@ -12,56 +12,49 @@ import { join, dirname } from 'path'
 import { fileURLToPath, pathToFileURL } from 'url'
 import { spawnSync } from 'child_process'
 import { enableNodeCompileCacheIfAvailable } from './node-compile-cache.mjs'
+import {
+  HEAP_SIZE_ENV,
+  HEAP_SIZE_FLAG,
+  hasHeapLimitFlag,
+  hasNodeFlag,
+  nodeOptionArgs,
+  resolveHeapSizeMb,
+  stripLauncherHeapArgs,
+} from './heap-limit.mjs'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const distPath = join(__dirname, '..', 'dist', 'cli.mjs')
 
 const HEAP_RELAUNCHED_ENV = 'OPENCLAUDE_HEAP_RELAUNCHED'
 const DISABLE_HEAP_RELAUNCH_ENV = 'OPENCLAUDE_DISABLE_HEAP_RELAUNCH'
-const HEAP_SIZE_ENV = 'OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB'
-const DEFAULT_HEAP_SIZE_MB = 8192
 
-function hasNodeFlag(args, flag) {
-  return args.some(arg => arg === flag || arg.startsWith(`${flag}=`))
+function currentNodeOptionArgs() {
+  return [...process.execArgv, ...nodeOptionArgs(process.env.NODE_OPTIONS)]
 }
 
-function hasNodeOptionFlag(flag) {
-  return hasNodeFlag([
-    ...process.execArgv,
-    ...(process.env.NODE_OPTIONS || '').split(/\s+/).filter(Boolean),
-  ], flag)
-}
-
-function getHeapSizeMb() {
-  // --max-memory flag overrides env var
-  const maxMemArg = process.argv.find(a => a.startsWith('--max-memory='))
-  if (maxMemArg) {
-    const mb = Number.parseInt(maxMemArg.split('=')[1] || '0', 10)
-    if (Number.isSafeInteger(mb) && mb > 0) {
-      process.env[HEAP_SIZE_ENV] = String(mb)
-      process.env.OPENCLAUDE_MAX_MEMORY_MB = String(mb)
-      return mb
-    }
+function applyResolvedHeapEnv(resolved) {
+  process.env[HEAP_SIZE_ENV] = String(resolved.mb)
+  if (resolved.setMaxMemoryEnv) {
+    process.env.OPENCLAUDE_MAX_MEMORY_MB = String(resolved.mb)
   }
-
-  const raw = process.env[HEAP_SIZE_ENV]
-  if (!raw) return DEFAULT_HEAP_SIZE_MB
-  const parsed = Number.parseInt(raw, 10)
-  return Number.isSafeInteger(parsed) && parsed > 0
-    ? parsed
-    : DEFAULT_HEAP_SIZE_MB
 }
 
 function relaunchWithLongSessionHeapIfNeeded() {
   if (process.env[DISABLE_HEAP_RELAUNCH_ENV] === '1') return
   if (process.env[HEAP_RELAUNCHED_ENV] === '1') return
-  const hasHeapLimit = hasNodeOptionFlag('--max-old-space-size')
-  const hasExplicitGc = hasNodeOptionFlag('--expose-gc')
+  const nodeArgs = currentNodeOptionArgs()
+  const hasHeapLimit = hasHeapLimitFlag(nodeArgs)
+  const hasExplicitGc = hasNodeFlag(nodeArgs, '--expose-gc')
   if (hasHeapLimit && hasExplicitGc) return
 
   const execArgv = [...process.execArgv]
   if (!hasHeapLimit) {
-    execArgv.push(`--max-old-space-size=${getHeapSizeMb()}`)
+    const resolved = resolveHeapSizeMb({
+      argv: process.argv.slice(2),
+      env: process.env,
+    })
+    applyResolvedHeapEnv(resolved)
+    execArgv.push(`${HEAP_SIZE_FLAG}=${resolved.mb}`)
   }
 
   // Expose explicit GC for long interactive sessions. NODE_OPTIONS cannot
@@ -70,11 +63,11 @@ function relaunchWithLongSessionHeapIfNeeded() {
     execArgv.push('--expose-gc')
   }
 
-  // Strip --max-memory flag before relaunching — it's a launcher-only arg
-  // that Commander in the built CLI would reject as unknown.
-  const childArgs = process.argv.slice(2).filter(
-    arg => !arg.startsWith('--max-memory=') && arg !== '--max-memory',
-  )
+  // Strip launcher-only heap args before relaunching — Commander in the built
+  // CLI would reject them as unknown. The native Node percentage flag in
+  // execArgv/NODE_OPTIONS is left untouched because this process already
+  // started with a Node that accepted it.
+  const childArgs = stripLauncherHeapArgs(process.argv.slice(2))
 
   // Preserve the original argv[1] (which may be a symlink like
   // /usr/local/bin/openclaude) instead of resolving it via import.meta.url.

--- a/bin/openclaude
+++ b/bin/openclaude
@@ -15,6 +15,7 @@ import { enableNodeCompileCacheIfAvailable } from './node-compile-cache.mjs'
 import {
   HEAP_SIZE_ENV,
   HEAP_SIZE_FLAG,
+  formatPercentageUnavailableStderr,
   hasHeapLimitFlag,
   hasNodeFlag,
   nodeOptionArgs,
@@ -53,6 +54,9 @@ function relaunchWithLongSessionHeapIfNeeded() {
       argv: process.argv.slice(2),
       env: process.env,
     })
+    if (resolved.source === 'percentage-unavailable') {
+      console.error(formatPercentageUnavailableStderr(resolved.percentage))
+    }
     applyResolvedHeapEnv(resolved)
     execArgv.push(`${HEAP_SIZE_FLAG}=${resolved.mb}`)
   }

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -417,20 +417,23 @@ limit is already present in `NODE_OPTIONS` or `process.execArgv`. That fixed cap
 is too large for small containers and too small for high-RAM workstations.
 
 To size the V8 old-space heap as a percentage of available memory (cgroup or OS
-constraint when Node reports one, otherwise total system RAM), pass Node's
-percentage flag through the OpenClaude launcher. The launcher converts it to an
-explicit `--max-old-space-size` in megabytes so the same command works on every
-supported Node version, including `22.0.0`:
+constraint when Node reports a real byte cap, otherwise total system RAM), pass
+the percentage through the OpenClaude launcher. OpenClaude converts
+`--max-old-space-size-percentage` and
+`OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE` to an explicit
+`--max-old-space-size` in megabytes so the same command works on every supported
+Node version, including `22.0.0`:
 
 ```bash
 openclaude --max-old-space-size-percentage=50
 openclaude --max-old-space-size-percentage=75
 ```
 
-You can also set `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE=50`. If
-`NODE_OPTIONS` or the Node process already contains
-`--max-old-space-size-percentage` or `--max-old-space-size`, OpenClaude leaves
-that native limit in place and does not append `8192`. `--max-memory=2048`
+You can also set `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE=50`. Putting the
+native flag in `NODE_OPTIONS` or `node --max-old-space-size-percentage=…` only
+works on Node versions that accept that option; Node 22.0.0 rejects it before
+OpenClaude starts. When a supporting Node already applied that native flag,
+OpenClaude leaves it in place and does not append `8192`. `--max-memory=2048`
 remains the explicit megabyte override and still wins over a percentage
 request.
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -429,13 +429,21 @@ openclaude --max-old-space-size-percentage=50
 openclaude --max-old-space-size-percentage=75
 ```
 
-You can also set `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE=50`. Putting the
-native flag in `NODE_OPTIONS` or `node --max-old-space-size-percentage=…` only
-works on Node versions that accept that option; Node 22.0.0 rejects it before
-OpenClaude starts. When a supporting Node already applied that native flag,
-OpenClaude leaves it in place and does not append `8192`. `--max-memory=2048`
-remains the explicit megabyte override and still wins over a percentage
-request.
+Heap size precedence, earlier wins:
+
+1. `--max-memory=<MB>` (explicit megabyte override)
+2. `--max-old-space-size-percentage`
+3. `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE`
+4. `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB`
+5. Default `8192`
+
+Putting the native flag in `NODE_OPTIONS` or
+`node --max-old-space-size-percentage=…` only works on Node versions that accept
+that option; Node 22.0.0 rejects it before OpenClaude starts. When a supporting
+Node already applied that native flag, OpenClaude leaves it in place and does
+not append `8192`. If a valid percentage is requested but available memory cannot
+be measured, OpenClaude prints one warning on stderr and uses `8192` instead
+of an unrelated megabyte environment value.
 
 ## Environment Variables
 
@@ -491,8 +499,8 @@ host. Without this variable the behavior is unchanged.
 | `OPENAI_API_BASE` | No | Compatibility alias for `OPENAI_BASE_URL` |
 | `API_TIMEOUT_MS` | No | Time-to-response-headers deadline for generic OpenAI-compatible requests, direct GitHub Copilot Responses, and Copilot chat-to-Responses fallback requests, in milliseconds (default: `600000`, or 10 minutes). The value must be a safe positive integer; invalid, zero, negative, or fractional values use the default, and values above `2147483647` are capped. The deadline is disarmed after headers arrive, so it does not limit response streaming. Export this runtime setting from your shell or launcher; the provider env-file loader ignores runtime/debug settings, so a value configured only there leaves the default in effect. First-party Codex OAuth Responses and the Anthropic SDK retain their existing timeout handling. |
 | `OPENCLAUDE_OLLAMA_NUM_CTX` | Ollama only | Request-level Ollama context window. Defaults to `32768`; set a larger value for longer same-session history if your model and hardware can handle it. |
-| `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB` | No | Explicit V8 old-space heap cap in megabytes for the Node launcher. Used when `--max-memory` and `--max-old-space-size-percentage` are unset. Default `8192`. |
-| `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE` | No | Size the V8 old-space heap as a percentage (greater than 0, up to 100) of constrained/container memory when Node reports it, otherwise total system RAM. Converted to `--max-old-space-size` so Node 22.0.0 can start. Overridden by `--max-memory`. |
+| `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB` | No | Explicit V8 old-space heap cap in megabytes for the Node launcher. Used only when `--max-memory`, `--max-old-space-size-percentage`, and `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE` are all unset. Default `8192`. |
+| `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE` | No | Size the V8 old-space heap as a percentage (greater than 0, up to 100) of constrained/container memory when Node reports it, otherwise total system RAM. Converted to `--max-old-space-size` so Node 22.0.0 can start. Precedence, earlier wins: `--max-memory` → `--max-old-space-size-percentage` → this variable → `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB` → default `8192`. |
 | `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` | No | JSON map of OpenAI-compatible model names to context windows, such as `{"custom-model":1000000}`. Use this when a custom provider does not expose context metadata from `/v1/models`. |
 | `CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS` | No | JSON map of OpenAI-compatible model names to max output tokens, such as `{"custom-model":32768}`. Use this when a custom provider does not expose output-limit metadata from `/v1/models`. |
 | `OPENCODE_API_KEY` | OpenCode Zen / Go | Shared API key for OpenCode Zen (pay-as-you-go) and OpenCode Go (subscription); get yours from https://opencode.ai |

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -441,7 +441,10 @@ Putting the native flag in `NODE_OPTIONS` or
 `node --max-old-space-size-percentage=…` only works on Node versions that accept
 that option; Node 22.0.0 rejects it before OpenClaude starts. When a supporting
 Node already applied that native flag, OpenClaude leaves it in place and does
-not append `8192`. If a valid percentage is requested but available memory cannot
+not append `8192`. Launcher-only flags (`--max-old-space-size-percentage`,
+`--max-memory=`) are still stripped so Commander can start. That native-flag
+short-circuit also skips OpenClaude’s numbered precedence, including
+`--max-memory`. If a valid percentage is requested but available memory cannot
 be measured, OpenClaude prints one warning on stderr and uses `8192` instead
 of an unrelated megabyte environment value.
 

--- a/docs/advanced-setup.md
+++ b/docs/advanced-setup.md
@@ -410,6 +410,30 @@ missing. Install only what you need:
 When installing OpenClaude from source (`bun install`), all of these are
 already present as dev dependencies, so source/dev builds need no extra steps.
 
+## Node.js heap size
+
+The installed CLI relaunches Node with `--max-old-space-size=8192` unless a heap
+limit is already present in `NODE_OPTIONS` or `process.execArgv`. That fixed cap
+is too large for small containers and too small for high-RAM workstations.
+
+To size the V8 old-space heap as a percentage of available memory (cgroup or OS
+constraint when Node reports one, otherwise total system RAM), pass Node's
+percentage flag through the OpenClaude launcher. The launcher converts it to an
+explicit `--max-old-space-size` in megabytes so the same command works on every
+supported Node version, including `22.0.0`:
+
+```bash
+openclaude --max-old-space-size-percentage=50
+openclaude --max-old-space-size-percentage=75
+```
+
+You can also set `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE=50`. If
+`NODE_OPTIONS` or the Node process already contains
+`--max-old-space-size-percentage` or `--max-old-space-size`, OpenClaude leaves
+that native limit in place and does not append `8192`. `--max-memory=2048`
+remains the explicit megabyte override and still wins over a percentage
+request.
+
 ## Environment Variables
 
 ### Custom (Anthropic-compatible) APIs
@@ -464,6 +488,8 @@ host. Without this variable the behavior is unchanged.
 | `OPENAI_API_BASE` | No | Compatibility alias for `OPENAI_BASE_URL` |
 | `API_TIMEOUT_MS` | No | Time-to-response-headers deadline for generic OpenAI-compatible requests, direct GitHub Copilot Responses, and Copilot chat-to-Responses fallback requests, in milliseconds (default: `600000`, or 10 minutes). The value must be a safe positive integer; invalid, zero, negative, or fractional values use the default, and values above `2147483647` are capped. The deadline is disarmed after headers arrive, so it does not limit response streaming. Export this runtime setting from your shell or launcher; the provider env-file loader ignores runtime/debug settings, so a value configured only there leaves the default in effect. First-party Codex OAuth Responses and the Anthropic SDK retain their existing timeout handling. |
 | `OPENCLAUDE_OLLAMA_NUM_CTX` | Ollama only | Request-level Ollama context window. Defaults to `32768`; set a larger value for longer same-session history if your model and hardware can handle it. |
+| `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB` | No | Explicit V8 old-space heap cap in megabytes for the Node launcher. Used when `--max-memory` and `--max-old-space-size-percentage` are unset. Default `8192`. |
+| `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE` | No | Size the V8 old-space heap as a percentage (greater than 0, up to 100) of constrained/container memory when Node reports it, otherwise total system RAM. Converted to `--max-old-space-size` so Node 22.0.0 can start. Overridden by `--max-memory`. |
 | `CLAUDE_CODE_OPENAI_CONTEXT_WINDOWS` | No | JSON map of OpenAI-compatible model names to context windows, such as `{"custom-model":1000000}`. Use this when a custom provider does not expose context metadata from `/v1/models`. |
 | `CLAUDE_CODE_OPENAI_MAX_OUTPUT_TOKENS` | No | JSON map of OpenAI-compatible model names to max output tokens, such as `{"custom-model":32768}`. Use this when a custom provider does not expose output-limit metadata from `/v1/models`. |
 | `OPENCODE_API_KEY` | OpenCode Zen / Go | Shared API key for OpenCode Zen (pay-as-you-go) and OpenCode Go (subscription); get yours from https://opencode.ai |

--- a/scripts/openclaude-bin-heap.test.ts
+++ b/scripts/openclaude-bin-heap.test.ts
@@ -78,6 +78,7 @@ describe('heap-limit percentage resolution', () => {
     expect(heapSizeMbFromPercentage(50, 2 * 1024 * 1024 * 1024)).toBe(1024)
     expect(heapSizeMbFromPercentage(100, FOUR_GIB)).toBe(4096)
     expect(heapSizeMbFromPercentage(50, 0)).toBeNull()
+    expect(heapSizeMbFromPercentage(50, 512 * 1024)).toBe(1)
   })
 
   test('prefers constrained memory over host totalmem', () => {
@@ -90,6 +91,12 @@ describe('heap-limit percentage resolution', () => {
     expect(
       getAvailableMemoryBytes({
         constrainedMemory: () => 0,
+        totalmem: () => FOUR_GIB,
+      }),
+    ).toBe(FOUR_GIB)
+    expect(
+      getAvailableMemoryBytes({
+        constrainedMemory: () => 18446744073709552000,
         totalmem: () => FOUR_GIB,
       }),
     ).toBe(FOUR_GIB)
@@ -152,6 +159,20 @@ describe('heap-limit percentage resolution', () => {
       mb: 1536,
       source: 'max-memory',
       setMaxMemoryEnv: true,
+    })
+  })
+
+  test('clamps a sub-megabyte percentage to 1 MB instead of the 8192 default', () => {
+    expect(
+      resolveHeapSizeMb({
+        argv: ['--max-old-space-size-percentage=50'],
+        env: {},
+        availableBytes: 512 * 1024,
+      }),
+    ).toEqual({
+      mb: 1,
+      source: 'argv-percentage',
+      percentage: 50,
     })
   })
 

--- a/scripts/openclaude-bin-heap.test.ts
+++ b/scripts/openclaude-bin-heap.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
@@ -53,6 +54,7 @@ describe('openclaude launcher heap guard', () => {
     expect(heapSource).toContain(HEAP_SIZE_ENV)
     expect(source).toContain('process.env.NODE_OPTIONS')
     expect(source).toContain('hasHeapLimitFlag(nodeArgs)')
+    expect(source).toContain('replaceProcessArgvWithStrippedLauncherArgs()')
     expect(heapSource).toContain(HEAP_PERCENTAGE_FLAG)
   })
 
@@ -61,6 +63,49 @@ describe('openclaude launcher heap guard', () => {
 
     expect(source).toContain("import * as nodeModule from 'node:module'")
     expect(source).not.toMatch(/import\s*\{[^}]*enableCompileCache[^}]*\}\s*from\s*['"]node:module['"]/s)
+  })
+
+  test('strips launcher-only percentage before Commander when native heap and expose-gc are present', () => {
+    const env = {
+      ...process.env,
+      NODE_OPTIONS: '--max-old-space-size=4096 --expose-gc',
+    }
+    delete env.OPENCLAUDE_HEAP_RELAUNCHED
+    delete env.OPENCLAUDE_DISABLE_HEAP_RELAUNCH
+    const result = spawnSync(
+      process.execPath,
+      [BIN_PATH, '--max-old-space-size-percentage=50', '--print', 'hi'],
+      {
+        encoding: 'utf8',
+        timeout: 8000,
+        env,
+      },
+    )
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
+    expect(output).not.toContain(
+      "unknown option '--max-old-space-size-percentage=50'",
+    )
+  })
+
+  test('strips launcher-only percentage before Commander when heap relaunch is disabled', () => {
+    const env = {
+      ...process.env,
+      OPENCLAUDE_DISABLE_HEAP_RELAUNCH: '1',
+    }
+    delete env.OPENCLAUDE_HEAP_RELAUNCHED
+    const result = spawnSync(
+      process.execPath,
+      [BIN_PATH, '--max-old-space-size-percentage=50', '--print', 'hi'],
+      {
+        encoding: 'utf8',
+        timeout: 8000,
+        env,
+      },
+    )
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
+    expect(output).not.toContain(
+      "unknown option '--max-old-space-size-percentage=50'",
+    )
   })
 })
 
@@ -137,6 +182,17 @@ describe('heap-limit percentage resolution', () => {
       '--max-memory=1024',
       'fix tests',
     ])).toEqual(['fix tests'])
+  })
+
+  test('does not consume a following prompt token that is not a percentage', () => {
+    expect(
+      stripLauncherHeapArgs([
+        '--max-old-space-size-percentage',
+        'fix',
+        'the',
+        'tests',
+      ]),
+    ).toEqual(['fix', 'the', 'tests'])
   })
 
   test('OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE sizes the heap from RAM', () => {

--- a/scripts/openclaude-bin-heap.test.ts
+++ b/scripts/openclaude-bin-heap.test.ts
@@ -2,16 +2,35 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
 
+import {
+  DEFAULT_HEAP_SIZE_MB,
+  HEAP_PERCENTAGE_ENV,
+  HEAP_PERCENTAGE_FLAG,
+  HEAP_SIZE_ENV,
+  HEAP_SIZE_FLAG,
+  getAvailableMemoryBytes,
+  hasHeapLimitFlag,
+  heapSizeMbFromPercentage,
+  parsePercentage,
+  resolveHeapSizeMb,
+  stripLauncherHeapArgs,
+} from '../bin/heap-limit.mjs'
+
 const BIN_PATH = join(import.meta.dir, '..', 'bin', 'openclaude')
 const COMPILE_CACHE_PATH = join(import.meta.dir, '..', 'bin', 'node-compile-cache.mjs')
+const HEAP_LIMIT_PATH = join(import.meta.dir, '..', 'bin', 'heap-limit.mjs')
+const FOUR_GIB = 4 * 1024 * 1024 * 1024
 
 describe('openclaude launcher heap guard', () => {
   test('raises the current Node heap before loading dist/cli.mjs', () => {
     const source = readFileSync(BIN_PATH, 'utf-8')
+    const heapSource = readFileSync(HEAP_LIMIT_PATH, 'utf-8')
 
-    expect(source).toContain('--max-old-space-size=')
+    expect(heapSource).toContain("export const HEAP_SIZE_FLAG = '--max-old-space-size'")
+    expect(source).toContain('`${HEAP_SIZE_FLAG}=${resolved.mb}`')
     expect(source).toContain('--expose-gc')
     expect(source).toContain('spawnSync(process.execPath')
+    expect(source).toContain("from './heap-limit.mjs'")
     const importingBranch = source.slice(source.indexOf('if (existsSync(distPath))'))
     const relaunchIndex = importingBranch.indexOf('relaunchWithLongSessionHeapIfNeeded()')
     const compileCacheIndex = importingBranch.indexOf('enableNodeCompileCacheIfAvailable()')
@@ -24,11 +43,14 @@ describe('openclaude launcher heap guard', () => {
 
   test('keeps user and troubleshooting escape hatches', () => {
     const source = readFileSync(BIN_PATH, 'utf-8')
+    const heapSource = readFileSync(HEAP_LIMIT_PATH, 'utf-8')
 
     expect(source).toContain('OPENCLAUDE_DISABLE_HEAP_RELAUNCH')
-    expect(source).toContain('OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB')
+    expect(source).toContain('HEAP_SIZE_ENV')
+    expect(heapSource).toContain(HEAP_SIZE_ENV)
     expect(source).toContain('process.env.NODE_OPTIONS')
-    expect(source).toContain("hasNodeOptionFlag('--max-old-space-size')")
+    expect(source).toContain('hasHeapLimitFlag(nodeArgs)')
+    expect(heapSource).toContain(HEAP_PERCENTAGE_FLAG)
   })
 
   test('feature-detects the compile-cache API without a named builtin import', () => {
@@ -36,5 +58,117 @@ describe('openclaude launcher heap guard', () => {
 
     expect(source).toContain("import * as nodeModule from 'node:module'")
     expect(source).not.toMatch(/import\s*\{[^}]*enableCompileCache[^}]*\}\s*from\s*['"]node:module['"]/s)
+  })
+})
+
+describe('heap-limit percentage resolution', () => {
+  test('parses Node-style percentages including a trailing percent sign', () => {
+    expect(parsePercentage('50')).toBe(50)
+    expect(parsePercentage('75%')).toBe(75)
+    expect(parsePercentage('100')).toBe(100)
+    expect(parsePercentage('0.5')).toBe(0.5)
+    expect(parsePercentage('0')).toBeNull()
+    expect(parsePercentage('101')).toBeNull()
+    expect(parsePercentage('')).toBeNull()
+    expect(parsePercentage('nope')).toBeNull()
+  })
+
+  test('converts a percentage of constrained memory into megabytes', () => {
+    expect(heapSizeMbFromPercentage(50, FOUR_GIB)).toBe(2048)
+    expect(heapSizeMbFromPercentage(50, 2 * 1024 * 1024 * 1024)).toBe(1024)
+    expect(heapSizeMbFromPercentage(100, FOUR_GIB)).toBe(4096)
+    expect(heapSizeMbFromPercentage(50, 0)).toBeNull()
+  })
+
+  test('prefers constrained memory over host totalmem', () => {
+    expect(
+      getAvailableMemoryBytes({
+        constrainedMemory: () => 2 * 1024 * 1024 * 1024,
+        totalmem: () => FOUR_GIB,
+      }),
+    ).toBe(2 * 1024 * 1024 * 1024)
+    expect(
+      getAvailableMemoryBytes({
+        constrainedMemory: () => 0,
+        totalmem: () => FOUR_GIB,
+      }),
+    ).toBe(FOUR_GIB)
+  })
+
+  test('treats native percentage flags as an existing heap limit', () => {
+    expect(hasHeapLimitFlag(['--max-old-space-size-percentage=50'])).toBe(true)
+    expect(hasHeapLimitFlag(['--max-old-space-size=4096'])).toBe(true)
+    expect(hasHeapLimitFlag(['--inspect=9229'])).toBe(false)
+  })
+
+  test('resolves --max-old-space-size-percentage from argv before the MB env', () => {
+    const resolved = resolveHeapSizeMb({
+      argv: ['--max-old-space-size-percentage=50', '--print'],
+      env: { [HEAP_SIZE_ENV]: '4096' },
+      availableBytes: FOUR_GIB,
+    })
+    expect(resolved).toEqual({
+      mb: 2048,
+      source: 'argv-percentage',
+      percentage: 50,
+    })
+  })
+
+  test('accepts a spaced percentage flag and strips launcher-only args', () => {
+    const resolved = resolveHeapSizeMb({
+      argv: ['--max-old-space-size-percentage', '25', 'fix tests'],
+      env: {},
+      availableBytes: FOUR_GIB,
+    })
+    expect(resolved.mb).toBe(1024)
+    expect(stripLauncherHeapArgs([
+      '--max-old-space-size-percentage',
+      '25',
+      '--max-memory=1024',
+      'fix tests',
+    ])).toEqual(['fix tests'])
+  })
+
+  test('OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE sizes the heap from RAM', () => {
+    const resolved = resolveHeapSizeMb({
+      argv: [],
+      env: { [HEAP_PERCENTAGE_ENV]: '75' },
+      availableBytes: FOUR_GIB,
+    })
+    expect(resolved).toEqual({
+      mb: 3072,
+      source: 'env-percentage',
+      percentage: 75,
+    })
+  })
+
+  test('--max-memory still wins over a percentage request', () => {
+    const resolved = resolveHeapSizeMb({
+      argv: ['--max-old-space-size-percentage=50', '--max-memory=1536'],
+      env: { [HEAP_PERCENTAGE_ENV]: '90' },
+      availableBytes: FOUR_GIB,
+    })
+    expect(resolved).toEqual({
+      mb: 1536,
+      source: 'max-memory',
+      setMaxMemoryEnv: true,
+    })
+  })
+
+  test('falls back to the 8192 MB default when no override is set', () => {
+    expect(resolveHeapSizeMb({ argv: [], env: {} })).toEqual({
+      mb: DEFAULT_HEAP_SIZE_MB,
+      source: 'default',
+    })
+  })
+
+  test('ignores an invalid percentage and uses the next source', () => {
+    expect(
+      resolveHeapSizeMb({
+        argv: ['--max-old-space-size-percentage=0'],
+        env: { [HEAP_SIZE_ENV]: '4096' },
+        availableBytes: FOUR_GIB,
+      }),
+    ).toEqual({ mb: 4096, source: 'env-mb' })
   })
 })

--- a/scripts/openclaude-bin-heap.test.ts
+++ b/scripts/openclaude-bin-heap.test.ts
@@ -23,6 +23,13 @@ const COMPILE_CACHE_PATH = join(import.meta.dir, '..', 'bin', 'node-compile-cach
 const HEAP_LIMIT_PATH = join(import.meta.dir, '..', 'bin', 'heap-limit.mjs')
 const FOUR_GIB = 4 * 1024 * 1024 * 1024
 
+function expectSuccessfulLauncherSpawn(
+  result: ReturnType<typeof spawnSync>,
+): void {
+  expect(result.error).toBeUndefined()
+  expect(result.status).toBe(0)
+}
+
 describe('openclaude launcher heap guard', () => {
   test('raises the current Node heap before loading dist/cli.mjs', () => {
     const source = readFileSync(BIN_PATH, 'utf-8')
@@ -68,19 +75,25 @@ describe('openclaude launcher heap guard', () => {
   test('strips launcher-only percentage before Commander when native heap and expose-gc are present', () => {
     const env = {
       ...process.env,
-      NODE_OPTIONS: '--max-old-space-size=4096 --expose-gc',
+      NODE_OPTIONS: '--max-old-space-size=4096',
     }
     delete env.OPENCLAUDE_HEAP_RELAUNCHED
     delete env.OPENCLAUDE_DISABLE_HEAP_RELAUNCH
     const result = spawnSync(
       process.execPath,
-      [BIN_PATH, '--max-old-space-size-percentage=50', '--print', 'hi'],
+      [
+        '--expose-gc',
+        BIN_PATH,
+        '--max-old-space-size-percentage=50',
+        '--version',
+      ],
       {
         encoding: 'utf8',
         timeout: 8000,
         env,
       },
     )
+    expectSuccessfulLauncherSpawn(result)
     const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
     expect(output).not.toContain(
       "unknown option '--max-old-space-size-percentage=50'",
@@ -95,13 +108,36 @@ describe('openclaude launcher heap guard', () => {
     delete env.OPENCLAUDE_HEAP_RELAUNCHED
     const result = spawnSync(
       process.execPath,
-      [BIN_PATH, '--max-old-space-size-percentage=50', '--print', 'hi'],
+      [BIN_PATH, '--max-old-space-size-percentage=50', '--version'],
       {
         encoding: 'utf8',
         timeout: 8000,
         env,
       },
     )
+    expectSuccessfulLauncherSpawn(result)
+    const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
+    expect(output).not.toContain(
+      "unknown option '--max-old-space-size-percentage=50'",
+    )
+  })
+
+  test('strips launcher-only percentage when OPENCLAUDE_HEAP_RELAUNCHED is already set', () => {
+    const env = {
+      ...process.env,
+      OPENCLAUDE_HEAP_RELAUNCHED: '1',
+    }
+    delete env.OPENCLAUDE_DISABLE_HEAP_RELAUNCH
+    const result = spawnSync(
+      process.execPath,
+      [BIN_PATH, '--max-old-space-size-percentage=50', '--version'],
+      {
+        encoding: 'utf8',
+        timeout: 8000,
+        env,
+      },
+    )
+    expectSuccessfulLauncherSpawn(result)
     const output = `${result.stdout ?? ''}${result.stderr ?? ''}`
     expect(output).not.toContain(
       "unknown option '--max-old-space-size-percentage=50'",

--- a/scripts/openclaude-bin-heap.test.ts
+++ b/scripts/openclaude-bin-heap.test.ts
@@ -8,6 +8,7 @@ import {
   HEAP_PERCENTAGE_FLAG,
   HEAP_SIZE_ENV,
   HEAP_SIZE_FLAG,
+  formatPercentageUnavailableStderr,
   getAvailableMemoryBytes,
   hasHeapLimitFlag,
   heapSizeMbFromPercentage,
@@ -28,6 +29,8 @@ describe('openclaude launcher heap guard', () => {
 
     expect(heapSource).toContain("export const HEAP_SIZE_FLAG = '--max-old-space-size'")
     expect(source).toContain('`${HEAP_SIZE_FLAG}=${resolved.mb}`')
+    expect(source).toContain('formatPercentageUnavailableStderr')
+    expect(source).toContain("resolved.source === 'percentage-unavailable'")
     expect(source).toContain('--expose-gc')
     expect(source).toContain('spawnSync(process.execPath')
     expect(source).toContain("from './heap-limit.mjs'")
@@ -191,5 +194,33 @@ describe('heap-limit percentage resolution', () => {
         availableBytes: FOUR_GIB,
       }),
     ).toEqual({ mb: 4096, source: 'env-mb' })
+  })
+
+  test('does not fall through to an unrelated MB env when memory is unknown', () => {
+    expect(
+      resolveHeapSizeMb({
+        argv: ['--max-old-space-size-percentage=50'],
+        env: { [HEAP_SIZE_ENV]: '4096' },
+        availableBytes: 0,
+      }),
+    ).toEqual({
+      mb: DEFAULT_HEAP_SIZE_MB,
+      source: 'percentage-unavailable',
+      percentage: 50,
+    })
+    expect(
+      resolveHeapSizeMb({
+        argv: [],
+        env: { [HEAP_PERCENTAGE_ENV]: '75', [HEAP_SIZE_ENV]: '4096' },
+        availableBytes: 0,
+      }),
+    ).toEqual({
+      mb: DEFAULT_HEAP_SIZE_MB,
+      source: 'percentage-unavailable',
+      percentage: 75,
+    })
+    expect(formatPercentageUnavailableStderr(50)).toBe(
+      'openclaude: could not convert heap percentage 50 to megabytes because available memory is unknown; using 8192',
+    )
   })
 })

--- a/scripts/verify-clean-install.ts
+++ b/scripts/verify-clean-install.ts
@@ -299,6 +299,7 @@ function checkTarballContents(tarballPath: string): void {
     'package/package.json',
     'package/bin/openclaude',
     'package/bin/node-compile-cache.mjs',
+    'package/bin/heap-limit.mjs',
     'package/dist/cli.mjs',
     'package/dist/sdk.mjs',
     'package/src/entrypoints/sdk.d.ts',

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -672,6 +672,26 @@ describe('background session CLI parsing', () => {
     ])
   })
 
+  it('preserves a spaced execArgv percentage value so Node still receives the argument', () => {
+    const config = buildBackgroundChildProcessConfig({
+      execPath: '/usr/bin/node',
+      execArgv: ['--max-old-space-size-percentage', '75'],
+      entrypoint: '/repo/bin/openclaude',
+      childArgs: ['--print', 'fix failing tests'],
+      processEnv: {},
+      stdoutLogPath: '/tmp/bg.out.log',
+      backgroundSessionId: 'bg-percentage-spaced-execargv',
+      processMarker: TEST_PROCESS_MARKER,
+      launcherPid: 707,
+    })
+
+    expect(config.args.slice(0, 3)).toEqual([
+      '--max-old-space-size-percentage',
+      '75',
+      '--expose-gc',
+    ])
+  })
+
   it('supplies launcher heap flags instead of relaunching to a different PID', () => {
     const config = buildBackgroundChildProcessConfig({
       execPath: '/usr/bin/node',

--- a/src/cli/bg.test.ts
+++ b/src/cli/bg.test.ts
@@ -632,6 +632,46 @@ describe('background session CLI parsing', () => {
     expect(config.env[BACKGROUND_SESSION_LAUNCHER_PID_ENV]).toBe('700')
   })
 
+  it('does not add a fixed heap cap when NODE_OPTIONS already has a percentage limit', () => {
+    const config = buildBackgroundChildProcessConfig({
+      execPath: '/usr/bin/node',
+      execArgv: [],
+      entrypoint: '/repo/bin/openclaude',
+      childArgs: ['--print', 'fix failing tests'],
+      processEnv: {
+        NODE_OPTIONS: '--max-old-space-size-percentage=50',
+      },
+      stdoutLogPath: '/tmp/bg.out.log',
+      backgroundSessionId: 'bg-percentage-node-options',
+      processMarker: TEST_PROCESS_MARKER,
+      launcherPid: 705,
+    })
+
+    expect(config.args.filter(arg => arg.startsWith('--max-old-space-size='))).toEqual(
+      [],
+    )
+    expect(config.args[0]).toBe('--expose-gc')
+  })
+
+  it('preserves an execArgv percentage heap flag instead of appending 8192', () => {
+    const config = buildBackgroundChildProcessConfig({
+      execPath: '/usr/bin/node',
+      execArgv: ['--max-old-space-size-percentage=75'],
+      entrypoint: '/repo/bin/openclaude',
+      childArgs: ['--print', 'fix failing tests'],
+      processEnv: {},
+      stdoutLogPath: '/tmp/bg.out.log',
+      backgroundSessionId: 'bg-percentage-execargv',
+      processMarker: TEST_PROCESS_MARKER,
+      launcherPid: 706,
+    })
+
+    expect(config.args.slice(0, 2)).toEqual([
+      '--max-old-space-size-percentage=75',
+      '--expose-gc',
+    ])
+  })
+
   it('supplies launcher heap flags instead of relaunching to a different PID', () => {
     const config = buildBackgroundChildProcessConfig({
       execPath: '/usr/bin/node',

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -193,6 +193,13 @@ function hasNodeFlag(args: string[], flag: string): boolean {
   return args.some(arg => arg === flag || arg.startsWith(`${flag}=`))
 }
 
+function hasHeapLimitFlag(args: string[]): boolean {
+  return (
+    hasNodeFlag(args, '--max-old-space-size') ||
+    hasNodeFlag(args, '--max-old-space-size-percentage')
+  )
+}
+
 function safeNodeExecArgvForBackground(
   execPath: string,
   execArgv: string[],
@@ -210,7 +217,7 @@ function safeNodeExecArgvForBackground(
     .split(/\s+/)
     .filter(Boolean)
   const effectiveArgs = [...safeArgs, ...nodeOptions]
-  if (!hasNodeFlag(effectiveArgs, '--max-old-space-size')) {
+  if (!hasHeapLimitFlag(effectiveArgs)) {
     const configuredHeap = Number.parseInt(processEnv[HEAP_SIZE_ENV] ?? '', 10)
     const heapSize =
       Number.isSafeInteger(configuredHeap) && configuredHeap > 0

--- a/src/cli/bg.ts
+++ b/src/cli/bg.ts
@@ -200,17 +200,38 @@ function hasHeapLimitFlag(args: string[]): boolean {
   )
 }
 
+function keepBackgroundNodeExecArg(arg: string): boolean {
+  return (
+    arg === '--expose-gc' ||
+    arg.startsWith('--max-old-space-size') ||
+    arg.startsWith('--heapsnapshot-near-heap-limit')
+  )
+}
+
+function isValueTakingHeapExecArg(arg: string): boolean {
+  return (
+    arg === '--max-old-space-size' ||
+    arg === '--max-old-space-size-percentage' ||
+    arg === '--heapsnapshot-near-heap-limit'
+  )
+}
+
 function safeNodeExecArgvForBackground(
   execPath: string,
   execArgv: string[],
   processEnv: NodeJS.ProcessEnv,
 ): string[] {
-  const safeArgs = execArgv.filter(
-    arg =>
-      arg === '--expose-gc' ||
-      arg.startsWith('--max-old-space-size') ||
-      arg.startsWith('--heapsnapshot-near-heap-limit'),
-  )
+  const safeArgs: string[] = []
+  for (let i = 0; i < execArgv.length; i++) {
+    const arg = execArgv[i]
+    if (!keepBackgroundNodeExecArg(arg)) continue
+    safeArgs.push(arg)
+    const next = execArgv[i + 1]
+    if (isValueTakingHeapExecArg(arg) && next && !next.startsWith('-')) {
+      i += 1
+      safeArgs.push(next)
+    }
+  }
   if (!isNodeExecutable(execPath)) return safeArgs
 
   const nodeOptions = (processEnv.NODE_OPTIONS ?? '')

--- a/src/entrypoints/applyChildProcessHeapOptions.ts
+++ b/src/entrypoints/applyChildProcessHeapOptions.ts
@@ -1,0 +1,21 @@
+const HEAP_SIZE_SUBSTRING = '--max-old-space-size'
+const HEAP_SIZE_ENV = 'OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB'
+const DEFAULT_HEAP_SIZE_MB = '8192'
+
+/**
+ * Apply a numeric V8 old-space cap to `NODE_OPTIONS` for subprocesses.
+ * Leaves an existing `--max-old-space-size` or
+ * `--max-old-space-size-percentage` flag unchanged because both contain the
+ * same substring. The current CLI process is already running; this only
+ * preserves a cap for tools spawned after startup.
+ */
+export function applyChildProcessHeapOptions(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  if (env.NODE_OPTIONS?.includes(HEAP_SIZE_SUBSTRING)) return
+  const existing = env.NODE_OPTIONS || ''
+  const heapMb = env[HEAP_SIZE_ENV] || DEFAULT_HEAP_SIZE_MB
+  env.NODE_OPTIONS = existing
+    ? `${existing} --max-old-space-size=${heapMb}`
+    : `--max-old-space-size=${heapMb}`
+}

--- a/src/entrypoints/applyChildProcessHeapOptions.ts
+++ b/src/entrypoints/applyChildProcessHeapOptions.ts
@@ -1,21 +1,46 @@
+import {
+  findEqualsOrNextFlagValue,
+  hasHeapLimitFlag,
+  HEAP_SIZE_FLAG,
+  parsePositiveIntegerMb,
+} from '../../bin/heap-limit.mjs'
+
 const HEAP_SIZE_SUBSTRING = '--max-old-space-size'
 const HEAP_SIZE_ENV = 'OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB'
 const DEFAULT_HEAP_SIZE_MB = '8192'
 
-/**
- * Apply a numeric V8 old-space cap to `NODE_OPTIONS` for subprocesses.
- * Leaves an existing `--max-old-space-size` or
- * `--max-old-space-size-percentage` flag unchanged because both contain the
- * same substring. The current CLI process is already running; this only
- * preserves a cap for tools spawned after startup.
- */
-export function applyChildProcessHeapOptions(
-  env: NodeJS.ProcessEnv = process.env,
-): void {
-  if (env.NODE_OPTIONS?.includes(HEAP_SIZE_SUBSTRING)) return
+function appendHeapMbToNodeOptions(env: NodeJS.ProcessEnv, heapMb: string): void {
   const existing = env.NODE_OPTIONS || ''
-  const heapMb = env[HEAP_SIZE_ENV] || DEFAULT_HEAP_SIZE_MB
   env.NODE_OPTIONS = existing
     ? `${existing} --max-old-space-size=${heapMb}`
     : `--max-old-space-size=${heapMb}`
+}
+
+/**
+ * Apply a numeric V8 old-space cap to `NODE_OPTIONS` for subprocesses.
+ * Child Node processes do not inherit the parent's `process.execArgv`, so a
+ * heap cap applied only there must be copied into `NODE_OPTIONS` for tools
+ * spawned after startup. Leaves an existing `NODE_OPTIONS` heap flag unchanged.
+ */
+export function applyChildProcessHeapOptions(
+  env: NodeJS.ProcessEnv = process.env,
+  execArgv: readonly string[] = process.execArgv,
+): void {
+  if (env.NODE_OPTIONS?.includes(HEAP_SIZE_SUBSTRING)) return
+
+  const execArgvList = [...execArgv]
+  if (hasHeapLimitFlag(execArgvList)) {
+    const execArgvMb = parsePositiveIntegerMb(
+      findEqualsOrNextFlagValue(execArgvList, HEAP_SIZE_FLAG),
+    )
+    if (execArgvMb == null) {
+      // Percentage or other non-MB heap flag already applies to this process.
+      return
+    }
+    appendHeapMbToNodeOptions(env, String(execArgvMb))
+    return
+  }
+
+  const heapMb = env[HEAP_SIZE_ENV] || DEFAULT_HEAP_SIZE_MB
+  appendHeapMbToNodeOptions(env, heapMb)
 }

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -125,7 +125,19 @@ describe('cli.tsx — NODE_OPTIONS --max-old-space-size (issue #402)', () => {
     expect(cliSource).toContain(
       "import { applyChildProcessHeapOptions } from './applyChildProcessHeapOptions.js'",
     )
-    expect(cliSource).toContain('applyChildProcessHeapOptions(process.env)')
+    expect(cliSource).toContain('applyChildProcessHeapOptions(process.env, process.execArgv)')
+  })
+
+  it('propagates a numeric process.execArgv heap cap to NODE_OPTIONS for subprocesses', () => {
+    const env: NodeJS.ProcessEnv = {}
+    applyChildProcessHeapOptions(env, ['--max-old-space-size=4096', '--expose-gc'])
+    expect(env.NODE_OPTIONS).toBe('--max-old-space-size=4096')
+  })
+
+  it('does not append 8192 when process.execArgv already has a percentage heap flag', () => {
+    const env: NodeJS.ProcessEnv = {}
+    applyChildProcessHeapOptions(env, ['--max-old-space-size-percentage=50'])
+    expect(env.NODE_OPTIONS).toBeUndefined()
   })
 
   it('sets --max-old-space-size=8192 when NODE_OPTIONS is not set', () => {

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -13,10 +13,11 @@ import {
   it,
   mock,
 } from 'bun:test'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { Command } from '@commander-js/extra-typings'
+import { applyChildProcessHeapOptions } from './applyChildProcessHeapOptions.js'
 import {
   BACKGROUND_SESSION_ID_ENV,
   BACKGROUND_SESSION_LAUNCHER_PID_ENV,
@@ -118,71 +119,61 @@ function clearRuntimeMocks() {
 }
 
 describe('cli.tsx — NODE_OPTIONS --max-old-space-size (issue #402)', () => {
-  const originalNodeOptions = process.env.NODE_OPTIONS
-  const originalHeapSizeMb = process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB
+  const cliSource = readFileSync(new URL('./cli.tsx', import.meta.url), 'utf8')
 
-  beforeEach(() => {
-    delete process.env.NODE_OPTIONS
-    delete process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB
-  })
-
-  afterEach(() => {
-    if (originalNodeOptions !== undefined) {
-      process.env.NODE_OPTIONS = originalNodeOptions
-    } else {
-      delete process.env.NODE_OPTIONS
-    }
-    if (originalHeapSizeMb !== undefined) {
-      process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB = originalHeapSizeMb
-    } else {
-      delete process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB
-    }
+  it('wires the child-process heap helper from the CLI entrypoint', () => {
+    expect(cliSource).toContain(
+      "import { applyChildProcessHeapOptions } from './applyChildProcessHeapOptions.js'",
+    )
+    expect(cliSource).toContain('applyChildProcessHeapOptions(process.env)')
   })
 
   it('sets --max-old-space-size=8192 when NODE_OPTIONS is not set', () => {
-    // Guard predicate: fires when the flag is absent
-    const shouldSetHeapCap = !process.env.NODE_OPTIONS?.includes('--max-old-space-size')
-    expect(shouldSetHeapCap).toBe(true)
+    const env: NodeJS.ProcessEnv = {}
+    applyChildProcessHeapOptions(env)
+    expect(env.NODE_OPTIONS).toBe('--max-old-space-size=8192')
   })
 
   it('does not override existing --max-old-space-size=4096', () => {
-    process.env.NODE_OPTIONS = '--max-old-space-size=4096 --experimental-vm-modules'
-
-    const shouldSetHeapCap = !process.env.NODE_OPTIONS.includes('--max-old-space-size')
-    expect(shouldSetHeapCap).toBe(false)
-    expect(process.env.NODE_OPTIONS).toContain('4096')
+    const env: NodeJS.ProcessEnv = {
+      NODE_OPTIONS: '--max-old-space-size=4096 --experimental-vm-modules',
+    }
+    applyChildProcessHeapOptions(env)
+    expect(env.NODE_OPTIONS).toBe(
+      '--max-old-space-size=4096 --experimental-vm-modules',
+    )
   })
 
   it('does not override existing --max-old-space-size=8192', () => {
-    process.env.NODE_OPTIONS = '--max-old-space-size=8192'
-
-    const shouldSetHeapCap = !process.env.NODE_OPTIONS.includes('--max-old-space-size')
-    expect(shouldSetHeapCap).toBe(false)
-    expect(process.env.NODE_OPTIONS).toBe('--max-old-space-size=8192')
+    const env: NodeJS.ProcessEnv = {
+      NODE_OPTIONS: '--max-old-space-size=8192',
+    }
+    applyChildProcessHeapOptions(env)
+    expect(env.NODE_OPTIONS).toBe('--max-old-space-size=8192')
   })
 
   it('appends --max-old-space-size when NODE_OPTIONS has other flags', () => {
-    process.env.NODE_OPTIONS = '--inspect=9229'
-
-    const heapMb = process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB || '8192'
-    const result = `${process.env.NODE_OPTIONS} --max-old-space-size=${heapMb}`
-    expect(result).toBe('--inspect=9229 --max-old-space-size=8192')
+    const env: NodeJS.ProcessEnv = { NODE_OPTIONS: '--inspect=9229' }
+    applyChildProcessHeapOptions(env)
+    expect(env.NODE_OPTIONS).toBe('--inspect=9229 --max-old-space-size=8192')
   })
 
   it('does not override existing --max-old-space-size-percentage=50', () => {
-    process.env.NODE_OPTIONS = '--max-old-space-size-percentage=50'
-
-    const shouldSetHeapCap = !process.env.NODE_OPTIONS.includes('--max-old-space-size')
-    expect(shouldSetHeapCap).toBe(false)
+    const env: NodeJS.ProcessEnv = {
+      NODE_OPTIONS: '--max-old-space-size-percentage=50',
+    }
+    applyChildProcessHeapOptions(env)
+    expect(env.NODE_OPTIONS).toBe('--max-old-space-size-percentage=50')
+    expect(env.NODE_OPTIONS).not.toMatch(/--max-old-space-size=\d+/)
   })
 
   it('uses OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB when appending a heap cap', () => {
-    process.env.NODE_OPTIONS = '--inspect=9229'
-    process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB = '2048'
-
-    const heapMb = process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB || '8192'
-    const result = `${process.env.NODE_OPTIONS} --max-old-space-size=${heapMb}`
-    expect(result).toBe('--inspect=9229 --max-old-space-size=2048')
+    const env: NodeJS.ProcessEnv = {
+      NODE_OPTIONS: '--inspect=9229',
+      OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB: '2048',
+    }
+    applyChildProcessHeapOptions(env)
+    expect(env.NODE_OPTIONS).toBe('--inspect=9229 --max-old-space-size=2048')
   })
 })
 

--- a/src/entrypoints/cli.test.ts
+++ b/src/entrypoints/cli.test.ts
@@ -119,9 +119,11 @@ function clearRuntimeMocks() {
 
 describe('cli.tsx — NODE_OPTIONS --max-old-space-size (issue #402)', () => {
   const originalNodeOptions = process.env.NODE_OPTIONS
+  const originalHeapSizeMb = process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB
 
   beforeEach(() => {
     delete process.env.NODE_OPTIONS
+    delete process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB
   })
 
   afterEach(() => {
@@ -129,6 +131,11 @@ describe('cli.tsx — NODE_OPTIONS --max-old-space-size (issue #402)', () => {
       process.env.NODE_OPTIONS = originalNodeOptions
     } else {
       delete process.env.NODE_OPTIONS
+    }
+    if (originalHeapSizeMb !== undefined) {
+      process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB = originalHeapSizeMb
+    } else {
+      delete process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB
     }
   })
 
@@ -157,8 +164,25 @@ describe('cli.tsx — NODE_OPTIONS --max-old-space-size (issue #402)', () => {
   it('appends --max-old-space-size when NODE_OPTIONS has other flags', () => {
     process.env.NODE_OPTIONS = '--inspect=9229'
 
-    const result = `${process.env.NODE_OPTIONS} --max-old-space-size=8192`
+    const heapMb = process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB || '8192'
+    const result = `${process.env.NODE_OPTIONS} --max-old-space-size=${heapMb}`
     expect(result).toBe('--inspect=9229 --max-old-space-size=8192')
+  })
+
+  it('does not override existing --max-old-space-size-percentage=50', () => {
+    process.env.NODE_OPTIONS = '--max-old-space-size-percentage=50'
+
+    const shouldSetHeapCap = !process.env.NODE_OPTIONS.includes('--max-old-space-size')
+    expect(shouldSetHeapCap).toBe(false)
+  })
+
+  it('uses OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB when appending a heap cap', () => {
+    process.env.NODE_OPTIONS = '--inspect=9229'
+    process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB = '2048'
+
+    const heapMb = process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB || '8192'
+    const result = `${process.env.NODE_OPTIONS} --max-old-space-size=${heapMb}`
+    expect(result).toBe('--inspect=9229 --max-old-space-size=2048')
   })
 })
 

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -3,6 +3,7 @@ import {
   BACKGROUND_SESSION_ID_ENV,
   BACKGROUND_SESSION_LAUNCHER_PID_ENV,
 } from '../cli/bgRouting.js'
+import { applyChildProcessHeapOptions } from './applyChildProcessHeapOptions.js'
 import {
   argsBeforeModelOwningSubcommand,
   parseRootOptionValue,
@@ -224,19 +225,8 @@ function getSkillsCliArgs(args: string[]): SkillsCliParseResult | undefined {
 // running by this point; the package launcher raises its heap before importing
 // dist/cli.mjs. Keeping NODE_OPTIONS here preserves the larger cap for tools or
 // subprocesses spawned after startup without overriding user-provided limits.
-// eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level, custom-rules/safe-env-boolean-check
-if (!process.env.NODE_OPTIONS?.includes('--max-old-space-size')) {
-  // eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level
-  const existing = process.env.NODE_OPTIONS || ''
-  // Launcher percentage/MB resolution writes OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB
-  // before importing this file so subprocesses inherit the same cap.
-  // eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level
-  const heapMb = process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB || '8192'
-  // eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level
-  process.env.NODE_OPTIONS = existing
-    ? `${existing} --max-old-space-size=${heapMb}`
-    : `--max-old-space-size=${heapMb}`
-}
+// eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level
+applyChildProcessHeapOptions(process.env)
 
 // Harness-science L0 ablation baseline. Inlined here (not init.ts) because
 // BashTool/AgentTool/PowerShellTool capture DISABLE_BACKGROUND_TASKS into

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -226,7 +226,7 @@ function getSkillsCliArgs(args: string[]): SkillsCliParseResult | undefined {
 // dist/cli.mjs. Keeping NODE_OPTIONS here preserves the larger cap for tools or
 // subprocesses spawned after startup without overriding user-provided limits.
 // eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level
-applyChildProcessHeapOptions(process.env)
+applyChildProcessHeapOptions(process.env, process.execArgv)
 
 // Harness-science L0 ablation baseline. Inlined here (not init.ts) because
 // BashTool/AgentTool/PowerShellTool capture DISABLE_BACKGROUND_TASKS into

--- a/src/entrypoints/cli.tsx
+++ b/src/entrypoints/cli.tsx
@@ -228,8 +228,14 @@ function getSkillsCliArgs(args: string[]): SkillsCliParseResult | undefined {
 if (!process.env.NODE_OPTIONS?.includes('--max-old-space-size')) {
   // eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level
   const existing = process.env.NODE_OPTIONS || ''
+  // Launcher percentage/MB resolution writes OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB
+  // before importing this file so subprocesses inherit the same cap.
   // eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level
-  process.env.NODE_OPTIONS = existing ? `${existing} --max-old-space-size=8192` : '--max-old-space-size=8192'
+  const heapMb = process.env.OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB || '8192'
+  // eslint-disable-next-line custom-rules/no-top-level-side-effects, custom-rules/no-process-env-top-level
+  process.env.NODE_OPTIONS = existing
+    ? `${existing} --max-old-space-size=${heapMb}`
+    : `--max-old-space-size=${heapMb}`
 }
 
 // Harness-science L0 ablation baseline. Inlined here (not init.ts) because


### PR DESCRIPTION
## Summary

- I reviewed `CONTRIBUTING.md` and `AGENTS.md`.
- OpenClaude now accepts `--max-old-space-size-percentage` (and `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_PERCENTAGE`) and converts it to `--max-old-space-size=<MB>` from a real cgroup/OS memory cap when Node reports one, otherwise total RAM. That keeps Node 22.0.0 working while letting small containers and large workstations avoid the fixed 8192 MB default.
- Native `NODE_OPTIONS` / `execArgv` heap or percentage flags are left in place. `--max-memory=` remains the explicit megabyte override.
- Unconstrained libuv `UINT64_MAX` `constrainedMemory()` values are ignored so percentage sizing uses host RAM; sub-megabyte results clamp to 1 MB; background launches keep spaced heap-flag values.

Fixes #2213

## Impact

- user-facing impact: `openclaude --max-old-space-size-percentage=50` (or the env var) sizes the V8 old-space heap as a percentage of available memory. Documented in `docs/advanced-setup.md`.
- developer/maintainer impact: heap math lives in `bin/heap-limit.mjs`; the published tarball now includes that file. Default 8192 MB is unchanged unless a percentage or explicit MB request is set.

## Testing

- [x] I ran the required [local preflight](https://github.com/Gitlawb/openclaude/blob/main/CONTRIBUTING.md#validation).
- exact commands and results:
  - `bun install --frozen-lockfile`
  - `bun run check` (build, smoke, knip, full tests) pass
  - `bun run typecheck` pass
  - `bun run typecheck:type-tests` pass
  - `node bin/openclaude --version` pass
  - `NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version` pass
  - `node bin/openclaude --max-old-space-size-percentage=50 --version` pass
  - `bun run test:provider` pass
  - `npm run test:provider-recommendation` pass
  - `git fetch https://github.com/Gitlawb/openclaude.git main && bun run security:pr-scan -- --base FETCH_HEAD --head HEAD` — no suspicious additions
- focused tests: `bun test scripts/openclaude-bin-heap.test.ts src/cli/bg.test.ts src/entrypoints/cli.test.ts scripts/openclaude-bin-compile-cache.test.ts` pass
- documented skipped checks, platform limitations, or verified pre-existing failures: web suite skipped (no `web/` changes). Native `NODE_OPTIONS=--max-old-space-size-percentage` still requires a Node that accepts that flag; Node 22.0.0 rejects it before OpenClaude starts.

## Notes

- provider/model path tested: none (launcher/heap only)
- screenshots attached (if UI changed): n/a
- follow-up work or known limitations: percentage is not applied on launcher-skip paths (`OPENCLAUDE_DISABLE_HEAP_RELAUNCH=1`, `node dist/cli.mjs`) unless `OPENCLAUDE_NODE_MAX_OLD_SPACE_SIZE_MB` is already set — same as `--max-memory`.
- final reviewed SHA: `4aa353f8dd42322c66296e826167cbdf486ff358`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Node.js memory limits using megabyte- or percentage-based settings.
  * Added automatic memory detection with sensible defaults for constrained environments.
  * Custom heap settings now take precedence over the default 8 GB limit.
  * Existing Node.js percentage-based memory flags are preserved.
* **Bug Fixes**
  * Improved handling of heap-limit arguments across CLI and background processes.
  * Prevented duplicate or conflicting memory limits during launcher startup.
* **Documentation**
  * Added configuration guidance and environment-variable references for heap sizing.
  * Documented compatibility behavior for percentage-based limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->