### PR TITLE
fix(plugins): keep Windows marketplace cache on copy ENOENT

### DIFF
--- a/src/services/plugins/pluginOperations.installLocation.test.ts
+++ b/src/services/plugins/pluginOperations.installLocation.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, afterEach, describe, expect, mock, test } from 'bun:test'
+
+const staleInstallLocation = '/stale/marketplaces/mymarketplace'
+const liveInstallLocation = '/live/marketplaces/temp_keep'
+
+const realMarketplaceManager = await import(
+  `../../utils/plugins/marketplaceManager.js?spread=${Date.now()}`
+)
+const realInstallationHelpers = await import(
+  `../../utils/plugins/pluginInstallationHelpers.js?spread=${Date.now()}`
+)
+
+let configLoadCount = 0
+let capturedInstallLocation: string | undefined
+
+mock.module('../../utils/plugins/marketplaceManager.js', () => ({
+  ...realMarketplaceManager,
+  getMarketplace: async () => ({
+    name: 'MyMarketplace',
+    owner: { name: 'test' },
+    plugins: [{ name: 'demo-plugin', source: './' }],
+  }),
+  getPluginById: async () => null,
+  loadKnownMarketplacesConfig: async () => {
+    configLoadCount++
+    const installLocation =
+      configLoadCount === 1 ? staleInstallLocation : liveInstallLocation
+    return {
+      MyMarketplace: {
+        source: { source: 'url', url: 'https://example.com/marketplace.json' },
+        installLocation,
+        lastUpdated: '2020-01-01T00:00:00.000Z',
+      },
+    }
+  },
+}))
+
+mock.module('../../utils/plugins/pluginInstallationHelpers.js', () => ({
+  ...realInstallationHelpers,
+  installResolvedPlugin: async (opts: {
+    marketplaceInstallLocation?: string
+  }) => {
+    capturedInstallLocation = opts.marketplaceInstallLocation
+    return { ok: true, closure: [] as string[], depNote: '' }
+  },
+}))
+
+afterAll(() => {
+  mock.module(
+    '../../utils/plugins/marketplaceManager.js',
+    () => realMarketplaceManager,
+  )
+  mock.module(
+    '../../utils/plugins/pluginInstallationHelpers.js',
+    () => realInstallationHelpers,
+  )
+})
+
+const { installPluginOp } = await import(
+  `./pluginOperations.ts?bust=install-location-${Date.now()}`
+)
+
+describe('installPluginOp keep-temp installLocation (#2183)', () => {
+  afterEach(() => {
+    configLoadCount = 0
+    capturedInstallLocation = undefined
+  })
+
+  test('install-by-name uses persisted installLocation after getMarketplace refetch', async () => {
+    const result = await installPluginOp('demo-plugin', 'user')
+    expect(result.success).toBe(true)
+    expect(capturedInstallLocation).toBe(liveInstallLocation)
+    expect(configLoadCount).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/src/services/plugins/pluginOperations.ts
+++ b/src/services/plugins/pluginOperations.ts
@@ -348,7 +348,9 @@ export async function installPluginOp(
         if (pluginEntry) {
           foundPlugin = pluginEntry
           foundMarketplace = mktName
-          marketplaceInstallLocation = mktConfig.installLocation
+          const refreshed = await loadKnownMarketplacesConfig()
+          marketplaceInstallLocation =
+            refreshed[mktName]?.installLocation ?? mktConfig.installLocation
           break
         }
       } catch (error) {

--- a/src/utils/permissions/pathValidation.expandTilde.test.ts
+++ b/src/utils/permissions/pathValidation.expandTilde.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { homedir } from 'os'
+import { join } from 'path'
+import { expandTilde } from './pathValidation.js'
+
+describe('expandTilde', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform)
+    }
+  })
+
+  test('expands ~/ using path.join so home and .openclaude stay separate', () => {
+    const expanded = expandTilde('~/.openclaude/plugins')
+    expect(expanded).toBe(join(homedir(), '.openclaude', 'plugins'))
+    expect(expanded).not.toMatch(/[^/\\]\.openclaude/)
+  })
+
+  test('expands a bare tilde to the home directory', () => {
+    expect(expandTilde('~')).toBe(homedir())
+  })
+
+  test('leaves non-tilde paths unchanged', () => {
+    expect(expandTilde('C:\\Users\\GarryLai\\.openclaude\\plugins')).toBe(
+      'C:\\Users\\GarryLai\\.openclaude\\plugins',
+    )
+    expect(expandTilde('/tmp/plugins')).toBe('/tmp/plugins')
+  })
+
+  test('expands ~\\ on win32 rather than leaving the tilde literal', () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    })
+    const expanded = expandTilde('~\\.openclaude\\plugins')
+    expect(expanded.startsWith(homedir())).toBe(true)
+    expect(expanded).not.toBe('~\\.openclaude\\plugins')
+    expect(expanded.includes('.openclaude')).toBe(true)
+    expect(expanded).not.toMatch(/[^/\\]\.openclaude/)
+  })
+})

--- a/src/utils/permissions/pathValidation.ts
+++ b/src/utils/permissions/pathValidation.ts
@@ -1,6 +1,6 @@
 import memoize from 'lodash-es/memoize.js'
 import { homedir } from 'os'
-import { dirname, isAbsolute, resolve } from 'path'
+import { dirname, isAbsolute, join, resolve } from 'path'
 import type { ToolPermissionContext } from '../../Tool.js'
 import { getPlatform } from '../../utils/platform.js'
 import {
@@ -76,14 +76,25 @@ export function getGlobBaseDirectory(path: string): string {
 /**
  * Expands tilde (~) at the start of a path to the user's home directory.
  * Note: ~username expansion is not supported for security reasons.
+ *
+ * Uses path.join rather than string concatenation. Concatenating
+ * `homedir() + path.slice(1)` keeps the leading `/` from `~/...`, which
+ * happens to work on POSIX (`/home/user` + `/.openclaude`) but on Windows
+ * produces mixed separators (`C:\Users\Name/.openclaude`) and, for any
+ * helper that strips `~/` including the slash, glues the names together
+ * (`C:\Users\Name.openclaude`). Plugin cache overrides such as
+ * CLAUDE_CODE_PLUGIN_CACHE_DIR=`~/.openclaude/plugins` go through this
+ * helper (issue #2183).
  */
 export function expandTilde(path: string): string {
+  if (path === '~') {
+    return homedir()
+  }
   if (
-    path === '~' ||
     path.startsWith('~/') ||
     (process.platform === 'win32' && path.startsWith('~\\'))
   ) {
-    return homedir() + path.slice(1)
+    return join(homedir(), path.slice(2))
   }
   return path
 }

--- a/src/utils/plugins/marketplaceManager.test.ts
+++ b/src/utils/plugins/marketplaceManager.test.ts
@@ -10,9 +10,10 @@ import {
   test,
 } from 'bun:test'
 import * as realAxios from 'axios'
-import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'fs'
 import { tmpdir } from 'os'
 import { join } from 'path'
+import * as realExecFileNoThrow from '../execFileNoThrow.js'
 import {
   getFsImplementation,
   NodeFsOperations,
@@ -282,6 +283,31 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
       },
       isAxiosError: () => false,
     }))
+    mock.module('../execFileNoThrow.js', () => ({
+      ...realExecFileNoThrow,
+      execFileNoThrow: async () => ({
+        code: 255,
+        stdout: '',
+        stderr: 'Permission denied',
+      }),
+      execFileNoThrowWithCwd: async (
+        _file: string,
+        args: string[] = [],
+      ) => {
+        if (args.includes('clone')) {
+          const targetPath = args.at(-1)
+          if (targetPath) {
+            mkdirSync(join(targetPath, '.claude-plugin'), { recursive: true })
+            writeFileSync(
+              join(targetPath, '.claude-plugin', 'marketplace.json'),
+              JSON.stringify(fakeMarketplaceJson),
+            )
+          }
+          return { code: 0, stdout: '', stderr: '' }
+        }
+        return { code: 1, stdout: '', stderr: 'not a git repository' }
+      },
+    }))
 
     // Re-import with mocked axios so the module under test picks up the mock.
     // The `?bust=` suffix is the same trick the dynamic import at the top of
@@ -308,6 +334,7 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
 
   afterAll(() => {
     mock.module('axios', () => realAxios)
+    mock.module('../execFileNoThrow.js', () => realExecFileNoThrow)
   })
 
   beforeEach(() => {
@@ -584,6 +611,73 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
       ),
     ).toBe(true)
     expect(pluginInfo!.marketplaceInstallLocation).not.toBe(staleCanonicalPath)
+  })
+
+  test('keeps the GitHub clone directory when copy fallback throws ENOENT', async () => {
+    renameSpy.mockImplementation(() => {
+      throw new Error('EXDEV: cross-device link not permitted, rename')
+    })
+    cpSpy.mockImplementation(async () => {
+      throw Object.assign(
+        new Error(
+          "ENOENT: no such file or directory, copyfile 'chromedevtools-chrome-devtools-mcp/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps' -> 'chrome-devtools-plugins/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps'",
+        ),
+        { code: 'ENOENT' },
+      )
+    })
+
+    const source: MarketplaceSource = {
+      source: 'github',
+      repo: 'ChromeDevTools/chrome-devtools-mcp',
+    }
+
+    const cacheDir = join(tempDir, 'marketplaces')
+    mkdirSync(cacheDir, { recursive: true })
+
+    const result = await loadAndCacheWithMockedAxios!(source)
+    const cloneDir = join(cacheDir, 'chromedevtools-chrome-devtools-mcp')
+
+    expect(result.marketplace.name).toBe('MyMarketplace')
+    expect(result.cachePath).toBe(cloneDir)
+    expect(
+      existsSync(join(cloneDir, '.claude-plugin', 'marketplace.json')),
+    ).toBe(true)
+    expect(existsSync(join(cacheDir, 'mymarketplace'))).toBe(false)
+    expect(cpSpy).toHaveBeenCalled()
+  })
+
+  test('getMarketplace refetch does not rewrite local file installLocation', async () => {
+    const localRoot = join(tempDir, 'local-marketplace')
+    mkdirSync(join(localRoot, '.claude-plugin'), { recursive: true })
+    writeFileSync(
+      join(localRoot, '.claude-plugin', 'marketplace.json'),
+      JSON.stringify(fakeMarketplaceJson),
+    )
+    const storedManifestPath = join(
+      localRoot,
+      '.claude-plugin',
+      'marketplace.json',
+    )
+    const missingCachePath = join(tempDir, 'missing-installLocation.json')
+
+    await saveKnownMarketplacesConfigWithMockedAxios!({
+      MyMarketplace: {
+        source: {
+          source: 'file',
+          path: storedManifestPath,
+        },
+        installLocation: missingCachePath,
+        lastUpdated: '2020-01-01T00:00:00.000Z',
+      },
+    })
+    clearMarketplacesCacheWithMockedAxios!()
+
+    const marketplace = await getMarketplaceWithMockedAxios!('MyMarketplace')
+    expect(marketplace.name).toBe('MyMarketplace')
+
+    const config = await loadKnownMarketplacesConfigWithMockedAxios!()
+    expect(config.MyMarketplace?.installLocation).toBe(missingCachePath)
+    expect(config.MyMarketplace?.installLocation).not.toBe(localRoot)
   })
 })
 

--- a/src/utils/plugins/marketplaceManager.test.ts
+++ b/src/utils/plugins/marketplaceManager.test.ts
@@ -249,6 +249,10 @@ describe('loadAndCacheMarketplace — Windows cache finalization (#1500)', () =>
  */
 describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
   let loadAndCacheWithMockedAxios: typeof loadAndCacheMarketplace
+  let getMarketplaceWithMockedAxios: typeof import('./marketplaceManager.js').getMarketplace
+  let saveKnownMarketplacesConfigWithMockedAxios: typeof import('./marketplaceManager.js').saveKnownMarketplacesConfig
+  let loadKnownMarketplacesConfigWithMockedAxios: typeof import('./marketplaceManager.js').loadKnownMarketplacesConfig
+  let clearMarketplacesCacheWithMockedAxios: typeof import('./marketplaceManager.js').clearMarketplacesCache
   let tempDir: string
   let originalFs: FsOperations
   let originalCacheDir: string | undefined
@@ -294,6 +298,10 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
       `./marketplaceManager.ts?bust=exdev-test-reimport-${Date.now()}`
     )) as typeof import('./marketplaceManager.js')
     loadAndCacheWithMockedAxios = mod._test.loadAndCacheMarketplace
+    getMarketplaceWithMockedAxios = mod.getMarketplace
+    saveKnownMarketplacesConfigWithMockedAxios = mod.saveKnownMarketplacesConfig
+    loadKnownMarketplacesConfigWithMockedAxios = mod.loadKnownMarketplacesConfig
+    clearMarketplacesCacheWithMockedAxios = mod.clearMarketplacesCache
   })
 
   afterAll(() => {
@@ -333,6 +341,7 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
   })
 
   afterEach(() => {
+    clearMarketplacesCacheWithMockedAxios?.()
     setFsImplementation(originalFs)
     if (originalCacheDir === undefined) {
       delete process.env.CLAUDE_CODE_PLUGIN_CACHE_DIR
@@ -445,6 +454,92 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
     expect(existsSync(result.cachePath)).toBe(true)
     expect(existsSync(join(cacheDir, 'mymarketplace'))).toBe(false)
     expect(cpSpy).toHaveBeenCalled()
+  })
+
+  test('keeps the temp cache when dest cleanup after copy ENOENT throws', async () => {
+    renameSpy.mockImplementation(() => {
+      throw new Error('EXDEV: cross-device link not permitted, rename')
+    })
+    let copyAttempted = false
+    cpSpy.mockImplementation(async () => {
+      copyAttempted = true
+      throw Object.assign(
+        new Error(
+          "ENOENT: no such file or directory, copyfile 'chromedevtools-chrome-devtools-mcp/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps' -> 'chrome-devtools-plugins/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps'",
+        ),
+        { code: 'ENOENT' },
+      )
+    })
+
+    const cacheDir = join(tempDir, 'marketplaces')
+    mkdirSync(cacheDir, { recursive: true })
+    const finalCachePath = join(cacheDir, 'mymarketplace')
+
+    setFsImplementation({
+      ...NodeFsOperations,
+      rm: async (path, options?: { recursive?: boolean; force?: boolean }) => {
+        rmCallCount++
+        if (copyAttempted && path === finalCachePath) {
+          throw Object.assign(new Error('EPERM: operation not permitted'), {
+            code: 'EPERM',
+          })
+        }
+        rmSync(path, options ?? { recursive: true, force: true })
+      },
+      rename: renameSpy,
+      cp: cpSpy,
+    })
+
+    const source: MarketplaceSource = {
+      source: 'url',
+      url: 'https://example.com/marketplace.json',
+    }
+
+    const result = await loadAndCacheWithMockedAxios!(source)
+
+    expect(result.marketplace.name).toBe('MyMarketplace')
+    expect(result.cachePath.startsWith(join(cacheDir, 'temp_'))).toBe(true)
+    expect(existsSync(result.cachePath)).toBe(true)
+    expect(cpSpy).toHaveBeenCalled()
+  })
+
+  test('getMarketplace refetch persists keep-temp cachePath as installLocation', async () => {
+    renameSpy.mockImplementation(() => {
+      throw new Error('EXDEV: cross-device link not permitted, rename')
+    })
+    cpSpy.mockImplementation(async () => {
+      throw Object.assign(
+        new Error(
+          "ENOENT: no such file or directory, copyfile 'chromedevtools-chrome-devtools-mcp/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps' -> 'chrome-devtools-plugins/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps'",
+        ),
+        { code: 'ENOENT' },
+      )
+    })
+
+    const cacheDir = join(tempDir, 'marketplaces')
+    mkdirSync(cacheDir, { recursive: true })
+    const staleCanonicalPath = join(cacheDir, 'mymarketplace')
+
+    await saveKnownMarketplacesConfigWithMockedAxios!({
+      MyMarketplace: {
+        source: {
+          source: 'url',
+          url: 'https://example.com/marketplace.json',
+        },
+        installLocation: staleCanonicalPath,
+        lastUpdated: '2020-01-01T00:00:00.000Z',
+      },
+    })
+    clearMarketplacesCacheWithMockedAxios!()
+
+    const marketplace = await getMarketplaceWithMockedAxios!('MyMarketplace')
+    expect(marketplace.name).toBe('MyMarketplace')
+
+    const config = await loadKnownMarketplacesConfigWithMockedAxios!()
+    const persisted = config.MyMarketplace?.installLocation
+    expect(persisted?.startsWith(join(cacheDir, 'temp_'))).toBe(true)
+    expect(existsSync(persisted!)).toBe(true)
+    expect(persisted).not.toBe(staleCanonicalPath)
   })
 })
 

--- a/src/utils/plugins/marketplaceManager.test.ts
+++ b/src/utils/plugins/marketplaceManager.test.ts
@@ -250,6 +250,7 @@ describe('loadAndCacheMarketplace — Windows cache finalization (#1500)', () =>
 describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
   let loadAndCacheWithMockedAxios: typeof loadAndCacheMarketplace
   let getMarketplaceWithMockedAxios: typeof import('./marketplaceManager.js').getMarketplace
+  let getPluginByIdWithMockedAxios: typeof import('./marketplaceManager.js').getPluginById
   let saveKnownMarketplacesConfigWithMockedAxios: typeof import('./marketplaceManager.js').saveKnownMarketplacesConfig
   let loadKnownMarketplacesConfigWithMockedAxios: typeof import('./marketplaceManager.js').loadKnownMarketplacesConfig
   let clearMarketplacesCacheWithMockedAxios: typeof import('./marketplaceManager.js').clearMarketplacesCache
@@ -266,7 +267,7 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
   const fakeMarketplaceJson = {
     name: 'MyMarketplace',
     owner: { name: 'test' },
-    plugins: [],
+    plugins: [{ name: 'demo-plugin', source: './' }],
   }
   const axiosGetSpy = mock(async () => ({
     data: fakeMarketplaceJson,
@@ -299,6 +300,7 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
     )) as typeof import('./marketplaceManager.js')
     loadAndCacheWithMockedAxios = mod._test.loadAndCacheMarketplace
     getMarketplaceWithMockedAxios = mod.getMarketplace
+    getPluginByIdWithMockedAxios = mod.getPluginById
     saveKnownMarketplacesConfigWithMockedAxios = mod.saveKnownMarketplacesConfig
     loadKnownMarketplacesConfigWithMockedAxios = mod.loadKnownMarketplacesConfig
     clearMarketplacesCacheWithMockedAxios = mod.clearMarketplacesCache
@@ -540,6 +542,48 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
     expect(persisted?.startsWith(join(cacheDir, 'temp_'))).toBe(true)
     expect(existsSync(persisted!)).toBe(true)
     expect(persisted).not.toBe(staleCanonicalPath)
+  })
+
+  test('getPluginById returns persisted keep-temp installLocation after refetch', async () => {
+    renameSpy.mockImplementation(() => {
+      throw new Error('EXDEV: cross-device link not permitted, rename')
+    })
+    cpSpy.mockImplementation(async () => {
+      throw Object.assign(
+        new Error(
+          "ENOENT: no such file or directory, copyfile 'chromedevtools-chrome-devtools-mcp/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps' -> 'chrome-devtools-plugins/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps'",
+        ),
+        { code: 'ENOENT' },
+      )
+    })
+
+    const cacheDir = join(tempDir, 'marketplaces')
+    mkdirSync(cacheDir, { recursive: true })
+    const staleCanonicalPath = join(cacheDir, 'mymarketplace')
+
+    await saveKnownMarketplacesConfigWithMockedAxios!({
+      MyMarketplace: {
+        source: {
+          source: 'url',
+          url: 'https://example.com/marketplace.json',
+        },
+        installLocation: staleCanonicalPath,
+        lastUpdated: '2020-01-01T00:00:00.000Z',
+      },
+    })
+    clearMarketplacesCacheWithMockedAxios!()
+
+    const pluginInfo = await getPluginByIdWithMockedAxios!(
+      'demo-plugin@MyMarketplace',
+    )
+    expect(pluginInfo).not.toBeNull()
+    expect(pluginInfo!.entry.name).toBe('demo-plugin')
+    expect(
+      pluginInfo!.marketplaceInstallLocation.startsWith(
+        join(cacheDir, 'temp_'),
+      ),
+    ).toBe(true)
+    expect(pluginInfo!.marketplaceInstallLocation).not.toBe(staleCanonicalPath)
   })
 })
 

--- a/src/utils/plugins/marketplaceManager.test.ts
+++ b/src/utils/plugins/marketplaceManager.test.ts
@@ -416,6 +416,36 @@ describe('loadAndCacheMarketplace — rename failure fallback (EXDEV)', () => {
     const newEntries = afterEntries.filter(e => !beforeEntries.has(e))
     expect(newEntries).toEqual(['mymarketplace'])
   })
+
+  test('keeps the temp cache when copy fallback throws ENOENT (issue #2183)', async () => {
+    renameSpy.mockImplementation(() => {
+      throw new Error('EXDEV: cross-device link not permitted, rename')
+    })
+    cpSpy.mockImplementation(async () => {
+      throw Object.assign(
+        new Error(
+          "ENOENT: no such file or directory, copyfile 'chromedevtools-chrome-devtools-mcp/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps' -> 'chrome-devtools-plugins/third_party/devtools-frontend/build/android/gyp/binary_baseline_profile.pydeps'",
+        ),
+        { code: 'ENOENT' },
+      )
+    })
+
+    const source: MarketplaceSource = {
+      source: 'url',
+      url: 'https://example.com/marketplace.json',
+    }
+
+    const cacheDir = join(tempDir, 'marketplaces')
+    mkdirSync(cacheDir, { recursive: true })
+
+    const result = await loadAndCacheWithMockedAxios!(source)
+
+    expect(result.marketplace.name).toBe('MyMarketplace')
+    expect(result.cachePath.startsWith(join(cacheDir, 'temp_'))).toBe(true)
+    expect(existsSync(result.cachePath)).toBe(true)
+    expect(existsSync(join(cacheDir, 'mymarketplace'))).toBe(false)
+    expect(cpSpy).toHaveBeenCalled()
+  })
 })
 
 /**

--- a/src/utils/plugins/marketplaceManager.ts
+++ b/src/utils/plugins/marketplaceManager.ts
@@ -1847,7 +1847,14 @@ async function loadAndCacheMarketplace(
               await fs.rm(temporaryCachePath, { recursive: true, force: true })
               temporaryCachePath = finalCachePath
             } catch (copyError) {
-              await fs.rm(finalCachePath, { recursive: true, force: true })
+              try {
+                await fs.rm(finalCachePath, { recursive: true, force: true })
+              } catch (cleanupError) {
+                logForDebugging(
+                  `Failed to remove partial marketplace cache at ${finalCachePath}: ${errorMessage(cleanupError)}`,
+                  { level: 'warn' },
+                )
+              }
               logForDebugging(
                 `Marketplace cache rename and copy failed; keeping ${temporaryCachePath}. rename=${errorMessage(renameError)} copy=${errorMessage(copyError)}`,
                 { level: 'warn' },
@@ -2287,16 +2294,22 @@ export const getMarketplace = memoize(
 
     // Cache doesn't exist or is invalid, fetch from source
     let marketplace: PluginMarketplace
+    let cachePath: string
     try {
-      ;({ marketplace } = await loadAndCacheMarketplace(entry.source))
+      ;({ marketplace, cachePath } = await loadAndCacheMarketplace(
+        entry.source,
+      ))
     } catch (error) {
       throw new Error(
         `Failed to load marketplace "${name}" from source (${entry.source.source}): ${errorMessage(error)}`,
       )
     }
 
-    // Update lastUpdated only when we actually fetch
+    // Persist cachePath: keep-temp recovery (#2183) may leave the live clone
+    // at temporaryCachePath instead of the canonical marketplace-name directory
+    // already stored in installLocation.
     config[name]!.lastUpdated = new Date().toISOString()
+    config[name]!.installLocation = cachePath
     await saveKnownMarketplacesConfig(config)
 
     return marketplace

--- a/src/utils/plugins/marketplaceManager.ts
+++ b/src/utils/plugins/marketplaceManager.ts
@@ -2305,11 +2305,17 @@ export const getMarketplace = memoize(
       )
     }
 
-    // Persist cachePath: keep-temp recovery (#2183) may leave the live clone
-    // at temporaryCachePath instead of the canonical marketplace-name directory
-    // already stored in installLocation.
+    // Persist cachePath for remote sources: keep-temp recovery (#2183) may
+    // leave the live clone at temporaryCachePath instead of the canonical
+    // marketplace-name directory already stored in installLocation.
+    // Local file/directory sources do not go through rename/copy; cachePath is
+    // the user's marketplace root. Overwriting a stored manifest path with that
+    // root would make removeMarketplaceSource recursively delete the user's
+    // directory.
     config[name]!.lastUpdated = new Date().toISOString()
-    config[name]!.installLocation = cachePath
+    if (!isLocalMarketplaceSource(entry.source)) {
+      config[name]!.installLocation = cachePath
+    }
     await saveKnownMarketplacesConfig(config)
 
     return marketplace

--- a/src/utils/plugins/marketplaceManager.ts
+++ b/src/utils/plugins/marketplaceManager.ts
@@ -2405,9 +2405,16 @@ export async function getPluginById(pluginId: string): Promise<{
       return null
     }
 
+    // getMarketplace refetch may persist a keep-temp cachePath (#2183) that
+    // differs from the snapshot loaded above.
+    const refreshedConfig = await loadKnownMarketplacesConfig()
+    const installLocation =
+      refreshedConfig[marketplaceName]?.installLocation ??
+      marketplaceConfig.installLocation
+
     return {
       entry: plugin,
-      marketplaceInstallLocation: marketplaceConfig.installLocation,
+      marketplaceInstallLocation: installLocation,
     }
   } catch (error) {
     logForDebugging(

--- a/src/utils/plugins/marketplaceManager.ts
+++ b/src/utils/plugins/marketplaceManager.ts
@@ -1831,14 +1831,30 @@ async function loadAndCacheMarketplace(
           // Rename temp cache to final name
           try {
             await fs.rename(temporaryCachePath, finalCachePath)
+            temporaryCachePath = finalCachePath
           } catch (renameError) {
             // Rename may fail for cross-device moves (EXDEV). Fall back to
-            // copy + delete.
-            await fs.cp(temporaryCachePath, finalCachePath, { recursive: true })
-            await fs.rm(temporaryCachePath, { recursive: true, force: true })
+            // copy + delete. Recursive copy can still throw ENOENT on Windows
+            // for dangling symlinks or unreadable nested files in large
+            // clones (ChromeDevTools/chrome-devtools-mcp third_party trees,
+            // issue #2183). The clone already succeeded and marketplace.json
+            // was parsed from temporaryCachePath — keep that directory rather
+            // than failing the add.
+            try {
+              await fs.cp(temporaryCachePath, finalCachePath, {
+                recursive: true,
+              })
+              await fs.rm(temporaryCachePath, { recursive: true, force: true })
+              temporaryCachePath = finalCachePath
+            } catch (copyError) {
+              await fs.rm(finalCachePath, { recursive: true, force: true })
+              logForDebugging(
+                `Marketplace cache rename and copy failed; keeping ${temporaryCachePath}. rename=${errorMessage(renameError)} copy=${errorMessage(copyError)}`,
+                { level: 'warn' },
+              )
+            }
           }
-          temporaryCachePath = finalCachePath
-          cleanupNeeded = false // Successfully renamed, no cleanup needed
+          cleanupNeeded = false // Clone is the live cache (renamed, copied, or kept)
         } catch (error) {
           const errorMsg = errorMessage(error)
           throw new Error(


### PR DESCRIPTION
## Summary

- `/plugin marketplace add` of GitHub marketplaces (including ChromeDevTools/chrome-devtools-mcp) no longer fails the add after a successful clone when Windows `fs.cp` hits ENOENT on nested unreadable/symlink files. The live clone is kept and persisted as `installLocation`.
- Plugin-cache tilde overrides (`CLAUDE_CODE_PLUGIN_CACHE_DIR=~/.openclaude/plugins`) now expand with `path.join`, so Windows keeps a separator between the home directory and `.openclaude`.
- Same-call consumers (`getPluginById`, install-by-name) reload the persisted keep-temp path after a refetch instead of returning the pre-refetch canonical directory.

Fixes #2183

## Impact

- user-facing impact: GitHub marketplace add completes on Windows when clone and `marketplace.json` parse succeed, even if rename/copy to the canonical marketplace-name directory fails. Plugin cache paths from `~/` settings no longer glue onto the home directory.
- developer/maintainer impact: keep-temp recovery can leave `installLocation` at a `temp_*` directory instead of the lowercased marketplace name. Callers must use the persisted path. Pre-rename destination `rm` failures and leftover partial canonical dirs are unchanged.

## Testing

- [x] I ran the required [local preflight](https://github.com/Gitlawb/openclaude/blob/main/CONTRIBUTING.md#validation).
- exact commands and results (head `baaa9d6cc72887d3af6a6f5fbb6073d1b317283b`):
  - `bun test src/utils/plugins/marketplaceManager.test.ts src/utils/permissions/pathValidation.expandTilde.test.ts` — pass (32 tests)
  - neighbor plugin/path tests — 49 pass
  - `bun run typecheck` / `bun run typecheck:type-tests` — pass
  - `bun run check` — process exit 0; same baseline/env failures inside the suite as on `main` (autoExtractFacts, ProviderManager timeouts, bughunter empty git context in sandbox, ExportDialog timeout)
  - `node bin/openclaude --version` and `NODE_DISABLE_COMPILE_CACHE=1 node bin/openclaude --version` — 0.30.0
  - `bun run test:provider` — 1608 pass, 36 skip
  - `npm run test:provider-recommendation` — 160 pass
  - `bun run security:pr-scan -- --base FETCH_HEAD --head HEAD` — no suspicious additions
- focused tests: keep-temp on copy ENOENT; dest-rm throw still keeps temp; `getMarketplace` persist; `getPluginById` returns persisted keep-temp path; `expandTilde` `~/` and win32 `~\`
- documented skipped checks, platform limitations, or verified pre-existing failures: no Windows host, so the reporter's native copyfile ENOENT was not reproduced on this machine. `bun run check` still surfaces the same baseline/env failures seen on `main`.

## Notes

- provider/model path tested: not applicable (marketplace cache / path expansion)
- screenshots attached (if UI changed): none
- follow-up work or known limitations: keep-temp does not repair a pre-rename destination `rm` throw (unchanged baseline). Cache-only startup paths read the stored `installLocation` and do not refetch. Re-add does not heal a previously stored broken path.

Final reviewed SHA: `baaa9d6cc72887d3af6a6f5fbb6073d1b317283b`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Plugin installations now refresh marketplace settings and use the current installation location.
  - Marketplace updates remain usable when cache copying or cleanup encounters errors.
  - Temporary marketplace locations are preserved after recovery or fallback scenarios.
  - Fixed home-directory expansion for bare `~` paths and paths using POSIX or Windows separators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->